### PR TITLE
chore: run refresh-all with latest sidekick

### DIFF
--- a/src/firestore/src/generated/gapic/client.rs
+++ b/src/firestore/src/generated/gapic/client.rs
@@ -126,6 +126,22 @@ impl Firestore {
     }
 
     /// Gets a single document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_document(&self) -> super::builder::firestore::GetDocument {
         super::builder::firestore::GetDocument::new(self.inner.clone())
     }
@@ -136,26 +152,104 @@ impl Firestore {
     }
 
     /// Updates or inserts a document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_document(&self) -> super::builder::firestore::UpdateDocument {
         super::builder::firestore::UpdateDocument::new(self.inner.clone())
     }
 
     /// Deletes a document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_document(&self) -> super::builder::firestore::DeleteDocument {
         super::builder::firestore::DeleteDocument::new(self.inner.clone())
     }
 
     /// Starts a new transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .begin_transaction()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn begin_transaction(&self) -> super::builder::firestore::BeginTransaction {
         super::builder::firestore::BeginTransaction::new(self.inner.clone())
     }
 
     /// Commits a transaction, while optionally updating documents.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .commit()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn commit(&self) -> super::builder::firestore::Commit {
         super::builder::firestore::Commit::new(self.inner.clone())
     }
 
     /// Rolls back a transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .rollback()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rollback(&self) -> super::builder::firestore::Rollback {
         super::builder::firestore::Rollback::new(self.inner.clone())
     }
@@ -168,6 +262,22 @@ impl Firestore {
     }
 
     /// Lists all the collection IDs underneath a document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_collection_ids()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_collection_ids(&self) -> super::builder::firestore::ListCollectionIds {
         super::builder::firestore::ListCollectionIds::new(self.inner.clone())
     }
@@ -185,11 +295,43 @@ impl Firestore {
     ///
     /// [google.firestore.v1.BatchWriteResponse]: crate::model::BatchWriteResponse
     /// [google.firestore.v1.Firestore.Commit]: crate::client::Firestore::commit
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_write()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_write(&self) -> super::builder::firestore::BatchWrite {
         super::builder::firestore::BatchWrite::new(self.inner.clone())
     }
 
     /// Creates a new document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore::client::Firestore;
+    /// async fn sample(
+    ///    client: &Firestore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_document(&self) -> super::builder::firestore::CreateDocument {
         super::builder::firestore::CreateDocument::new(self.inner.clone())
     }

--- a/src/generated/api/apikeys/v2/src/client.rs
+++ b/src/generated/api/apikeys/v2/src/client.rs
@@ -150,6 +150,23 @@ impl ApiKeys {
     ///
     /// NOTE: Key is a global resource; hence the only supported value for
     /// location is `global`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apikeys_v2::client::ApiKeys;
+    /// async fn sample(
+    ///    client: &ApiKeys,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_key(&self) -> super::builder::api_keys::GetKey {
         super::builder::api_keys::GetKey::new(self.inner.clone())
     }
@@ -158,6 +175,22 @@ impl ApiKeys {
     ///
     /// NOTE: Key is a global resource; hence the only supported value for
     /// location is `global`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apikeys_v2::client::ApiKeys;
+    /// async fn sample(
+    ///    client: &ApiKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_key_string()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_key_string(&self) -> super::builder::api_keys::GetKeyString {
         super::builder::api_keys::GetKeyString::new(self.inner.clone())
     }
@@ -223,6 +256,22 @@ impl ApiKeys {
     /// purged, resource name will not be set.
     /// The service account must have the `apikeys.keys.lookup` permission
     /// on the parent project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apikeys_v2::client::ApiKeys;
+    /// async fn sample(
+    ///    client: &ApiKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_key(&self) -> super::builder::api_keys::LookupKey {
         super::builder::api_keys::LookupKey::new(self.inner.clone())
     }
@@ -230,6 +279,22 @@ impl ApiKeys {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apikeys_v2::client::ApiKeys;
+    /// async fn sample(
+    ///    client: &ApiKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_keys::GetOperation {
         super::builder::api_keys::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/api/cloudquotas/v1/src/client.rs
+++ b/src/generated/api/cloudquotas/v1/src/client.rs
@@ -130,6 +130,23 @@ impl CloudQuotas {
     }
 
     /// Retrieve the QuotaInfo of a quota for a project, folder or organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
+    /// async fn sample(
+    ///    client: &CloudQuotas,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_quota_info()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_quota_info(&self) -> super::builder::cloud_quotas::GetQuotaInfo {
         super::builder::cloud_quotas::GetQuotaInfo::new(self.inner.clone())
     }
@@ -140,17 +157,66 @@ impl CloudQuotas {
     }
 
     /// Gets details of a single QuotaPreference.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
+    /// async fn sample(
+    ///    client: &CloudQuotas,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_quota_preference()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_quota_preference(&self) -> super::builder::cloud_quotas::GetQuotaPreference {
         super::builder::cloud_quotas::GetQuotaPreference::new(self.inner.clone())
     }
 
     /// Creates a new QuotaPreference that declares the desired value for a quota.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
+    /// async fn sample(
+    ///    client: &CloudQuotas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_quota_preference()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_quota_preference(&self) -> super::builder::cloud_quotas::CreateQuotaPreference {
         super::builder::cloud_quotas::CreateQuotaPreference::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single QuotaPreference. It can updates the
     /// config in any states, not just the ones pending approval.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
+    /// async fn sample(
+    ///    client: &CloudQuotas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_quota_preference()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_quota_preference(&self) -> super::builder::cloud_quotas::UpdateQuotaPreference {
         super::builder::cloud_quotas::UpdateQuotaPreference::new(self.inner.clone())
     }

--- a/src/generated/api/servicecontrol/v1/src/client.rs
+++ b/src/generated/api/servicecontrol/v1/src/client.rs
@@ -135,6 +135,22 @@ impl QuotaController {
     /// `UNKNOWN`, `DEADLINE_EXCEEDED`, and `UNAVAILABLE`. To ensure system
     /// reliability, the server may inject these errors to prohibit any hard
     /// dependency on the quota functionality.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicecontrol_v1::client::QuotaController;
+    /// async fn sample(
+    ///    client: &QuotaController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .allocate_quota()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn allocate_quota(&self) -> super::builder::quota_controller::AllocateQuota {
         super::builder::quota_controller::AllocateQuota::new(self.inner.clone())
     }
@@ -267,6 +283,22 @@ impl ServiceController {
     /// [Cloud IAM](https://cloud.google.com/iam).
     ///
     /// [google.api.servicecontrol.v1.CheckRequest]: crate::model::CheckRequest
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
+    /// async fn sample(
+    ///    client: &ServiceController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check(&self) -> super::builder::service_controller::Check {
         super::builder::service_controller::Check::new(self.inner.clone())
     }
@@ -288,6 +320,22 @@ impl ServiceController {
     /// [Google Cloud IAM](https://cloud.google.com/iam).
     ///
     /// [google.api.servicecontrol.v1.ReportRequest]: crate::model::ReportRequest
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
+    /// async fn sample(
+    ///    client: &ServiceController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn report(&self) -> super::builder::service_controller::Report {
         super::builder::service_controller::Report::new(self.inner.clone())
     }

--- a/src/generated/api/servicecontrol/v2/src/client.rs
+++ b/src/generated/api/servicecontrol/v2/src/client.rs
@@ -146,6 +146,22 @@ impl ServiceController {
     /// on the specified service. For more information, see
     /// [Service Control API Access
     /// Control](https://cloud.google.com/service-infrastructure/docs/service-control/access-control).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
+    /// async fn sample(
+    ///    client: &ServiceController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check(&self) -> super::builder::service_controller::Check {
         super::builder::service_controller::Check::new(self.inner.clone())
     }
@@ -165,6 +181,22 @@ impl ServiceController {
     /// on the specified service. For more information, see
     /// [Service Control API Access
     /// Control](https://cloud.google.com/service-infrastructure/docs/service-control/access-control).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
+    /// async fn sample(
+    ///    client: &ServiceController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn report(&self) -> super::builder::service_controller::Report {
         super::builder::service_controller::Report::new(self.inner.clone())
     }

--- a/src/generated/api/servicemanagement/v1/src/client.rs
+++ b/src/generated/api/servicemanagement/v1/src/client.rs
@@ -130,6 +130,22 @@ impl ServiceManager {
 
     /// Gets a managed service. Authentication is required unless the service is
     /// public.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::service_manager::GetService {
         super::builder::service_manager::GetService::new(self.inner.clone())
     }
@@ -210,6 +226,22 @@ impl ServiceManager {
     }
 
     /// Gets a service configuration (version) for a managed service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_config(&self) -> super::builder::service_manager::GetServiceConfig {
         super::builder::service_manager::GetServiceConfig::new(self.inner.clone())
     }
@@ -224,6 +256,22 @@ impl ServiceManager {
     /// eventually.
     ///
     /// [google.api.servicemanagement.v1.ServiceManager.CreateServiceRollout]: crate::client::ServiceManager::create_service_rollout
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service_config(&self) -> super::builder::service_manager::CreateServiceConfig {
         super::builder::service_manager::CreateServiceConfig::new(self.inner.clone())
     }
@@ -268,6 +316,22 @@ impl ServiceManager {
     /// [rollout][google.api.servicemanagement.v1.Rollout].
     ///
     /// [google.api.servicemanagement.v1.Rollout]: crate::model::Rollout
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_rollout()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_rollout(&self) -> super::builder::service_manager::GetServiceRollout {
         super::builder::service_manager::GetServiceRollout::new(self.inner.clone())
     }
@@ -311,6 +375,22 @@ impl ServiceManager {
     /// If GenerateConfigReportRequest.old_value is not specified, this method
     /// will compare GenerateConfigReportRequest.new_value with the last pushed
     /// service configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_config_report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_config_report(&self) -> super::builder::service_manager::GenerateConfigReport {
         super::builder::service_manager::GenerateConfigReport::new(self.inner.clone())
     }
@@ -320,12 +400,44 @@ impl ServiceManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::service_manager::SetIamPolicy {
         super::builder::service_manager::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::service_manager::GetIamPolicy {
         super::builder::service_manager::GetIamPolicy::new(self.inner.clone())
     }
@@ -337,6 +449,22 @@ impl ServiceManager {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::service_manager::TestIamPermissions {
         super::builder::service_manager::TestIamPermissions::new(self.inner.clone())
     }
@@ -349,6 +477,22 @@ impl ServiceManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+    /// async fn sample(
+    ///    client: &ServiceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::service_manager::GetOperation {
         super::builder::service_manager::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/api/serviceusage/v1/src/client.rs
+++ b/src/generated/api/serviceusage/v1/src/client.rs
@@ -159,6 +159,22 @@ impl ServiceUsage {
     }
 
     /// Returns the service configuration and enabled state for a given service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+    /// async fn sample(
+    ///    client: &ServiceUsage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::service_usage::GetService {
         super::builder::service_usage::GetService::new(self.inner.clone())
     }
@@ -199,6 +215,22 @@ impl ServiceUsage {
 
     /// Returns the service configurations and enabled states for a given list of
     /// services.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+    /// async fn sample(
+    ///    client: &ServiceUsage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_get_services()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_get_services(&self) -> super::builder::service_usage::BatchGetServices {
         super::builder::service_usage::BatchGetServices::new(self.inner.clone())
     }
@@ -213,6 +245,22 @@ impl ServiceUsage {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+    /// async fn sample(
+    ///    client: &ServiceUsage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::service_usage::GetOperation {
         super::builder::service_usage::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/appengine/v1/src/client.rs
+++ b/src/generated/appengine/v1/src/client.rs
@@ -119,6 +119,22 @@ impl Applications {
     }
 
     /// Gets information about an application.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Applications;
+    /// async fn sample(
+    ///    client: &Applications
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_application()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_application(&self) -> super::builder::applications::GetApplication {
         super::builder::applications::GetApplication::new(self.inner.clone())
     }
@@ -198,6 +214,22 @@ impl Applications {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Applications;
+    /// async fn sample(
+    ///    client: &Applications
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::applications::GetOperation {
         super::builder::applications::GetOperation::new(self.inner.clone())
     }
@@ -311,6 +343,22 @@ impl Services {
     }
 
     /// Gets the current configuration of the specified service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::services::GetService {
         super::builder::services::GetService::new(self.inner.clone())
     }
@@ -355,6 +403,22 @@ impl Services {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::services::GetOperation {
         super::builder::services::GetOperation::new(self.inner.clone())
     }
@@ -470,6 +534,22 @@ impl Versions {
     /// Gets the specified Version resource.
     /// By default, only a `BASIC_VIEW` will be returned.
     /// Specify the `FULL_VIEW` parameter to get the full resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::versions::GetVersion {
         super::builder::versions::GetVersion::new(self.inner.clone())
     }
@@ -564,6 +644,22 @@ impl Versions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::versions::GetOperation {
         super::builder::versions::GetOperation::new(self.inner.clone())
     }
@@ -680,6 +776,22 @@ impl Instances {
     }
 
     /// Gets instance information.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::instances::GetInstance {
         super::builder::instances::GetInstance::new(self.inner.clone())
     }
@@ -742,6 +854,22 @@ impl Instances {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instances::GetOperation {
         super::builder::instances::GetOperation::new(self.inner.clone())
     }
@@ -868,26 +996,105 @@ impl Firewall {
     ///
     /// If the final rule does not match traffic with the '*' wildcard IP range,
     /// then an "allow all" rule is explicitly added to the end of the list.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_update_ingress_rules()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_update_ingress_rules(&self) -> super::builder::firewall::BatchUpdateIngressRules {
         super::builder::firewall::BatchUpdateIngressRules::new(self.inner.clone())
     }
 
     /// Creates a firewall rule for the application.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_ingress_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_ingress_rule(&self) -> super::builder::firewall::CreateIngressRule {
         super::builder::firewall::CreateIngressRule::new(self.inner.clone())
     }
 
     /// Gets the specified firewall rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ingress_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ingress_rule(&self) -> super::builder::firewall::GetIngressRule {
         super::builder::firewall::GetIngressRule::new(self.inner.clone())
     }
 
     /// Updates the specified firewall rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_ingress_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_ingress_rule(&self) -> super::builder::firewall::UpdateIngressRule {
         super::builder::firewall::UpdateIngressRule::new(self.inner.clone())
     }
 
     /// Deletes the specified firewall rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_ingress_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_ingress_rule(&self) -> super::builder::firewall::DeleteIngressRule {
         super::builder::firewall::DeleteIngressRule::new(self.inner.clone())
     }
@@ -902,6 +1109,22 @@ impl Firewall {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::Firewall;
+    /// async fn sample(
+    ///    client: &Firewall
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::firewall::GetOperation {
         super::builder::firewall::GetOperation::new(self.inner.clone())
     }
@@ -1031,6 +1254,22 @@ impl AuthorizedDomains {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedDomains;
+    /// async fn sample(
+    ///    client: &AuthorizedDomains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::authorized_domains::GetOperation {
         super::builder::authorized_domains::GetOperation::new(self.inner.clone())
     }
@@ -1150,6 +1389,22 @@ impl AuthorizedCertificates {
     }
 
     /// Gets the specified SSL certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// async fn sample(
+    ///    client: &AuthorizedCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_authorized_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_authorized_certificate(
         &self,
     ) -> super::builder::authorized_certificates::GetAuthorizedCertificate {
@@ -1157,6 +1412,22 @@ impl AuthorizedCertificates {
     }
 
     /// Uploads the specified SSL certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// async fn sample(
+    ///    client: &AuthorizedCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_authorized_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_authorized_certificate(
         &self,
     ) -> super::builder::authorized_certificates::CreateAuthorizedCertificate {
@@ -1170,6 +1441,22 @@ impl AuthorizedCertificates {
     /// certificate. The new certificate must be applicable to the same domains as
     /// the original certificate. The certificate `display_name` may also be
     /// updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// async fn sample(
+    ///    client: &AuthorizedCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_authorized_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_authorized_certificate(
         &self,
     ) -> super::builder::authorized_certificates::UpdateAuthorizedCertificate {
@@ -1179,6 +1466,21 @@ impl AuthorizedCertificates {
     }
 
     /// Deletes the specified SSL certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// async fn sample(
+    ///    client: &AuthorizedCertificates
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_authorized_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_authorized_certificate(
         &self,
     ) -> super::builder::authorized_certificates::DeleteAuthorizedCertificate {
@@ -1197,6 +1499,22 @@ impl AuthorizedCertificates {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
+    /// async fn sample(
+    ///    client: &AuthorizedCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::authorized_certificates::GetOperation {
         super::builder::authorized_certificates::GetOperation::new(self.inner.clone())
     }
@@ -1310,6 +1628,22 @@ impl DomainMappings {
     }
 
     /// Gets the specified domain mapping.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::DomainMappings;
+    /// async fn sample(
+    ///    client: &DomainMappings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_domain_mapping()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_domain_mapping(&self) -> super::builder::domain_mappings::GetDomainMapping {
         super::builder::domain_mappings::GetDomainMapping::new(self.inner.clone())
     }
@@ -1376,6 +1710,22 @@ impl DomainMappings {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_appengine_v1::client::DomainMappings;
+    /// async fn sample(
+    ///    client: &DomainMappings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::domain_mappings::GetOperation {
         super::builder::domain_mappings::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/bigtable/admin/v2/src/client.rs
+++ b/src/generated/bigtable/admin/v2/src/client.rs
@@ -145,11 +145,44 @@ impl BigtableInstanceAdmin {
     }
 
     /// Gets information about an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::bigtable_instance_admin::GetInstance {
         super::builder::bigtable_instance_admin::GetInstance::new(self.inner.clone())
     }
 
     /// Lists information about instances in a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_instances()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_instances(&self) -> super::builder::bigtable_instance_admin::ListInstances {
         super::builder::bigtable_instance_admin::ListInstances::new(self.inner.clone())
     }
@@ -157,6 +190,22 @@ impl BigtableInstanceAdmin {
     /// Updates an instance within a project. This method updates only the display
     /// name and type for an Instance. To update other Instance properties, such as
     /// labels, use PartialUpdateInstance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_instance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_instance(&self) -> super::builder::bigtable_instance_admin::UpdateInstance {
         super::builder::bigtable_instance_admin::UpdateInstance::new(self.inner.clone())
     }
@@ -180,6 +229,22 @@ impl BigtableInstanceAdmin {
     }
 
     /// Delete an instance from a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_instance(&self) -> super::builder::bigtable_instance_admin::DeleteInstance {
         super::builder::bigtable_instance_admin::DeleteInstance::new(self.inner.clone())
     }
@@ -206,11 +271,44 @@ impl BigtableInstanceAdmin {
     }
 
     /// Gets information about a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::bigtable_instance_admin::GetCluster {
         super::builder::bigtable_instance_admin::GetCluster::new(self.inner.clone())
     }
 
     /// Lists information about clusters in an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_clusters()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_clusters(&self) -> super::builder::bigtable_instance_admin::ListClusters {
         super::builder::bigtable_instance_admin::ListClusters::new(self.inner.clone())
     }
@@ -263,16 +361,65 @@ impl BigtableInstanceAdmin {
     }
 
     /// Deletes a cluster from an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_cluster(&self) -> super::builder::bigtable_instance_admin::DeleteCluster {
         super::builder::bigtable_instance_admin::DeleteCluster::new(self.inner.clone())
     }
 
     /// Creates an app profile within an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_app_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_app_profile(&self) -> super::builder::bigtable_instance_admin::CreateAppProfile {
         super::builder::bigtable_instance_admin::CreateAppProfile::new(self.inner.clone())
     }
 
     /// Gets information about an app profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_app_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_app_profile(&self) -> super::builder::bigtable_instance_admin::GetAppProfile {
         super::builder::bigtable_instance_admin::GetAppProfile::new(self.inner.clone())
     }
@@ -298,23 +445,87 @@ impl BigtableInstanceAdmin {
     }
 
     /// Deletes an app profile from an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_app_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_app_profile(&self) -> super::builder::bigtable_instance_admin::DeleteAppProfile {
         super::builder::bigtable_instance_admin::DeleteAppProfile::new(self.inner.clone())
     }
 
     /// Gets the access control policy for an instance resource. Returns an empty
     /// policy if an instance exists but does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::bigtable_instance_admin::GetIamPolicy {
         super::builder::bigtable_instance_admin::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the access control policy on an instance resource. Replaces any
     /// existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::bigtable_instance_admin::SetIamPolicy {
         super::builder::bigtable_instance_admin::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that the caller has on the specified instance resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::bigtable_instance_admin::TestIamPermissions {
@@ -345,6 +556,23 @@ impl BigtableInstanceAdmin {
     }
 
     /// Gets information about a logical view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_logical_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_logical_view(&self) -> super::builder::bigtable_instance_admin::GetLogicalView {
         super::builder::bigtable_instance_admin::GetLogicalView::new(self.inner.clone())
     }
@@ -372,6 +600,22 @@ impl BigtableInstanceAdmin {
     }
 
     /// Deletes a logical view from an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_logical_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_logical_view(
         &self,
     ) -> super::builder::bigtable_instance_admin::DeleteLogicalView {
@@ -396,6 +640,23 @@ impl BigtableInstanceAdmin {
     }
 
     /// Gets information about a materialized view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_materialized_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_materialized_view(
         &self,
     ) -> super::builder::bigtable_instance_admin::GetMaterializedView {
@@ -427,6 +688,22 @@ impl BigtableInstanceAdmin {
     }
 
     /// Deletes a materialized view from an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_materialized_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_materialized_view(
         &self,
     ) -> super::builder::bigtable_instance_admin::DeleteMaterializedView {
@@ -443,6 +720,22 @@ impl BigtableInstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::bigtable_instance_admin::GetOperation {
         super::builder::bigtable_instance_admin::GetOperation::new(self.inner.clone())
     }
@@ -450,6 +743,21 @@ impl BigtableInstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::bigtable_instance_admin::DeleteOperation {
         super::builder::bigtable_instance_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -457,6 +765,21 @@ impl BigtableInstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+    /// async fn sample(
+    ///    client: &BigtableInstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::bigtable_instance_admin::CancelOperation {
         super::builder::bigtable_instance_admin::CancelOperation::new(self.inner.clone())
     }
@@ -573,6 +896,22 @@ impl BigtableTableAdmin {
     /// Creates a new table in the specified instance.
     /// The table can be created with a full set of initial column families,
     /// specified in the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_table(&self) -> super::builder::bigtable_table_admin::CreateTable {
         super::builder::bigtable_table_admin::CreateTable::new(self.inner.clone())
     }
@@ -607,6 +946,23 @@ impl BigtableTableAdmin {
     }
 
     /// Gets metadata information about the specified table.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_table()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_table(&self) -> super::builder::bigtable_table_admin::GetTable {
         super::builder::bigtable_table_admin::GetTable::new(self.inner.clone())
     }
@@ -627,6 +983,21 @@ impl BigtableTableAdmin {
     }
 
     /// Permanently deletes a specified table and all of its data.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_table(&self) -> super::builder::bigtable_table_admin::DeleteTable {
         super::builder::bigtable_table_admin::DeleteTable::new(self.inner.clone())
     }
@@ -671,6 +1042,23 @@ impl BigtableTableAdmin {
     }
 
     /// Gets information from a specified AuthorizedView.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_authorized_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_authorized_view(&self) -> super::builder::bigtable_table_admin::GetAuthorizedView {
         super::builder::bigtable_table_admin::GetAuthorizedView::new(self.inner.clone())
     }
@@ -693,6 +1081,22 @@ impl BigtableTableAdmin {
     }
 
     /// Permanently deletes a specified AuthorizedView.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_authorized_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_authorized_view(
         &self,
     ) -> super::builder::bigtable_table_admin::DeleteAuthorizedView {
@@ -703,6 +1107,22 @@ impl BigtableTableAdmin {
     /// Either all or none of the modifications will occur before this method
     /// returns, but data requests received prior to that point may see a table
     /// where only some modifications have taken effect.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .modify_column_families()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn modify_column_families(
         &self,
     ) -> super::builder::bigtable_table_admin::ModifyColumnFamilies {
@@ -712,6 +1132,21 @@ impl BigtableTableAdmin {
     /// Permanently drop/delete a row range from a specified table. The request can
     /// specify whether to delete all rows in a table, or only those that match a
     /// particular prefix.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .drop_row_range()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn drop_row_range(&self) -> super::builder::bigtable_table_admin::DropRowRange {
         super::builder::bigtable_table_admin::DropRowRange::new(self.inner.clone())
     }
@@ -720,6 +1155,22 @@ impl BigtableTableAdmin {
     /// CheckConsistency to check whether mutations to the table that finished
     /// before this call started have been replicated. The tokens will be available
     /// for 90 days.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_consistency_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_consistency_token(
         &self,
     ) -> super::builder::bigtable_table_admin::GenerateConsistencyToken {
@@ -729,6 +1180,22 @@ impl BigtableTableAdmin {
     /// Checks replication consistency based on a consistency token, that is, if
     /// replication has caught up based on the conditions specified in the token
     /// and the check request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_consistency()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_consistency(&self) -> super::builder::bigtable_table_admin::CheckConsistency {
         super::builder::bigtable_table_admin::CheckConsistency::new(self.inner.clone())
     }
@@ -762,6 +1229,23 @@ impl BigtableTableAdmin {
     /// feature might be changed in backward-incompatible ways and is not
     /// recommended for production use. It is not subject to any SLA or deprecation
     /// policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_snapshot()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_snapshot(&self) -> super::builder::bigtable_table_admin::GetSnapshot {
         super::builder::bigtable_table_admin::GetSnapshot::new(self.inner.clone())
     }
@@ -784,6 +1268,21 @@ impl BigtableTableAdmin {
     /// feature might be changed in backward-incompatible ways and is not
     /// recommended for production use. It is not subject to any SLA or deprecation
     /// policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_snapshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_snapshot(&self) -> super::builder::bigtable_table_admin::DeleteSnapshot {
         super::builder::bigtable_table_admin::DeleteSnapshot::new(self.inner.clone())
     }
@@ -817,16 +1316,64 @@ impl BigtableTableAdmin {
     }
 
     /// Gets metadata on a pending or completed Cloud Bigtable Backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::bigtable_table_admin::GetBackup {
         super::builder::bigtable_table_admin::GetBackup::new(self.inner.clone())
     }
 
     /// Updates a pending or completed Cloud Bigtable Backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_backup(&self) -> super::builder::bigtable_table_admin::UpdateBackup {
         super::builder::bigtable_table_admin::UpdateBackup::new(self.inner.clone())
     }
 
     /// Deletes a pending or completed Cloud Bigtable backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_backup(&self) -> super::builder::bigtable_table_admin::DeleteBackup {
         super::builder::bigtable_table_admin::DeleteBackup::new(self.inner.clone())
     }
@@ -883,18 +1430,66 @@ impl BigtableTableAdmin {
     /// Gets the access control policy for a Bigtable resource.
     /// Returns an empty policy if the resource exists but does not have a policy
     /// set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::bigtable_table_admin::GetIamPolicy {
         super::builder::bigtable_table_admin::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the access control policy on a Bigtable resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::bigtable_table_admin::SetIamPolicy {
         super::builder::bigtable_table_admin::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that the caller has on the specified Bigtable
     /// resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::bigtable_table_admin::TestIamPermissions {
         super::builder::bigtable_table_admin::TestIamPermissions::new(self.inner.clone())
     }
@@ -930,6 +1525,23 @@ impl BigtableTableAdmin {
     }
 
     /// Gets metadata information about the specified schema bundle.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema_bundle()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema_bundle(&self) -> super::builder::bigtable_table_admin::GetSchemaBundle {
         super::builder::bigtable_table_admin::GetSchemaBundle::new(self.inner.clone())
     }
@@ -940,6 +1552,22 @@ impl BigtableTableAdmin {
     }
 
     /// Deletes a schema bundle in the specified table.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_schema_bundle()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema_bundle(&self) -> super::builder::bigtable_table_admin::DeleteSchemaBundle {
         super::builder::bigtable_table_admin::DeleteSchemaBundle::new(self.inner.clone())
     }
@@ -954,6 +1582,22 @@ impl BigtableTableAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::bigtable_table_admin::GetOperation {
         super::builder::bigtable_table_admin::GetOperation::new(self.inner.clone())
     }
@@ -961,6 +1605,21 @@ impl BigtableTableAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::bigtable_table_admin::DeleteOperation {
         super::builder::bigtable_table_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -968,6 +1627,21 @@ impl BigtableTableAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
+    /// async fn sample(
+    ///    client: &BigtableTableAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::bigtable_table_admin::CancelOperation {
         super::builder::bigtable_table_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/accessapproval/v1/src/client.rs
+++ b/src/generated/cloud/accessapproval/v1/src/client.rs
@@ -160,6 +160,22 @@ impl AccessApproval {
     }
 
     /// Gets an approval request. Returns NOT_FOUND if the request does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_approval_request()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_approval_request(&self) -> super::builder::access_approval::GetApprovalRequest {
         super::builder::access_approval::GetApprovalRequest::new(self.inner.clone())
     }
@@ -168,6 +184,22 @@ impl AccessApproval {
     ///
     /// Returns NOT_FOUND if the request does not exist. Returns
     /// FAILED_PRECONDITION if the request exists but is not in a pending state.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .approve_approval_request()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn approve_approval_request(
         &self,
     ) -> super::builder::access_approval::ApproveApprovalRequest {
@@ -184,6 +216,22 @@ impl AccessApproval {
     ///
     /// Returns FAILED_PRECONDITION if the request exists but is not in a pending
     /// state.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .dismiss_approval_request()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn dismiss_approval_request(
         &self,
     ) -> super::builder::access_approval::DismissApprovalRequest {
@@ -198,6 +246,22 @@ impl AccessApproval {
     ///
     /// Returns FAILED_PRECONDITION if the request exists but is not in an approved
     /// state.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .invalidate_approval_request()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn invalidate_approval_request(
         &self,
     ) -> super::builder::access_approval::InvalidateApprovalRequest {
@@ -205,6 +269,22 @@ impl AccessApproval {
     }
 
     /// Gets the settings associated with a project, folder, or organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_access_approval_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_access_approval_settings(
         &self,
     ) -> super::builder::access_approval::GetAccessApprovalSettings {
@@ -213,6 +293,22 @@ impl AccessApproval {
 
     /// Updates the settings associated with a project, folder, or organization.
     /// Settings to update are determined by the value of field_mask.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_access_approval_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_access_approval_settings(
         &self,
     ) -> super::builder::access_approval::UpdateAccessApprovalSettings {
@@ -225,6 +321,21 @@ impl AccessApproval {
     /// Approval disabled. If Access Approval is enabled at a higher level of the
     /// hierarchy, then Access Approval will still be enabled at this level as
     /// the settings are inherited.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_access_approval_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_access_approval_settings(
         &self,
     ) -> super::builder::access_approval::DeleteAccessApprovalSettings {
@@ -233,6 +344,22 @@ impl AccessApproval {
 
     /// Retrieves the service account that is used by Access Approval to access KMS
     /// keys for signing approved approval requests.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_accessapproval_v1::client::AccessApproval;
+    /// async fn sample(
+    ///    client: &AccessApproval
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_access_approval_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_access_approval_service_account(
         &self,
     ) -> super::builder::access_approval::GetAccessApprovalServiceAccount {

--- a/src/generated/cloud/advisorynotifications/v1/src/client.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/client.rs
@@ -130,6 +130,23 @@ impl AdvisoryNotificationsService {
     }
 
     /// Gets a notification.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+    /// async fn sample(
+    ///    client: &AdvisoryNotificationsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notification()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notification(
         &self,
     ) -> super::builder::advisory_notifications_service::GetNotification {
@@ -137,11 +154,44 @@ impl AdvisoryNotificationsService {
     }
 
     /// Get notification settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+    /// async fn sample(
+    ///    client: &AdvisoryNotificationsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_settings(&self) -> super::builder::advisory_notifications_service::GetSettings {
         super::builder::advisory_notifications_service::GetSettings::new(self.inner.clone())
     }
 
     /// Update notification settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+    /// async fn sample(
+    ///    client: &AdvisoryNotificationsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_settings(
         &self,
     ) -> super::builder::advisory_notifications_service::UpdateSettings {

--- a/src/generated/cloud/aiplatform/v1/src/client.rs
+++ b/src/generated/cloud/aiplatform/v1/src/client.rs
@@ -126,6 +126,22 @@ impl DataFoundryService {
     }
 
     /// Generates synthetic data based on the provided configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_synthetic_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_synthetic_data(
         &self,
     ) -> super::builder::data_foundry_service::GenerateSyntheticData {
@@ -138,6 +154,22 @@ impl DataFoundryService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_foundry_service::GetLocation {
         super::builder::data_foundry_service::GetLocation::new(self.inner.clone())
     }
@@ -147,12 +179,44 @@ impl DataFoundryService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_foundry_service::SetIamPolicy {
         super::builder::data_foundry_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_foundry_service::GetIamPolicy {
         super::builder::data_foundry_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -164,6 +228,22 @@ impl DataFoundryService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::data_foundry_service::TestIamPermissions {
         super::builder::data_foundry_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -178,6 +258,22 @@ impl DataFoundryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_foundry_service::GetOperation {
         super::builder::data_foundry_service::GetOperation::new(self.inner.clone())
     }
@@ -185,6 +281,21 @@ impl DataFoundryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_foundry_service::DeleteOperation {
         super::builder::data_foundry_service::DeleteOperation::new(self.inner.clone())
     }
@@ -192,6 +303,21 @@ impl DataFoundryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_foundry_service::CancelOperation {
         super::builder::data_foundry_service::CancelOperation::new(self.inner.clone())
     }
@@ -199,6 +325,22 @@ impl DataFoundryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
+    /// async fn sample(
+    ///    client: &DataFoundryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::data_foundry_service::WaitOperation {
         super::builder::data_foundry_service::WaitOperation::new(self.inner.clone())
     }
@@ -325,11 +467,44 @@ impl DatasetService {
     }
 
     /// Gets a Dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset(&self) -> super::builder::dataset_service::GetDataset {
         super::builder::dataset_service::GetDataset::new(self.inner.clone())
     }
 
     /// Updates a Dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_dataset(&self) -> super::builder::dataset_service::UpdateDataset {
         super::builder::dataset_service::UpdateDataset::new(self.inner.clone())
     }
@@ -400,6 +575,22 @@ impl DatasetService {
     }
 
     /// Updates a DatasetVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_dataset_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_dataset_version(&self) -> super::builder::dataset_service::UpdateDatasetVersion {
         super::builder::dataset_service::UpdateDatasetVersion::new(self.inner.clone())
     }
@@ -420,6 +611,23 @@ impl DatasetService {
     }
 
     /// Gets a Dataset version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset_version(&self) -> super::builder::dataset_service::GetDatasetVersion {
         super::builder::dataset_service::GetDatasetVersion::new(self.inner.clone())
     }
@@ -477,6 +685,23 @@ impl DatasetService {
     }
 
     /// Gets an AnnotationSpec.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_annotation_spec()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_annotation_spec(&self) -> super::builder::dataset_service::GetAnnotationSpec {
         super::builder::dataset_service::GetAnnotationSpec::new(self.inner.clone())
     }
@@ -494,6 +719,22 @@ impl DatasetService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dataset_service::GetLocation {
         super::builder::dataset_service::GetLocation::new(self.inner.clone())
     }
@@ -503,12 +744,44 @@ impl DatasetService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dataset_service::SetIamPolicy {
         super::builder::dataset_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dataset_service::GetIamPolicy {
         super::builder::dataset_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -520,6 +793,22 @@ impl DatasetService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::dataset_service::TestIamPermissions {
         super::builder::dataset_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -534,6 +823,22 @@ impl DatasetService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::dataset_service::GetOperation {
         super::builder::dataset_service::GetOperation::new(self.inner.clone())
     }
@@ -541,6 +846,21 @@ impl DatasetService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::dataset_service::DeleteOperation {
         super::builder::dataset_service::DeleteOperation::new(self.inner.clone())
     }
@@ -548,6 +868,21 @@ impl DatasetService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::dataset_service::CancelOperation {
         super::builder::dataset_service::CancelOperation::new(self.inner.clone())
     }
@@ -555,6 +890,22 @@ impl DatasetService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::dataset_service::WaitOperation {
         super::builder::dataset_service::WaitOperation::new(self.inner.clone())
     }
@@ -689,6 +1040,23 @@ impl DeploymentResourcePoolService {
     }
 
     /// Get a DeploymentResourcePool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment_resource_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment_resource_pool(
         &self,
     ) -> super::builder::deployment_resource_pool_service::GetDeploymentResourcePool {
@@ -761,6 +1129,22 @@ impl DeploymentResourcePoolService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::deployment_resource_pool_service::GetLocation {
         super::builder::deployment_resource_pool_service::GetLocation::new(self.inner.clone())
     }
@@ -770,12 +1154,44 @@ impl DeploymentResourcePoolService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::deployment_resource_pool_service::SetIamPolicy {
         super::builder::deployment_resource_pool_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::deployment_resource_pool_service::GetIamPolicy {
         super::builder::deployment_resource_pool_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -787,6 +1203,22 @@ impl DeploymentResourcePoolService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::deployment_resource_pool_service::TestIamPermissions {
@@ -807,6 +1239,22 @@ impl DeploymentResourcePoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::deployment_resource_pool_service::GetOperation {
         super::builder::deployment_resource_pool_service::GetOperation::new(self.inner.clone())
     }
@@ -814,6 +1262,21 @@ impl DeploymentResourcePoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::deployment_resource_pool_service::DeleteOperation {
@@ -823,6 +1286,21 @@ impl DeploymentResourcePoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::deployment_resource_pool_service::CancelOperation {
@@ -832,6 +1310,22 @@ impl DeploymentResourcePoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
+    /// async fn sample(
+    ///    client: &DeploymentResourcePoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(
         &self,
     ) -> super::builder::deployment_resource_pool_service::WaitOperation {
@@ -963,6 +1457,23 @@ impl EndpointService {
     }
 
     /// Gets an Endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_endpoint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_endpoint(&self) -> super::builder::endpoint_service::GetEndpoint {
         super::builder::endpoint_service::GetEndpoint::new(self.inner.clone())
     }
@@ -973,6 +1484,22 @@ impl EndpointService {
     }
 
     /// Updates an Endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_endpoint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_endpoint(&self) -> super::builder::endpoint_service::UpdateEndpoint {
         super::builder::endpoint_service::UpdateEndpoint::new(self.inner.clone())
     }
@@ -1064,6 +1591,22 @@ impl EndpointService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::endpoint_service::GetLocation {
         super::builder::endpoint_service::GetLocation::new(self.inner.clone())
     }
@@ -1073,12 +1616,44 @@ impl EndpointService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::endpoint_service::SetIamPolicy {
         super::builder::endpoint_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::endpoint_service::GetIamPolicy {
         super::builder::endpoint_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1090,6 +1665,22 @@ impl EndpointService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::endpoint_service::TestIamPermissions {
         super::builder::endpoint_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1104,6 +1695,22 @@ impl EndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::endpoint_service::GetOperation {
         super::builder::endpoint_service::GetOperation::new(self.inner.clone())
     }
@@ -1111,6 +1718,21 @@ impl EndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::endpoint_service::DeleteOperation {
         super::builder::endpoint_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1118,6 +1740,21 @@ impl EndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::endpoint_service::CancelOperation {
         super::builder::endpoint_service::CancelOperation::new(self.inner.clone())
     }
@@ -1125,6 +1762,22 @@ impl EndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EndpointService;
+    /// async fn sample(
+    ///    client: &EndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::endpoint_service::WaitOperation {
         super::builder::endpoint_service::WaitOperation::new(self.inner.clone())
     }
@@ -1239,6 +1892,22 @@ impl EvaluationService {
     }
 
     /// Evaluates instances based on a given metric.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .evaluate_instances()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn evaluate_instances(&self) -> super::builder::evaluation_service::EvaluateInstances {
         super::builder::evaluation_service::EvaluateInstances::new(self.inner.clone())
     }
@@ -1249,6 +1918,22 @@ impl EvaluationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::evaluation_service::GetLocation {
         super::builder::evaluation_service::GetLocation::new(self.inner.clone())
     }
@@ -1258,12 +1943,44 @@ impl EvaluationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::evaluation_service::SetIamPolicy {
         super::builder::evaluation_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::evaluation_service::GetIamPolicy {
         super::builder::evaluation_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1275,6 +1992,22 @@ impl EvaluationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::evaluation_service::TestIamPermissions {
         super::builder::evaluation_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1289,6 +2022,22 @@ impl EvaluationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::evaluation_service::GetOperation {
         super::builder::evaluation_service::GetOperation::new(self.inner.clone())
     }
@@ -1296,6 +2045,21 @@ impl EvaluationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::evaluation_service::DeleteOperation {
         super::builder::evaluation_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1303,6 +2067,21 @@ impl EvaluationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::evaluation_service::CancelOperation {
         super::builder::evaluation_service::CancelOperation::new(self.inner.clone())
     }
@@ -1310,6 +2089,22 @@ impl EvaluationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::EvaluationService;
+    /// async fn sample(
+    ///    client: &EvaluationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::evaluation_service::WaitOperation {
         super::builder::evaluation_service::WaitOperation::new(self.inner.clone())
     }
@@ -1445,6 +2240,23 @@ impl FeatureOnlineStoreAdminService {
     }
 
     /// Gets details of a single FeatureOnlineStore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature_online_store()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature_online_store(
         &self,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureOnlineStore {
@@ -1521,6 +2333,23 @@ impl FeatureOnlineStoreAdminService {
     }
 
     /// Gets details of a single FeatureView.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature_view(
         &self,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureView {
@@ -1575,6 +2404,22 @@ impl FeatureOnlineStoreAdminService {
     }
 
     /// Triggers on-demand sync for the FeatureView.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sync_feature_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn sync_feature_view(
         &self,
     ) -> super::builder::feature_online_store_admin_service::SyncFeatureView {
@@ -1582,6 +2427,23 @@ impl FeatureOnlineStoreAdminService {
     }
 
     /// Gets details of a single FeatureViewSync.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature_view_sync()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature_view_sync(
         &self,
     ) -> super::builder::feature_online_store_admin_service::GetFeatureViewSync {
@@ -1607,6 +2469,22 @@ impl FeatureOnlineStoreAdminService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::feature_online_store_admin_service::GetLocation {
         super::builder::feature_online_store_admin_service::GetLocation::new(self.inner.clone())
     }
@@ -1616,6 +2494,22 @@ impl FeatureOnlineStoreAdminService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::feature_online_store_admin_service::SetIamPolicy {
@@ -1624,6 +2518,22 @@ impl FeatureOnlineStoreAdminService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::feature_online_store_admin_service::GetIamPolicy {
@@ -1637,6 +2547,22 @@ impl FeatureOnlineStoreAdminService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::feature_online_store_admin_service::TestIamPermissions {
@@ -1657,6 +2583,22 @@ impl FeatureOnlineStoreAdminService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::feature_online_store_admin_service::GetOperation {
@@ -1666,6 +2608,21 @@ impl FeatureOnlineStoreAdminService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::feature_online_store_admin_service::DeleteOperation {
@@ -1675,6 +2632,21 @@ impl FeatureOnlineStoreAdminService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::feature_online_store_admin_service::CancelOperation {
@@ -1684,6 +2656,22 @@ impl FeatureOnlineStoreAdminService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(
         &self,
     ) -> super::builder::feature_online_store_admin_service::WaitOperation {
@@ -1801,6 +2789,22 @@ impl FeatureOnlineStoreService {
     }
 
     /// Fetch feature values under a FeatureView.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_feature_values()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_feature_values(
         &self,
     ) -> super::builder::feature_online_store_service::FetchFeatureValues {
@@ -1810,6 +2814,22 @@ impl FeatureOnlineStoreService {
     /// Search the nearest entities under a FeatureView.
     /// Search only works for indexable feature view; if a feature view isn't
     /// indexable, returns Invalid argument response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_nearest_entities()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_nearest_entities(
         &self,
     ) -> super::builder::feature_online_store_service::SearchNearestEntities {
@@ -1818,6 +2838,22 @@ impl FeatureOnlineStoreService {
 
     /// RPC to generate an access token for the given feature view. FeatureViews
     /// under the same FeatureOnlineStore share the same access token.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_fetch_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_fetch_access_token(
         &self,
     ) -> super::builder::feature_online_store_service::GenerateFetchAccessToken {
@@ -1832,6 +2868,22 @@ impl FeatureOnlineStoreService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::feature_online_store_service::GetLocation {
         super::builder::feature_online_store_service::GetLocation::new(self.inner.clone())
     }
@@ -1841,12 +2893,44 @@ impl FeatureOnlineStoreService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::feature_online_store_service::SetIamPolicy {
         super::builder::feature_online_store_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::feature_online_store_service::GetIamPolicy {
         super::builder::feature_online_store_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1858,6 +2942,22 @@ impl FeatureOnlineStoreService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::feature_online_store_service::TestIamPermissions {
@@ -1874,6 +2974,22 @@ impl FeatureOnlineStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::feature_online_store_service::GetOperation {
         super::builder::feature_online_store_service::GetOperation::new(self.inner.clone())
     }
@@ -1881,6 +2997,21 @@ impl FeatureOnlineStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::feature_online_store_service::DeleteOperation {
@@ -1890,6 +3021,21 @@ impl FeatureOnlineStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::feature_online_store_service::CancelOperation {
@@ -1899,6 +3045,22 @@ impl FeatureOnlineStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
+    /// async fn sample(
+    ///    client: &FeatureOnlineStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::feature_online_store_service::WaitOperation {
         super::builder::feature_online_store_service::WaitOperation::new(self.inner.clone())
     }
@@ -2031,6 +3193,23 @@ impl FeatureRegistryService {
     }
 
     /// Gets details of a single FeatureGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature_group(&self) -> super::builder::feature_registry_service::GetFeatureGroup {
         super::builder::feature_registry_service::GetFeatureGroup::new(self.inner.clone())
     }
@@ -2109,6 +3288,23 @@ impl FeatureRegistryService {
     }
 
     /// Gets details of a single Feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature(&self) -> super::builder::feature_registry_service::GetFeature {
         super::builder::feature_registry_service::GetFeature::new(self.inner.clone())
     }
@@ -2154,6 +3350,22 @@ impl FeatureRegistryService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::feature_registry_service::GetLocation {
         super::builder::feature_registry_service::GetLocation::new(self.inner.clone())
     }
@@ -2163,12 +3375,44 @@ impl FeatureRegistryService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::feature_registry_service::SetIamPolicy {
         super::builder::feature_registry_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::feature_registry_service::GetIamPolicy {
         super::builder::feature_registry_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -2180,6 +3424,22 @@ impl FeatureRegistryService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::feature_registry_service::TestIamPermissions {
@@ -2196,6 +3456,22 @@ impl FeatureRegistryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::feature_registry_service::GetOperation {
         super::builder::feature_registry_service::GetOperation::new(self.inner.clone())
     }
@@ -2203,6 +3479,21 @@ impl FeatureRegistryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::feature_registry_service::DeleteOperation {
         super::builder::feature_registry_service::DeleteOperation::new(self.inner.clone())
     }
@@ -2210,6 +3501,21 @@ impl FeatureRegistryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::feature_registry_service::CancelOperation {
         super::builder::feature_registry_service::CancelOperation::new(self.inner.clone())
     }
@@ -2217,6 +3523,22 @@ impl FeatureRegistryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
+    /// async fn sample(
+    ///    client: &FeatureRegistryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::feature_registry_service::WaitOperation {
         super::builder::feature_registry_service::WaitOperation::new(self.inner.clone())
     }
@@ -2334,6 +3656,22 @@ impl FeaturestoreOnlineServingService {
     /// Reads Feature values of a specific entity of an EntityType. For reading
     /// feature values of multiple entities of an EntityType, please use
     /// StreamingReadFeatureValues.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_feature_values()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_feature_values(
         &self,
     ) -> super::builder::featurestore_online_serving_service::ReadFeatureValues {
@@ -2347,6 +3685,22 @@ impl FeaturestoreOnlineServingService {
     /// The Feature values are merged into existing entities if any. The Feature
     /// values to be written must have timestamp within the online storage
     /// retention.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_feature_values()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_feature_values(
         &self,
     ) -> super::builder::featurestore_online_serving_service::WriteFeatureValues {
@@ -2363,6 +3717,22 @@ impl FeaturestoreOnlineServingService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::featurestore_online_serving_service::GetLocation {
         super::builder::featurestore_online_serving_service::GetLocation::new(self.inner.clone())
     }
@@ -2372,6 +3742,22 @@ impl FeaturestoreOnlineServingService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::featurestore_online_serving_service::SetIamPolicy {
@@ -2380,6 +3766,22 @@ impl FeaturestoreOnlineServingService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::featurestore_online_serving_service::GetIamPolicy {
@@ -2393,6 +3795,22 @@ impl FeaturestoreOnlineServingService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::featurestore_online_serving_service::TestIamPermissions {
@@ -2413,6 +3831,22 @@ impl FeaturestoreOnlineServingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::featurestore_online_serving_service::GetOperation {
@@ -2422,6 +3856,21 @@ impl FeaturestoreOnlineServingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::featurestore_online_serving_service::DeleteOperation {
@@ -2433,6 +3882,21 @@ impl FeaturestoreOnlineServingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::featurestore_online_serving_service::CancelOperation {
@@ -2444,6 +3908,22 @@ impl FeaturestoreOnlineServingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
+    /// async fn sample(
+    ///    client: &FeaturestoreOnlineServingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(
         &self,
     ) -> super::builder::featurestore_online_serving_service::WaitOperation {
@@ -2575,6 +4055,23 @@ impl FeaturestoreService {
     }
 
     /// Gets details of a single Featurestore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_featurestore()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_featurestore(&self) -> super::builder::featurestore_service::GetFeaturestore {
         super::builder::featurestore_service::GetFeaturestore::new(self.inner.clone())
     }
@@ -2631,6 +4128,23 @@ impl FeaturestoreService {
     }
 
     /// Gets details of a single EntityType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entity_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entity_type(&self) -> super::builder::featurestore_service::GetEntityType {
         super::builder::featurestore_service::GetEntityType::new(self.inner.clone())
     }
@@ -2641,6 +4155,22 @@ impl FeaturestoreService {
     }
 
     /// Updates the parameters of a single EntityType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_entity_type(&self) -> super::builder::featurestore_service::UpdateEntityType {
         super::builder::featurestore_service::UpdateEntityType::new(self.inner.clone())
     }
@@ -2694,6 +4224,23 @@ impl FeaturestoreService {
     }
 
     /// Gets details of a single Feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature(&self) -> super::builder::featurestore_service::GetFeature {
         super::builder::featurestore_service::GetFeature::new(self.inner.clone())
     }
@@ -2704,6 +4251,22 @@ impl FeaturestoreService {
     }
 
     /// Updates the parameters of a single Feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_feature()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_feature(&self) -> super::builder::featurestore_service::UpdateFeature {
         super::builder::featurestore_service::UpdateFeature::new(self.inner.clone())
     }
@@ -2835,6 +4398,22 @@ impl FeaturestoreService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::featurestore_service::GetLocation {
         super::builder::featurestore_service::GetLocation::new(self.inner.clone())
     }
@@ -2844,12 +4423,44 @@ impl FeaturestoreService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::featurestore_service::SetIamPolicy {
         super::builder::featurestore_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::featurestore_service::GetIamPolicy {
         super::builder::featurestore_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -2861,6 +4472,22 @@ impl FeaturestoreService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::featurestore_service::TestIamPermissions {
         super::builder::featurestore_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -2875,6 +4502,22 @@ impl FeaturestoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::featurestore_service::GetOperation {
         super::builder::featurestore_service::GetOperation::new(self.inner.clone())
     }
@@ -2882,6 +4525,21 @@ impl FeaturestoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::featurestore_service::DeleteOperation {
         super::builder::featurestore_service::DeleteOperation::new(self.inner.clone())
     }
@@ -2889,6 +4547,21 @@ impl FeaturestoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::featurestore_service::CancelOperation {
         super::builder::featurestore_service::CancelOperation::new(self.inner.clone())
     }
@@ -2896,6 +4569,22 @@ impl FeaturestoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
+    /// async fn sample(
+    ///    client: &FeaturestoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::featurestore_service::WaitOperation {
         super::builder::featurestore_service::WaitOperation::new(self.inner.clone())
     }
@@ -3011,6 +4700,22 @@ impl GenAiCacheService {
 
     /// Creates cached content, this call will initialize the cached content in the
     /// data storage, and users need to pay for the cache data storage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_cached_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_cached_content(
         &self,
     ) -> super::builder::gen_ai_cache_service::CreateCachedContent {
@@ -3018,11 +4723,44 @@ impl GenAiCacheService {
     }
 
     /// Gets cached content configurations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cached_content()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cached_content(&self) -> super::builder::gen_ai_cache_service::GetCachedContent {
         super::builder::gen_ai_cache_service::GetCachedContent::new(self.inner.clone())
     }
 
     /// Updates cached content configurations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_cached_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_cached_content(
         &self,
     ) -> super::builder::gen_ai_cache_service::UpdateCachedContent {
@@ -3030,6 +4768,22 @@ impl GenAiCacheService {
     }
 
     /// Deletes cached content
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_cached_content()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_cached_content(
         &self,
     ) -> super::builder::gen_ai_cache_service::DeleteCachedContent {
@@ -3047,6 +4801,22 @@ impl GenAiCacheService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::gen_ai_cache_service::GetLocation {
         super::builder::gen_ai_cache_service::GetLocation::new(self.inner.clone())
     }
@@ -3056,12 +4826,44 @@ impl GenAiCacheService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::gen_ai_cache_service::SetIamPolicy {
         super::builder::gen_ai_cache_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::gen_ai_cache_service::GetIamPolicy {
         super::builder::gen_ai_cache_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -3073,6 +4875,22 @@ impl GenAiCacheService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::gen_ai_cache_service::TestIamPermissions {
         super::builder::gen_ai_cache_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -3087,6 +4905,22 @@ impl GenAiCacheService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::gen_ai_cache_service::GetOperation {
         super::builder::gen_ai_cache_service::GetOperation::new(self.inner.clone())
     }
@@ -3094,6 +4928,21 @@ impl GenAiCacheService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::gen_ai_cache_service::DeleteOperation {
         super::builder::gen_ai_cache_service::DeleteOperation::new(self.inner.clone())
     }
@@ -3101,6 +4950,21 @@ impl GenAiCacheService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::gen_ai_cache_service::CancelOperation {
         super::builder::gen_ai_cache_service::CancelOperation::new(self.inner.clone())
     }
@@ -3108,6 +4972,22 @@ impl GenAiCacheService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
+    /// async fn sample(
+    ///    client: &GenAiCacheService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::gen_ai_cache_service::WaitOperation {
         super::builder::gen_ai_cache_service::WaitOperation::new(self.inner.clone())
     }
@@ -3223,11 +5103,44 @@ impl GenAiTuningService {
 
     /// Creates a TuningJob. A created TuningJob right away will be attempted to
     /// be run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tuning_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tuning_job(&self) -> super::builder::gen_ai_tuning_service::CreateTuningJob {
         super::builder::gen_ai_tuning_service::CreateTuningJob::new(self.inner.clone())
     }
 
     /// Gets a TuningJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tuning_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tuning_job(&self) -> super::builder::gen_ai_tuning_service::GetTuningJob {
         super::builder::gen_ai_tuning_service::GetTuningJob::new(self.inner.clone())
     }
@@ -3254,6 +5167,21 @@ impl GenAiTuningService {
     /// [google.cloud.aiplatform.v1.TuningJob.error]: crate::model::TuningJob::error
     /// [google.cloud.aiplatform.v1.TuningJob.state]: crate::model::TuningJob::state
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_tuning_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_tuning_job(&self) -> super::builder::gen_ai_tuning_service::CancelTuningJob {
         super::builder::gen_ai_tuning_service::CancelTuningJob::new(self.inner.clone())
     }
@@ -3279,6 +5207,22 @@ impl GenAiTuningService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::gen_ai_tuning_service::GetLocation {
         super::builder::gen_ai_tuning_service::GetLocation::new(self.inner.clone())
     }
@@ -3288,12 +5232,44 @@ impl GenAiTuningService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::gen_ai_tuning_service::SetIamPolicy {
         super::builder::gen_ai_tuning_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::gen_ai_tuning_service::GetIamPolicy {
         super::builder::gen_ai_tuning_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -3305,6 +5281,22 @@ impl GenAiTuningService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::gen_ai_tuning_service::TestIamPermissions {
@@ -3321,6 +5313,22 @@ impl GenAiTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::gen_ai_tuning_service::GetOperation {
         super::builder::gen_ai_tuning_service::GetOperation::new(self.inner.clone())
     }
@@ -3328,6 +5336,21 @@ impl GenAiTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::gen_ai_tuning_service::DeleteOperation {
         super::builder::gen_ai_tuning_service::DeleteOperation::new(self.inner.clone())
     }
@@ -3335,6 +5358,21 @@ impl GenAiTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::gen_ai_tuning_service::CancelOperation {
         super::builder::gen_ai_tuning_service::CancelOperation::new(self.inner.clone())
     }
@@ -3342,6 +5380,22 @@ impl GenAiTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
+    /// async fn sample(
+    ///    client: &GenAiTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::gen_ai_tuning_service::WaitOperation {
         super::builder::gen_ai_tuning_service::WaitOperation::new(self.inner.clone())
     }
@@ -3473,6 +5527,23 @@ impl IndexEndpointService {
     }
 
     /// Gets an IndexEndpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_index_endpoint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_index_endpoint(&self) -> super::builder::index_endpoint_service::GetIndexEndpoint {
         super::builder::index_endpoint_service::GetIndexEndpoint::new(self.inner.clone())
     }
@@ -3485,6 +5556,22 @@ impl IndexEndpointService {
     }
 
     /// Updates an IndexEndpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_index_endpoint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_index_endpoint(
         &self,
     ) -> super::builder::index_endpoint_service::UpdateIndexEndpoint {
@@ -3564,6 +5651,22 @@ impl IndexEndpointService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::index_endpoint_service::GetLocation {
         super::builder::index_endpoint_service::GetLocation::new(self.inner.clone())
     }
@@ -3573,12 +5676,44 @@ impl IndexEndpointService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::index_endpoint_service::SetIamPolicy {
         super::builder::index_endpoint_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::index_endpoint_service::GetIamPolicy {
         super::builder::index_endpoint_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -3590,6 +5725,22 @@ impl IndexEndpointService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::index_endpoint_service::TestIamPermissions {
@@ -3606,6 +5757,22 @@ impl IndexEndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::index_endpoint_service::GetOperation {
         super::builder::index_endpoint_service::GetOperation::new(self.inner.clone())
     }
@@ -3613,6 +5780,21 @@ impl IndexEndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::index_endpoint_service::DeleteOperation {
         super::builder::index_endpoint_service::DeleteOperation::new(self.inner.clone())
     }
@@ -3620,6 +5802,21 @@ impl IndexEndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::index_endpoint_service::CancelOperation {
         super::builder::index_endpoint_service::CancelOperation::new(self.inner.clone())
     }
@@ -3627,6 +5824,22 @@ impl IndexEndpointService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
+    /// async fn sample(
+    ///    client: &IndexEndpointService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::index_endpoint_service::WaitOperation {
         super::builder::index_endpoint_service::WaitOperation::new(self.inner.clone())
     }
@@ -3753,6 +5966,23 @@ impl IndexService {
     }
 
     /// Gets an Index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_index()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_index(&self) -> super::builder::index_service::GetIndex {
         super::builder::index_service::GetIndex::new(self.inner.clone())
     }
@@ -3798,11 +6028,43 @@ impl IndexService {
     }
 
     /// Add/update Datapoints into an Index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .upsert_datapoints()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn upsert_datapoints(&self) -> super::builder::index_service::UpsertDatapoints {
         super::builder::index_service::UpsertDatapoints::new(self.inner.clone())
     }
 
     /// Remove Datapoints from an Index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_datapoints()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_datapoints(&self) -> super::builder::index_service::RemoveDatapoints {
         super::builder::index_service::RemoveDatapoints::new(self.inner.clone())
     }
@@ -3813,6 +6075,22 @@ impl IndexService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::index_service::GetLocation {
         super::builder::index_service::GetLocation::new(self.inner.clone())
     }
@@ -3822,12 +6100,44 @@ impl IndexService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::index_service::SetIamPolicy {
         super::builder::index_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::index_service::GetIamPolicy {
         super::builder::index_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -3839,6 +6149,22 @@ impl IndexService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::index_service::TestIamPermissions {
         super::builder::index_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -3853,6 +6179,22 @@ impl IndexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::index_service::GetOperation {
         super::builder::index_service::GetOperation::new(self.inner.clone())
     }
@@ -3860,6 +6202,21 @@ impl IndexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::index_service::DeleteOperation {
         super::builder::index_service::DeleteOperation::new(self.inner.clone())
     }
@@ -3867,6 +6224,21 @@ impl IndexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::index_service::CancelOperation {
         super::builder::index_service::CancelOperation::new(self.inner.clone())
     }
@@ -3874,6 +6246,22 @@ impl IndexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::IndexService;
+    /// async fn sample(
+    ///    client: &IndexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::index_service::WaitOperation {
         super::builder::index_service::WaitOperation::new(self.inner.clone())
     }
@@ -3986,11 +6374,44 @@ impl JobService {
 
     /// Creates a CustomJob. A created CustomJob right away
     /// will be attempted to be run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_custom_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_custom_job(&self) -> super::builder::job_service::CreateCustomJob {
         super::builder::job_service::CreateCustomJob::new(self.inner.clone())
     }
 
     /// Gets a CustomJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_custom_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_custom_job(&self) -> super::builder::job_service::GetCustomJob {
         super::builder::job_service::GetCustomJob::new(self.inner.clone())
     }
@@ -4033,16 +6454,64 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.CustomJob.state]: crate::model::CustomJob::state
     /// [google.cloud.aiplatform.v1.JobService.GetCustomJob]: crate::client::JobService::get_custom_job
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_custom_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_custom_job(&self) -> super::builder::job_service::CancelCustomJob {
         super::builder::job_service::CancelCustomJob::new(self.inner.clone())
     }
 
     /// Creates a DataLabelingJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_labeling_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_labeling_job(&self) -> super::builder::job_service::CreateDataLabelingJob {
         super::builder::job_service::CreateDataLabelingJob::new(self.inner.clone())
     }
 
     /// Gets a DataLabelingJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_labeling_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_labeling_job(&self) -> super::builder::job_service::GetDataLabelingJob {
         super::builder::job_service::GetDataLabelingJob::new(self.inner.clone())
     }
@@ -4068,11 +6537,42 @@ impl JobService {
     }
 
     /// Cancels a DataLabelingJob. Success of cancellation is not guaranteed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_data_labeling_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_data_labeling_job(&self) -> super::builder::job_service::CancelDataLabelingJob {
         super::builder::job_service::CancelDataLabelingJob::new(self.inner.clone())
     }
 
     /// Creates a HyperparameterTuningJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_hyperparameter_tuning_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_hyperparameter_tuning_job(
         &self,
     ) -> super::builder::job_service::CreateHyperparameterTuningJob {
@@ -4080,6 +6580,23 @@ impl JobService {
     }
 
     /// Gets a HyperparameterTuningJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_hyperparameter_tuning_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_hyperparameter_tuning_job(
         &self,
     ) -> super::builder::job_service::GetHyperparameterTuningJob {
@@ -4129,6 +6646,21 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.HyperparameterTuningJob.state]: crate::model::HyperparameterTuningJob::state
     /// [google.cloud.aiplatform.v1.JobService.GetHyperparameterTuningJob]: crate::client::JobService::get_hyperparameter_tuning_job
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_hyperparameter_tuning_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_hyperparameter_tuning_job(
         &self,
     ) -> super::builder::job_service::CancelHyperparameterTuningJob {
@@ -4136,11 +6668,44 @@ impl JobService {
     }
 
     /// Creates a NasJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_nas_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_nas_job(&self) -> super::builder::job_service::CreateNasJob {
         super::builder::job_service::CreateNasJob::new(self.inner.clone())
     }
 
     /// Gets a NasJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_nas_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_nas_job(&self) -> super::builder::job_service::GetNasJob {
         super::builder::job_service::GetNasJob::new(self.inner.clone())
     }
@@ -4183,11 +6748,43 @@ impl JobService {
     /// [google.cloud.aiplatform.v1.NasJob.error]: crate::model::NasJob::error
     /// [google.cloud.aiplatform.v1.NasJob.state]: crate::model::NasJob::state
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_nas_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_nas_job(&self) -> super::builder::job_service::CancelNasJob {
         super::builder::job_service::CancelNasJob::new(self.inner.clone())
     }
 
     /// Gets a NasTrialDetail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_nas_trial_detail()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_nas_trial_detail(&self) -> super::builder::job_service::GetNasTrialDetail {
         super::builder::job_service::GetNasTrialDetail::new(self.inner.clone())
     }
@@ -4199,6 +6796,22 @@ impl JobService {
 
     /// Creates a BatchPredictionJob. A BatchPredictionJob once created will
     /// right away be attempted to start.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_batch_prediction_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_batch_prediction_job(
         &self,
     ) -> super::builder::job_service::CreateBatchPredictionJob {
@@ -4206,6 +6819,23 @@ impl JobService {
     }
 
     /// Gets a BatchPredictionJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_batch_prediction_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_batch_prediction_job(&self) -> super::builder::job_service::GetBatchPredictionJob {
         super::builder::job_service::GetBatchPredictionJob::new(self.inner.clone())
     }
@@ -4250,6 +6880,21 @@ impl JobService {
     ///
     /// [google.cloud.aiplatform.v1.BatchPredictionJob.state]: crate::model::BatchPredictionJob::state
     /// [google.cloud.aiplatform.v1.JobService.GetBatchPredictionJob]: crate::client::JobService::get_batch_prediction_job
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_batch_prediction_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_batch_prediction_job(
         &self,
     ) -> super::builder::job_service::CancelBatchPredictionJob {
@@ -4258,6 +6903,22 @@ impl JobService {
 
     /// Creates a ModelDeploymentMonitoringJob. It will run periodically on a
     /// configured interval.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_model_deployment_monitoring_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_model_deployment_monitoring_job(
         &self,
     ) -> super::builder::job_service::CreateModelDeploymentMonitoringJob {
@@ -4274,6 +6935,23 @@ impl JobService {
     }
 
     /// Gets a ModelDeploymentMonitoringJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model_deployment_monitoring_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model_deployment_monitoring_job(
         &self,
     ) -> super::builder::job_service::GetModelDeploymentMonitoringJob {
@@ -4327,6 +7005,21 @@ impl JobService {
     /// to 'PAUSED'.
     ///
     /// [google.cloud.aiplatform.v1.ModelDeploymentMonitoringJob.state]: crate::model::ModelDeploymentMonitoringJob::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .pause_model_deployment_monitoring_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_model_deployment_monitoring_job(
         &self,
     ) -> super::builder::job_service::PauseModelDeploymentMonitoringJob {
@@ -4336,6 +7029,21 @@ impl JobService {
     /// Resumes a paused ModelDeploymentMonitoringJob. It will start to run from
     /// next scheduled time. A deleted ModelDeploymentMonitoringJob can't be
     /// resumed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .resume_model_deployment_monitoring_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_model_deployment_monitoring_job(
         &self,
     ) -> super::builder::job_service::ResumeModelDeploymentMonitoringJob {
@@ -4348,6 +7056,22 @@ impl JobService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::job_service::GetLocation {
         super::builder::job_service::GetLocation::new(self.inner.clone())
     }
@@ -4357,12 +7081,44 @@ impl JobService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::job_service::SetIamPolicy {
         super::builder::job_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::job_service::GetIamPolicy {
         super::builder::job_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -4374,6 +7130,22 @@ impl JobService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::job_service::TestIamPermissions {
         super::builder::job_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -4388,6 +7160,22 @@ impl JobService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::job_service::GetOperation {
         super::builder::job_service::GetOperation::new(self.inner.clone())
     }
@@ -4395,6 +7183,21 @@ impl JobService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::job_service::DeleteOperation {
         super::builder::job_service::DeleteOperation::new(self.inner.clone())
     }
@@ -4402,6 +7205,21 @@ impl JobService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::job_service::CancelOperation {
         super::builder::job_service::CancelOperation::new(self.inner.clone())
     }
@@ -4409,6 +7227,22 @@ impl JobService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::job_service::WaitOperation {
         super::builder::job_service::WaitOperation::new(self.inner.clone())
     }
@@ -4523,11 +7357,43 @@ impl LlmUtilityService {
     }
 
     /// Perform a token counting.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .count_tokens()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn count_tokens(&self) -> super::builder::llm_utility_service::CountTokens {
         super::builder::llm_utility_service::CountTokens::new(self.inner.clone())
     }
 
     /// Return a list of tokens based on the input text.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compute_tokens()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compute_tokens(&self) -> super::builder::llm_utility_service::ComputeTokens {
         super::builder::llm_utility_service::ComputeTokens::new(self.inner.clone())
     }
@@ -4538,6 +7404,22 @@ impl LlmUtilityService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::llm_utility_service::GetLocation {
         super::builder::llm_utility_service::GetLocation::new(self.inner.clone())
     }
@@ -4547,12 +7429,44 @@ impl LlmUtilityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::llm_utility_service::SetIamPolicy {
         super::builder::llm_utility_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::llm_utility_service::GetIamPolicy {
         super::builder::llm_utility_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -4564,6 +7478,22 @@ impl LlmUtilityService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::llm_utility_service::TestIamPermissions {
         super::builder::llm_utility_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -4578,6 +7508,22 @@ impl LlmUtilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::llm_utility_service::GetOperation {
         super::builder::llm_utility_service::GetOperation::new(self.inner.clone())
     }
@@ -4585,6 +7531,21 @@ impl LlmUtilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::llm_utility_service::DeleteOperation {
         super::builder::llm_utility_service::DeleteOperation::new(self.inner.clone())
     }
@@ -4592,6 +7553,21 @@ impl LlmUtilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::llm_utility_service::CancelOperation {
         super::builder::llm_utility_service::CancelOperation::new(self.inner.clone())
     }
@@ -4599,6 +7575,22 @@ impl LlmUtilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
+    /// async fn sample(
+    ///    client: &LlmUtilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::llm_utility_service::WaitOperation {
         super::builder::llm_utility_service::WaitOperation::new(self.inner.clone())
     }
@@ -4711,12 +7703,44 @@ impl MatchService {
     }
 
     /// Finds the nearest neighbors of each vector within the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .find_neighbors()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn find_neighbors(&self) -> super::builder::match_service::FindNeighbors {
         super::builder::match_service::FindNeighbors::new(self.inner.clone())
     }
 
     /// Reads the datapoints/vectors of the given IDs.
     /// A maximum of 1000 datapoints can be retrieved in a batch.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_index_datapoints()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_index_datapoints(&self) -> super::builder::match_service::ReadIndexDatapoints {
         super::builder::match_service::ReadIndexDatapoints::new(self.inner.clone())
     }
@@ -4727,6 +7751,22 @@ impl MatchService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::match_service::GetLocation {
         super::builder::match_service::GetLocation::new(self.inner.clone())
     }
@@ -4736,12 +7776,44 @@ impl MatchService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::match_service::SetIamPolicy {
         super::builder::match_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::match_service::GetIamPolicy {
         super::builder::match_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -4753,6 +7825,22 @@ impl MatchService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::match_service::TestIamPermissions {
         super::builder::match_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -4767,6 +7855,22 @@ impl MatchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::match_service::GetOperation {
         super::builder::match_service::GetOperation::new(self.inner.clone())
     }
@@ -4774,6 +7878,21 @@ impl MatchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::match_service::DeleteOperation {
         super::builder::match_service::DeleteOperation::new(self.inner.clone())
     }
@@ -4781,6 +7900,21 @@ impl MatchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::match_service::CancelOperation {
         super::builder::match_service::CancelOperation::new(self.inner.clone())
     }
@@ -4788,6 +7922,22 @@ impl MatchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MatchService;
+    /// async fn sample(
+    ///    client: &MatchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::match_service::WaitOperation {
         super::builder::match_service::WaitOperation::new(self.inner.clone())
     }
@@ -4917,6 +8067,23 @@ impl MetadataService {
     }
 
     /// Retrieves a specific MetadataStore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metadata_store()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metadata_store(&self) -> super::builder::metadata_service::GetMetadataStore {
         super::builder::metadata_service::GetMetadataStore::new(self.inner.clone())
     }
@@ -4943,11 +8110,44 @@ impl MetadataService {
     }
 
     /// Creates an Artifact associated with a MetadataStore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_artifact()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_artifact(&self) -> super::builder::metadata_service::CreateArtifact {
         super::builder::metadata_service::CreateArtifact::new(self.inner.clone())
     }
 
     /// Retrieves a specific Artifact.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_artifact()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_artifact(&self) -> super::builder::metadata_service::GetArtifact {
         super::builder::metadata_service::GetArtifact::new(self.inner.clone())
     }
@@ -4958,6 +8158,22 @@ impl MetadataService {
     }
 
     /// Updates a stored Artifact.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_artifact()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_artifact(&self) -> super::builder::metadata_service::UpdateArtifact {
         super::builder::metadata_service::UpdateArtifact::new(self.inner.clone())
     }
@@ -4993,11 +8209,44 @@ impl MetadataService {
     }
 
     /// Creates a Context associated with a MetadataStore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_context()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_context(&self) -> super::builder::metadata_service::CreateContext {
         super::builder::metadata_service::CreateContext::new(self.inner.clone())
     }
 
     /// Retrieves a specific Context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_context()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_context(&self) -> super::builder::metadata_service::GetContext {
         super::builder::metadata_service::GetContext::new(self.inner.clone())
     }
@@ -5008,6 +8257,22 @@ impl MetadataService {
     }
 
     /// Updates a stored Context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_context()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_context(&self) -> super::builder::metadata_service::UpdateContext {
         super::builder::metadata_service::UpdateContext::new(self.inner.clone())
     }
@@ -5045,6 +8310,22 @@ impl MetadataService {
     /// Adds a set of Artifacts and Executions to a Context. If any of the
     /// Artifacts or Executions have already been added to a Context, they are
     /// simply skipped.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_context_artifacts_and_executions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_context_artifacts_and_executions(
         &self,
     ) -> super::builder::metadata_service::AddContextArtifactsAndExecutions {
@@ -5056,6 +8337,22 @@ impl MetadataService {
     /// simply skipped. If this call would create a cycle or cause any Context to
     /// have more than 10 parents, the request will fail with an INVALID_ARGUMENT
     /// error.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_context_children()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_context_children(&self) -> super::builder::metadata_service::AddContextChildren {
         super::builder::metadata_service::AddContextChildren::new(self.inner.clone())
     }
@@ -5063,6 +8360,22 @@ impl MetadataService {
     /// Remove a set of children contexts from a parent Context. If any of the
     /// child Contexts were NOT added to the parent Context, they are
     /// simply skipped.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_context_children()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_context_children(
         &self,
     ) -> super::builder::metadata_service::RemoveContextChildren {
@@ -5071,6 +8384,22 @@ impl MetadataService {
 
     /// Retrieves Artifacts and Executions within the specified Context, connected
     /// by Event edges and returned as a LineageSubgraph.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_context_lineage_subgraph()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_context_lineage_subgraph(
         &self,
     ) -> super::builder::metadata_service::QueryContextLineageSubgraph {
@@ -5078,11 +8407,44 @@ impl MetadataService {
     }
 
     /// Creates an Execution associated with a MetadataStore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_execution()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_execution(&self) -> super::builder::metadata_service::CreateExecution {
         super::builder::metadata_service::CreateExecution::new(self.inner.clone())
     }
 
     /// Retrieves a specific Execution.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_execution()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_execution(&self) -> super::builder::metadata_service::GetExecution {
         super::builder::metadata_service::GetExecution::new(self.inner.clone())
     }
@@ -5093,6 +8455,22 @@ impl MetadataService {
     }
 
     /// Updates a stored Execution.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_execution()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_execution(&self) -> super::builder::metadata_service::UpdateExecution {
         super::builder::metadata_service::UpdateExecution::new(self.inner.clone())
     }
@@ -5131,6 +8509,22 @@ impl MetadataService {
     /// Artifact was used as an input or output for an Execution. If an Event
     /// already exists between the Execution and the Artifact, the Event is
     /// skipped.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_execution_events()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_execution_events(&self) -> super::builder::metadata_service::AddExecutionEvents {
         super::builder::metadata_service::AddExecutionEvents::new(self.inner.clone())
     }
@@ -5138,6 +8532,22 @@ impl MetadataService {
     /// Obtains the set of input and output Artifacts for this Execution, in the
     /// form of LineageSubgraph that also contains the Execution and connecting
     /// Events.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_execution_inputs_and_outputs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_execution_inputs_and_outputs(
         &self,
     ) -> super::builder::metadata_service::QueryExecutionInputsAndOutputs {
@@ -5145,11 +8555,44 @@ impl MetadataService {
     }
 
     /// Creates a MetadataSchema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_metadata_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_metadata_schema(&self) -> super::builder::metadata_service::CreateMetadataSchema {
         super::builder::metadata_service::CreateMetadataSchema::new(self.inner.clone())
     }
 
     /// Retrieves a specific MetadataSchema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metadata_schema()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metadata_schema(&self) -> super::builder::metadata_service::GetMetadataSchema {
         super::builder::metadata_service::GetMetadataSchema::new(self.inner.clone())
     }
@@ -5161,6 +8604,22 @@ impl MetadataService {
 
     /// Retrieves lineage of an Artifact represented through Artifacts and
     /// Executions connected by Event edges and returned as a LineageSubgraph.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_artifact_lineage_subgraph()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_artifact_lineage_subgraph(
         &self,
     ) -> super::builder::metadata_service::QueryArtifactLineageSubgraph {
@@ -5173,6 +8632,22 @@ impl MetadataService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::metadata_service::GetLocation {
         super::builder::metadata_service::GetLocation::new(self.inner.clone())
     }
@@ -5182,12 +8657,44 @@ impl MetadataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::metadata_service::SetIamPolicy {
         super::builder::metadata_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::metadata_service::GetIamPolicy {
         super::builder::metadata_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -5199,6 +8706,22 @@ impl MetadataService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::metadata_service::TestIamPermissions {
         super::builder::metadata_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -5213,6 +8736,22 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::metadata_service::GetOperation {
         super::builder::metadata_service::GetOperation::new(self.inner.clone())
     }
@@ -5220,6 +8759,21 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::metadata_service::DeleteOperation {
         super::builder::metadata_service::DeleteOperation::new(self.inner.clone())
     }
@@ -5227,6 +8781,21 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::metadata_service::CancelOperation {
         super::builder::metadata_service::CancelOperation::new(self.inner.clone())
     }
@@ -5234,6 +8803,22 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::metadata_service::WaitOperation {
         super::builder::metadata_service::WaitOperation::new(self.inner.clone())
     }
@@ -5381,6 +8966,22 @@ impl MigrationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::migration_service::GetLocation {
         super::builder::migration_service::GetLocation::new(self.inner.clone())
     }
@@ -5390,12 +8991,44 @@ impl MigrationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::migration_service::SetIamPolicy {
         super::builder::migration_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::migration_service::GetIamPolicy {
         super::builder::migration_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -5407,6 +9040,22 @@ impl MigrationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::migration_service::TestIamPermissions {
         super::builder::migration_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -5421,6 +9070,22 @@ impl MigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::migration_service::GetOperation {
         super::builder::migration_service::GetOperation::new(self.inner.clone())
     }
@@ -5428,6 +9093,21 @@ impl MigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::migration_service::DeleteOperation {
         super::builder::migration_service::DeleteOperation::new(self.inner.clone())
     }
@@ -5435,6 +9115,21 @@ impl MigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::migration_service::CancelOperation {
         super::builder::migration_service::CancelOperation::new(self.inner.clone())
     }
@@ -5442,6 +9137,22 @@ impl MigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::migration_service::WaitOperation {
         super::builder::migration_service::WaitOperation::new(self.inner.clone())
     }
@@ -5556,6 +9267,23 @@ impl ModelGardenService {
     }
 
     /// Gets a Model Garden publisher model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_publisher_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_publisher_model(&self) -> super::builder::model_garden_service::GetPublisherModel {
         super::builder::model_garden_service::GetPublisherModel::new(self.inner.clone())
     }
@@ -5581,6 +9309,22 @@ impl ModelGardenService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::model_garden_service::GetLocation {
         super::builder::model_garden_service::GetLocation::new(self.inner.clone())
     }
@@ -5590,12 +9334,44 @@ impl ModelGardenService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::model_garden_service::SetIamPolicy {
         super::builder::model_garden_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::model_garden_service::GetIamPolicy {
         super::builder::model_garden_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -5607,6 +9383,22 @@ impl ModelGardenService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::model_garden_service::TestIamPermissions {
         super::builder::model_garden_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -5621,6 +9413,22 @@ impl ModelGardenService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::model_garden_service::GetOperation {
         super::builder::model_garden_service::GetOperation::new(self.inner.clone())
     }
@@ -5628,6 +9436,21 @@ impl ModelGardenService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::model_garden_service::DeleteOperation {
         super::builder::model_garden_service::DeleteOperation::new(self.inner.clone())
     }
@@ -5635,6 +9458,21 @@ impl ModelGardenService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::model_garden_service::CancelOperation {
         super::builder::model_garden_service::CancelOperation::new(self.inner.clone())
     }
@@ -5642,6 +9480,22 @@ impl ModelGardenService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
+    /// async fn sample(
+    ///    client: &ModelGardenService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::model_garden_service::WaitOperation {
         super::builder::model_garden_service::WaitOperation::new(self.inner.clone())
     }
@@ -5768,6 +9622,23 @@ impl ModelService {
     }
 
     /// Gets a Model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model(&self) -> super::builder::model_service::GetModel {
         super::builder::model_service::GetModel::new(self.inner.clone())
     }
@@ -5790,6 +9661,22 @@ impl ModelService {
     }
 
     /// Updates a Model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_model(&self) -> super::builder::model_service::UpdateModel {
         super::builder::model_service::UpdateModel::new(self.inner.clone())
     }
@@ -5862,6 +9749,22 @@ impl ModelService {
     }
 
     /// Merges a set of aliases for a Model version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .merge_version_aliases()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn merge_version_aliases(&self) -> super::builder::model_service::MergeVersionAliases {
         super::builder::model_service::MergeVersionAliases::new(self.inner.clone())
     }
@@ -5909,11 +9812,43 @@ impl ModelService {
     }
 
     /// Imports an externally generated ModelEvaluation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_model_evaluation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_model_evaluation(&self) -> super::builder::model_service::ImportModelEvaluation {
         super::builder::model_service::ImportModelEvaluation::new(self.inner.clone())
     }
 
     /// Imports a list of externally generated ModelEvaluationSlice.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_import_model_evaluation_slices()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_import_model_evaluation_slices(
         &self,
     ) -> super::builder::model_service::BatchImportModelEvaluationSlices {
@@ -5921,6 +9856,22 @@ impl ModelService {
     }
 
     /// Imports a list of externally generated EvaluatedAnnotations.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_import_evaluated_annotations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_import_evaluated_annotations(
         &self,
     ) -> super::builder::model_service::BatchImportEvaluatedAnnotations {
@@ -5928,6 +9879,23 @@ impl ModelService {
     }
 
     /// Gets a ModelEvaluation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model_evaluation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model_evaluation(&self) -> super::builder::model_service::GetModelEvaluation {
         super::builder::model_service::GetModelEvaluation::new(self.inner.clone())
     }
@@ -5938,6 +9906,23 @@ impl ModelService {
     }
 
     /// Gets a ModelEvaluationSlice.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model_evaluation_slice()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model_evaluation_slice(
         &self,
     ) -> super::builder::model_service::GetModelEvaluationSlice {
@@ -5957,6 +9942,22 @@ impl ModelService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::model_service::GetLocation {
         super::builder::model_service::GetLocation::new(self.inner.clone())
     }
@@ -5966,12 +9967,44 @@ impl ModelService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::model_service::SetIamPolicy {
         super::builder::model_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::model_service::GetIamPolicy {
         super::builder::model_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -5983,6 +10016,22 @@ impl ModelService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::model_service::TestIamPermissions {
         super::builder::model_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -5997,6 +10046,22 @@ impl ModelService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::model_service::GetOperation {
         super::builder::model_service::GetOperation::new(self.inner.clone())
     }
@@ -6004,6 +10069,21 @@ impl ModelService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::model_service::DeleteOperation {
         super::builder::model_service::DeleteOperation::new(self.inner.clone())
     }
@@ -6011,6 +10091,21 @@ impl ModelService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::model_service::CancelOperation {
         super::builder::model_service::CancelOperation::new(self.inner.clone())
     }
@@ -6018,6 +10113,22 @@ impl ModelService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::model_service::WaitOperation {
         super::builder::model_service::WaitOperation::new(self.inner.clone())
     }
@@ -6149,6 +10260,23 @@ impl NotebookService {
     }
 
     /// Gets a NotebookRuntimeTemplate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notebook_runtime_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notebook_runtime_template(
         &self,
     ) -> super::builder::notebook_service::GetNotebookRuntimeTemplate {
@@ -6180,6 +10308,22 @@ impl NotebookService {
     }
 
     /// Updates a NotebookRuntimeTemplate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_notebook_runtime_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_notebook_runtime_template(
         &self,
     ) -> super::builder::notebook_service::UpdateNotebookRuntimeTemplate {
@@ -6205,6 +10349,23 @@ impl NotebookService {
     }
 
     /// Gets a NotebookRuntime.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notebook_runtime()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notebook_runtime(&self) -> super::builder::notebook_service::GetNotebookRuntime {
         super::builder::notebook_service::GetNotebookRuntime::new(self.inner.clone())
     }
@@ -6296,6 +10457,23 @@ impl NotebookService {
     }
 
     /// Gets a NotebookExecutionJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notebook_execution_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notebook_execution_job(
         &self,
     ) -> super::builder::notebook_service::GetNotebookExecutionJob {
@@ -6332,6 +10510,22 @@ impl NotebookService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::notebook_service::GetLocation {
         super::builder::notebook_service::GetLocation::new(self.inner.clone())
     }
@@ -6341,12 +10535,44 @@ impl NotebookService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::notebook_service::SetIamPolicy {
         super::builder::notebook_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::notebook_service::GetIamPolicy {
         super::builder::notebook_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -6358,6 +10584,22 @@ impl NotebookService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::notebook_service::TestIamPermissions {
         super::builder::notebook_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -6372,6 +10614,22 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::notebook_service::GetOperation {
         super::builder::notebook_service::GetOperation::new(self.inner.clone())
     }
@@ -6379,6 +10637,21 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::notebook_service::DeleteOperation {
         super::builder::notebook_service::DeleteOperation::new(self.inner.clone())
     }
@@ -6386,6 +10659,21 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::notebook_service::CancelOperation {
         super::builder::notebook_service::CancelOperation::new(self.inner.clone())
     }
@@ -6393,6 +10681,22 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::notebook_service::WaitOperation {
         super::builder::notebook_service::WaitOperation::new(self.inner.clone())
     }
@@ -6527,6 +10831,23 @@ impl PersistentResourceService {
     }
 
     /// Gets a PersistentResource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_persistent_resource()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_persistent_resource(
         &self,
     ) -> super::builder::persistent_resource_service::GetPersistentResource {
@@ -6605,6 +10926,22 @@ impl PersistentResourceService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::persistent_resource_service::GetLocation {
         super::builder::persistent_resource_service::GetLocation::new(self.inner.clone())
     }
@@ -6614,12 +10951,44 @@ impl PersistentResourceService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::persistent_resource_service::SetIamPolicy {
         super::builder::persistent_resource_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::persistent_resource_service::GetIamPolicy {
         super::builder::persistent_resource_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -6631,6 +11000,22 @@ impl PersistentResourceService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::persistent_resource_service::TestIamPermissions {
@@ -6647,6 +11032,22 @@ impl PersistentResourceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::persistent_resource_service::GetOperation {
         super::builder::persistent_resource_service::GetOperation::new(self.inner.clone())
     }
@@ -6654,6 +11055,21 @@ impl PersistentResourceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::persistent_resource_service::DeleteOperation {
         super::builder::persistent_resource_service::DeleteOperation::new(self.inner.clone())
     }
@@ -6661,6 +11077,21 @@ impl PersistentResourceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::persistent_resource_service::CancelOperation {
         super::builder::persistent_resource_service::CancelOperation::new(self.inner.clone())
     }
@@ -6668,6 +11099,22 @@ impl PersistentResourceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
+    /// async fn sample(
+    ///    client: &PersistentResourceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::persistent_resource_service::WaitOperation {
         super::builder::persistent_resource_service::WaitOperation::new(self.inner.clone())
     }
@@ -6785,6 +11232,22 @@ impl PipelineService {
 
     /// Creates a TrainingPipeline. A created TrainingPipeline right away will be
     /// attempted to be run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_training_pipeline()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_training_pipeline(
         &self,
     ) -> super::builder::pipeline_service::CreateTrainingPipeline {
@@ -6792,6 +11255,23 @@ impl PipelineService {
     }
 
     /// Gets a TrainingPipeline.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_training_pipeline()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_training_pipeline(&self) -> super::builder::pipeline_service::GetTrainingPipeline {
         super::builder::pipeline_service::GetTrainingPipeline::new(self.inner.clone())
     }
@@ -6839,6 +11319,21 @@ impl PipelineService {
     /// [google.cloud.aiplatform.v1.TrainingPipeline.error]: crate::model::TrainingPipeline::error
     /// [google.cloud.aiplatform.v1.TrainingPipeline.state]: crate::model::TrainingPipeline::state
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_training_pipeline()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_training_pipeline(
         &self,
     ) -> super::builder::pipeline_service::CancelTrainingPipeline {
@@ -6846,11 +11341,44 @@ impl PipelineService {
     }
 
     /// Creates a PipelineJob. A PipelineJob will run immediately when created.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_pipeline_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_pipeline_job(&self) -> super::builder::pipeline_service::CreatePipelineJob {
         super::builder::pipeline_service::CreatePipelineJob::new(self.inner.clone())
     }
 
     /// Gets a PipelineJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pipeline_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pipeline_job(&self) -> super::builder::pipeline_service::GetPipelineJob {
         super::builder::pipeline_service::GetPipelineJob::new(self.inner.clone())
     }
@@ -6912,6 +11440,21 @@ impl PipelineService {
     /// [google.cloud.aiplatform.v1.PipelineJob.state]: crate::model::PipelineJob::state
     /// [google.cloud.aiplatform.v1.PipelineService.GetPipelineJob]: crate::client::PipelineService::get_pipeline_job
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_pipeline_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_pipeline_job(&self) -> super::builder::pipeline_service::CancelPipelineJob {
         super::builder::pipeline_service::CancelPipelineJob::new(self.inner.clone())
     }
@@ -6945,6 +11488,22 @@ impl PipelineService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::pipeline_service::GetLocation {
         super::builder::pipeline_service::GetLocation::new(self.inner.clone())
     }
@@ -6954,12 +11513,44 @@ impl PipelineService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::pipeline_service::SetIamPolicy {
         super::builder::pipeline_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::pipeline_service::GetIamPolicy {
         super::builder::pipeline_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -6971,6 +11562,22 @@ impl PipelineService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::pipeline_service::TestIamPermissions {
         super::builder::pipeline_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -6985,6 +11592,22 @@ impl PipelineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::pipeline_service::GetOperation {
         super::builder::pipeline_service::GetOperation::new(self.inner.clone())
     }
@@ -6992,6 +11615,21 @@ impl PipelineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::pipeline_service::DeleteOperation {
         super::builder::pipeline_service::DeleteOperation::new(self.inner.clone())
     }
@@ -6999,6 +11637,21 @@ impl PipelineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::pipeline_service::CancelOperation {
         super::builder::pipeline_service::CancelOperation::new(self.inner.clone())
     }
@@ -7006,6 +11659,22 @@ impl PipelineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PipelineService;
+    /// async fn sample(
+    ///    client: &PipelineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::pipeline_service::WaitOperation {
         super::builder::pipeline_service::WaitOperation::new(self.inner.clone())
     }
@@ -7120,6 +11789,22 @@ impl PredictionService {
     }
 
     /// Perform an online prediction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .predict()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn predict(&self) -> super::builder::prediction_service::Predict {
         super::builder::prediction_service::Predict::new(self.inner.clone())
     }
@@ -7139,18 +11824,66 @@ impl PredictionService {
     ///
     /// [google.cloud.aiplatform.v1.DeployedModel]: crate::model::DeployedModel
     /// [google.cloud.aiplatform.v1.Endpoint]: crate::model::Endpoint
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .raw_predict()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn raw_predict(&self) -> super::builder::prediction_service::RawPredict {
         super::builder::prediction_service::RawPredict::new(self.inner.clone())
     }
 
     /// Perform an unary online prediction request to a gRPC model server for
     /// Vertex first-party products and frameworks.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .direct_predict()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn direct_predict(&self) -> super::builder::prediction_service::DirectPredict {
         super::builder::prediction_service::DirectPredict::new(self.inner.clone())
     }
 
     /// Perform an unary online prediction request to a gRPC model server for
     /// custom containers.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .direct_raw_predict()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn direct_raw_predict(&self) -> super::builder::prediction_service::DirectRawPredict {
         super::builder::prediction_service::DirectRawPredict::new(self.inner.clone())
     }
@@ -7169,16 +11902,64 @@ impl PredictionService {
     ///
     /// [google.cloud.aiplatform.v1.DeployedModel.explanation_spec]: crate::model::DeployedModel::explanation_spec
     /// [google.cloud.aiplatform.v1.ExplainRequest.deployed_model_id]: crate::model::ExplainRequest::deployed_model_id
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .explain()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn explain(&self) -> super::builder::prediction_service::Explain {
         super::builder::prediction_service::Explain::new(self.inner.clone())
     }
 
     /// Generate content with multimodal inputs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_content(&self) -> super::builder::prediction_service::GenerateContent {
         super::builder::prediction_service::GenerateContent::new(self.inner.clone())
     }
 
     /// Embed content with multimodal inputs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .embed_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn embed_content(&self) -> super::builder::prediction_service::EmbedContent {
         super::builder::prediction_service::EmbedContent::new(self.inner.clone())
     }
@@ -7189,6 +11970,22 @@ impl PredictionService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::prediction_service::GetLocation {
         super::builder::prediction_service::GetLocation::new(self.inner.clone())
     }
@@ -7198,12 +11995,44 @@ impl PredictionService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::prediction_service::SetIamPolicy {
         super::builder::prediction_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::prediction_service::GetIamPolicy {
         super::builder::prediction_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -7215,6 +12044,22 @@ impl PredictionService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::prediction_service::TestIamPermissions {
         super::builder::prediction_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -7229,6 +12074,22 @@ impl PredictionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::prediction_service::GetOperation {
         super::builder::prediction_service::GetOperation::new(self.inner.clone())
     }
@@ -7236,6 +12097,21 @@ impl PredictionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::prediction_service::DeleteOperation {
         super::builder::prediction_service::DeleteOperation::new(self.inner.clone())
     }
@@ -7243,6 +12119,21 @@ impl PredictionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::prediction_service::CancelOperation {
         super::builder::prediction_service::CancelOperation::new(self.inner.clone())
     }
@@ -7250,6 +12141,22 @@ impl PredictionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::prediction_service::WaitOperation {
         super::builder::prediction_service::WaitOperation::new(self.inner.clone())
     }
@@ -7365,6 +12272,22 @@ impl ReasoningEngineExecutionService {
     }
 
     /// Queries using a reasoning engine.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_reasoning_engine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_reasoning_engine(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::QueryReasoningEngine {
@@ -7381,6 +12304,22 @@ impl ReasoningEngineExecutionService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::reasoning_engine_execution_service::GetLocation {
         super::builder::reasoning_engine_execution_service::GetLocation::new(self.inner.clone())
     }
@@ -7390,6 +12329,22 @@ impl ReasoningEngineExecutionService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::SetIamPolicy {
@@ -7398,6 +12353,22 @@ impl ReasoningEngineExecutionService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::GetIamPolicy {
@@ -7411,6 +12382,22 @@ impl ReasoningEngineExecutionService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::TestIamPermissions {
@@ -7431,6 +12418,22 @@ impl ReasoningEngineExecutionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::GetOperation {
@@ -7440,6 +12443,21 @@ impl ReasoningEngineExecutionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::DeleteOperation {
@@ -7449,6 +12467,21 @@ impl ReasoningEngineExecutionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::CancelOperation {
@@ -7458,6 +12491,22 @@ impl ReasoningEngineExecutionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineExecutionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(
         &self,
     ) -> super::builder::reasoning_engine_execution_service::WaitOperation {
@@ -7591,6 +12640,23 @@ impl ReasoningEngineService {
     }
 
     /// Gets a reasoning engine.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_reasoning_engine()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_reasoning_engine(
         &self,
     ) -> super::builder::reasoning_engine_service::GetReasoningEngine {
@@ -7644,6 +12710,22 @@ impl ReasoningEngineService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::reasoning_engine_service::GetLocation {
         super::builder::reasoning_engine_service::GetLocation::new(self.inner.clone())
     }
@@ -7653,12 +12735,44 @@ impl ReasoningEngineService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reasoning_engine_service::SetIamPolicy {
         super::builder::reasoning_engine_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reasoning_engine_service::GetIamPolicy {
         super::builder::reasoning_engine_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -7670,6 +12784,22 @@ impl ReasoningEngineService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::reasoning_engine_service::TestIamPermissions {
@@ -7686,6 +12816,22 @@ impl ReasoningEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reasoning_engine_service::GetOperation {
         super::builder::reasoning_engine_service::GetOperation::new(self.inner.clone())
     }
@@ -7693,6 +12839,21 @@ impl ReasoningEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::reasoning_engine_service::DeleteOperation {
         super::builder::reasoning_engine_service::DeleteOperation::new(self.inner.clone())
     }
@@ -7700,6 +12861,21 @@ impl ReasoningEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::reasoning_engine_service::CancelOperation {
         super::builder::reasoning_engine_service::CancelOperation::new(self.inner.clone())
     }
@@ -7707,6 +12883,22 @@ impl ReasoningEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
+    /// async fn sample(
+    ///    client: &ReasoningEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::reasoning_engine_service::WaitOperation {
         super::builder::reasoning_engine_service::WaitOperation::new(self.inner.clone())
     }
@@ -7822,6 +13014,22 @@ impl ScheduleService {
     }
 
     /// Creates a Schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_schedule(&self) -> super::builder::schedule_service::CreateSchedule {
         super::builder::schedule_service::CreateSchedule::new(self.inner.clone())
     }
@@ -7842,6 +13050,23 @@ impl ScheduleService {
     }
 
     /// Gets a Schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schedule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schedule(&self) -> super::builder::schedule_service::GetSchedule {
         super::builder::schedule_service::GetSchedule::new(self.inner.clone())
     }
@@ -7857,6 +13082,21 @@ impl ScheduleService {
     /// will NOT be paused or canceled.
     ///
     /// [google.cloud.aiplatform.v1.Schedule.state]: crate::model::Schedule::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .pause_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_schedule(&self) -> super::builder::schedule_service::PauseSchedule {
         super::builder::schedule_service::PauseSchedule::new(self.inner.clone())
     }
@@ -7873,6 +13113,21 @@ impl ScheduleService {
     ///
     /// [google.cloud.aiplatform.v1.Schedule.catch_up]: crate::model::Schedule::catch_up
     /// [google.cloud.aiplatform.v1.Schedule.state]: crate::model::Schedule::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .resume_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_schedule(&self) -> super::builder::schedule_service::ResumeSchedule {
         super::builder::schedule_service::ResumeSchedule::new(self.inner.clone())
     }
@@ -7884,6 +13139,22 @@ impl ScheduleService {
     /// time_specification in the updated Schedule. All unstarted runs before the
     /// update time will be skipped while already created runs will NOT be paused
     /// or canceled.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_schedule(&self) -> super::builder::schedule_service::UpdateSchedule {
         super::builder::schedule_service::UpdateSchedule::new(self.inner.clone())
     }
@@ -7894,6 +13165,22 @@ impl ScheduleService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::schedule_service::GetLocation {
         super::builder::schedule_service::GetLocation::new(self.inner.clone())
     }
@@ -7903,12 +13190,44 @@ impl ScheduleService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::schedule_service::SetIamPolicy {
         super::builder::schedule_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::schedule_service::GetIamPolicy {
         super::builder::schedule_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -7920,6 +13239,22 @@ impl ScheduleService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::schedule_service::TestIamPermissions {
         super::builder::schedule_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -7934,6 +13269,22 @@ impl ScheduleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::schedule_service::GetOperation {
         super::builder::schedule_service::GetOperation::new(self.inner.clone())
     }
@@ -7941,6 +13292,21 @@ impl ScheduleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::schedule_service::DeleteOperation {
         super::builder::schedule_service::DeleteOperation::new(self.inner.clone())
     }
@@ -7948,6 +13314,21 @@ impl ScheduleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::schedule_service::CancelOperation {
         super::builder::schedule_service::CancelOperation::new(self.inner.clone())
     }
@@ -7955,6 +13336,22 @@ impl ScheduleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::ScheduleService;
+    /// async fn sample(
+    ///    client: &ScheduleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::schedule_service::WaitOperation {
         super::builder::schedule_service::WaitOperation::new(self.inner.clone())
     }
@@ -8091,6 +13488,23 @@ impl SpecialistPoolService {
     }
 
     /// Gets a SpecialistPool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_specialist_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_specialist_pool(
         &self,
     ) -> super::builder::specialist_pool_service::GetSpecialistPool {
@@ -8144,6 +13558,22 @@ impl SpecialistPoolService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::specialist_pool_service::GetLocation {
         super::builder::specialist_pool_service::GetLocation::new(self.inner.clone())
     }
@@ -8153,12 +13583,44 @@ impl SpecialistPoolService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::specialist_pool_service::SetIamPolicy {
         super::builder::specialist_pool_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::specialist_pool_service::GetIamPolicy {
         super::builder::specialist_pool_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -8170,6 +13632,22 @@ impl SpecialistPoolService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::specialist_pool_service::TestIamPermissions {
@@ -8186,6 +13664,22 @@ impl SpecialistPoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::specialist_pool_service::GetOperation {
         super::builder::specialist_pool_service::GetOperation::new(self.inner.clone())
     }
@@ -8193,6 +13687,21 @@ impl SpecialistPoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::specialist_pool_service::DeleteOperation {
         super::builder::specialist_pool_service::DeleteOperation::new(self.inner.clone())
     }
@@ -8200,6 +13709,21 @@ impl SpecialistPoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::specialist_pool_service::CancelOperation {
         super::builder::specialist_pool_service::CancelOperation::new(self.inner.clone())
     }
@@ -8207,6 +13731,22 @@ impl SpecialistPoolService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
+    /// async fn sample(
+    ///    client: &SpecialistPoolService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::specialist_pool_service::WaitOperation {
         super::builder::specialist_pool_service::WaitOperation::new(self.inner.clone())
     }
@@ -8336,6 +13876,23 @@ impl TensorboardService {
     }
 
     /// Gets a Tensorboard.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tensorboard()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tensorboard(&self) -> super::builder::tensorboard_service::GetTensorboard {
         super::builder::tensorboard_service::GetTensorboard::new(self.inner.clone())
     }
@@ -8376,6 +13933,22 @@ impl TensorboardService {
     }
 
     /// Returns a list of monthly active users for a given TensorBoard instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_tensorboard_usage()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_tensorboard_usage(
         &self,
     ) -> super::builder::tensorboard_service::ReadTensorboardUsage {
@@ -8383,6 +13956,22 @@ impl TensorboardService {
     }
 
     /// Returns the storage size for a given TensorBoard instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_tensorboard_size()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_tensorboard_size(
         &self,
     ) -> super::builder::tensorboard_service::ReadTensorboardSize {
@@ -8390,6 +13979,22 @@ impl TensorboardService {
     }
 
     /// Creates a TensorboardExperiment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tensorboard_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tensorboard_experiment(
         &self,
     ) -> super::builder::tensorboard_service::CreateTensorboardExperiment {
@@ -8397,6 +14002,23 @@ impl TensorboardService {
     }
 
     /// Gets a TensorboardExperiment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tensorboard_experiment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tensorboard_experiment(
         &self,
     ) -> super::builder::tensorboard_service::GetTensorboardExperiment {
@@ -8404,6 +14026,22 @@ impl TensorboardService {
     }
 
     /// Updates a TensorboardExperiment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tensorboard_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tensorboard_experiment(
         &self,
     ) -> super::builder::tensorboard_service::UpdateTensorboardExperiment {
@@ -8435,6 +14073,22 @@ impl TensorboardService {
     }
 
     /// Creates a TensorboardRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tensorboard_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tensorboard_run(
         &self,
     ) -> super::builder::tensorboard_service::CreateTensorboardRun {
@@ -8442,6 +14096,22 @@ impl TensorboardService {
     }
 
     /// Batch create TensorboardRuns.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_create_tensorboard_runs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_create_tensorboard_runs(
         &self,
     ) -> super::builder::tensorboard_service::BatchCreateTensorboardRuns {
@@ -8449,11 +14119,44 @@ impl TensorboardService {
     }
 
     /// Gets a TensorboardRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tensorboard_run()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tensorboard_run(&self) -> super::builder::tensorboard_service::GetTensorboardRun {
         super::builder::tensorboard_service::GetTensorboardRun::new(self.inner.clone())
     }
 
     /// Updates a TensorboardRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tensorboard_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tensorboard_run(
         &self,
     ) -> super::builder::tensorboard_service::UpdateTensorboardRun {
@@ -8485,6 +14188,22 @@ impl TensorboardService {
     }
 
     /// Batch create TensorboardTimeSeries that belong to a TensorboardExperiment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_create_tensorboard_time_series()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_create_tensorboard_time_series(
         &self,
     ) -> super::builder::tensorboard_service::BatchCreateTensorboardTimeSeries {
@@ -8494,6 +14213,22 @@ impl TensorboardService {
     }
 
     /// Creates a TensorboardTimeSeries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tensorboard_time_series()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tensorboard_time_series(
         &self,
     ) -> super::builder::tensorboard_service::CreateTensorboardTimeSeries {
@@ -8501,6 +14236,23 @@ impl TensorboardService {
     }
 
     /// Gets a TensorboardTimeSeries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tensorboard_time_series()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tensorboard_time_series(
         &self,
     ) -> super::builder::tensorboard_service::GetTensorboardTimeSeries {
@@ -8508,6 +14260,22 @@ impl TensorboardService {
     }
 
     /// Updates a TensorboardTimeSeries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tensorboard_time_series()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tensorboard_time_series(
         &self,
     ) -> super::builder::tensorboard_service::UpdateTensorboardTimeSeries {
@@ -8543,6 +14311,22 @@ impl TensorboardService {
     /// data points stored is less than the limit, all data is returned.
     /// Otherwise, the number limit of data points is randomly selected from
     /// this time series and returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_read_tensorboard_time_series_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_read_tensorboard_time_series_data(
         &self,
     ) -> super::builder::tensorboard_service::BatchReadTensorboardTimeSeriesData {
@@ -8556,6 +14340,22 @@ impl TensorboardService {
     /// data points is randomly selected from this time series and returned.
     /// This value can be changed by changing max_data_points, which can't be
     /// greater than 10k.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_tensorboard_time_series_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_tensorboard_time_series_data(
         &self,
     ) -> super::builder::tensorboard_service::ReadTensorboardTimeSeriesData {
@@ -8564,6 +14364,22 @@ impl TensorboardService {
 
     /// Write time series data points of multiple TensorboardTimeSeries in multiple
     /// TensorboardRun's. If any data fail to be ingested, an error is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_tensorboard_experiment_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_tensorboard_experiment_data(
         &self,
     ) -> super::builder::tensorboard_service::WriteTensorboardExperimentData {
@@ -8572,6 +14388,22 @@ impl TensorboardService {
 
     /// Write time series data points into multiple TensorboardTimeSeries under
     /// a TensorboardRun. If any data fail to be ingested, an error is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_tensorboard_run_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_tensorboard_run_data(
         &self,
     ) -> super::builder::tensorboard_service::WriteTensorboardRunData {
@@ -8594,6 +14426,22 @@ impl TensorboardService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::tensorboard_service::GetLocation {
         super::builder::tensorboard_service::GetLocation::new(self.inner.clone())
     }
@@ -8603,12 +14451,44 @@ impl TensorboardService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::tensorboard_service::SetIamPolicy {
         super::builder::tensorboard_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::tensorboard_service::GetIamPolicy {
         super::builder::tensorboard_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -8620,6 +14500,22 @@ impl TensorboardService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::tensorboard_service::TestIamPermissions {
         super::builder::tensorboard_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -8634,6 +14530,22 @@ impl TensorboardService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tensorboard_service::GetOperation {
         super::builder::tensorboard_service::GetOperation::new(self.inner.clone())
     }
@@ -8641,6 +14553,21 @@ impl TensorboardService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::tensorboard_service::DeleteOperation {
         super::builder::tensorboard_service::DeleteOperation::new(self.inner.clone())
     }
@@ -8648,6 +14575,21 @@ impl TensorboardService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::tensorboard_service::CancelOperation {
         super::builder::tensorboard_service::CancelOperation::new(self.inner.clone())
     }
@@ -8655,6 +14597,22 @@ impl TensorboardService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::TensorboardService;
+    /// async fn sample(
+    ///    client: &TensorboardService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::tensorboard_service::WaitOperation {
         super::builder::tensorboard_service::WaitOperation::new(self.inner.clone())
     }
@@ -8799,6 +14757,23 @@ impl VertexRagDataService {
     }
 
     /// Gets a RagCorpus.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rag_corpus()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rag_corpus(&self) -> super::builder::vertex_rag_data_service::GetRagCorpus {
         super::builder::vertex_rag_data_service::GetRagCorpus::new(self.inner.clone())
     }
@@ -8824,6 +14799,22 @@ impl VertexRagDataService {
     }
 
     /// Upload a file into a RagCorpus.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .upload_rag_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn upload_rag_file(&self) -> super::builder::vertex_rag_data_service::UploadRagFile {
         super::builder::vertex_rag_data_service::UploadRagFile::new(self.inner.clone())
     }
@@ -8844,6 +14835,23 @@ impl VertexRagDataService {
     }
 
     /// Gets a RagFile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rag_file()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rag_file(&self) -> super::builder::vertex_rag_data_service::GetRagFile {
         super::builder::vertex_rag_data_service::GetRagFile::new(self.inner.clone())
     }
@@ -8886,6 +14894,23 @@ impl VertexRagDataService {
     }
 
     /// Gets a RagEngineConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rag_engine_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rag_engine_config(
         &self,
     ) -> super::builder::vertex_rag_data_service::GetRagEngineConfig {
@@ -8898,6 +14923,22 @@ impl VertexRagDataService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vertex_rag_data_service::GetLocation {
         super::builder::vertex_rag_data_service::GetLocation::new(self.inner.clone())
     }
@@ -8907,12 +14948,44 @@ impl VertexRagDataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::vertex_rag_data_service::SetIamPolicy {
         super::builder::vertex_rag_data_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::vertex_rag_data_service::GetIamPolicy {
         super::builder::vertex_rag_data_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -8924,6 +14997,22 @@ impl VertexRagDataService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::vertex_rag_data_service::TestIamPermissions {
@@ -8940,6 +15029,22 @@ impl VertexRagDataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vertex_rag_data_service::GetOperation {
         super::builder::vertex_rag_data_service::GetOperation::new(self.inner.clone())
     }
@@ -8947,6 +15052,21 @@ impl VertexRagDataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vertex_rag_data_service::DeleteOperation {
         super::builder::vertex_rag_data_service::DeleteOperation::new(self.inner.clone())
     }
@@ -8954,6 +15074,21 @@ impl VertexRagDataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::vertex_rag_data_service::CancelOperation {
         super::builder::vertex_rag_data_service::CancelOperation::new(self.inner.clone())
     }
@@ -8961,6 +15096,22 @@ impl VertexRagDataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
+    /// async fn sample(
+    ///    client: &VertexRagDataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::vertex_rag_data_service::WaitOperation {
         super::builder::vertex_rag_data_service::WaitOperation::new(self.inner.clone())
     }
@@ -9075,12 +15226,44 @@ impl VertexRagService {
     }
 
     /// Retrieves relevant contexts for a query.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_contexts()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retrieve_contexts(&self) -> super::builder::vertex_rag_service::RetrieveContexts {
         super::builder::vertex_rag_service::RetrieveContexts::new(self.inner.clone())
     }
 
     /// Given an input prompt, it returns augmented prompt from vertex rag store
     /// to guide LLM towards generating grounded responses.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .augment_prompt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn augment_prompt(&self) -> super::builder::vertex_rag_service::AugmentPrompt {
         super::builder::vertex_rag_service::AugmentPrompt::new(self.inner.clone())
     }
@@ -9088,6 +15271,22 @@ impl VertexRagService {
     /// Given an input text, it returns a score that evaluates the factuality of
     /// the text. It also extracts and returns claims from the text and provides
     /// supporting facts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .corroborate_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn corroborate_content(&self) -> super::builder::vertex_rag_service::CorroborateContent {
         super::builder::vertex_rag_service::CorroborateContent::new(self.inner.clone())
     }
@@ -9098,6 +15297,22 @@ impl VertexRagService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vertex_rag_service::GetLocation {
         super::builder::vertex_rag_service::GetLocation::new(self.inner.clone())
     }
@@ -9107,12 +15322,44 @@ impl VertexRagService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::vertex_rag_service::SetIamPolicy {
         super::builder::vertex_rag_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::vertex_rag_service::GetIamPolicy {
         super::builder::vertex_rag_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -9124,6 +15371,22 @@ impl VertexRagService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::vertex_rag_service::TestIamPermissions {
         super::builder::vertex_rag_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -9138,6 +15401,22 @@ impl VertexRagService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vertex_rag_service::GetOperation {
         super::builder::vertex_rag_service::GetOperation::new(self.inner.clone())
     }
@@ -9145,6 +15424,21 @@ impl VertexRagService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vertex_rag_service::DeleteOperation {
         super::builder::vertex_rag_service::DeleteOperation::new(self.inner.clone())
     }
@@ -9152,6 +15446,21 @@ impl VertexRagService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::vertex_rag_service::CancelOperation {
         super::builder::vertex_rag_service::CancelOperation::new(self.inner.clone())
     }
@@ -9159,6 +15468,22 @@ impl VertexRagService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VertexRagService;
+    /// async fn sample(
+    ///    client: &VertexRagService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::vertex_rag_service::WaitOperation {
         super::builder::vertex_rag_service::WaitOperation::new(self.inner.clone())
     }
@@ -9275,11 +15600,44 @@ impl VizierService {
 
     /// Creates a Study. A resource name will be generated after creation of the
     /// Study.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_study()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_study(&self) -> super::builder::vizier_service::CreateStudy {
         super::builder::vizier_service::CreateStudy::new(self.inner.clone())
     }
 
     /// Gets a Study by name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_study()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_study(&self) -> super::builder::vizier_service::GetStudy {
         super::builder::vizier_service::GetStudy::new(self.inner.clone())
     }
@@ -9290,12 +15648,43 @@ impl VizierService {
     }
 
     /// Deletes a Study.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_study()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_study(&self) -> super::builder::vizier_service::DeleteStudy {
         super::builder::vizier_service::DeleteStudy::new(self.inner.clone())
     }
 
     /// Looks a study up using the user-defined display_name field instead of the
     /// fully qualified resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_study()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_study(&self) -> super::builder::vizier_service::LookupStudy {
         super::builder::vizier_service::LookupStudy::new(self.inner.clone())
     }
@@ -9323,11 +15712,44 @@ impl VizierService {
     }
 
     /// Adds a user provided Trial to a Study.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_trial()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_trial(&self) -> super::builder::vizier_service::CreateTrial {
         super::builder::vizier_service::CreateTrial::new(self.inner.clone())
     }
 
     /// Gets a Trial.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_trial()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_trial(&self) -> super::builder::vizier_service::GetTrial {
         super::builder::vizier_service::GetTrial::new(self.inner.clone())
     }
@@ -9339,16 +15761,63 @@ impl VizierService {
 
     /// Adds a measurement of the objective metrics to a Trial. This measurement
     /// is assumed to have been taken before the Trial is complete.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_trial_measurement()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_trial_measurement(&self) -> super::builder::vizier_service::AddTrialMeasurement {
         super::builder::vizier_service::AddTrialMeasurement::new(self.inner.clone())
     }
 
     /// Marks a Trial as complete.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_trial()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_trial(&self) -> super::builder::vizier_service::CompleteTrial {
         super::builder::vizier_service::CompleteTrial::new(self.inner.clone())
     }
 
     /// Deletes a Trial.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_trial()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_trial(&self) -> super::builder::vizier_service::DeleteTrial {
         super::builder::vizier_service::DeleteTrial::new(self.inner.clone())
     }
@@ -9376,6 +15845,22 @@ impl VizierService {
     }
 
     /// Stops a Trial.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_trial()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_trial(&self) -> super::builder::vizier_service::StopTrial {
         super::builder::vizier_service::StopTrial::new(self.inner.clone())
     }
@@ -9384,6 +15869,22 @@ impl VizierService {
     /// optimal Trials for single-objective Study. The definition of
     /// pareto-optimal can be checked in wiki page.
     /// <https://en.wikipedia.org/wiki/Pareto_efficiency>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_optimal_trials()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_optimal_trials(&self) -> super::builder::vizier_service::ListOptimalTrials {
         super::builder::vizier_service::ListOptimalTrials::new(self.inner.clone())
     }
@@ -9394,6 +15895,22 @@ impl VizierService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vizier_service::GetLocation {
         super::builder::vizier_service::GetLocation::new(self.inner.clone())
     }
@@ -9403,12 +15920,44 @@ impl VizierService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::vizier_service::SetIamPolicy {
         super::builder::vizier_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::vizier_service::GetIamPolicy {
         super::builder::vizier_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -9420,6 +15969,22 @@ impl VizierService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::vizier_service::TestIamPermissions {
         super::builder::vizier_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -9434,6 +15999,22 @@ impl VizierService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vizier_service::GetOperation {
         super::builder::vizier_service::GetOperation::new(self.inner.clone())
     }
@@ -9441,6 +16022,21 @@ impl VizierService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vizier_service::DeleteOperation {
         super::builder::vizier_service::DeleteOperation::new(self.inner.clone())
     }
@@ -9448,6 +16044,21 @@ impl VizierService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::vizier_service::CancelOperation {
         super::builder::vizier_service::CancelOperation::new(self.inner.clone())
     }
@@ -9455,6 +16066,22 @@ impl VizierService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_aiplatform_v1::client::VizierService;
+    /// async fn sample(
+    ///    client: &VizierService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::vizier_service::WaitOperation {
         super::builder::vizier_service::WaitOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/alloydb/v1/src/client.rs
+++ b/src/generated/cloud/alloydb/v1/src/client.rs
@@ -144,6 +144,22 @@ impl AlloyDBCSQLAdmin {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBCSQLAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBCSQLAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::alloy_dbcsql_admin::GetLocation {
         super::builder::alloy_dbcsql_admin::GetLocation::new(self.inner.clone())
     }
@@ -158,6 +174,22 @@ impl AlloyDBCSQLAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBCSQLAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBCSQLAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::alloy_dbcsql_admin::GetOperation {
         super::builder::alloy_dbcsql_admin::GetOperation::new(self.inner.clone())
     }
@@ -165,6 +197,21 @@ impl AlloyDBCSQLAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBCSQLAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBCSQLAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::alloy_dbcsql_admin::DeleteOperation {
         super::builder::alloy_dbcsql_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -172,6 +219,21 @@ impl AlloyDBCSQLAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBCSQLAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBCSQLAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::alloy_dbcsql_admin::CancelOperation {
         super::builder::alloy_dbcsql_admin::CancelOperation::new(self.inner.clone())
     }
@@ -285,6 +347,23 @@ impl AlloyDBAdmin {
     }
 
     /// Gets details of a single Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::alloy_db_admin::GetCluster {
         super::builder::alloy_db_admin::GetCluster::new(self.inner.clone())
     }
@@ -458,6 +537,23 @@ impl AlloyDBAdmin {
     }
 
     /// Gets details of a single Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::alloy_db_admin::GetInstance {
         super::builder::alloy_db_admin::GetInstance::new(self.inner.clone())
     }
@@ -598,6 +694,22 @@ impl AlloyDBAdmin {
     }
 
     /// Executes a SQL statement in a database inside an AlloyDB instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .execute_sql()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn execute_sql(&self) -> super::builder::alloy_db_admin::ExecuteSql {
         super::builder::alloy_db_admin::ExecuteSql::new(self.inner.clone())
     }
@@ -608,6 +720,23 @@ impl AlloyDBAdmin {
     }
 
     /// Gets details of a single Backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::alloy_db_admin::GetBackup {
         super::builder::alloy_db_admin::GetBackup::new(self.inner.clone())
     }
@@ -669,6 +798,22 @@ impl AlloyDBAdmin {
     /// Auth Proxy client. The endpoint's behavior is subject to change without
     /// notice, so do not rely on its behavior remaining constant. Future changes
     /// will not break AlloyDB connectors or the Auth Proxy client.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_client_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_client_certificate(
         &self,
     ) -> super::builder::alloy_db_admin::GenerateClientCertificate {
@@ -676,6 +821,22 @@ impl AlloyDBAdmin {
     }
 
     /// Get instance metadata used for a connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection_info(&self) -> super::builder::alloy_db_admin::GetConnectionInfo {
         super::builder::alloy_db_admin::GetConnectionInfo::new(self.inner.clone())
     }
@@ -686,21 +847,86 @@ impl AlloyDBAdmin {
     }
 
     /// Gets details of a single User.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_user()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_user(&self) -> super::builder::alloy_db_admin::GetUser {
         super::builder::alloy_db_admin::GetUser::new(self.inner.clone())
     }
 
     /// Creates a new User in a given project, location, and cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_user()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_user(&self) -> super::builder::alloy_db_admin::CreateUser {
         super::builder::alloy_db_admin::CreateUser::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single User.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_user()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_user(&self) -> super::builder::alloy_db_admin::UpdateUser {
         super::builder::alloy_db_admin::UpdateUser::new(self.inner.clone())
     }
 
     /// Deletes a single User.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_user()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_user(&self) -> super::builder::alloy_db_admin::DeleteUser {
         super::builder::alloy_db_admin::DeleteUser::new(self.inner.clone())
     }
@@ -716,6 +942,22 @@ impl AlloyDBAdmin {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::alloy_db_admin::GetLocation {
         super::builder::alloy_db_admin::GetLocation::new(self.inner.clone())
     }
@@ -730,6 +972,22 @@ impl AlloyDBAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::alloy_db_admin::GetOperation {
         super::builder::alloy_db_admin::GetOperation::new(self.inner.clone())
     }
@@ -737,6 +995,21 @@ impl AlloyDBAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::alloy_db_admin::DeleteOperation {
         super::builder::alloy_db_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -744,6 +1017,21 @@ impl AlloyDBAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+    /// async fn sample(
+    ///    client: &AlloyDBAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::alloy_db_admin::CancelOperation {
         super::builder::alloy_db_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/apigateway/v1/src/client.rs
+++ b/src/generated/cloud/apigateway/v1/src/client.rs
@@ -127,6 +127,23 @@ impl ApiGatewayService {
     }
 
     /// Gets details of a single Gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_gateway()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_gateway(&self) -> super::builder::api_gateway_service::GetGateway {
         super::builder::api_gateway_service::GetGateway::new(self.inner.clone())
     }
@@ -182,6 +199,23 @@ impl ApiGatewayService {
     }
 
     /// Gets details of a single Api.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_api()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_api(&self) -> super::builder::api_gateway_service::GetApi {
         super::builder::api_gateway_service::GetApi::new(self.inner.clone())
     }
@@ -237,6 +271,23 @@ impl ApiGatewayService {
     }
 
     /// Gets details of a single ApiConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_api_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_api_config(&self) -> super::builder::api_gateway_service::GetApiConfig {
         super::builder::api_gateway_service::GetApiConfig::new(self.inner.clone())
     }
@@ -296,6 +347,22 @@ impl ApiGatewayService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_gateway_service::GetOperation {
         super::builder::api_gateway_service::GetOperation::new(self.inner.clone())
     }
@@ -303,6 +370,21 @@ impl ApiGatewayService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_gateway_service::DeleteOperation {
         super::builder::api_gateway_service::DeleteOperation::new(self.inner.clone())
     }
@@ -310,6 +392,21 @@ impl ApiGatewayService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+    /// async fn sample(
+    ///    client: &ApiGatewayService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_gateway_service::CancelOperation {
         super::builder::api_gateway_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/apihub/v1/src/client.rs
+++ b/src/generated/cloud/apihub/v1/src/client.rs
@@ -120,11 +120,44 @@ impl ApiHub {
 
     /// Create an API resource in the API hub.
     /// Once an API resource is created, versions can be added to it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_api()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_api(&self) -> super::builder::api_hub::CreateApi {
         super::builder::api_hub::CreateApi::new(self.inner.clone())
     }
 
     /// Get API resource details including the API versions contained in it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_api()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_api(&self) -> super::builder::api_hub::GetApi {
         super::builder::api_hub::GetApi::new(self.inner.clone())
     }
@@ -167,17 +200,65 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Api.target_user]: crate::model::Api::target_user
     /// [google.cloud.apihub.v1.Api.team]: crate::model::Api::team
     /// [google.cloud.apihub.v1.UpdateApiRequest.update_mask]: crate::model::UpdateApiRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_api()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_api(&self) -> super::builder::api_hub::UpdateApi {
         super::builder::api_hub::UpdateApi::new(self.inner.clone())
     }
 
     /// Delete an API resource in the API hub. API can only be deleted if all
     /// underlying versions are deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_api()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_api(&self) -> super::builder::api_hub::DeleteApi {
         super::builder::api_hub::DeleteApi::new(self.inner.clone())
     }
 
     /// Create an API version for an API resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_version(&self) -> super::builder::api_hub::CreateVersion {
         super::builder::api_hub::CreateVersion::new(self.inner.clone())
     }
@@ -185,6 +266,23 @@ impl ApiHub {
     /// Get details about the API version of an API resource. This will include
     /// information about the specs and operations present in the API
     /// version as well as the deployments linked to it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::api_hub::GetVersion {
         super::builder::api_hub::GetVersion::new(self.inner.clone())
     }
@@ -220,12 +318,44 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Version.display_name]: crate::model::Version::display_name
     /// [google.cloud.apihub.v1.Version.documentation]: crate::model::Version::documentation
     /// [google.cloud.apihub.v1.Version.lifecycle]: crate::model::Version::lifecycle
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_version(&self) -> super::builder::api_hub::UpdateVersion {
         super::builder::api_hub::UpdateVersion::new(self.inner.clone())
     }
 
     /// Delete an API version. Version can only be deleted if all underlying specs,
     /// operations, definitions and linked deployments are deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_version(&self) -> super::builder::api_hub::DeleteVersion {
         super::builder::api_hub::DeleteVersion::new(self.inner.clone())
     }
@@ -255,6 +385,22 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.ApiHub.GetSpec]: crate::client::ApiHub::get_spec
     /// [google.cloud.apihub.v1.ApiHub.GetSpecContents]: crate::client::ApiHub::get_spec_contents
     /// [google.cloud.apihub.v1.ApiHub.ListApiOperations]: crate::client::ApiHub::list_api_operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_spec()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_spec(&self) -> super::builder::api_hub::CreateSpec {
         super::builder::api_hub::CreateSpec::new(self.inner.clone())
     }
@@ -265,11 +411,44 @@ impl ApiHub {
     /// to retrieve the same.
     ///
     /// [google.cloud.apihub.v1.ApiHub.GetSpecContents]: crate::client::ApiHub::get_spec_contents
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_spec()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_spec(&self) -> super::builder::api_hub::GetSpec {
         super::builder::api_hub::GetSpec::new(self.inner.clone())
     }
 
     /// Get spec contents.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_spec_contents()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_spec_contents(&self) -> super::builder::api_hub::GetSpecContents {
         super::builder::api_hub::GetSpecContents::new(self.inner.clone())
     }
@@ -311,6 +490,22 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Spec.source_uri]: crate::model::Spec::source_uri
     /// [google.cloud.apihub.v1.Spec.spec_type]: crate::model::Spec::spec_type
     /// [google.cloud.apihub.v1.UpdateSpecRequest.update_mask]: crate::model::UpdateSpecRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_spec()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_spec(&self) -> super::builder::api_hub::UpdateSpec {
         super::builder::api_hub::UpdateSpec::new(self.inner.clone())
     }
@@ -318,6 +513,22 @@ impl ApiHub {
     /// Delete a spec.
     /// Deleting a spec will also delete the associated operations from the
     /// version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_spec()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_spec(&self) -> super::builder::api_hub::DeleteSpec {
         super::builder::api_hub::DeleteSpec::new(self.inner.clone())
     }
@@ -325,11 +536,44 @@ impl ApiHub {
     /// Create an apiOperation in an API version.
     /// An apiOperation can be created only if the version has no apiOperations
     /// which were created by parsing a spec.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_api_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_api_operation(&self) -> super::builder::api_hub::CreateApiOperation {
         super::builder::api_hub::CreateApiOperation::new(self.inner.clone())
     }
 
     /// Get details about a particular operation in API version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_api_operation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_api_operation(&self) -> super::builder::api_hub::GetApiOperation {
         super::builder::api_hub::GetApiOperation::new(self.inner.clone())
     }
@@ -363,6 +607,22 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.ApiOperation]: crate::model::ApiOperation
     /// [google.cloud.apihub.v1.ApiOperation.attributes]: crate::model::ApiOperation::attributes
     /// [google.cloud.apihub.v1.UpdateApiOperationRequest.update_mask]: crate::model::UpdateApiOperationRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_api_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_api_operation(&self) -> super::builder::api_hub::UpdateApiOperation {
         super::builder::api_hub::UpdateApiOperation::new(self.inner.clone())
     }
@@ -370,11 +630,44 @@ impl ApiHub {
     /// Delete an operation in an API version and we can delete only the
     /// operations created via create API. If the operation was created by parsing
     /// the spec, then it can be deleted by editing or deleting the spec.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_api_operation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_api_operation(&self) -> super::builder::api_hub::DeleteApiOperation {
         super::builder::api_hub::DeleteApiOperation::new(self.inner.clone())
     }
 
     /// Get details about a definition in an API version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_definition()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_definition(&self) -> super::builder::api_hub::GetDefinition {
         super::builder::api_hub::GetDefinition::new(self.inner.clone())
     }
@@ -382,11 +675,44 @@ impl ApiHub {
     /// Create a deployment resource in the API hub.
     /// Once a deployment resource is created, it can be associated with API
     /// versions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_deployment(&self) -> super::builder::api_hub::CreateDeployment {
         super::builder::api_hub::CreateDeployment::new(self.inner.clone())
     }
 
     /// Get details about a deployment and the API versions linked to it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment(&self) -> super::builder::api_hub::GetDeployment {
         super::builder::api_hub::GetDeployment::new(self.inner.clone())
     }
@@ -431,11 +757,43 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Deployment.slo]: crate::model::Deployment::slo
     /// [google.cloud.apihub.v1.Deployment.source_uri]: crate::model::Deployment::source_uri
     /// [google.cloud.apihub.v1.UpdateDeploymentRequest.update_mask]: crate::model::UpdateDeploymentRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_deployment(&self) -> super::builder::api_hub::UpdateDeployment {
         super::builder::api_hub::UpdateDeployment::new(self.inner.clone())
     }
 
     /// Delete a deployment resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_deployment(&self) -> super::builder::api_hub::DeleteDeployment {
         super::builder::api_hub::DeleteDeployment::new(self.inner.clone())
     }
@@ -450,11 +808,44 @@ impl ApiHub {
     ///
     /// [google.cloud.apihub.v1.ApiHub.ListAttributes]: crate::client::ApiHub::list_attributes
     /// [google.cloud.apihub.v1.ApiHub.UpdateAttribute]: crate::client::ApiHub::update_attribute
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_attribute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_attribute(&self) -> super::builder::api_hub::CreateAttribute {
         super::builder::api_hub::CreateAttribute::new(self.inner.clone())
     }
 
     /// Get details about the attribute.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attribute()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attribute(&self) -> super::builder::api_hub::GetAttribute {
         super::builder::api_hub::GetAttribute::new(self.inner.clone())
     }
@@ -489,6 +880,22 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.Attribute.description]: crate::model::Attribute::description
     /// [google.cloud.apihub.v1.Attribute.display_name]: crate::model::Attribute::display_name
     /// [google.cloud.apihub.v1.UpdateAttributeRequest.update_mask]: crate::model::UpdateAttributeRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_attribute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_attribute(&self) -> super::builder::api_hub::UpdateAttribute {
         super::builder::api_hub::UpdateAttribute::new(self.inner.clone())
     }
@@ -498,6 +905,22 @@ impl ApiHub {
     /// Note: System defined attributes cannot be deleted. All
     /// associations of the attribute being deleted with any API hub resource will
     /// also get deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_attribute()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_attribute(&self) -> super::builder::api_hub::DeleteAttribute {
         super::builder::api_hub::DeleteAttribute::new(self.inner.clone())
     }
@@ -513,11 +936,44 @@ impl ApiHub {
     }
 
     /// Create an External API resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_external_api()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_external_api(&self) -> super::builder::api_hub::CreateExternalApi {
         super::builder::api_hub::CreateExternalApi::new(self.inner.clone())
     }
 
     /// Get details about an External API resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_external_api()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_external_api(&self) -> super::builder::api_hub::GetExternalApi {
         super::builder::api_hub::GetExternalApi::new(self.inner.clone())
     }
@@ -541,11 +997,43 @@ impl ApiHub {
     /// [google.cloud.apihub.v1.ExternalApi.endpoints]: crate::model::ExternalApi::endpoints
     /// [google.cloud.apihub.v1.ExternalApi.paths]: crate::model::ExternalApi::paths
     /// [google.cloud.apihub.v1.UpdateExternalApiRequest.update_mask]: crate::model::UpdateExternalApiRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_external_api()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_external_api(&self) -> super::builder::api_hub::UpdateExternalApi {
         super::builder::api_hub::UpdateExternalApi::new(self.inner.clone())
     }
 
     /// Delete an External API resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_external_api()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_external_api(&self) -> super::builder::api_hub::DeleteExternalApi {
         super::builder::api_hub::DeleteExternalApi::new(self.inner.clone())
     }
@@ -561,6 +1049,22 @@ impl ApiHub {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub::GetLocation {
         super::builder::api_hub::GetLocation::new(self.inner.clone())
     }
@@ -575,6 +1079,22 @@ impl ApiHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub::GetOperation {
         super::builder::api_hub::GetOperation::new(self.inner.clone())
     }
@@ -582,6 +1102,21 @@ impl ApiHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub::DeleteOperation {
         super::builder::api_hub::DeleteOperation::new(self.inner.clone())
     }
@@ -589,6 +1124,21 @@ impl ApiHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHub;
+    /// async fn sample(
+    ///    client: &ApiHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub::CancelOperation {
         super::builder::api_hub::CancelOperation::new(self.inner.clone())
     }
@@ -703,11 +1253,44 @@ impl ApiHubDependencies {
     }
 
     /// Create a dependency between two entities in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_dependency()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_dependency(&self) -> super::builder::api_hub_dependencies::CreateDependency {
         super::builder::api_hub_dependencies::CreateDependency::new(self.inner.clone())
     }
 
     /// Get details about a dependency resource in the API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dependency()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dependency(&self) -> super::builder::api_hub_dependencies::GetDependency {
         super::builder::api_hub_dependencies::GetDependency::new(self.inner.clone())
     }
@@ -724,11 +1307,43 @@ impl ApiHubDependencies {
     /// [google.cloud.apihub.v1.Dependency]: crate::model::Dependency
     /// [google.cloud.apihub.v1.Dependency.description]: crate::model::Dependency::description
     /// [google.cloud.apihub.v1.UpdateDependencyRequest.update_mask]: crate::model::UpdateDependencyRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_dependency()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_dependency(&self) -> super::builder::api_hub_dependencies::UpdateDependency {
         super::builder::api_hub_dependencies::UpdateDependency::new(self.inner.clone())
     }
 
     /// Delete the dependency resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_dependency()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_dependency(&self) -> super::builder::api_hub_dependencies::DeleteDependency {
         super::builder::api_hub_dependencies::DeleteDependency::new(self.inner.clone())
     }
@@ -744,6 +1359,22 @@ impl ApiHubDependencies {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub_dependencies::GetLocation {
         super::builder::api_hub_dependencies::GetLocation::new(self.inner.clone())
     }
@@ -758,6 +1389,22 @@ impl ApiHubDependencies {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub_dependencies::GetOperation {
         super::builder::api_hub_dependencies::GetOperation::new(self.inner.clone())
     }
@@ -765,6 +1412,21 @@ impl ApiHubDependencies {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub_dependencies::DeleteOperation {
         super::builder::api_hub_dependencies::DeleteOperation::new(self.inner.clone())
     }
@@ -772,6 +1434,21 @@ impl ApiHubDependencies {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
+    /// async fn sample(
+    ///    client: &ApiHubDependencies
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub_dependencies::CancelOperation {
         super::builder::api_hub_dependencies::CancelOperation::new(self.inner.clone())
     }
@@ -902,6 +1579,22 @@ impl ApiHubCollect {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCollect;
+    /// async fn sample(
+    ///    client: &ApiHubCollect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub_collect::GetLocation {
         super::builder::api_hub_collect::GetLocation::new(self.inner.clone())
     }
@@ -916,6 +1609,22 @@ impl ApiHubCollect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCollect;
+    /// async fn sample(
+    ///    client: &ApiHubCollect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub_collect::GetOperation {
         super::builder::api_hub_collect::GetOperation::new(self.inner.clone())
     }
@@ -923,6 +1632,21 @@ impl ApiHubCollect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCollect;
+    /// async fn sample(
+    ///    client: &ApiHubCollect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub_collect::DeleteOperation {
         super::builder::api_hub_collect::DeleteOperation::new(self.inner.clone())
     }
@@ -930,6 +1654,21 @@ impl ApiHubCollect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCollect;
+    /// async fn sample(
+    ///    client: &ApiHubCollect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub_collect::CancelOperation {
         super::builder::api_hub_collect::CancelOperation::new(self.inner.clone())
     }
@@ -1040,11 +1779,44 @@ impl ApiHubCurate {
 
     /// Create a curation resource in the API hub.
     /// Once a curation resource is created, plugin instances can start using it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_curation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_curation(&self) -> super::builder::api_hub_curate::CreateCuration {
         super::builder::api_hub_curate::CreateCuration::new(self.inner.clone())
     }
 
     /// Get curation resource details.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_curation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_curation(&self) -> super::builder::api_hub_curate::GetCuration {
         super::builder::api_hub_curate::GetCuration::new(self.inner.clone())
     }
@@ -1068,12 +1840,44 @@ impl ApiHubCurate {
     /// [google.cloud.apihub.v1.Curation.description]: crate::model::Curation::description
     /// [google.cloud.apihub.v1.Curation.display_name]: crate::model::Curation::display_name
     /// [google.cloud.apihub.v1.UpdateApiRequest.update_mask]: crate::model::UpdateApiRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_curation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_curation(&self) -> super::builder::api_hub_curate::UpdateCuration {
         super::builder::api_hub_curate::UpdateCuration::new(self.inner.clone())
     }
 
     /// Delete a curation resource in the API hub. A curation can only be deleted
     /// if it's not being used by any plugin instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_curation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_curation(&self) -> super::builder::api_hub_curate::DeleteCuration {
         super::builder::api_hub_curate::DeleteCuration::new(self.inner.clone())
     }
@@ -1084,6 +1888,22 @@ impl ApiHubCurate {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub_curate::GetLocation {
         super::builder::api_hub_curate::GetLocation::new(self.inner.clone())
     }
@@ -1098,6 +1918,22 @@ impl ApiHubCurate {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub_curate::GetOperation {
         super::builder::api_hub_curate::GetOperation::new(self.inner.clone())
     }
@@ -1105,6 +1941,21 @@ impl ApiHubCurate {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub_curate::DeleteOperation {
         super::builder::api_hub_curate::DeleteOperation::new(self.inner.clone())
     }
@@ -1112,6 +1963,21 @@ impl ApiHubCurate {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubCurate;
+    /// async fn sample(
+    ///    client: &ApiHubCurate
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub_curate::CancelOperation {
         super::builder::api_hub_curate::CancelOperation::new(self.inner.clone())
     }
@@ -1232,6 +2098,23 @@ impl ApiHubDiscovery {
 
     /// Gets a DiscoveredAPIObservation in a given project, location and
     /// ApiObservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_discovered_api_observation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_discovered_api_observation(
         &self,
     ) -> super::builder::api_hub_discovery::GetDiscoveredApiObservation {
@@ -1248,6 +2131,23 @@ impl ApiHubDiscovery {
 
     /// Gets a DiscoveredAPIOperation in a given project, location,
     /// ApiObservation and ApiOperation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_discovered_api_operation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_discovered_api_operation(
         &self,
     ) -> super::builder::api_hub_discovery::GetDiscoveredApiOperation {
@@ -1260,6 +2160,22 @@ impl ApiHubDiscovery {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub_discovery::GetLocation {
         super::builder::api_hub_discovery::GetLocation::new(self.inner.clone())
     }
@@ -1274,6 +2190,22 @@ impl ApiHubDiscovery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub_discovery::GetOperation {
         super::builder::api_hub_discovery::GetOperation::new(self.inner.clone())
     }
@@ -1281,6 +2213,21 @@ impl ApiHubDiscovery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub_discovery::DeleteOperation {
         super::builder::api_hub_discovery::DeleteOperation::new(self.inner.clone())
     }
@@ -1288,6 +2235,21 @@ impl ApiHubDiscovery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
+    /// async fn sample(
+    ///    client: &ApiHubDiscovery
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub_discovery::CancelOperation {
         super::builder::api_hub_discovery::CancelOperation::new(self.inner.clone())
     }
@@ -1404,6 +2366,22 @@ impl HostProjectRegistrationService {
     /// attached as a runtime project to another host project.
     /// A project can be registered as a host project only once. Subsequent
     /// register calls for the same project will fail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_host_project_registration()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_host_project_registration(
         &self,
     ) -> super::builder::host_project_registration_service::CreateHostProjectRegistration {
@@ -1413,6 +2391,23 @@ impl HostProjectRegistrationService {
     }
 
     /// Get a host project registration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_host_project_registration()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_host_project_registration(
         &self,
     ) -> super::builder::host_project_registration_service::GetHostProjectRegistration {
@@ -1438,6 +2433,22 @@ impl HostProjectRegistrationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::host_project_registration_service::GetLocation {
         super::builder::host_project_registration_service::GetLocation::new(self.inner.clone())
     }
@@ -1454,6 +2465,22 @@ impl HostProjectRegistrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::host_project_registration_service::GetOperation {
         super::builder::host_project_registration_service::GetOperation::new(self.inner.clone())
     }
@@ -1461,6 +2488,21 @@ impl HostProjectRegistrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::host_project_registration_service::DeleteOperation {
@@ -1470,6 +2512,21 @@ impl HostProjectRegistrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
+    /// async fn sample(
+    ///    client: &HostProjectRegistrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::host_project_registration_service::CancelOperation {
@@ -1580,16 +2637,65 @@ impl LintingService {
     }
 
     /// Get the style guide being used for linting.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_style_guide()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_style_guide(&self) -> super::builder::linting_service::GetStyleGuide {
         super::builder::linting_service::GetStyleGuide::new(self.inner.clone())
     }
 
     /// Update the styleGuide to be used for liniting in by API hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_style_guide()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_style_guide(&self) -> super::builder::linting_service::UpdateStyleGuide {
         super::builder::linting_service::UpdateStyleGuide::new(self.inner.clone())
     }
 
     /// Get the contents of the style guide.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_style_guide_contents()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_style_guide_contents(
         &self,
     ) -> super::builder::linting_service::GetStyleGuideContents {
@@ -1599,6 +2705,21 @@ impl LintingService {
     /// Lints the requested spec and updates the corresponding API Spec with the
     /// lint response. This lint response will be available in all subsequent
     /// Get and List Spec calls to Core service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .lint_spec()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lint_spec(&self) -> super::builder::linting_service::LintSpec {
         super::builder::linting_service::LintSpec::new(self.inner.clone())
     }
@@ -1609,6 +2730,22 @@ impl LintingService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::linting_service::GetLocation {
         super::builder::linting_service::GetLocation::new(self.inner.clone())
     }
@@ -1623,6 +2760,22 @@ impl LintingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::linting_service::GetOperation {
         super::builder::linting_service::GetOperation::new(self.inner.clone())
     }
@@ -1630,6 +2783,21 @@ impl LintingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::linting_service::DeleteOperation {
         super::builder::linting_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1637,6 +2805,21 @@ impl LintingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::LintingService;
+    /// async fn sample(
+    ///    client: &LintingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::linting_service::CancelOperation {
         super::builder::linting_service::CancelOperation::new(self.inner.clone())
     }
@@ -1745,24 +2928,89 @@ impl ApiHubPlugin {
     }
 
     /// Get an API Hub plugin.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_plugin()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_plugin(&self) -> super::builder::api_hub_plugin::GetPlugin {
         super::builder::api_hub_plugin::GetPlugin::new(self.inner.clone())
     }
 
     /// Enables a plugin.
     /// The `state` of the plugin after enabling is `ENABLED`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .enable_plugin()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_plugin(&self) -> super::builder::api_hub_plugin::EnablePlugin {
         super::builder::api_hub_plugin::EnablePlugin::new(self.inner.clone())
     }
 
     /// Disables a plugin.
     /// The `state` of the plugin after disabling is `DISABLED`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_plugin()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_plugin(&self) -> super::builder::api_hub_plugin::DisablePlugin {
         super::builder::api_hub_plugin::DisablePlugin::new(self.inner.clone())
     }
 
     /// Create an API Hub plugin resource in the API hub.
     /// Once a plugin is created, it can be used to create plugin instances.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_plugin()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_plugin(&self) -> super::builder::api_hub_plugin::CreatePlugin {
         super::builder::api_hub_plugin::CreatePlugin::new(self.inner.clone())
     }
@@ -1821,6 +3069,23 @@ impl ApiHubPlugin {
     }
 
     /// Get an API Hub plugin instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_plugin_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_plugin_instance(&self) -> super::builder::api_hub_plugin::GetPluginInstance {
         super::builder::api_hub_plugin::GetPluginInstance::new(self.inner.clone())
     }
@@ -1889,6 +3154,22 @@ impl ApiHubPlugin {
     /// [google.cloud.apihub.v1.PluginInstance.auth_config]: crate::model::PluginInstance::auth_config
     /// [google.cloud.apihub.v1.PluginInstance.display_name]: crate::model::PluginInstance::display_name
     /// [google.cloud.apihub.v1.UpdatePluginInstanceRequest.update_mask]: crate::model::UpdatePluginInstanceRequest::update_mask
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_plugin_instance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_plugin_instance(&self) -> super::builder::api_hub_plugin::UpdatePluginInstance {
         super::builder::api_hub_plugin::UpdatePluginInstance::new(self.inner.clone())
     }
@@ -1914,6 +3195,22 @@ impl ApiHubPlugin {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::api_hub_plugin::GetLocation {
         super::builder::api_hub_plugin::GetLocation::new(self.inner.clone())
     }
@@ -1928,6 +3225,22 @@ impl ApiHubPlugin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::api_hub_plugin::GetOperation {
         super::builder::api_hub_plugin::GetOperation::new(self.inner.clone())
     }
@@ -1935,6 +3248,21 @@ impl ApiHubPlugin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::api_hub_plugin::DeleteOperation {
         super::builder::api_hub_plugin::DeleteOperation::new(self.inner.clone())
     }
@@ -1942,6 +3270,21 @@ impl ApiHubPlugin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
+    /// async fn sample(
+    ///    client: &ApiHubPlugin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::api_hub_plugin::CancelOperation {
         super::builder::api_hub_plugin::CancelOperation::new(self.inner.clone())
     }
@@ -2080,12 +3423,45 @@ impl Provisioning {
     }
 
     /// Gets details of a single API Hub instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_api_hub_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_api_hub_instance(&self) -> super::builder::provisioning::GetApiHubInstance {
         super::builder::provisioning::GetApiHubInstance::new(self.inner.clone())
     }
 
     /// Looks up an Api Hub instance in a given GCP project. There will always be
     /// only one Api Hub instance for a GCP project across all locations.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_api_hub_instance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_api_hub_instance(&self) -> super::builder::provisioning::LookupApiHubInstance {
         super::builder::provisioning::LookupApiHubInstance::new(self.inner.clone())
     }
@@ -2096,6 +3472,22 @@ impl Provisioning {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::provisioning::GetLocation {
         super::builder::provisioning::GetLocation::new(self.inner.clone())
     }
@@ -2110,6 +3502,22 @@ impl Provisioning {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::provisioning::GetOperation {
         super::builder::provisioning::GetOperation::new(self.inner.clone())
     }
@@ -2117,6 +3525,21 @@ impl Provisioning {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::provisioning::DeleteOperation {
         super::builder::provisioning::DeleteOperation::new(self.inner.clone())
     }
@@ -2124,6 +3547,21 @@ impl Provisioning {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::Provisioning;
+    /// async fn sample(
+    ///    client: &Provisioning
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::provisioning::CancelOperation {
         super::builder::provisioning::CancelOperation::new(self.inner.clone())
     }
@@ -2236,6 +3674,22 @@ impl RuntimeProjectAttachmentService {
     }
 
     /// Attaches a runtime project to the host project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_runtime_project_attachment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_runtime_project_attachment(
         &self,
     ) -> super::builder::runtime_project_attachment_service::CreateRuntimeProjectAttachment {
@@ -2245,6 +3699,23 @@ impl RuntimeProjectAttachmentService {
     }
 
     /// Gets a runtime project attachment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_runtime_project_attachment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_runtime_project_attachment(
         &self,
     ) -> super::builder::runtime_project_attachment_service::GetRuntimeProjectAttachment {
@@ -2264,6 +3735,22 @@ impl RuntimeProjectAttachmentService {
 
     /// Delete a runtime project attachment in the API Hub. This call will detach
     /// the runtime project from the host project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_runtime_project_attachment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_runtime_project_attachment(
         &self,
     ) -> super::builder::runtime_project_attachment_service::DeleteRuntimeProjectAttachment {
@@ -2274,6 +3761,22 @@ impl RuntimeProjectAttachmentService {
 
     /// Look up a runtime project attachment. This API can be called in the context
     /// of any project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_runtime_project_attachment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_runtime_project_attachment(
         &self,
     ) -> super::builder::runtime_project_attachment_service::LookupRuntimeProjectAttachment {
@@ -2290,6 +3793,22 @@ impl RuntimeProjectAttachmentService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::runtime_project_attachment_service::GetLocation {
         super::builder::runtime_project_attachment_service::GetLocation::new(self.inner.clone())
     }
@@ -2306,6 +3825,22 @@ impl RuntimeProjectAttachmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::runtime_project_attachment_service::GetOperation {
@@ -2315,6 +3850,21 @@ impl RuntimeProjectAttachmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::runtime_project_attachment_service::DeleteOperation {
@@ -2324,6 +3874,21 @@ impl RuntimeProjectAttachmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
+    /// async fn sample(
+    ///    client: &RuntimeProjectAttachmentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::runtime_project_attachment_service::CancelOperation {

--- a/src/generated/cloud/apphub/v1/src/client.rs
+++ b/src/generated/cloud/apphub/v1/src/client.rs
@@ -120,6 +120,22 @@ impl AppHub {
 
     /// Lists a service project attachment for a given service project. You can
     /// call this API from any project to find if it is attached to a host project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_service_project_attachment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_service_project_attachment(
         &self,
     ) -> super::builder::app_hub::LookupServiceProjectAttachment {
@@ -151,6 +167,23 @@ impl AppHub {
     }
 
     /// Gets a service project attachment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_project_attachment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_project_attachment(
         &self,
     ) -> super::builder::app_hub::GetServiceProjectAttachment {
@@ -177,6 +210,22 @@ impl AppHub {
     /// Detaches a service project from a host project.
     /// You can call this API from any service project without needing access to
     /// the host project that it is attached to.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .detach_service_project_attachment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn detach_service_project_attachment(
         &self,
     ) -> super::builder::app_hub::DetachServiceProjectAttachment {
@@ -190,12 +239,45 @@ impl AppHub {
     }
 
     /// Gets a Discovered Service in a host project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_discovered_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_discovered_service(&self) -> super::builder::app_hub::GetDiscoveredService {
         super::builder::app_hub::GetDiscoveredService::new(self.inner.clone())
     }
 
     /// Lists a Discovered Service in a host project and location, with a
     /// given resource URI.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_discovered_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_discovered_service(&self) -> super::builder::app_hub::LookupDiscoveredService {
         super::builder::app_hub::LookupDiscoveredService::new(self.inner.clone())
     }
@@ -221,6 +303,23 @@ impl AppHub {
     }
 
     /// Gets a Service in an Application.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::app_hub::GetService {
         super::builder::app_hub::GetService::new(self.inner.clone())
     }
@@ -262,12 +361,45 @@ impl AppHub {
     }
 
     /// Gets a Discovered Workload in a host project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_discovered_workload()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_discovered_workload(&self) -> super::builder::app_hub::GetDiscoveredWorkload {
         super::builder::app_hub::GetDiscoveredWorkload::new(self.inner.clone())
     }
 
     /// Lists a Discovered Workload in a host project and location, with a
     /// given resource URI.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_discovered_workload()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_discovered_workload(&self) -> super::builder::app_hub::LookupDiscoveredWorkload {
         super::builder::app_hub::LookupDiscoveredWorkload::new(self.inner.clone())
     }
@@ -293,6 +425,23 @@ impl AppHub {
     }
 
     /// Gets a Workload in an Application.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workload()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workload(&self) -> super::builder::app_hub::GetWorkload {
         super::builder::app_hub::GetWorkload::new(self.inner.clone())
     }
@@ -348,6 +497,23 @@ impl AppHub {
     }
 
     /// Gets an Application in a host project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_application()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_application(&self) -> super::builder::app_hub::GetApplication {
         super::builder::app_hub::GetApplication::new(self.inner.clone())
     }
@@ -388,6 +554,22 @@ impl AppHub {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::app_hub::GetLocation {
         super::builder::app_hub::GetLocation::new(self.inner.clone())
     }
@@ -397,12 +579,44 @@ impl AppHub {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::app_hub::SetIamPolicy {
         super::builder::app_hub::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::app_hub::GetIamPolicy {
         super::builder::app_hub::GetIamPolicy::new(self.inner.clone())
     }
@@ -414,6 +628,22 @@ impl AppHub {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::app_hub::TestIamPermissions {
         super::builder::app_hub::TestIamPermissions::new(self.inner.clone())
     }
@@ -428,6 +658,22 @@ impl AppHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::app_hub::GetOperation {
         super::builder::app_hub::GetOperation::new(self.inner.clone())
     }
@@ -435,6 +681,21 @@ impl AppHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::app_hub::DeleteOperation {
         super::builder::app_hub::DeleteOperation::new(self.inner.clone())
     }
@@ -442,6 +703,21 @@ impl AppHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_apphub_v1::client::AppHub;
+    /// async fn sample(
+    ///    client: &AppHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::app_hub::CancelOperation {
         super::builder::app_hub::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/asset/v1/src/client.rs
+++ b/src/generated/cloud/asset/v1/src/client.rs
@@ -159,32 +159,128 @@ impl AssetService {
     /// deleted status.
     /// If a specified asset does not exist, this API returns an INVALID_ARGUMENT
     /// error.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_get_assets_history()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_get_assets_history(&self) -> super::builder::asset_service::BatchGetAssetsHistory {
         super::builder::asset_service::BatchGetAssetsHistory::new(self.inner.clone())
     }
 
     /// Creates a feed in a parent project/folder/organization to listen to its
     /// asset updates.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_feed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_feed(&self) -> super::builder::asset_service::CreateFeed {
         super::builder::asset_service::CreateFeed::new(self.inner.clone())
     }
 
     /// Gets details about an asset feed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feed()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feed(&self) -> super::builder::asset_service::GetFeed {
         super::builder::asset_service::GetFeed::new(self.inner.clone())
     }
 
     /// Lists all asset feeds in a parent project/folder/organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_feeds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_feeds(&self) -> super::builder::asset_service::ListFeeds {
         super::builder::asset_service::ListFeeds::new(self.inner.clone())
     }
 
     /// Updates an asset feed configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_feed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_feed(&self) -> super::builder::asset_service::UpdateFeed {
         super::builder::asset_service::UpdateFeed::new(self.inner.clone())
     }
 
     /// Deletes an asset feed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_feed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_feed(&self) -> super::builder::asset_service::DeleteFeed {
         super::builder::asset_service::DeleteFeed::new(self.inner.clone())
     }
@@ -207,6 +303,22 @@ impl AssetService {
 
     /// Analyzes IAM policies to answer which identities have what accesses on
     /// which resources.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .analyze_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn analyze_iam_policy(&self) -> super::builder::asset_service::AnalyzeIamPolicy {
         super::builder::asset_service::AnalyzeIamPolicy::new(self.inner.clone())
     }
@@ -245,6 +357,22 @@ impl AssetService {
     /// permissions of viewing different hierarchical policies and configurations.
     /// The policies and configuration are subject to change before the actual
     /// resource migration takes place.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .analyze_move()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn analyze_move(&self) -> super::builder::asset_service::AnalyzeMove {
         super::builder::asset_service::AnalyzeMove::new(self.inner.clone())
     }
@@ -261,16 +389,65 @@ impl AssetService {
     /// Note, the query result has approximately 10 GB limitation enforced by
     /// [BigQuery](https://cloud.google.com/bigquery/docs/best-practices-performance-output).
     /// Queries return larger results will result in errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_assets()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_assets(&self) -> super::builder::asset_service::QueryAssets {
         super::builder::asset_service::QueryAssets::new(self.inner.clone())
     }
 
     /// Creates a saved query in a parent project/folder/organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_saved_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_saved_query(&self) -> super::builder::asset_service::CreateSavedQuery {
         super::builder::asset_service::CreateSavedQuery::new(self.inner.clone())
     }
 
     /// Gets details about a saved query.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_saved_query()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_saved_query(&self) -> super::builder::asset_service::GetSavedQuery {
         super::builder::asset_service::GetSavedQuery::new(self.inner.clone())
     }
@@ -281,16 +458,63 @@ impl AssetService {
     }
 
     /// Updates a saved query.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_saved_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_saved_query(&self) -> super::builder::asset_service::UpdateSavedQuery {
         super::builder::asset_service::UpdateSavedQuery::new(self.inner.clone())
     }
 
     /// Deletes a saved query.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_saved_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_saved_query(&self) -> super::builder::asset_service::DeleteSavedQuery {
         super::builder::asset_service::DeleteSavedQuery::new(self.inner.clone())
     }
 
     /// Gets effective IAM policies for a batch of resources.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_get_effective_iam_policies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_get_effective_iam_policies(
         &self,
     ) -> super::builder::asset_service::BatchGetEffectiveIamPolicies {
@@ -368,6 +592,22 @@ impl AssetService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_asset_v1::client::AssetService;
+    /// async fn sample(
+    ///    client: &AssetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::asset_service::GetOperation {
         super::builder::asset_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/assuredworkloads/v1/src/client.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/client.rs
@@ -141,6 +141,22 @@ impl AssuredWorkloadsService {
     /// Currently allows updating of workload display_name and labels.
     /// For force updates don't set etag field in the Workload.
     /// Only one update operation per workload can be in progress.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// async fn sample(
+    ///    client: &AssuredWorkloadsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_workload()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_workload(&self) -> super::builder::assured_workloads_service::UpdateWorkload {
         super::builder::assured_workloads_service::UpdateWorkload::new(self.inner.clone())
     }
@@ -151,6 +167,22 @@ impl AssuredWorkloadsService {
     /// In addition to assuredworkloads.workload.update permission, the user should
     /// also have orgpolicy.policy.set permission on the folder resource
     /// to use this functionality.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// async fn sample(
+    ///    client: &AssuredWorkloadsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restrict_allowed_resources()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restrict_allowed_resources(
         &self,
     ) -> super::builder::assured_workloads_service::RestrictAllowedResources {
@@ -160,11 +192,43 @@ impl AssuredWorkloadsService {
     /// Deletes the workload. Make sure that workload's direct children are already
     /// in a deleted state, otherwise the request will fail with a
     /// FAILED_PRECONDITION error.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// async fn sample(
+    ///    client: &AssuredWorkloadsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_workload()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_workload(&self) -> super::builder::assured_workloads_service::DeleteWorkload {
         super::builder::assured_workloads_service::DeleteWorkload::new(self.inner.clone())
     }
 
     /// Gets Assured Workload associated with a CRM Node
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// async fn sample(
+    ///    client: &AssuredWorkloadsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workload()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workload(&self) -> super::builder::assured_workloads_service::GetWorkload {
         super::builder::assured_workloads_service::GetWorkload::new(self.inner.clone())
     }
@@ -184,6 +248,22 @@ impl AssuredWorkloadsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+    /// async fn sample(
+    ///    client: &AssuredWorkloadsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::assured_workloads_service::GetOperation {
         super::builder::assured_workloads_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/backupdr/v1/src/client.rs
+++ b/src/generated/cloud/backupdr/v1/src/client.rs
@@ -124,6 +124,23 @@ impl BackupDR {
     }
 
     /// Gets details of a single ManagementServer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_management_server()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_management_server(&self) -> super::builder::backup_dr::GetManagementServer {
         super::builder::backup_dr::GetManagementServer::new(self.inner.clone())
     }
@@ -186,6 +203,23 @@ impl BackupDR {
     }
 
     /// Gets details of a BackupVault.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_vault()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_vault(&self) -> super::builder::backup_dr::GetBackupVault {
         super::builder::backup_dr::GetBackupVault::new(self.inner.clone())
     }
@@ -226,6 +260,23 @@ impl BackupDR {
     }
 
     /// Gets details of a DataSource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_source(&self) -> super::builder::backup_dr::GetDataSource {
         super::builder::backup_dr::GetDataSource::new(self.inner.clone())
     }
@@ -258,6 +309,23 @@ impl BackupDR {
     }
 
     /// Gets details of a Backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::backup_dr::GetBackup {
         super::builder::backup_dr::GetBackup::new(self.inner.clone())
     }
@@ -338,6 +406,23 @@ impl BackupDR {
     }
 
     /// Gets details of a single BackupPlan.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_plan()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_plan(&self) -> super::builder::backup_dr::GetBackupPlan {
         super::builder::backup_dr::GetBackupPlan::new(self.inner.clone())
     }
@@ -363,6 +448,23 @@ impl BackupDR {
     }
 
     /// Gets details of a single BackupPlanRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_plan_revision()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_plan_revision(&self) -> super::builder::backup_dr::GetBackupPlanRevision {
         super::builder::backup_dr::GetBackupPlanRevision::new(self.inner.clone())
     }
@@ -407,6 +509,23 @@ impl BackupDR {
     }
 
     /// Gets details of a single BackupPlanAssociation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_plan_association()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_plan_association(
         &self,
     ) -> super::builder::backup_dr::GetBackupPlanAssociation {
@@ -462,6 +581,23 @@ impl BackupDR {
     }
 
     /// Gets details of a single DataSourceReference.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_source_reference()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_source_reference(&self) -> super::builder::backup_dr::GetDataSourceReference {
         super::builder::backup_dr::GetDataSourceReference::new(self.inner.clone())
     }
@@ -501,6 +637,22 @@ impl BackupDR {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::backup_dr::GetLocation {
         super::builder::backup_dr::GetLocation::new(self.inner.clone())
     }
@@ -510,12 +662,44 @@ impl BackupDR {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::backup_dr::SetIamPolicy {
         super::builder::backup_dr::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::backup_dr::GetIamPolicy {
         super::builder::backup_dr::GetIamPolicy::new(self.inner.clone())
     }
@@ -527,6 +711,22 @@ impl BackupDR {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::backup_dr::TestIamPermissions {
         super::builder::backup_dr::TestIamPermissions::new(self.inner.clone())
     }
@@ -541,6 +741,22 @@ impl BackupDR {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::backup_dr::GetOperation {
         super::builder::backup_dr::GetOperation::new(self.inner.clone())
     }
@@ -548,6 +764,21 @@ impl BackupDR {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::backup_dr::DeleteOperation {
         super::builder::backup_dr::DeleteOperation::new(self.inner.clone())
     }
@@ -555,6 +786,21 @@ impl BackupDR {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_backupdr_v1::client::BackupDR;
+    /// async fn sample(
+    ///    client: &BackupDR
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::backup_dr::CancelOperation {
         super::builder::backup_dr::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/baremetalsolution/v2/src/client.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/client.rs
@@ -134,6 +134,23 @@ impl BareMetalSolution {
     }
 
     /// Get details about a single server.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::bare_metal_solution::GetInstance {
         super::builder::bare_metal_solution::GetInstance::new(self.inner.clone())
     }
@@ -155,6 +172,22 @@ impl BareMetalSolution {
 
     /// RenameInstance sets a new name for an instance.
     /// Use with caution, previous names become immediately invalidated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_instance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rename_instance(&self) -> super::builder::bare_metal_solution::RenameInstance {
         super::builder::bare_metal_solution::RenameInstance::new(self.inner.clone())
     }
@@ -264,11 +297,42 @@ impl BareMetalSolution {
 
     /// Register a public SSH key in the specified project for use with the
     /// interactive serial console feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_ssh_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_ssh_key(&self) -> super::builder::bare_metal_solution::CreateSSHKey {
         super::builder::bare_metal_solution::CreateSSHKey::new(self.inner.clone())
     }
 
     /// Deletes a public SSH key registered in the specified project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_ssh_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_ssh_key(&self) -> super::builder::bare_metal_solution::DeleteSSHKey {
         super::builder::bare_metal_solution::DeleteSSHKey::new(self.inner.clone())
     }
@@ -279,6 +343,23 @@ impl BareMetalSolution {
     }
 
     /// Get details of a single storage volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_volume()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_volume(&self) -> super::builder::bare_metal_solution::GetVolume {
         super::builder::bare_metal_solution::GetVolume::new(self.inner.clone())
     }
@@ -300,6 +381,22 @@ impl BareMetalSolution {
 
     /// RenameVolume sets a new name for a volume.
     /// Use with caution, previous names become immediately invalidated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_volume()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rename_volume(&self) -> super::builder::bare_metal_solution::RenameVolume {
         super::builder::bare_metal_solution::RenameVolume::new(self.inner.clone())
     }
@@ -342,11 +439,44 @@ impl BareMetalSolution {
 
     /// List all Networks (and used IPs for each Network) in the vendor account
     /// associated with the specified project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_network_usage()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_network_usage(&self) -> super::builder::bare_metal_solution::ListNetworkUsage {
         super::builder::bare_metal_solution::ListNetworkUsage::new(self.inner.clone())
     }
 
     /// Get details of a single network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_network()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_network(&self) -> super::builder::bare_metal_solution::GetNetwork {
         super::builder::bare_metal_solution::GetNetwork::new(self.inner.clone())
     }
@@ -368,6 +498,22 @@ impl BareMetalSolution {
 
     /// Takes a snapshot of a boot volume.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_volume_snapshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_volume_snapshot(
         &self,
     ) -> super::builder::bare_metal_solution::CreateVolumeSnapshot {
@@ -394,6 +540,21 @@ impl BareMetalSolution {
 
     /// Deletes a volume snapshot.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_volume_snapshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_volume_snapshot(
         &self,
     ) -> super::builder::bare_metal_solution::DeleteVolumeSnapshot {
@@ -402,6 +563,23 @@ impl BareMetalSolution {
 
     /// Returns the specified snapshot resource.
     /// Returns INVALID_ARGUMENT if called for a non-boot volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_volume_snapshot()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_volume_snapshot(&self) -> super::builder::bare_metal_solution::GetVolumeSnapshot {
         super::builder::bare_metal_solution::GetVolumeSnapshot::new(self.inner.clone())
     }
@@ -416,6 +594,23 @@ impl BareMetalSolution {
     }
 
     /// Get details of a single storage logical unit number(LUN).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lun()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lun(&self) -> super::builder::bare_metal_solution::GetLun {
         super::builder::bare_metal_solution::GetLun::new(self.inner.clone())
     }
@@ -442,6 +637,23 @@ impl BareMetalSolution {
     }
 
     /// Get details of a single NFS share.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_nfs_share()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_nfs_share(&self) -> super::builder::bare_metal_solution::GetNfsShare {
         super::builder::bare_metal_solution::GetNfsShare::new(self.inner.clone())
     }
@@ -483,6 +695,22 @@ impl BareMetalSolution {
 
     /// RenameNfsShare sets a new name for an nfsshare.
     /// Use with caution, previous names become immediately invalidated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_nfs_share()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rename_nfs_share(&self) -> super::builder::bare_metal_solution::RenameNfsShare {
         super::builder::bare_metal_solution::RenameNfsShare::new(self.inner.clone())
     }
@@ -510,6 +738,22 @@ impl BareMetalSolution {
     }
 
     /// Submit a provisiong configuration for a given project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .submit_provisioning_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn submit_provisioning_config(
         &self,
     ) -> super::builder::bare_metal_solution::SubmitProvisioningConfig {
@@ -517,6 +761,23 @@ impl BareMetalSolution {
     }
 
     /// Get ProvisioningConfig by name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_provisioning_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_provisioning_config(
         &self,
     ) -> super::builder::bare_metal_solution::GetProvisioningConfig {
@@ -524,6 +785,22 @@ impl BareMetalSolution {
     }
 
     /// Create new ProvisioningConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_provisioning_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_provisioning_config(
         &self,
     ) -> super::builder::bare_metal_solution::CreateProvisioningConfig {
@@ -531,6 +808,22 @@ impl BareMetalSolution {
     }
 
     /// Update existing ProvisioningConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_provisioning_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_provisioning_config(
         &self,
     ) -> super::builder::bare_metal_solution::UpdateProvisioningConfig {
@@ -539,6 +832,22 @@ impl BareMetalSolution {
 
     /// RenameNetwork sets a new name for a network.
     /// Use with caution, previous names become immediately invalidated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_network()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rename_network(&self) -> super::builder::bare_metal_solution::RenameNetwork {
         super::builder::bare_metal_solution::RenameNetwork::new(self.inner.clone())
     }
@@ -554,6 +863,22 @@ impl BareMetalSolution {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::bare_metal_solution::GetLocation {
         super::builder::bare_metal_solution::GetLocation::new(self.inner.clone())
     }
@@ -561,6 +886,22 @@ impl BareMetalSolution {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+    /// async fn sample(
+    ///    client: &BareMetalSolution
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::bare_metal_solution::GetOperation {
         super::builder::bare_metal_solution::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
@@ -142,6 +142,23 @@ impl AppConnectionsService {
     }
 
     /// Gets details of a single AppConnection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_app_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_app_connection(&self) -> super::builder::app_connections_service::GetAppConnection {
         super::builder::app_connections_service::GetAppConnection::new(self.inner.clone())
     }
@@ -212,6 +229,22 @@ impl AppConnectionsService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::app_connections_service::GetLocation {
         super::builder::app_connections_service::GetLocation::new(self.inner.clone())
     }
@@ -221,12 +254,44 @@ impl AppConnectionsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::app_connections_service::SetIamPolicy {
         super::builder::app_connections_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::app_connections_service::GetIamPolicy {
         super::builder::app_connections_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -238,6 +303,22 @@ impl AppConnectionsService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::app_connections_service::TestIamPermissions {
@@ -254,6 +335,22 @@ impl AppConnectionsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::app_connections_service::GetOperation {
         super::builder::app_connections_service::GetOperation::new(self.inner.clone())
     }
@@ -261,6 +358,21 @@ impl AppConnectionsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::app_connections_service::DeleteOperation {
         super::builder::app_connections_service::DeleteOperation::new(self.inner.clone())
     }
@@ -268,6 +380,21 @@ impl AppConnectionsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+    /// async fn sample(
+    ///    client: &AppConnectionsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::app_connections_service::CancelOperation {
         super::builder::app_connections_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
@@ -140,6 +140,23 @@ impl AppConnectorsService {
     }
 
     /// Gets details of a single AppConnector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_app_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_app_connector(&self) -> super::builder::app_connectors_service::GetAppConnector {
         super::builder::app_connectors_service::GetAppConnector::new(self.inner.clone())
     }
@@ -216,6 +233,22 @@ impl AppConnectorsService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::app_connectors_service::GetLocation {
         super::builder::app_connectors_service::GetLocation::new(self.inner.clone())
     }
@@ -225,12 +258,44 @@ impl AppConnectorsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::app_connectors_service::SetIamPolicy {
         super::builder::app_connectors_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::app_connectors_service::GetIamPolicy {
         super::builder::app_connectors_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -242,6 +307,22 @@ impl AppConnectorsService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::app_connectors_service::TestIamPermissions {
@@ -258,6 +339,22 @@ impl AppConnectorsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::app_connectors_service::GetOperation {
         super::builder::app_connectors_service::GetOperation::new(self.inner.clone())
     }
@@ -265,6 +362,21 @@ impl AppConnectorsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::app_connectors_service::DeleteOperation {
         super::builder::app_connectors_service::DeleteOperation::new(self.inner.clone())
     }
@@ -272,6 +384,21 @@ impl AppConnectorsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+    /// async fn sample(
+    ///    client: &AppConnectorsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::app_connectors_service::CancelOperation {
         super::builder::app_connectors_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
@@ -140,6 +140,23 @@ impl AppGatewaysService {
     }
 
     /// Gets details of a single AppGateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_app_gateway()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_app_gateway(&self) -> super::builder::app_gateways_service::GetAppGateway {
         super::builder::app_gateways_service::GetAppGateway::new(self.inner.clone())
     }
@@ -180,6 +197,22 @@ impl AppGatewaysService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::app_gateways_service::GetLocation {
         super::builder::app_gateways_service::GetLocation::new(self.inner.clone())
     }
@@ -189,12 +222,44 @@ impl AppGatewaysService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::app_gateways_service::SetIamPolicy {
         super::builder::app_gateways_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::app_gateways_service::GetIamPolicy {
         super::builder::app_gateways_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -206,6 +271,22 @@ impl AppGatewaysService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::app_gateways_service::TestIamPermissions {
         super::builder::app_gateways_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -220,6 +301,22 @@ impl AppGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::app_gateways_service::GetOperation {
         super::builder::app_gateways_service::GetOperation::new(self.inner.clone())
     }
@@ -227,6 +324,21 @@ impl AppGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::app_gateways_service::DeleteOperation {
         super::builder::app_gateways_service::DeleteOperation::new(self.inner.clone())
     }
@@ -234,6 +346,21 @@ impl AppGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+    /// async fn sample(
+    ///    client: &AppGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::app_gateways_service::CancelOperation {
         super::builder::app_gateways_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
@@ -142,6 +142,23 @@ impl ClientConnectorServicesService {
     }
 
     /// Gets details of a single ClientConnectorService.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_client_connector_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_client_connector_service(
         &self,
     ) -> super::builder::client_connector_services_service::GetClientConnectorService {
@@ -215,6 +232,22 @@ impl ClientConnectorServicesService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::client_connector_services_service::GetLocation {
         super::builder::client_connector_services_service::GetLocation::new(self.inner.clone())
     }
@@ -224,6 +257,22 @@ impl ClientConnectorServicesService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::client_connector_services_service::SetIamPolicy {
@@ -232,6 +281,22 @@ impl ClientConnectorServicesService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::client_connector_services_service::GetIamPolicy {
@@ -245,6 +310,22 @@ impl ClientConnectorServicesService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::client_connector_services_service::TestIamPermissions {
@@ -265,6 +346,22 @@ impl ClientConnectorServicesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::client_connector_services_service::GetOperation {
         super::builder::client_connector_services_service::GetOperation::new(self.inner.clone())
     }
@@ -272,6 +369,21 @@ impl ClientConnectorServicesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::client_connector_services_service::DeleteOperation {
@@ -281,6 +393,21 @@ impl ClientConnectorServicesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+    /// async fn sample(
+    ///    client: &ClientConnectorServicesService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::client_connector_services_service::CancelOperation {

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
@@ -139,6 +139,23 @@ impl ClientGatewaysService {
     }
 
     /// Gets details of a single ClientGateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_client_gateway()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_client_gateway(&self) -> super::builder::client_gateways_service::GetClientGateway {
         super::builder::client_gateways_service::GetClientGateway::new(self.inner.clone())
     }
@@ -183,6 +200,22 @@ impl ClientGatewaysService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::client_gateways_service::GetLocation {
         super::builder::client_gateways_service::GetLocation::new(self.inner.clone())
     }
@@ -192,12 +225,44 @@ impl ClientGatewaysService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::client_gateways_service::SetIamPolicy {
         super::builder::client_gateways_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::client_gateways_service::GetIamPolicy {
         super::builder::client_gateways_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -209,6 +274,22 @@ impl ClientGatewaysService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::client_gateways_service::TestIamPermissions {
@@ -225,6 +306,22 @@ impl ClientGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::client_gateways_service::GetOperation {
         super::builder::client_gateways_service::GetOperation::new(self.inner.clone())
     }
@@ -232,6 +329,21 @@ impl ClientGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::client_gateways_service::DeleteOperation {
         super::builder::client_gateways_service::DeleteOperation::new(self.inner.clone())
     }
@@ -239,6 +351,21 @@ impl ClientGatewaysService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+    /// async fn sample(
+    ///    client: &ClientGatewaysService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::client_gateways_service::CancelOperation {
         super::builder::client_gateways_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/biglake/v1/src/client.rs
+++ b/src/generated/cloud/biglake/v1/src/client.rs
@@ -157,6 +157,22 @@ impl IcebergCatalogService {
     /// config allowlisting).
     ///
     /// This is not a GCP resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iceberg_catalog_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iceberg_catalog_config(
         &self,
     ) -> super::builder::iceberg_catalog_service::GetIcebergCatalogConfig {
@@ -165,6 +181,22 @@ impl IcebergCatalogService {
 
     /// Lists Iceberg namespaces in the catalog. We only support one level of
     /// nesting for namespaces.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_iceberg_namespaces()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_iceberg_namespaces(
         &self,
     ) -> super::builder::iceberg_catalog_service::ListIcebergNamespaces {
@@ -173,6 +205,22 @@ impl IcebergCatalogService {
 
     /// Gets an Iceberg namespace in the catalog (or checks if it exists, if the
     /// method is HEAD).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iceberg_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iceberg_namespace(
         &self,
     ) -> super::builder::iceberg_catalog_service::GetIcebergNamespace {
@@ -180,6 +228,22 @@ impl IcebergCatalogService {
     }
 
     /// Creates a namespace in the catalog.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_iceberg_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_iceberg_namespace(
         &self,
     ) -> super::builder::iceberg_catalog_service::CreateIcebergNamespace {
@@ -187,6 +251,21 @@ impl IcebergCatalogService {
     }
 
     /// Returns 204, not 200 on success.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_iceberg_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_iceberg_namespace(
         &self,
     ) -> super::builder::iceberg_catalog_service::DeleteIcebergNamespace {
@@ -194,6 +273,22 @@ impl IcebergCatalogService {
     }
 
     /// Updates namespace properties.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_iceberg_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_iceberg_namespace(
         &self,
     ) -> super::builder::iceberg_catalog_service::UpdateIcebergNamespace {
@@ -201,6 +296,22 @@ impl IcebergCatalogService {
     }
 
     /// Lists table identifiers (not *tables*) in the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_iceberg_table_identifiers()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_iceberg_table_identifiers(
         &self,
     ) -> super::builder::iceberg_catalog_service::ListIcebergTableIdentifiers {
@@ -210,6 +321,22 @@ impl IcebergCatalogService {
     }
 
     /// Creates a table in the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_iceberg_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_iceberg_table(
         &self,
     ) -> super::builder::iceberg_catalog_service::CreateIcebergTable {
@@ -217,6 +344,21 @@ impl IcebergCatalogService {
     }
 
     /// Deletes a table in the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_iceberg_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_iceberg_table(
         &self,
     ) -> super::builder::iceberg_catalog_service::DeleteIcebergTable {
@@ -224,11 +366,43 @@ impl IcebergCatalogService {
     }
 
     /// Gets a table in the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iceberg_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iceberg_table(&self) -> super::builder::iceberg_catalog_service::GetIcebergTable {
         super::builder::iceberg_catalog_service::GetIcebergTable::new(self.inner.clone())
     }
 
     /// Loads credentials for a table in the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .load_iceberg_table_credentials()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn load_iceberg_table_credentials(
         &self,
     ) -> super::builder::iceberg_catalog_service::LoadIcebergTableCredentials {
@@ -239,6 +413,22 @@ impl IcebergCatalogService {
 
     /// This is CommitTable Iceberg API, which maps to `UpdateIcebergTable` in the
     /// Google API nomenclature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_iceberg_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_iceberg_table(
         &self,
     ) -> super::builder::iceberg_catalog_service::UpdateIcebergTable {
@@ -246,6 +436,22 @@ impl IcebergCatalogService {
     }
 
     /// Register a table using given metadata file location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .register_iceberg_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn register_iceberg_table(
         &self,
     ) -> super::builder::iceberg_catalog_service::RegisterIcebergTable {
@@ -253,6 +459,22 @@ impl IcebergCatalogService {
     }
 
     /// Returns the Iceberg REST Catalog configuration options.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iceberg_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iceberg_catalog(
         &self,
     ) -> super::builder::iceberg_catalog_service::GetIcebergCatalog {
@@ -260,6 +482,22 @@ impl IcebergCatalogService {
     }
 
     /// Lists the Iceberg REST Catalogs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_iceberg_catalogs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_iceberg_catalogs(
         &self,
     ) -> super::builder::iceberg_catalog_service::ListIcebergCatalogs {
@@ -271,6 +509,21 @@ impl IcebergCatalogService {
     /// namespace.
     ///
     /// Delete is not supported for all catalog types.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_iceberg_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_iceberg_catalog(
         &self,
     ) -> super::builder::iceberg_catalog_service::DeleteIcebergCatalog {
@@ -278,6 +531,22 @@ impl IcebergCatalogService {
     }
 
     /// Update the Iceberg REST Catalog configuration options.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_iceberg_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_iceberg_catalog(
         &self,
     ) -> super::builder::iceberg_catalog_service::UpdateIcebergCatalog {
@@ -291,6 +560,22 @@ impl IcebergCatalogService {
     ///
     /// If the bucket does not exist, of the caller does not have bucket metadata
     /// permissions, the catalog will not be created.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_iceberg_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_iceberg_catalog(
         &self,
     ) -> super::builder::iceberg_catalog_service::CreateIcebergCatalog {
@@ -298,6 +583,22 @@ impl IcebergCatalogService {
     }
 
     /// Failover the catalog to a new primary replica region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+    /// async fn sample(
+    ///    client: &IcebergCatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .failover_iceberg_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn failover_iceberg_catalog(
         &self,
     ) -> super::builder::iceberg_catalog_service::FailoverIcebergCatalog {

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
@@ -140,11 +140,44 @@ impl AnalyticsHubService {
     }
 
     /// Gets the details of a data exchange.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_exchange()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_exchange(&self) -> super::builder::analytics_hub_service::GetDataExchange {
         super::builder::analytics_hub_service::GetDataExchange::new(self.inner.clone())
     }
 
     /// Creates a new data exchange.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_exchange()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_exchange(
         &self,
     ) -> super::builder::analytics_hub_service::CreateDataExchange {
@@ -152,6 +185,22 @@ impl AnalyticsHubService {
     }
 
     /// Updates an existing data exchange.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_exchange()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_exchange(
         &self,
     ) -> super::builder::analytics_hub_service::UpdateDataExchange {
@@ -159,6 +208,21 @@ impl AnalyticsHubService {
     }
 
     /// Deletes an existing data exchange.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_exchange()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_exchange(
         &self,
     ) -> super::builder::analytics_hub_service::DeleteDataExchange {
@@ -171,21 +235,85 @@ impl AnalyticsHubService {
     }
 
     /// Gets the details of a listing.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_listing()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_listing(&self) -> super::builder::analytics_hub_service::GetListing {
         super::builder::analytics_hub_service::GetListing::new(self.inner.clone())
     }
 
     /// Creates a new listing.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_listing()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_listing(&self) -> super::builder::analytics_hub_service::CreateListing {
         super::builder::analytics_hub_service::CreateListing::new(self.inner.clone())
     }
 
     /// Updates an existing listing.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_listing()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_listing(&self) -> super::builder::analytics_hub_service::UpdateListing {
         super::builder::analytics_hub_service::UpdateListing::new(self.inner.clone())
     }
 
     /// Deletes a listing.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_listing()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_listing(&self) -> super::builder::analytics_hub_service::DeleteListing {
         super::builder::analytics_hub_service::DeleteListing::new(self.inner.clone())
     }
@@ -196,6 +324,22 @@ impl AnalyticsHubService {
     /// reference only BigQuery datasets.
     /// Upon subscription to a listing for a BigQuery dataset, Analytics Hub
     /// creates a linked dataset in the subscriber's project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .subscribe_listing()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn subscribe_listing(&self) -> super::builder::analytics_hub_service::SubscribeListing {
         super::builder::analytics_hub_service::SubscribeListing::new(self.inner.clone())
     }
@@ -240,6 +384,23 @@ impl AnalyticsHubService {
     }
 
     /// Gets the details of a Subscription.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_subscription()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_subscription(&self) -> super::builder::analytics_hub_service::GetSubscription {
         super::builder::analytics_hub_service::GetSubscription::new(self.inner.clone())
     }
@@ -259,6 +420,22 @@ impl AnalyticsHubService {
     }
 
     /// Revokes a given subscription.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .revoke_subscription()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn revoke_subscription(&self) -> super::builder::analytics_hub_service::RevokeSubscription {
         super::builder::analytics_hub_service::RevokeSubscription::new(self.inner.clone())
     }
@@ -279,16 +456,64 @@ impl AnalyticsHubService {
     }
 
     /// Gets the IAM policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::analytics_hub_service::GetIamPolicy {
         super::builder::analytics_hub_service::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::analytics_hub_service::SetIamPolicy {
         super::builder::analytics_hub_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the permissions that a caller has.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::analytics_hub_service::TestIamPermissions {
@@ -296,6 +521,22 @@ impl AnalyticsHubService {
     }
 
     /// Creates a new QueryTemplate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_query_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_query_template(
         &self,
     ) -> super::builder::analytics_hub_service::CreateQueryTemplate {
@@ -303,6 +544,23 @@ impl AnalyticsHubService {
     }
 
     /// Gets a QueryTemplate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_query_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_query_template(&self) -> super::builder::analytics_hub_service::GetQueryTemplate {
         super::builder::analytics_hub_service::GetQueryTemplate::new(self.inner.clone())
     }
@@ -315,6 +573,22 @@ impl AnalyticsHubService {
     }
 
     /// Updates an existing QueryTemplate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_query_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_query_template(
         &self,
     ) -> super::builder::analytics_hub_service::UpdateQueryTemplate {
@@ -322,6 +596,22 @@ impl AnalyticsHubService {
     }
 
     /// Deletes a query template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_query_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_query_template(
         &self,
     ) -> super::builder::analytics_hub_service::DeleteQueryTemplate {
@@ -329,6 +619,22 @@ impl AnalyticsHubService {
     }
 
     /// Submits a query template for approval.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .submit_query_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn submit_query_template(
         &self,
     ) -> super::builder::analytics_hub_service::SubmitQueryTemplate {
@@ -336,6 +642,22 @@ impl AnalyticsHubService {
     }
 
     /// Approves a query template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .approve_query_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn approve_query_template(
         &self,
     ) -> super::builder::analytics_hub_service::ApproveQueryTemplate {
@@ -345,6 +667,22 @@ impl AnalyticsHubService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+    /// async fn sample(
+    ///    client: &AnalyticsHubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::analytics_hub_service::GetOperation {
         super::builder::analytics_hub_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/connection/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/client.rs
@@ -122,11 +122,44 @@ impl ConnectionService {
     }
 
     /// Creates a new connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_connection(&self) -> super::builder::connection_service::CreateConnection {
         super::builder::connection_service::CreateConnection::new(self.inner.clone())
     }
 
     /// Returns specified connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection(&self) -> super::builder::connection_service::GetConnection {
         super::builder::connection_service::GetConnection::new(self.inner.clone())
     }
@@ -138,11 +171,42 @@ impl ConnectionService {
 
     /// Updates the specified connection. For security reasons, also resets
     /// credential if connection properties are in the update field mask.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_connection(&self) -> super::builder::connection_service::UpdateConnection {
         super::builder::connection_service::UpdateConnection::new(self.inner.clone())
     }
 
     /// Deletes connection and associated credential.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_connection(&self) -> super::builder::connection_service::DeleteConnection {
         super::builder::connection_service::DeleteConnection::new(self.inner.clone())
     }
@@ -150,6 +214,22 @@ impl ConnectionService {
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::connection_service::GetIamPolicy {
         super::builder::connection_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -158,6 +238,22 @@ impl ConnectionService {
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::connection_service::SetIamPolicy {
         super::builder::connection_service::SetIamPolicy::new(self.inner.clone())
     }
@@ -169,6 +265,22 @@ impl ConnectionService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+    /// async fn sample(
+    ///    client: &ConnectionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::connection_service::TestIamPermissions {
         super::builder::connection_service::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
@@ -123,27 +123,107 @@ impl DataPolicyService {
 
     /// Creates a new data policy under a project with the given `dataPolicyId`
     /// (used as the display name), policy tag, and data policy type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_policy(&self) -> super::builder::data_policy_service::CreateDataPolicy {
         super::builder::data_policy_service::CreateDataPolicy::new(self.inner.clone())
     }
 
     /// Updates the metadata for an existing data policy. The target data policy
     /// can be specified by the resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_policy(&self) -> super::builder::data_policy_service::UpdateDataPolicy {
         super::builder::data_policy_service::UpdateDataPolicy::new(self.inner.clone())
     }
 
     /// Renames the id (display name) of the specified data policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rename_data_policy(&self) -> super::builder::data_policy_service::RenameDataPolicy {
         super::builder::data_policy_service::RenameDataPolicy::new(self.inner.clone())
     }
 
     /// Deletes the data policy specified by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_policy(&self) -> super::builder::data_policy_service::DeleteDataPolicy {
         super::builder::data_policy_service::DeleteDataPolicy::new(self.inner.clone())
     }
 
     /// Gets the data policy specified by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_policy(&self) -> super::builder::data_policy_service::GetDataPolicy {
         super::builder::data_policy_service::GetDataPolicy::new(self.inner.clone())
     }
@@ -154,16 +234,64 @@ impl DataPolicyService {
     }
 
     /// Gets the IAM policy for the specified data policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_policy_service::GetIamPolicy {
         super::builder::data_policy_service::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM policy for the specified data policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_policy_service::SetIamPolicy {
         super::builder::data_policy_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the caller's permission on the specified data policy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::data_policy_service::TestIamPermissions {
         super::builder::data_policy_service::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/datapolicies/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v2/src/client.rs
@@ -123,6 +123,22 @@ impl DataPolicyService {
 
     /// Creates a new data policy under a project with the given `data_policy_id`
     /// (used as the display name), and data policy type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_policy(&self) -> super::builder::data_policy_service::CreateDataPolicy {
         super::builder::data_policy_service::CreateDataPolicy::new(self.inner.clone())
     }
@@ -132,6 +148,22 @@ impl DataPolicyService {
     /// If the request contains a duplicate grantee, the grantee will be ignored.
     /// If the request contains a grantee that already exists, the grantee will be
     /// ignored.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_grantees()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_grantees(&self) -> super::builder::data_policy_service::AddGrantees {
         super::builder::data_policy_service::AddGrantees::new(self.inner.clone())
     }
@@ -140,22 +172,87 @@ impl DataPolicyService {
     /// The grantees will be removed from the existing grantees.
     /// If the request contains a grantee that does not exist, the grantee will be
     /// ignored.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_grantees()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_grantees(&self) -> super::builder::data_policy_service::RemoveGrantees {
         super::builder::data_policy_service::RemoveGrantees::new(self.inner.clone())
     }
 
     /// Updates the metadata for an existing data policy. The target data policy
     /// can be specified by the resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_policy(&self) -> super::builder::data_policy_service::UpdateDataPolicy {
         super::builder::data_policy_service::UpdateDataPolicy::new(self.inner.clone())
     }
 
     /// Deletes the data policy specified by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_policy(&self) -> super::builder::data_policy_service::DeleteDataPolicy {
         super::builder::data_policy_service::DeleteDataPolicy::new(self.inner.clone())
     }
 
     /// Gets the data policy specified by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_policy(&self) -> super::builder::data_policy_service::GetDataPolicy {
         super::builder::data_policy_service::GetDataPolicy::new(self.inner.clone())
     }
@@ -166,16 +263,64 @@ impl DataPolicyService {
     }
 
     /// Gets the IAM policy for the specified data policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_policy_service::GetIamPolicy {
         super::builder::data_policy_service::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM policy for the specified data policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_policy_service::SetIamPolicy {
         super::builder::data_policy_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the caller's permission on the specified data policy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+    /// async fn sample(
+    ///    client: &DataPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::data_policy_service::TestIamPermissions {
         super::builder::data_policy_service::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
@@ -122,6 +122,23 @@ impl DataTransferService {
     }
 
     /// Retrieves a supported data source and returns its settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_source(&self) -> super::builder::data_transfer_service::GetDataSource {
         super::builder::data_transfer_service::GetDataSource::new(self.inner.clone())
     }
@@ -132,6 +149,22 @@ impl DataTransferService {
     }
 
     /// Creates a new data transfer configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_transfer_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_transfer_config(
         &self,
     ) -> super::builder::data_transfer_service::CreateTransferConfig {
@@ -140,6 +173,22 @@ impl DataTransferService {
 
     /// Updates a data transfer configuration.
     /// All fields must be set, even if they are not updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_transfer_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_transfer_config(
         &self,
     ) -> super::builder::data_transfer_service::UpdateTransferConfig {
@@ -148,6 +197,21 @@ impl DataTransferService {
 
     /// Deletes a data transfer configuration, including any associated transfer
     /// runs and logs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_transfer_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_transfer_config(
         &self,
     ) -> super::builder::data_transfer_service::DeleteTransferConfig {
@@ -155,6 +219,23 @@ impl DataTransferService {
     }
 
     /// Returns information about a data transfer config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_transfer_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_transfer_config(&self) -> super::builder::data_transfer_service::GetTransferConfig {
         super::builder::data_transfer_service::GetTransferConfig::new(self.inner.clone())
     }
@@ -172,6 +253,22 @@ impl DataTransferService {
     /// range, one transfer run is created.
     /// Note that runs are created per UTC time in the time range.
     /// DEPRECATED: use StartManualTransferRuns instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .schedule_transfer_runs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn schedule_transfer_runs(
         &self,
@@ -183,6 +280,22 @@ impl DataTransferService {
     /// current time. The transfer runs can be created for a time range where the
     /// run_time is between start_time (inclusive) and end_time (exclusive), or for
     /// a specific run_time.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_manual_transfer_runs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_manual_transfer_runs(
         &self,
     ) -> super::builder::data_transfer_service::StartManualTransferRuns {
@@ -190,11 +303,43 @@ impl DataTransferService {
     }
 
     /// Returns information about the particular transfer run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_transfer_run()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_transfer_run(&self) -> super::builder::data_transfer_service::GetTransferRun {
         super::builder::data_transfer_service::GetTransferRun::new(self.inner.clone())
     }
 
     /// Deletes the specified transfer run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_transfer_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_transfer_run(&self) -> super::builder::data_transfer_service::DeleteTransferRun {
         super::builder::data_transfer_service::DeleteTransferRun::new(self.inner.clone())
     }
@@ -211,6 +356,22 @@ impl DataTransferService {
 
     /// Returns true if valid credentials exist for the given data source and
     /// requesting user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_valid_creds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_valid_creds(&self) -> super::builder::data_transfer_service::CheckValidCreds {
         super::builder::data_transfer_service::CheckValidCreds::new(self.inner.clone())
     }
@@ -223,6 +384,21 @@ impl DataTransferService {
     /// [BigQuery Web UI](https://cloud.google.com/bigquery/bigquery-web-ui) and
     /// [Data Transfer
     /// Service](https://cloud.google.com/bigquery/docs/working-with-transfers).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .enroll_data_sources()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enroll_data_sources(&self) -> super::builder::data_transfer_service::EnrollDataSources {
         super::builder::data_transfer_service::EnrollDataSources::new(self.inner.clone())
     }
@@ -232,6 +408,21 @@ impl DataTransferService {
     /// in the ListDataSources RPC and will also no longer appear in the [BigQuery
     /// UI](https://console.cloud.google.com/bigquery). Data transfers
     /// configurations of unenrolled data sources will not be scheduled.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .unenroll_data_sources()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn unenroll_data_sources(
         &self,
     ) -> super::builder::data_transfer_service::UnenrollDataSources {
@@ -244,6 +435,22 @@ impl DataTransferService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_transfer_service::GetLocation {
         super::builder::data_transfer_service::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/migration/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/client.rs
@@ -122,6 +122,22 @@ impl MigrationService {
     }
 
     /// Creates a migration workflow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_migration_workflow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_migration_workflow(
         &self,
     ) -> super::builder::migration_service::CreateMigrationWorkflow {
@@ -129,6 +145,23 @@ impl MigrationService {
     }
 
     /// Gets a previously created migration workflow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_migration_workflow()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_migration_workflow(
         &self,
     ) -> super::builder::migration_service::GetMigrationWorkflow {
@@ -143,6 +176,21 @@ impl MigrationService {
     }
 
     /// Deletes a migration workflow by name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_migration_workflow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_migration_workflow(
         &self,
     ) -> super::builder::migration_service::DeleteMigrationWorkflow {
@@ -153,6 +201,21 @@ impl MigrationService {
     /// from DRAFT to RUNNING. This is a no-op if the state is already RUNNING.
     /// An error will be signaled if the state is anything other than DRAFT or
     /// RUNNING.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .start_migration_workflow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_migration_workflow(
         &self,
     ) -> super::builder::migration_service::StartMigrationWorkflow {
@@ -160,6 +223,23 @@ impl MigrationService {
     }
 
     /// Gets a previously created migration subtask.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+    /// async fn sample(
+    ///    client: &MigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_migration_subtask()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_migration_subtask(&self) -> super::builder::migration_service::GetMigrationSubtask {
         super::builder::migration_service::GetMigrationSubtask::new(self.inner.clone())
     }

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -136,6 +136,22 @@ impl ReservationService {
     }
 
     /// Creates a new reservation resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_reservation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_reservation(&self) -> super::builder::reservation_service::CreateReservation {
         super::builder::reservation_service::CreateReservation::new(self.inner.clone())
     }
@@ -146,6 +162,23 @@ impl ReservationService {
     }
 
     /// Returns information about the reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_reservation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_reservation(&self) -> super::builder::reservation_service::GetReservation {
         super::builder::reservation_service::GetReservation::new(self.inner.clone())
     }
@@ -153,11 +186,42 @@ impl ReservationService {
     /// Deletes a reservation.
     /// Returns `google.rpc.Code.FAILED_PRECONDITION` when reservation has
     /// assignments.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_reservation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_reservation(&self) -> super::builder::reservation_service::DeleteReservation {
         super::builder::reservation_service::DeleteReservation::new(self.inner.clone())
     }
 
     /// Updates an existing reservation resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_reservation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_reservation(&self) -> super::builder::reservation_service::UpdateReservation {
         super::builder::reservation_service::UpdateReservation::new(self.inner.clone())
     }
@@ -167,11 +231,43 @@ impl ReservationService {
     /// new primary location for the reservation.
     /// Attempting to failover a reservation in the current primary location will
     /// fail with the error code `google.rpc.Code.FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .failover_reservation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn failover_reservation(&self) -> super::builder::reservation_service::FailoverReservation {
         super::builder::reservation_service::FailoverReservation::new(self.inner.clone())
     }
 
     /// Creates a new capacity commitment resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_capacity_commitment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_capacity_commitment(
         &self,
     ) -> super::builder::reservation_service::CreateCapacityCommitment {
@@ -186,6 +282,23 @@ impl ReservationService {
     }
 
     /// Returns information about the capacity commitment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_capacity_commitment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_capacity_commitment(
         &self,
     ) -> super::builder::reservation_service::GetCapacityCommitment {
@@ -195,6 +308,21 @@ impl ReservationService {
     /// Deletes a capacity commitment. Attempting to delete capacity commitment
     /// before its commitment_end_time will fail with the error code
     /// `google.rpc.Code.FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_capacity_commitment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_capacity_commitment(
         &self,
     ) -> super::builder::reservation_service::DeleteCapacityCommitment {
@@ -208,6 +336,22 @@ impl ReservationService {
     /// Plan can only be changed to a plan of a longer commitment period.
     /// Attempting to change to a plan with shorter commitment period will fail
     /// with the error code `google.rpc.Code.FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_capacity_commitment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_capacity_commitment(
         &self,
     ) -> super::builder::reservation_service::UpdateCapacityCommitment {
@@ -222,6 +366,22 @@ impl ReservationService {
     /// For example, in order to downgrade from 10000 slots to 8000, you might
     /// split a 10000 capacity commitment into commitments of 2000 and 8000. Then,
     /// you delete the first one after the commitment end time passes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .split_capacity_commitment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn split_capacity_commitment(
         &self,
     ) -> super::builder::reservation_service::SplitCapacityCommitment {
@@ -235,6 +395,22 @@ impl ReservationService {
     ///
     /// Attempting to merge capacity commitments of different plan will fail
     /// with the error code `google.rpc.Code.FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .merge_capacity_commitments()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn merge_capacity_commitments(
         &self,
     ) -> super::builder::reservation_service::MergeCapacityCommitments {
@@ -276,6 +452,22 @@ impl ReservationService {
     ///
     /// Returns `google.rpc.Code.INVALID_ARGUMENT` when location of the assignment
     /// does not match location of the reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_assignment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_assignment(&self) -> super::builder::reservation_service::CreateAssignment {
         super::builder::reservation_service::CreateAssignment::new(self.inner.clone())
     }
@@ -320,6 +512,22 @@ impl ReservationService {
     /// affect the other assignment `<project1, res1>`. After said deletion,
     /// queries from `project1` will still use `res1` while queries from
     /// `project2` will switch to use on-demand mode.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_assignment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_assignment(&self) -> super::builder::reservation_service::DeleteAssignment {
         super::builder::reservation_service::DeleteAssignment::new(self.inner.clone())
     }
@@ -383,6 +591,22 @@ impl ReservationService {
     /// This differs from removing an existing assignment and recreating a new one
     /// by providing a transactional change that ensures an assignee always has an
     /// associated reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_assignment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_assignment(&self) -> super::builder::reservation_service::MoveAssignment {
         super::builder::reservation_service::MoveAssignment::new(self.inner.clone())
     }
@@ -390,11 +614,44 @@ impl ReservationService {
     /// Updates an existing assignment.
     ///
     /// Only the `priority` field can be updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_assignment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_assignment(&self) -> super::builder::reservation_service::UpdateAssignment {
         super::builder::reservation_service::UpdateAssignment::new(self.inner.clone())
     }
 
     /// Retrieves a BI reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_bi_reservation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_bi_reservation(&self) -> super::builder::reservation_service::GetBiReservation {
         super::builder::reservation_service::GetBiReservation::new(self.inner.clone())
     }
@@ -407,6 +664,22 @@ impl ReservationService {
     /// In order to reserve BI capacity it needs to be updated to an amount
     /// greater than 0. In order to release BI capacity reservation size
     /// must be set to 0.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_bi_reservation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_bi_reservation(
         &self,
     ) -> super::builder::reservation_service::UpdateBiReservation {
@@ -429,6 +702,22 @@ impl ReservationService {
     ///
     /// - `bigqueryreservation.reservations.getIamPolicy` to get policies on
     ///   reservations.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reservation_service::GetIamPolicy {
         super::builder::reservation_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -444,6 +733,22 @@ impl ReservationService {
     ///
     /// - `bigqueryreservation.reservations.setIamPolicy` to set policies on
     ///   reservations.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reservation_service::SetIamPolicy {
         super::builder::reservation_service::SetIamPolicy::new(self.inner.clone())
     }
@@ -456,11 +761,43 @@ impl ReservationService {
     /// - Reservations
     ///
     /// No Google IAM permissions are required to call this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::reservation_service::TestIamPermissions {
         super::builder::reservation_service::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Creates a new reservation group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_reservation_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_reservation_group(
         &self,
     ) -> super::builder::reservation_service::CreateReservationGroup {
@@ -468,6 +805,23 @@ impl ReservationService {
     }
 
     /// Returns information about the reservation group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_reservation_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_reservation_group(
         &self,
     ) -> super::builder::reservation_service::GetReservationGroup {
@@ -477,6 +831,22 @@ impl ReservationService {
     /// Deletes a reservation.
     /// Returns `google.rpc.Code.FAILED_PRECONDITION` when reservation has
     /// assignments.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+    /// async fn sample(
+    ///    client: &ReservationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_reservation_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_reservation_group(
         &self,
     ) -> super::builder::reservation_service::DeleteReservationGroup {

--- a/src/generated/cloud/bigquery/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/v2/src/client.rs
@@ -119,11 +119,43 @@ impl DatasetService {
     }
 
     /// Returns the dataset specified by datasetID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset(&self) -> super::builder::dataset_service::GetDataset {
         super::builder::dataset_service::GetDataset::new(self.inner.clone())
     }
 
     /// Creates a new empty dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert_dataset(&self) -> super::builder::dataset_service::InsertDataset {
         super::builder::dataset_service::InsertDataset::new(self.inner.clone())
     }
@@ -132,6 +164,22 @@ impl DatasetService {
     /// entire dataset resource, whereas the patch method only replaces fields that
     /// are provided in the submitted dataset resource.
     /// This method supports RFC5789 patch semantics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch_dataset(&self) -> super::builder::dataset_service::PatchDataset {
         super::builder::dataset_service::PatchDataset::new(self.inner.clone())
     }
@@ -139,6 +187,22 @@ impl DatasetService {
     /// Updates information in an existing dataset. The update method replaces the
     /// entire dataset resource, whereas the patch method only replaces fields that
     /// are provided in the submitted dataset resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_dataset(&self) -> super::builder::dataset_service::UpdateDataset {
         super::builder::dataset_service::UpdateDataset::new(self.inner.clone())
     }
@@ -147,6 +211,21 @@ impl DatasetService {
     /// a dataset, you must delete all its tables, either manually or by specifying
     /// deleteContents. Immediately after deletion, you can create another dataset
     /// with the same name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_dataset(&self) -> super::builder::dataset_service::DeleteDataset {
         super::builder::dataset_service::DeleteDataset::new(self.inner.clone())
     }
@@ -160,6 +239,22 @@ impl DatasetService {
     /// Undeletes a dataset which is within time travel window based on datasetId.
     /// If a time is specified, the dataset version deleted at that time is
     /// undeleted, else the last live version is undeleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::DatasetService;
+    /// async fn sample(
+    ///    client: &DatasetService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .undelete_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn undelete_dataset(&self) -> super::builder::dataset_service::UndeleteDataset {
         super::builder::dataset_service::UndeleteDataset::new(self.inner.clone())
     }
@@ -269,6 +364,22 @@ impl JobService {
     /// Requests that a job be cancelled. This call will return immediately, and
     /// the client will need to poll for the job status to see if the cancel
     /// completed successfully. Cancelled jobs may still incur costs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_job(&self) -> super::builder::job_service::CancelJob {
         super::builder::job_service::CancelJob::new(self.inner.clone())
     }
@@ -276,6 +387,22 @@ impl JobService {
     /// Returns information about a specific job. Job information is available for
     /// a six month period after creation. Requires that you're the person who ran
     /// the job, or have the Is Owner project role.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::job_service::GetJob {
         super::builder::job_service::GetJob::new(self.inner.clone())
     }
@@ -291,12 +418,43 @@ impl JobService {
     ///   configuration and a data stream together.  In this case, the Upload URI
     ///   accepts the job configuration and the data as two distinct multipart MIME
     ///   parts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert_job(&self) -> super::builder::job_service::InsertJob {
         super::builder::job_service::InsertJob::new(self.inner.clone())
     }
 
     /// Requests the deletion of the metadata of a job. This call returns when the
     /// job's metadata is deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::job_service::DeleteJob {
         super::builder::job_service::DeleteJob::new(self.inner.clone())
     }
@@ -311,12 +469,44 @@ impl JobService {
     }
 
     /// RPC to get the results of a query job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_query_results()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_query_results(&self) -> super::builder::job_service::GetQueryResults {
         super::builder::job_service::GetQueryResults::new(self.inner.clone())
     }
 
     /// Runs a BigQuery SQL query synchronously and returns query results if the
     /// query completes within a specified timeout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query(&self) -> super::builder::job_service::Query {
         super::builder::job_service::Query::new(self.inner.clone())
     }
@@ -425,6 +615,22 @@ impl ModelService {
     }
 
     /// Gets the specified model resource by model ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model(&self) -> super::builder::model_service::GetModel {
         super::builder::model_service::GetModel::new(self.inner.clone())
     }
@@ -437,11 +643,42 @@ impl ModelService {
     }
 
     /// Patch specific fields in the specified model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch_model(&self) -> super::builder::model_service::PatchModel {
         super::builder::model_service::PatchModel::new(self.inner.clone())
     }
 
     /// Deletes the model specified by modelId from the dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_model(&self) -> super::builder::model_service::DeleteModel {
         super::builder::model_service::DeleteModel::new(self.inner.clone())
     }
@@ -551,6 +788,22 @@ impl ProjectService {
 
     /// RPC to get the service account for a project used for interactions with
     /// Google Cloud KMS
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::ProjectService;
+    /// async fn sample(
+    ///    client: &ProjectService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_account(&self) -> super::builder::project_service::GetServiceAccount {
         super::builder::project_service::GetServiceAccount::new(self.inner.clone())
     }
@@ -659,22 +912,85 @@ impl RoutineService {
     }
 
     /// Gets the specified routine resource by routine ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RoutineService;
+    /// async fn sample(
+    ///    client: &RoutineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_routine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_routine(&self) -> super::builder::routine_service::GetRoutine {
         super::builder::routine_service::GetRoutine::new(self.inner.clone())
     }
 
     /// Creates a new routine in the dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RoutineService;
+    /// async fn sample(
+    ///    client: &RoutineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert_routine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert_routine(&self) -> super::builder::routine_service::InsertRoutine {
         super::builder::routine_service::InsertRoutine::new(self.inner.clone())
     }
 
     /// Updates information in an existing routine. The update method replaces the
     /// entire Routine resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RoutineService;
+    /// async fn sample(
+    ///    client: &RoutineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_routine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_routine(&self) -> super::builder::routine_service::UpdateRoutine {
         super::builder::routine_service::UpdateRoutine::new(self.inner.clone())
     }
 
     /// Deletes the routine specified by routineId from the dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RoutineService;
+    /// async fn sample(
+    ///    client: &RoutineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_routine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_routine(&self) -> super::builder::routine_service::DeleteRoutine {
         super::builder::routine_service::DeleteRoutine::new(self.inner.clone())
     }
@@ -799,6 +1115,22 @@ impl RowAccessPolicyService {
     }
 
     /// Gets the specified row access policy by policy ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// async fn sample(
+    ///    client: &RowAccessPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_row_access_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_row_access_policy(
         &self,
     ) -> super::builder::row_access_policy_service::GetRowAccessPolicy {
@@ -806,6 +1138,22 @@ impl RowAccessPolicyService {
     }
 
     /// Creates a row access policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// async fn sample(
+    ///    client: &RowAccessPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_row_access_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_row_access_policy(
         &self,
     ) -> super::builder::row_access_policy_service::CreateRowAccessPolicy {
@@ -813,6 +1161,22 @@ impl RowAccessPolicyService {
     }
 
     /// Updates a row access policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// async fn sample(
+    ///    client: &RowAccessPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_row_access_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_row_access_policy(
         &self,
     ) -> super::builder::row_access_policy_service::UpdateRowAccessPolicy {
@@ -820,6 +1184,21 @@ impl RowAccessPolicyService {
     }
 
     /// Deletes a row access policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// async fn sample(
+    ///    client: &RowAccessPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_row_access_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_row_access_policy(
         &self,
     ) -> super::builder::row_access_policy_service::DeleteRowAccessPolicy {
@@ -827,6 +1206,21 @@ impl RowAccessPolicyService {
     }
 
     /// Deletes provided row access policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
+    /// async fn sample(
+    ///    client: &RowAccessPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .batch_delete_row_access_policies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_delete_row_access_policies(
         &self,
     ) -> super::builder::row_access_policy_service::BatchDeleteRowAccessPolicies {
@@ -942,11 +1336,43 @@ impl TableService {
     /// Gets the specified table resource by table ID.
     /// This method does not return the data in the table, it only returns the
     /// table resource, which describes the structure of this table.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// async fn sample(
+    ///    client: &TableService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_table(&self) -> super::builder::table_service::GetTable {
         super::builder::table_service::GetTable::new(self.inner.clone())
     }
 
     /// Creates a new, empty table in the dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// async fn sample(
+    ///    client: &TableService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert_table(&self) -> super::builder::table_service::InsertTable {
         super::builder::table_service::InsertTable::new(self.inner.clone())
     }
@@ -955,6 +1381,22 @@ impl TableService {
     /// entire table resource, whereas the patch method only replaces fields that
     /// are provided in the submitted table resource.
     /// This method supports RFC5789 patch semantics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// async fn sample(
+    ///    client: &TableService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch_table(&self) -> super::builder::table_service::PatchTable {
         super::builder::table_service::PatchTable::new(self.inner.clone())
     }
@@ -962,12 +1404,43 @@ impl TableService {
     /// Updates information in an existing table. The update method replaces the
     /// entire Table resource, whereas the patch method only replaces fields that
     /// are provided in the submitted Table resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// async fn sample(
+    ///    client: &TableService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_table(&self) -> super::builder::table_service::UpdateTable {
         super::builder::table_service::UpdateTable::new(self.inner.clone())
     }
 
     /// Deletes the table specified by tableId from the dataset.
     /// If the table contains data, all the data will be deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_v2::client::TableService;
+    /// async fn sample(
+    ///    client: &TableService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_table()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_table(&self) -> super::builder::table_service::DeleteTable {
         super::builder::table_service::DeleteTable::new(self.inner.clone())
     }

--- a/src/generated/cloud/billing/v1/src/client.rs
+++ b/src/generated/cloud/billing/v1/src/client.rs
@@ -122,6 +122,23 @@ impl CloudBilling {
     /// Gets information about a billing account. The current authenticated user
     /// must be a [viewer of the billing
     /// account](https://cloud.google.com/billing/docs/how-to/billing-access).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_billing_account()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_billing_account(&self) -> super::builder::cloud_billing::GetBillingAccount {
         super::builder::cloud_billing::GetBillingAccount::new(self.inner.clone())
     }
@@ -139,6 +156,22 @@ impl CloudBilling {
     /// IAM permission, which is typically given to the
     /// [administrator](https://cloud.google.com/billing/docs/how-to/billing-access)
     /// of the billing account.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_billing_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_billing_account(&self) -> super::builder::cloud_billing::UpdateBillingAccount {
         super::builder::cloud_billing::UpdateBillingAccount::new(self.inner.clone())
     }
@@ -158,6 +191,22 @@ impl CloudBilling {
     /// [administrators](https://cloud.google.com/billing/docs/how-to/billing-access).
     /// This method will return an error if the parent account has not been
     /// provisioned for subaccounts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_billing_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_billing_account(&self) -> super::builder::cloud_billing::CreateBillingAccount {
         super::builder::cloud_billing::CreateBillingAccount::new(self.inner.clone())
     }
@@ -177,6 +226,22 @@ impl CloudBilling {
     /// which can be granted by assigning the [Project
     /// Viewer](https://cloud.google.com/iam/docs/understanding-roles#predefined_roles)
     /// role.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project_billing_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project_billing_info(&self) -> super::builder::cloud_billing::GetProjectBillingInfo {
         super::builder::cloud_billing::GetProjectBillingInfo::new(self.inner.clone())
     }
@@ -213,6 +278,22 @@ impl CloudBilling {
     /// resources used by the project will be shut down. Thus, unless you wish to
     /// disable billing, you should always call this method with the name of an
     /// *open* billing account.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_project_billing_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_project_billing_info(
         &self,
     ) -> super::builder::cloud_billing::UpdateProjectBillingInfo {
@@ -223,6 +304,22 @@ impl CloudBilling {
     /// The caller must have the `billing.accounts.getIamPolicy` permission on the
     /// account, which is often given to billing account
     /// [viewers](https://cloud.google.com/billing/docs/how-to/billing-access).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cloud_billing::GetIamPolicy {
         super::builder::cloud_billing::GetIamPolicy::new(self.inner.clone())
     }
@@ -232,6 +329,22 @@ impl CloudBilling {
     /// The caller must have the `billing.accounts.setIamPolicy` permission on the
     /// account, which is often given to billing account
     /// [administrators](https://cloud.google.com/billing/docs/how-to/billing-access).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cloud_billing::SetIamPolicy {
         super::builder::cloud_billing::SetIamPolicy::new(self.inner.clone())
     }
@@ -239,11 +352,43 @@ impl CloudBilling {
     /// Tests the access control policy for a billing account. This method takes
     /// the resource and a set of permissions as input and returns the subset of
     /// the input permissions that the caller is allowed for that resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::cloud_billing::TestIamPermissions {
         super::builder::cloud_billing::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Changes which parent organization a billing account belongs to.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_billing_v1::client::CloudBilling;
+    /// async fn sample(
+    ///    client: &CloudBilling
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_billing_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_billing_account(&self) -> super::builder::cloud_billing::MoveBillingAccount {
         super::builder::cloud_billing::MoveBillingAccount::new(self.inner.clone())
     }

--- a/src/generated/cloud/binaryauthorization/v1/src/client.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/client.rs
@@ -141,6 +141,23 @@ impl BinauthzManagementServiceV1 {
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
     /// [google.cloud.binaryauthorization.v1.Policy]: crate::model::Policy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy(&self) -> super::builder::binauthz_management_service_v_1::GetPolicy {
         super::builder::binauthz_management_service_v_1::GetPolicy::new(self.inner.clone())
     }
@@ -152,6 +169,22 @@ impl BinauthzManagementServiceV1 {
     /// if the request is malformed.
     ///
     /// [google.cloud.binaryauthorization.v1.Policy]: crate::model::Policy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_policy(&self) -> super::builder::binauthz_management_service_v_1::UpdatePolicy {
         super::builder::binauthz_management_service_v_1::UpdatePolicy::new(self.inner.clone())
     }
@@ -162,6 +195,22 @@ impl BinauthzManagementServiceV1 {
     /// [attestor][google.cloud.binaryauthorization.v1.Attestor] already exists.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_attestor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_attestor(
         &self,
     ) -> super::builder::binauthz_management_service_v_1::CreateAttestor {
@@ -172,6 +221,23 @@ impl BinauthzManagementServiceV1 {
     /// Returns NOT_FOUND if the [attestor][google.cloud.binaryauthorization.v1.Attestor] does not exist.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attestor()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attestor(&self) -> super::builder::binauthz_management_service_v_1::GetAttestor {
         super::builder::binauthz_management_service_v_1::GetAttestor::new(self.inner.clone())
     }
@@ -180,6 +246,22 @@ impl BinauthzManagementServiceV1 {
     /// Returns NOT_FOUND if the [attestor][google.cloud.binaryauthorization.v1.Attestor] does not exist.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_attestor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_attestor(
         &self,
     ) -> super::builder::binauthz_management_service_v_1::UpdateAttestor {
@@ -198,6 +280,21 @@ impl BinauthzManagementServiceV1 {
     /// [attestor][google.cloud.binaryauthorization.v1.Attestor] does not exist.
     ///
     /// [google.cloud.binaryauthorization.v1.Attestor]: crate::model::Attestor
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+    /// async fn sample(
+    ///    client: &BinauthzManagementServiceV1
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_attestor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_attestor(
         &self,
     ) -> super::builder::binauthz_management_service_v_1::DeleteAttestor {
@@ -310,6 +407,23 @@ impl SystemPolicyV1 {
     }
 
     /// Gets the current system policy in the specified location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::SystemPolicyV1;
+    /// async fn sample(
+    ///    client: &SystemPolicyV1,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_system_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_system_policy(&self) -> super::builder::system_policy_v_1::GetSystemPolicy {
         super::builder::system_policy_v_1::GetSystemPolicy::new(self.inner.clone())
     }
@@ -422,6 +536,22 @@ impl ValidationHelperV1 {
 
     /// Returns whether the given Attestation for the given image URI
     /// was signed by the given Attestor
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_binaryauthorization_v1::client::ValidationHelperV1;
+    /// async fn sample(
+    ///    client: &ValidationHelperV1
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_attestation_occurrence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_attestation_occurrence(
         &self,
     ) -> super::builder::validation_helper_v_1::ValidateAttestationOccurrence {

--- a/src/generated/cloud/certificatemanager/v1/src/client.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/client.rs
@@ -153,6 +153,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single Certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate(&self) -> super::builder::certificate_manager::GetCertificate {
         super::builder::certificate_manager::GetCertificate::new(self.inner.clone())
     }
@@ -210,6 +227,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single CertificateMap.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_map()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_map(&self) -> super::builder::certificate_manager::GetCertificateMap {
         super::builder::certificate_manager::GetCertificateMap::new(self.inner.clone())
     }
@@ -275,6 +309,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single CertificateMapEntry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_map_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_map_entry(
         &self,
     ) -> super::builder::certificate_manager::GetCertificateMapEntry {
@@ -340,6 +391,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single DnsAuthorization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dns_authorization()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dns_authorization(
         &self,
     ) -> super::builder::certificate_manager::GetDnsAuthorization {
@@ -405,6 +473,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single CertificateIssuanceConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_issuance_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_issuance_config(
         &self,
     ) -> super::builder::certificate_manager::GetCertificateIssuanceConfig {
@@ -455,6 +540,23 @@ impl CertificateManager {
     }
 
     /// Gets details of a single TrustConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_trust_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_trust_config(&self) -> super::builder::certificate_manager::GetTrustConfig {
         super::builder::certificate_manager::GetTrustConfig::new(self.inner.clone())
     }
@@ -510,6 +612,22 @@ impl CertificateManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::certificate_manager::GetLocation {
         super::builder::certificate_manager::GetLocation::new(self.inner.clone())
     }
@@ -524,6 +642,22 @@ impl CertificateManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::certificate_manager::GetOperation {
         super::builder::certificate_manager::GetOperation::new(self.inner.clone())
     }
@@ -531,6 +665,21 @@ impl CertificateManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::certificate_manager::DeleteOperation {
         super::builder::certificate_manager::DeleteOperation::new(self.inner.clone())
     }
@@ -538,6 +687,21 @@ impl CertificateManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+    /// async fn sample(
+    ///    client: &CertificateManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::certificate_manager::CancelOperation {
         super::builder::certificate_manager::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/chronicle/v1/src/client.rs
+++ b/src/generated/cloud/chronicle/v1/src/client.rs
@@ -129,6 +129,22 @@ impl DataAccessControlService {
     /// label can see data with that label. Currently, the data access label
     /// resource only includes custom labels, which are labels that correspond
     /// to UDM queries over event data.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_access_label()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_access_label(
         &self,
     ) -> super::builder::data_access_control_service::CreateDataAccessLabel {
@@ -136,6 +152,23 @@ impl DataAccessControlService {
     }
 
     /// Gets a data access label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_access_label()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_access_label(
         &self,
     ) -> super::builder::data_access_control_service::GetDataAccessLabel {
@@ -150,6 +183,22 @@ impl DataAccessControlService {
     }
 
     /// Updates a data access label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_access_label()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_access_label(
         &self,
     ) -> super::builder::data_access_control_service::UpdateDataAccessLabel {
@@ -159,6 +208,21 @@ impl DataAccessControlService {
     /// Deletes a data access label. When a label is deleted, new
     /// data that enters in the system will not receive the label, but the label
     /// will not be removed from old data that still refers to it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_access_label()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_access_label(
         &self,
     ) -> super::builder::data_access_control_service::DeleteDataAccessLabel {
@@ -171,6 +235,22 @@ impl DataAccessControlService {
     /// labels C and D, then the group of people attached to the scope
     /// will have permissions to see all events labeled with A or B (or both) and
     /// not labeled with either C or D.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_access_scope()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_access_scope(
         &self,
     ) -> super::builder::data_access_control_service::CreateDataAccessScope {
@@ -178,6 +258,23 @@ impl DataAccessControlService {
     }
 
     /// Retrieves an existing data access scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_access_scope()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_access_scope(
         &self,
     ) -> super::builder::data_access_control_service::GetDataAccessScope {
@@ -192,6 +289,22 @@ impl DataAccessControlService {
     }
 
     /// Updates a data access scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_access_scope()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_access_scope(
         &self,
     ) -> super::builder::data_access_control_service::UpdateDataAccessScope {
@@ -199,6 +312,21 @@ impl DataAccessControlService {
     }
 
     /// Deletes a data access scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_access_scope()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_access_scope(
         &self,
     ) -> super::builder::data_access_control_service::DeleteDataAccessScope {
@@ -215,6 +343,22 @@ impl DataAccessControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_access_control_service::GetOperation {
         super::builder::data_access_control_service::GetOperation::new(self.inner.clone())
     }
@@ -222,6 +366,21 @@ impl DataAccessControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_access_control_service::DeleteOperation {
         super::builder::data_access_control_service::DeleteOperation::new(self.inner.clone())
     }
@@ -229,6 +388,21 @@ impl DataAccessControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+    /// async fn sample(
+    ///    client: &DataAccessControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_access_control_service::CancelOperation {
         super::builder::data_access_control_service::CancelOperation::new(self.inner.clone())
     }
@@ -337,6 +511,23 @@ impl EntityService {
     }
 
     /// Gets watchlist details for the given watchlist ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_watchlist()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_watchlist(&self) -> super::builder::entity_service::GetWatchlist {
         super::builder::entity_service::GetWatchlist::new(self.inner.clone())
     }
@@ -348,16 +539,64 @@ impl EntityService {
 
     /// Creates a watchlist for the given instance.
     /// Note that there can be at most 200 watchlists per instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_watchlist()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_watchlist(&self) -> super::builder::entity_service::CreateWatchlist {
         super::builder::entity_service::CreateWatchlist::new(self.inner.clone())
     }
 
     /// Updates the watchlist for the given instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_watchlist()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_watchlist(&self) -> super::builder::entity_service::UpdateWatchlist {
         super::builder::entity_service::UpdateWatchlist::new(self.inner.clone())
     }
 
     /// Deletes the watchlist for the given instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_watchlist()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_watchlist(&self) -> super::builder::entity_service::DeleteWatchlist {
         super::builder::entity_service::DeleteWatchlist::new(self.inner.clone())
     }
@@ -372,6 +611,22 @@ impl EntityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::entity_service::GetOperation {
         super::builder::entity_service::GetOperation::new(self.inner.clone())
     }
@@ -379,6 +634,21 @@ impl EntityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::entity_service::DeleteOperation {
         super::builder::entity_service::DeleteOperation::new(self.inner.clone())
     }
@@ -386,6 +656,21 @@ impl EntityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::EntityService;
+    /// async fn sample(
+    ///    client: &EntityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::entity_service::CancelOperation {
         super::builder::entity_service::CancelOperation::new(self.inner.clone())
     }
@@ -497,6 +782,23 @@ impl InstanceService {
     }
 
     /// Gets a Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::InstanceService;
+    /// async fn sample(
+    ///    client: &InstanceService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::instance_service::GetInstance {
         super::builder::instance_service::GetInstance::new(self.inner.clone())
     }
@@ -511,6 +813,22 @@ impl InstanceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::InstanceService;
+    /// async fn sample(
+    ///    client: &InstanceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_service::GetOperation {
         super::builder::instance_service::GetOperation::new(self.inner.clone())
     }
@@ -518,6 +836,21 @@ impl InstanceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::InstanceService;
+    /// async fn sample(
+    ///    client: &InstanceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::instance_service::DeleteOperation {
         super::builder::instance_service::DeleteOperation::new(self.inner.clone())
     }
@@ -525,6 +858,21 @@ impl InstanceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::InstanceService;
+    /// async fn sample(
+    ///    client: &InstanceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::instance_service::CancelOperation {
         super::builder::instance_service::CancelOperation::new(self.inner.clone())
     }
@@ -636,6 +984,23 @@ impl ReferenceListService {
     }
 
     /// Gets a single reference list.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_reference_list()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_reference_list(&self) -> super::builder::reference_list_service::GetReferenceList {
         super::builder::reference_list_service::GetReferenceList::new(self.inner.clone())
     }
@@ -648,6 +1013,22 @@ impl ReferenceListService {
     }
 
     /// Creates a new reference list.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_reference_list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_reference_list(
         &self,
     ) -> super::builder::reference_list_service::CreateReferenceList {
@@ -655,6 +1036,22 @@ impl ReferenceListService {
     }
 
     /// Updates an existing reference list.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_reference_list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_reference_list(
         &self,
     ) -> super::builder::reference_list_service::UpdateReferenceList {
@@ -671,6 +1068,22 @@ impl ReferenceListService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reference_list_service::GetOperation {
         super::builder::reference_list_service::GetOperation::new(self.inner.clone())
     }
@@ -678,6 +1091,21 @@ impl ReferenceListService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::reference_list_service::DeleteOperation {
         super::builder::reference_list_service::DeleteOperation::new(self.inner.clone())
     }
@@ -685,6 +1113,21 @@ impl ReferenceListService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::ReferenceListService;
+    /// async fn sample(
+    ///    client: &ReferenceListService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::reference_list_service::CancelOperation {
         super::builder::reference_list_service::CancelOperation::new(self.inner.clone())
     }
@@ -793,11 +1236,44 @@ impl RuleService {
     }
 
     /// Creates a new Rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_rule(&self) -> super::builder::rule_service::CreateRule {
         super::builder::rule_service::CreateRule::new(self.inner.clone())
     }
 
     /// Gets a Rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::rule_service::GetRule {
         super::builder::rule_service::GetRule::new(self.inner.clone())
     }
@@ -808,11 +1284,42 @@ impl RuleService {
     }
 
     /// Updates a Rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_rule(&self) -> super::builder::rule_service::UpdateRule {
         super::builder::rule_service::UpdateRule::new(self.inner.clone())
     }
 
     /// Deletes a Rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_rule(&self) -> super::builder::rule_service::DeleteRule {
         super::builder::rule_service::DeleteRule::new(self.inner.clone())
     }
@@ -838,6 +1345,23 @@ impl RuleService {
     }
 
     /// Get a Retrohunt.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_retrohunt()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_retrohunt(&self) -> super::builder::rule_service::GetRetrohunt {
         super::builder::rule_service::GetRetrohunt::new(self.inner.clone())
     }
@@ -848,6 +1372,23 @@ impl RuleService {
     }
 
     /// Gets a RuleDeployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule_deployment(&self) -> super::builder::rule_service::GetRuleDeployment {
         super::builder::rule_service::GetRuleDeployment::new(self.inner.clone())
     }
@@ -861,6 +1402,22 @@ impl RuleService {
     /// Failures are not necessarily atomic. If there is a request to update
     /// multiple fields, and any update to a single field fails, an error will be
     /// returned, but other fields may remain successfully updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_rule_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_rule_deployment(&self) -> super::builder::rule_service::UpdateRuleDeployment {
         super::builder::rule_service::UpdateRuleDeployment::new(self.inner.clone())
     }
@@ -875,6 +1432,22 @@ impl RuleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::rule_service::GetOperation {
         super::builder::rule_service::GetOperation::new(self.inner.clone())
     }
@@ -882,6 +1455,21 @@ impl RuleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::rule_service::DeleteOperation {
         super::builder::rule_service::DeleteOperation::new(self.inner.clone())
     }
@@ -889,6 +1477,21 @@ impl RuleService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_chronicle_v1::client::RuleService;
+    /// async fn sample(
+    ///    client: &RuleService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::rule_service::CancelOperation {
         super::builder::rule_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
@@ -123,6 +123,23 @@ impl CloudControlsPartnerCore {
     }
 
     /// Gets details of a single workload
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workload()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workload(&self) -> super::builder::cloud_controls_partner_core::GetWorkload {
         super::builder::cloud_controls_partner_core::GetWorkload::new(self.inner.clone())
     }
@@ -133,6 +150,23 @@ impl CloudControlsPartnerCore {
     }
 
     /// Gets details of a single customer
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_customer()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_customer(&self) -> super::builder::cloud_controls_partner_core::GetCustomer {
         super::builder::cloud_controls_partner_core::GetCustomer::new(self.inner.clone())
     }
@@ -143,6 +177,23 @@ impl CloudControlsPartnerCore {
     }
 
     /// Gets the EKM connections associated with a workload
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ekm_connections()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ekm_connections(
         &self,
     ) -> super::builder::cloud_controls_partner_core::GetEkmConnections {
@@ -150,6 +201,23 @@ impl CloudControlsPartnerCore {
     }
 
     /// Gets the partner permissions granted for a workload
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_partner_permissions()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_partner_permissions(
         &self,
     ) -> super::builder::cloud_controls_partner_core::GetPartnerPermissions {
@@ -168,21 +236,86 @@ impl CloudControlsPartnerCore {
     }
 
     /// Get details of a Partner.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_partner()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_partner(&self) -> super::builder::cloud_controls_partner_core::GetPartner {
         super::builder::cloud_controls_partner_core::GetPartner::new(self.inner.clone())
     }
 
     /// Creates a new customer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_customer()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_customer(&self) -> super::builder::cloud_controls_partner_core::CreateCustomer {
         super::builder::cloud_controls_partner_core::CreateCustomer::new(self.inner.clone())
     }
 
     /// Update details of a single customer
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_customer()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_customer(&self) -> super::builder::cloud_controls_partner_core::UpdateCustomer {
         super::builder::cloud_controls_partner_core::UpdateCustomer::new(self.inner.clone())
     }
 
     /// Delete details of a single customer
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerCore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_customer()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_customer(&self) -> super::builder::cloud_controls_partner_core::DeleteCustomer {
         super::builder::cloud_controls_partner_core::DeleteCustomer::new(self.inner.clone())
     }
@@ -308,6 +441,23 @@ impl CloudControlsPartnerMonitoring {
     }
 
     /// Gets details of a single Violation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerMonitoring;
+    /// async fn sample(
+    ///    client: &CloudControlsPartnerMonitoring,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_violation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_violation(&self) -> super::builder::cloud_controls_partner_monitoring::GetViolation {
         super::builder::cloud_controls_partner_monitoring::GetViolation::new(self.inner.clone())
     }

--- a/src/generated/cloud/clouddms/v1/src/client.rs
+++ b/src/generated/cloud/clouddms/v1/src/client.rs
@@ -127,6 +127,23 @@ impl DataMigrationService {
     }
 
     /// Gets details of a single migration job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_migration_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_migration_job(&self) -> super::builder::data_migration_service::GetMigrationJob {
         super::builder::data_migration_service::GetMigrationJob::new(self.inner.clone())
     }
@@ -287,12 +304,44 @@ impl DataMigrationService {
 
     /// Generate a SSH configuration script to configure the reverse SSH
     /// connectivity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_ssh_script()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_ssh_script(&self) -> super::builder::data_migration_service::GenerateSshScript {
         super::builder::data_migration_service::GenerateSshScript::new(self.inner.clone())
     }
 
     /// Generate a TCP Proxy configuration script to configure a cloud-hosted VM
     /// running a TCP Proxy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_tcp_proxy_script()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_tcp_proxy_script(
         &self,
     ) -> super::builder::data_migration_service::GenerateTcpProxyScript {
@@ -308,6 +357,23 @@ impl DataMigrationService {
     }
 
     /// Gets details of a single connection profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection_profile(
         &self,
     ) -> super::builder::data_migration_service::GetConnectionProfile {
@@ -385,6 +451,23 @@ impl DataMigrationService {
     }
 
     /// Gets details of a single private connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_private_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_private_connection(
         &self,
     ) -> super::builder::data_migration_service::GetPrivateConnection {
@@ -416,6 +499,23 @@ impl DataMigrationService {
     }
 
     /// Gets details of a single conversion workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversion_workspace()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversion_workspace(
         &self,
     ) -> super::builder::data_migration_service::GetConversionWorkspace {
@@ -481,11 +581,42 @@ impl DataMigrationService {
     }
 
     /// Creates a new mapping rule for a given conversion workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_mapping_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_mapping_rule(&self) -> super::builder::data_migration_service::CreateMappingRule {
         super::builder::data_migration_service::CreateMappingRule::new(self.inner.clone())
     }
 
     /// Deletes a single mapping rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_mapping_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_mapping_rule(&self) -> super::builder::data_migration_service::DeleteMappingRule {
         super::builder::data_migration_service::DeleteMappingRule::new(self.inner.clone())
     }
@@ -496,6 +627,23 @@ impl DataMigrationService {
     }
 
     /// Gets the details of a mapping rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_mapping_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_mapping_rule(&self) -> super::builder::data_migration_service::GetMappingRule {
         super::builder::data_migration_service::GetMappingRule::new(self.inner.clone())
     }
@@ -622,6 +770,22 @@ impl DataMigrationService {
     /// The background jobs are not resources like conversion workspaces or
     /// mapping rules, and they can't be created, updated or deleted.
     /// Instead, they are a way to expose the data plane jobs log.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_background_jobs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_background_jobs(
         &self,
     ) -> super::builder::data_migration_service::SearchBackgroundJobs {
@@ -630,6 +794,22 @@ impl DataMigrationService {
 
     /// Retrieves a list of committed revisions of a specific conversion
     /// workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .describe_conversion_workspace_revisions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn describe_conversion_workspace_revisions(
         &self,
     ) -> super::builder::data_migration_service::DescribeConversionWorkspaceRevisions {
@@ -640,6 +820,22 @@ impl DataMigrationService {
 
     /// Fetches a set of static IP addresses that need to be allowlisted by the
     /// customer when using the static-IP connectivity method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_static_ips()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_static_ips(&self) -> super::builder::data_migration_service::FetchStaticIps {
         super::builder::data_migration_service::FetchStaticIps::new(self.inner.clone())
     }
@@ -650,6 +846,22 @@ impl DataMigrationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_migration_service::GetLocation {
         super::builder::data_migration_service::GetLocation::new(self.inner.clone())
     }
@@ -659,12 +871,44 @@ impl DataMigrationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_migration_service::SetIamPolicy {
         super::builder::data_migration_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_migration_service::GetIamPolicy {
         super::builder::data_migration_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -676,6 +920,22 @@ impl DataMigrationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::data_migration_service::TestIamPermissions {
@@ -692,6 +952,22 @@ impl DataMigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_migration_service::GetOperation {
         super::builder::data_migration_service::GetOperation::new(self.inner.clone())
     }
@@ -699,6 +975,21 @@ impl DataMigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_migration_service::DeleteOperation {
         super::builder::data_migration_service::DeleteOperation::new(self.inner.clone())
     }
@@ -706,6 +997,21 @@ impl DataMigrationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_clouddms_v1::client::DataMigrationService;
+    /// async fn sample(
+    ///    client: &DataMigrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_migration_service::CancelOperation {
         super::builder::data_migration_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/cloudsecuritycompliance/v1/src/client.rs
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/src/client.rs
@@ -119,6 +119,22 @@ impl Audit {
     }
 
     /// Generates an audit scope report for a framework.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_framework_audit_scope_report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_framework_audit_scope_report(
         &self,
     ) -> super::builder::audit::GenerateFrameworkAuditScopeReport {
@@ -146,6 +162,23 @@ impl Audit {
     }
 
     /// Gets the details for a framework audit.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_framework_audit()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_framework_audit(&self) -> super::builder::audit::GetFrameworkAudit {
         super::builder::audit::GetFrameworkAudit::new(self.inner.clone())
     }
@@ -156,6 +189,22 @@ impl Audit {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::audit::GetLocation {
         super::builder::audit::GetLocation::new(self.inner.clone())
     }
@@ -170,6 +219,22 @@ impl Audit {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::audit::GetOperation {
         super::builder::audit::GetOperation::new(self.inner.clone())
     }
@@ -177,6 +242,21 @@ impl Audit {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::audit::DeleteOperation {
         super::builder::audit::DeleteOperation::new(self.inner.clone())
     }
@@ -184,6 +264,21 @@ impl Audit {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+    /// async fn sample(
+    ///    client: &Audit
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::audit::CancelOperation {
         super::builder::audit::CancelOperation::new(self.inner.clone())
     }
@@ -299,6 +394,22 @@ impl CmEnrollmentService {
     /// an audit.
     /// Use this method to enroll a resource in Compliance Manager or to
     /// create or update feature-specific configurations.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_cm_enrollment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_cm_enrollment(
         &self,
     ) -> super::builder::cm_enrollment_service::UpdateCmEnrollment {
@@ -309,6 +420,22 @@ impl CmEnrollmentService {
     /// An effective enrollment is either a direct enrollment of a
     /// resource (if it exists), or an enrollment of the closest parent of a
     /// resource that's enrolled in Compliance Manager.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .calculate_effective_cm_enrollment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn calculate_effective_cm_enrollment(
         &self,
     ) -> super::builder::cm_enrollment_service::CalculateEffectiveCmEnrollment {
@@ -323,6 +450,22 @@ impl CmEnrollmentService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cm_enrollment_service::GetLocation {
         super::builder::cm_enrollment_service::GetLocation::new(self.inner.clone())
     }
@@ -337,6 +480,22 @@ impl CmEnrollmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cm_enrollment_service::GetOperation {
         super::builder::cm_enrollment_service::GetOperation::new(self.inner.clone())
     }
@@ -344,6 +503,21 @@ impl CmEnrollmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cm_enrollment_service::DeleteOperation {
         super::builder::cm_enrollment_service::DeleteOperation::new(self.inner.clone())
     }
@@ -351,6 +525,21 @@ impl CmEnrollmentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
+    /// async fn sample(
+    ///    client: &CmEnrollmentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cm_enrollment_service::CancelOperation {
         super::builder::cm_enrollment_service::CancelOperation::new(self.inner.clone())
     }
@@ -472,6 +661,23 @@ impl Config {
     ///
     /// To retrieve a specific major version, include `major_revision_id` in
     /// the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_framework()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_framework(&self) -> super::builder::config::GetFramework {
         super::builder::config::GetFramework::new(self.inner.clone())
     }
@@ -479,6 +685,22 @@ impl Config {
     /// Creates a custom framework in a given parent resource.
     /// You can't create built-in frameworks because those are managed by
     /// Google.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_framework()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_framework(&self) -> super::builder::config::CreateFramework {
         super::builder::config::CreateFramework::new(self.inner.clone())
     }
@@ -495,6 +717,22 @@ impl Config {
     ///
     /// You can only update frameworks with the `CUSTOM` type.
     /// A successful update creates a new version of the framework.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_framework()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_framework(&self) -> super::builder::config::UpdateFramework {
         super::builder::config::UpdateFramework::new(self.inner.clone())
     }
@@ -506,6 +744,22 @@ impl Config {
     ///   with type `CUSTOM`.
     /// - You can't delete frameworks that are deployed to a resource.
     /// - You can't restore a deleted framework. This action is permanent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_framework()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_framework(&self) -> super::builder::config::DeleteFramework {
         super::builder::config::DeleteFramework::new(self.inner.clone())
     }
@@ -525,6 +779,23 @@ impl Config {
     /// By default, the latest major version of the cloud control is returned.
     /// To retrieve a specific major version, include `major_revision_id` in
     /// the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cloud_control()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cloud_control(&self) -> super::builder::config::GetCloudControl {
         super::builder::config::GetCloudControl::new(self.inner.clone())
     }
@@ -533,6 +804,22 @@ impl Config {
     /// resource.
     /// You can't create built-in cloud controls because those are managed by
     /// Google.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_cloud_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_cloud_control(&self) -> super::builder::config::CreateCloudControl {
         super::builder::config::CreateCloudControl::new(self.inner.clone())
     }
@@ -549,6 +836,22 @@ impl Config {
     ///
     /// You can only update cloud controls with the `CUSTOM` type.
     /// A successful update creates a new version of the cloud control.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_cloud_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_cloud_control(&self) -> super::builder::config::UpdateCloudControl {
         super::builder::config::UpdateCloudControl::new(self.inner.clone())
     }
@@ -561,6 +864,22 @@ impl Config {
     /// - You can't delete cloud controls if any of the versions are referenced
     ///   by a framework.
     /// - You can't restore a deleted cloud control. This action is permanent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_cloud_control()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_cloud_control(&self) -> super::builder::config::DeleteCloudControl {
         super::builder::config::DeleteCloudControl::new(self.inner.clone())
     }
@@ -571,6 +890,22 @@ impl Config {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::config::GetLocation {
         super::builder::config::GetLocation::new(self.inner.clone())
     }
@@ -585,6 +920,22 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::config::GetOperation {
         super::builder::config::GetOperation::new(self.inner.clone())
     }
@@ -592,6 +943,21 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::config::DeleteOperation {
         super::builder::config::DeleteOperation::new(self.inner.clone())
     }
@@ -599,6 +965,21 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::config::CancelOperation {
         super::builder::config::CancelOperation::new(self.inner.clone())
     }
@@ -745,6 +1126,23 @@ impl Deployment {
     }
 
     /// Gets details about a framework deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_framework_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_framework_deployment(&self) -> super::builder::deployment::GetFrameworkDeployment {
         super::builder::deployment::GetFrameworkDeployment::new(self.inner.clone())
     }
@@ -757,6 +1155,23 @@ impl Deployment {
     }
 
     /// Gets details about a cloud control deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cloud_control_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cloud_control_deployment(
         &self,
     ) -> super::builder::deployment::GetCloudControlDeployment {
@@ -776,6 +1191,22 @@ impl Deployment {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::deployment::GetLocation {
         super::builder::deployment::GetLocation::new(self.inner.clone())
     }
@@ -790,6 +1221,22 @@ impl Deployment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::deployment::GetOperation {
         super::builder::deployment::GetOperation::new(self.inner.clone())
     }
@@ -797,6 +1244,21 @@ impl Deployment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::deployment::DeleteOperation {
         super::builder::deployment::DeleteOperation::new(self.inner.clone())
     }
@@ -804,6 +1266,21 @@ impl Deployment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
+    /// async fn sample(
+    ///    client: &Deployment
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::deployment::CancelOperation {
         super::builder::deployment::CancelOperation::new(self.inner.clone())
     }
@@ -924,6 +1401,22 @@ impl Monitoring {
     }
 
     /// Fetches the framework compliance report for a given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_framework_compliance_report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_framework_compliance_report(
         &self,
     ) -> super::builder::monitoring::FetchFrameworkComplianceReport {
@@ -938,6 +1431,22 @@ impl Monitoring {
     }
 
     /// Gets the aggregated compliance report over time for a given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .aggregate_framework_compliance_report()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn aggregate_framework_compliance_report(
         &self,
     ) -> super::builder::monitoring::AggregateFrameworkComplianceReport {
@@ -950,6 +1459,22 @@ impl Monitoring {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::monitoring::GetLocation {
         super::builder::monitoring::GetLocation::new(self.inner.clone())
     }
@@ -964,6 +1489,22 @@ impl Monitoring {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::monitoring::GetOperation {
         super::builder::monitoring::GetOperation::new(self.inner.clone())
     }
@@ -971,6 +1512,21 @@ impl Monitoring {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::monitoring::DeleteOperation {
         super::builder::monitoring::DeleteOperation::new(self.inner.clone())
     }
@@ -978,6 +1534,21 @@ impl Monitoring {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
+    /// async fn sample(
+    ///    client: &Monitoring
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::monitoring::CancelOperation {
         super::builder::monitoring::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
@@ -123,11 +123,43 @@ impl LicenseManagementService {
     }
 
     /// Gets the license pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// async fn sample(
+    ///    client: &LicenseManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_license_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_license_pool(&self) -> super::builder::license_management_service::GetLicensePool {
         super::builder::license_management_service::GetLicensePool::new(self.inner.clone())
     }
 
     /// Updates the license pool if one exists for this Order.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// async fn sample(
+    ///    client: &LicenseManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_license_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_license_pool(
         &self,
     ) -> super::builder::license_management_service::UpdateLicensePool {
@@ -135,11 +167,43 @@ impl LicenseManagementService {
     }
 
     /// Assigns a license to a user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// async fn sample(
+    ///    client: &LicenseManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .assign()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn assign(&self) -> super::builder::license_management_service::Assign {
         super::builder::license_management_service::Assign::new(self.inner.clone())
     }
 
     /// Unassigns a license from a user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// async fn sample(
+    ///    client: &LicenseManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .unassign()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn unassign(&self) -> super::builder::license_management_service::Unassign {
         super::builder::license_management_service::Unassign::new(self.inner.clone())
     }
@@ -154,6 +218,22 @@ impl LicenseManagementService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+    /// async fn sample(
+    ///    client: &LicenseManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::license_management_service::GetOperation {
         super::builder::license_management_service::GetOperation::new(self.inner.clone())
     }
@@ -304,6 +384,22 @@ impl ConsumerProcurementService {
     /// [Order][google.cloud.commerce.consumer.procurement.v1.Order] resource.
     ///
     /// [google.cloud.commerce.consumer.procurement.v1.Order]: crate::model::Order
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::ConsumerProcurementService;
+    /// async fn sample(
+    ///    client: &ConsumerProcurementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_order()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_order(&self) -> super::builder::consumer_procurement_service::GetOrder {
         super::builder::consumer_procurement_service::GetOrder::new(self.inner.clone())
     }
@@ -357,6 +453,22 @@ impl ConsumerProcurementService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_commerce_consumer_procurement_v1::client::ConsumerProcurementService;
+    /// async fn sample(
+    ///    client: &ConsumerProcurementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::consumer_procurement_service::GetOperation {
         super::builder::consumer_procurement_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/compute/v1/src/client.rs
+++ b/src/generated/cloud/compute/v1/src/client.rs
@@ -134,6 +134,22 @@ impl AcceleratorTypes {
     }
 
     /// Returns the specified accelerator type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::AcceleratorTypes;
+    /// async fn sample(
+    ///    client: &AcceleratorTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::accelerator_types::Get {
         super::builder::accelerator_types::Get::new(self.inner.clone())
     }
@@ -264,6 +280,22 @@ impl Addresses {
     }
 
     /// Returns the specified address resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Addresses;
+    /// async fn sample(
+    ///    client: &Addresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::addresses::Get {
         super::builder::addresses::Get::new(self.inner.clone())
     }
@@ -292,11 +324,43 @@ impl Addresses {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Addresses;
+    /// async fn sample(
+    ///    client: &Addresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::addresses::TestIamPermissions {
         super::builder::addresses::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Addresses;
+    /// async fn sample(
+    ///    client: &Addresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::addresses::GetOperation {
         super::builder::addresses::GetOperation::new(self.inner.clone())
     }
@@ -411,6 +475,22 @@ impl Advice {
     /// with specified accelerators, within the specified time and location limits.
     /// The method recommends creating future reservations for the requested
     /// resources.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Advice;
+    /// async fn sample(
+    ///    client: &Advice
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .calendar_mode()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn calendar_mode(&self) -> super::builder::advice::CalendarMode {
         super::builder::advice::CalendarMode::new(self.inner.clone())
     }
@@ -535,6 +615,22 @@ impl Autoscalers {
     }
 
     /// Returns the specified autoscaler resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Autoscalers;
+    /// async fn sample(
+    ///    client: &Autoscalers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::autoscalers::Get {
         super::builder::autoscalers::Get::new(self.inner.clone())
     }
@@ -566,6 +662,22 @@ impl Autoscalers {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Autoscalers;
+    /// async fn sample(
+    ///    client: &Autoscalers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::autoscalers::GetOperation {
         super::builder::autoscalers::GetOperation::new(self.inner.clone())
     }
@@ -694,12 +806,44 @@ impl BackendBuckets {
     }
 
     /// Returns the specified BackendBucket resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendBuckets;
+    /// async fn sample(
+    ///    client: &BackendBuckets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::backend_buckets::Get {
         super::builder::backend_buckets::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendBuckets;
+    /// async fn sample(
+    ///    client: &BackendBuckets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::backend_buckets::GetIamPolicy {
         super::builder::backend_buckets::GetIamPolicy::new(self.inner.clone())
     }
@@ -733,11 +877,43 @@ impl BackendBuckets {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendBuckets;
+    /// async fn sample(
+    ///    client: &BackendBuckets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::backend_buckets::SetIamPolicy {
         super::builder::backend_buckets::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendBuckets;
+    /// async fn sample(
+    ///    client: &BackendBuckets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::backend_buckets::TestIamPermissions {
         super::builder::backend_buckets::TestIamPermissions::new(self.inner.clone())
     }
@@ -749,6 +925,22 @@ impl BackendBuckets {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendBuckets;
+    /// async fn sample(
+    ///    client: &BackendBuckets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::backend_buckets::GetOperation {
         super::builder::backend_buckets::GetOperation::new(self.inner.clone())
     }
@@ -889,11 +1081,42 @@ impl BackendServices {
     }
 
     /// Returns the specified BackendService resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::backend_services::Get {
         super::builder::backend_services::Get::new(self.inner.clone())
     }
 
     /// Returns effective security policies applied to this backend service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .get_effective_security_policies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_effective_security_policies(
         &self,
     ) -> super::builder::backend_services::GetEffectiveSecurityPolicies {
@@ -908,12 +1131,44 @@ impl BackendServices {
     /// {
     /// "group": "/zones/us-east1-b/instanceGroups/lb-backend-example"
     /// }
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_health()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_health(&self) -> super::builder::backend_services::GetHealth {
         super::builder::backend_services::GetHealth::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::backend_services::GetIamPolicy {
         super::builder::backend_services::GetIamPolicy::new(self.inner.clone())
     }
@@ -954,6 +1209,22 @@ impl BackendServices {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::backend_services::SetIamPolicy {
         super::builder::backend_services::SetIamPolicy::new(self.inner.clone())
     }
@@ -966,6 +1237,22 @@ impl BackendServices {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::backend_services::TestIamPermissions {
         super::builder::backend_services::TestIamPermissions::new(self.inner.clone())
     }
@@ -978,6 +1265,22 @@ impl BackendServices {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::BackendServices;
+    /// async fn sample(
+    ///    client: &BackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::backend_services::GetOperation {
         super::builder::backend_services::GetOperation::new(self.inner.clone())
     }
@@ -1097,6 +1400,22 @@ impl CrossSiteNetworks {
     }
 
     /// Returns the specified cross-site network in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::CrossSiteNetworks;
+    /// async fn sample(
+    ///    client: &CrossSiteNetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::cross_site_networks::Get {
         super::builder::cross_site_networks::Get::new(self.inner.clone())
     }
@@ -1121,6 +1440,22 @@ impl CrossSiteNetworks {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::CrossSiteNetworks;
+    /// async fn sample(
+    ///    client: &CrossSiteNetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cross_site_networks::GetOperation {
         super::builder::cross_site_networks::GetOperation::new(self.inner.clone())
     }
@@ -1240,6 +1575,22 @@ impl DiskTypes {
     }
 
     /// Returns the specified disk type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::DiskTypes;
+    /// async fn sample(
+    ///    client: &DiskTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::disk_types::Get {
         super::builder::disk_types::Get::new(self.inner.clone())
     }
@@ -1400,12 +1751,44 @@ impl Disks {
     }
 
     /// Returns the specified persistent disk.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Disks;
+    /// async fn sample(
+    ///    client: &Disks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::disks::Get {
         super::builder::disks::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Disks;
+    /// async fn sample(
+    ///    client: &Disks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::disks::GetIamPolicy {
         super::builder::disks::GetIamPolicy::new(self.inner.clone())
     }
@@ -1438,6 +1821,22 @@ impl Disks {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Disks;
+    /// async fn sample(
+    ///    client: &Disks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::disks::SetIamPolicy {
         super::builder::disks::SetIamPolicy::new(self.inner.clone())
     }
@@ -1467,6 +1866,22 @@ impl Disks {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Disks;
+    /// async fn sample(
+    ///    client: &Disks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::disks::TestIamPermissions {
         super::builder::disks::TestIamPermissions::new(self.inner.clone())
     }
@@ -1479,6 +1894,22 @@ impl Disks {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Disks;
+    /// async fn sample(
+    ///    client: &Disks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::disks::GetOperation {
         super::builder::disks::GetOperation::new(self.inner.clone())
     }
@@ -1599,6 +2030,22 @@ impl ExternalVpnGateways {
 
     /// Returns the specified externalVpnGateway. Get a list of available
     /// externalVpnGateways by making a list() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ExternalVpnGateways;
+    /// async fn sample(
+    ///    client: &ExternalVpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::external_vpn_gateways::Get {
         super::builder::external_vpn_gateways::Get::new(self.inner.clone())
     }
@@ -1623,6 +2070,22 @@ impl ExternalVpnGateways {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ExternalVpnGateways;
+    /// async fn sample(
+    ///    client: &ExternalVpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::external_vpn_gateways::TestIamPermissions {
@@ -1630,6 +2093,22 @@ impl ExternalVpnGateways {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ExternalVpnGateways;
+    /// async fn sample(
+    ///    client: &ExternalVpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::external_vpn_gateways::GetOperation {
         super::builder::external_vpn_gateways::GetOperation::new(self.inner.clone())
     }
@@ -1764,22 +2243,86 @@ impl FirewallPolicies {
     }
 
     /// Returns the specified firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::firewall_policies::Get {
         super::builder::firewall_policies::Get::new(self.inner.clone())
     }
 
     /// Gets an association with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_association()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_association(&self) -> super::builder::firewall_policies::GetAssociation {
         super::builder::firewall_policies::GetAssociation::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::firewall_policies::GetIamPolicy {
         super::builder::firewall_policies::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets a rule of the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::firewall_policies::GetRule {
         super::builder::firewall_policies::GetRule::new(self.inner.clone())
     }
@@ -1797,6 +2340,22 @@ impl FirewallPolicies {
     }
 
     /// Lists associations of a specified target, i.e., organization or folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_associations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_associations(&self) -> super::builder::firewall_policies::ListAssociations {
         super::builder::firewall_policies::ListAssociations::new(self.inner.clone())
     }
@@ -1828,17 +2387,65 @@ impl FirewallPolicies {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::firewall_policies::SetIamPolicy {
         super::builder::firewall_policies::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::firewall_policies::TestIamPermissions {
         super::builder::firewall_policies::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource. Gets a list of operations
     /// by making a `list()` request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FirewallPolicies;
+    /// async fn sample(
+    ///    client: &FirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::firewall_policies::GetOperation {
         super::builder::firewall_policies::GetOperation::new(self.inner.clone())
     }
@@ -1955,6 +2562,22 @@ impl Firewalls {
     }
 
     /// Returns the specified firewall.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Firewalls;
+    /// async fn sample(
+    ///    client: &Firewalls
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::firewalls::Get {
         super::builder::firewalls::Get::new(self.inner.clone())
     }
@@ -1980,6 +2603,22 @@ impl Firewalls {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Firewalls;
+    /// async fn sample(
+    ///    client: &Firewalls
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::firewalls::TestIamPermissions {
         super::builder::firewalls::TestIamPermissions::new(self.inner.clone())
     }
@@ -1993,6 +2632,22 @@ impl Firewalls {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Firewalls;
+    /// async fn sample(
+    ///    client: &Firewalls
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::firewalls::GetOperation {
         super::builder::firewalls::GetOperation::new(self.inner.clone())
     }
@@ -2120,6 +2775,22 @@ impl ForwardingRules {
     }
 
     /// Returns the specified ForwardingRule resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ForwardingRules;
+    /// async fn sample(
+    ///    client: &ForwardingRules
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::forwarding_rules::Get {
         super::builder::forwarding_rules::Get::new(self.inner.clone())
     }
@@ -2159,6 +2830,22 @@ impl ForwardingRules {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ForwardingRules;
+    /// async fn sample(
+    ///    client: &ForwardingRules
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::forwarding_rules::GetOperation {
         super::builder::forwarding_rules::GetOperation::new(self.inner.clone())
     }
@@ -2291,6 +2978,22 @@ impl FutureReservations {
     }
 
     /// Retrieves information about the specified future reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FutureReservations;
+    /// async fn sample(
+    ///    client: &FutureReservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::future_reservations::Get {
         super::builder::future_reservations::Get::new(self.inner.clone())
     }
@@ -2312,6 +3015,22 @@ impl FutureReservations {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::FutureReservations;
+    /// async fn sample(
+    ///    client: &FutureReservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::future_reservations::GetOperation {
         super::builder::future_reservations::GetOperation::new(self.inner.clone())
     }
@@ -2431,6 +3150,22 @@ impl GlobalAddresses {
     }
 
     /// Returns the specified address resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalAddresses;
+    /// async fn sample(
+    ///    client: &GlobalAddresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_addresses::Get {
         super::builder::global_addresses::Get::new(self.inner.clone())
     }
@@ -2458,11 +3193,43 @@ impl GlobalAddresses {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalAddresses;
+    /// async fn sample(
+    ///    client: &GlobalAddresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::global_addresses::TestIamPermissions {
         super::builder::global_addresses::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalAddresses;
+    /// async fn sample(
+    ///    client: &GlobalAddresses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::global_addresses::GetOperation {
         super::builder::global_addresses::GetOperation::new(self.inner.clone())
     }
@@ -2583,6 +3350,22 @@ impl GlobalForwardingRules {
 
     /// Returns the specified GlobalForwardingRule resource. Gets a list of
     /// available forwarding rules by making a list() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalForwardingRules;
+    /// async fn sample(
+    ///    client: &GlobalForwardingRules
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_forwarding_rules::Get {
         super::builder::global_forwarding_rules::Get::new(self.inner.clone())
     }
@@ -2622,6 +3405,22 @@ impl GlobalForwardingRules {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalForwardingRules;
+    /// async fn sample(
+    ///    client: &GlobalForwardingRules
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::global_forwarding_rules::GetOperation {
         super::builder::global_forwarding_rules::GetOperation::new(self.inner.clone())
     }
@@ -2761,6 +3560,22 @@ impl GlobalNetworkEndpointGroups {
     }
 
     /// Returns the specified network endpoint group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalNetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &GlobalNetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_network_endpoint_groups::Get {
         super::builder::global_network_endpoint_groups::Get::new(self.inner.clone())
     }
@@ -2787,6 +3602,22 @@ impl GlobalNetworkEndpointGroups {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalNetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &GlobalNetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::global_network_endpoint_groups::GetOperation {
         super::builder::global_network_endpoint_groups::GetOperation::new(self.inner.clone())
     }
@@ -2909,11 +3740,42 @@ impl GlobalOperations {
     }
 
     /// Deletes the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalOperations;
+    /// async fn sample(
+    ///    client: &GlobalOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::global_operations::Delete {
         super::builder::global_operations::Delete::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalOperations;
+    /// async fn sample(
+    ///    client: &GlobalOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_operations::Get {
         super::builder::global_operations::Get::new(self.inner.clone())
     }
@@ -2942,6 +3804,22 @@ impl GlobalOperations {
     /// - If the default deadline is reached, there is no guarantee that the
     ///   operation is actually done when the method returns. Be prepared to retry
     ///   if the operation is not `DONE`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalOperations;
+    /// async fn sample(
+    ///    client: &GlobalOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait(&self) -> super::builder::global_operations::Wait {
         super::builder::global_operations::Wait::new(self.inner.clone())
     }
@@ -3057,12 +3935,43 @@ impl GlobalOrganizationOperations {
     }
 
     /// Deletes the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalOrganizationOperations;
+    /// async fn sample(
+    ///    client: &GlobalOrganizationOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::global_organization_operations::Delete {
         super::builder::global_organization_operations::Delete::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource. Gets a list of operations
     /// by making a `list()` request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalOrganizationOperations;
+    /// async fn sample(
+    ///    client: &GlobalOrganizationOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_organization_operations::Get {
         super::builder::global_organization_operations::Get::new(self.inner.clone())
     }
@@ -3189,6 +4098,22 @@ impl GlobalPublicDelegatedPrefixes {
     }
 
     /// Returns the specified global PublicDelegatedPrefix resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalPublicDelegatedPrefixes;
+    /// async fn sample(
+    ///    client: &GlobalPublicDelegatedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::global_public_delegated_prefixes::Get {
         super::builder::global_public_delegated_prefixes::Get::new(self.inner.clone())
     }
@@ -3213,6 +4138,22 @@ impl GlobalPublicDelegatedPrefixes {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::GlobalPublicDelegatedPrefixes;
+    /// async fn sample(
+    ///    client: &GlobalPublicDelegatedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::global_public_delegated_prefixes::GetOperation {
         super::builder::global_public_delegated_prefixes::GetOperation::new(self.inner.clone())
     }
@@ -3338,6 +4279,22 @@ impl HealthChecks {
     }
 
     /// Returns the specified HealthCheck resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HealthChecks;
+    /// async fn sample(
+    ///    client: &HealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::health_checks::Get {
         super::builder::health_checks::Get::new(self.inner.clone())
     }
@@ -3369,6 +4326,22 @@ impl HealthChecks {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HealthChecks;
+    /// async fn sample(
+    ///    client: &HealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::health_checks::GetOperation {
         super::builder::health_checks::GetOperation::new(self.inner.clone())
     }
@@ -3488,6 +4461,22 @@ impl HttpHealthChecks {
     }
 
     /// Returns the specified HttpHealthCheck resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HttpHealthChecks;
+    /// async fn sample(
+    ///    client: &HttpHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::http_health_checks::Get {
         super::builder::http_health_checks::Get::new(self.inner.clone())
     }
@@ -3519,6 +4508,22 @@ impl HttpHealthChecks {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HttpHealthChecks;
+    /// async fn sample(
+    ///    client: &HttpHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::http_health_checks::GetOperation {
         super::builder::http_health_checks::GetOperation::new(self.inner.clone())
     }
@@ -3638,6 +4643,22 @@ impl HttpsHealthChecks {
     }
 
     /// Returns the specified HttpsHealthCheck resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HttpsHealthChecks;
+    /// async fn sample(
+    ///    client: &HttpsHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::https_health_checks::Get {
         super::builder::https_health_checks::Get::new(self.inner.clone())
     }
@@ -3669,6 +4690,22 @@ impl HttpsHealthChecks {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::HttpsHealthChecks;
+    /// async fn sample(
+    ///    client: &HttpsHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::https_health_checks::GetOperation {
         super::builder::https_health_checks::GetOperation::new(self.inner.clone())
     }
@@ -3784,6 +4821,22 @@ impl ImageFamilyViews {
 
     /// Returns the latest image that is part of an image family, is not
     /// deprecated and is rolled out in the specified zone.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ImageFamilyViews;
+    /// async fn sample(
+    ///    client: &ImageFamilyViews
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::image_family_views::Get {
         super::builder::image_family_views::Get::new(self.inner.clone())
     }
@@ -3907,6 +4960,22 @@ impl Images {
     }
 
     /// Returns the specified image.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::images::Get {
         super::builder::images::Get::new(self.inner.clone())
     }
@@ -3914,12 +4983,44 @@ impl Images {
     /// Returns the latest image that is part of an image family and is not
     /// deprecated. For more information on image families, seePublic
     /// image families documentation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_from_family()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_from_family(&self) -> super::builder::images::GetFromFamily {
         super::builder::images::GetFromFamily::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::images::GetIamPolicy {
         super::builder::images::GetIamPolicy::new(self.inner.clone())
     }
@@ -3950,6 +5051,22 @@ impl Images {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::images::SetIamPolicy {
         super::builder::images::SetIamPolicy::new(self.inner.clone())
     }
@@ -3961,11 +5078,43 @@ impl Images {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::images::TestIamPermissions {
         super::builder::images::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Images;
+    /// async fn sample(
+    ///    client: &Images
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::images::GetOperation {
         super::builder::images::GetOperation::new(self.inner.clone())
     }
@@ -4096,6 +5245,22 @@ impl InstanceGroupManagerResizeRequests {
     }
 
     /// Returns all of the details about the specified resize request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroupManagerResizeRequests;
+    /// async fn sample(
+    ///    client: &InstanceGroupManagerResizeRequests
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instance_group_manager_resize_requests::Get {
         super::builder::instance_group_manager_resize_requests::Get::new(self.inner.clone())
     }
@@ -4113,6 +5278,22 @@ impl InstanceGroupManagerResizeRequests {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroupManagerResizeRequests;
+    /// async fn sample(
+    ///    client: &InstanceGroupManagerResizeRequests
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::instance_group_manager_resize_requests::GetOperation {
@@ -4309,6 +5490,22 @@ impl InstanceGroupManagers {
     }
 
     /// Returns all of the details about the specified managed instance group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroupManagers;
+    /// async fn sample(
+    ///    client: &InstanceGroupManagers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instance_group_managers::Get {
         super::builder::instance_group_managers::Get::new(self.inner.clone())
     }
@@ -4563,6 +5760,22 @@ impl InstanceGroupManagers {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroupManagers;
+    /// async fn sample(
+    ///    client: &InstanceGroupManagers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_group_managers::GetOperation {
         super::builder::instance_group_managers::GetOperation::new(self.inner.clone())
     }
@@ -4703,6 +5916,22 @@ impl InstanceGroups {
     /// For managed instance groups, use theinstanceGroupManagers
     /// or regionInstanceGroupManagers
     /// methods instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroups;
+    /// async fn sample(
+    ///    client: &InstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instance_groups::Get {
         super::builder::instance_groups::Get::new(self.inner.clone())
     }
@@ -4748,11 +5977,43 @@ impl InstanceGroups {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroups;
+    /// async fn sample(
+    ///    client: &InstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::instance_groups::TestIamPermissions {
         super::builder::instance_groups::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceGroups;
+    /// async fn sample(
+    ///    client: &InstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_groups::GetOperation {
         super::builder::instance_groups::GetOperation::new(self.inner.clone())
     }
@@ -4867,6 +6128,22 @@ impl InstanceSettings {
     }
 
     /// Get Instance settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceSettings;
+    /// async fn sample(
+    ///    client: &InstanceSettings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instance_settings::Get {
         super::builder::instance_settings::Get::new(self.inner.clone())
     }
@@ -4877,6 +6154,22 @@ impl InstanceSettings {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceSettings;
+    /// async fn sample(
+    ///    client: &InstanceSettings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_settings::GetOperation {
         super::builder::instance_settings::GetOperation::new(self.inner.clone())
     }
@@ -5007,12 +6300,44 @@ impl InstanceTemplates {
     }
 
     /// Returns the specified instance template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceTemplates;
+    /// async fn sample(
+    ///    client: &InstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instance_templates::Get {
         super::builder::instance_templates::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceTemplates;
+    /// async fn sample(
+    ///    client: &InstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::instance_templates::GetIamPolicy {
         super::builder::instance_templates::GetIamPolicy::new(self.inner.clone())
     }
@@ -5034,16 +6359,64 @@ impl InstanceTemplates {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceTemplates;
+    /// async fn sample(
+    ///    client: &InstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::instance_templates::SetIamPolicy {
         super::builder::instance_templates::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceTemplates;
+    /// async fn sample(
+    ///    client: &InstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::instance_templates::TestIamPermissions {
         super::builder::instance_templates::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstanceTemplates;
+    /// async fn sample(
+    ///    client: &InstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_templates::GetOperation {
         super::builder::instance_templates::GetOperation::new(self.inner.clone())
     }
@@ -5225,37 +6598,149 @@ impl Instances {
     }
 
     /// Returns the specified Instance resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instances::Get {
         super::builder::instances::Get::new(self.inner.clone())
     }
 
     /// Returns effective firewalls applied to an interface of the instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_effective_firewalls()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_effective_firewalls(&self) -> super::builder::instances::GetEffectiveFirewalls {
         super::builder::instances::GetEffectiveFirewalls::new(self.inner.clone())
     }
 
     /// Returns the specified guest attributes entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_guest_attributes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_guest_attributes(&self) -> super::builder::instances::GetGuestAttributes {
         super::builder::instances::GetGuestAttributes::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::instances::GetIamPolicy {
         super::builder::instances::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the screenshot from the specified instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_screenshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_screenshot(&self) -> super::builder::instances::GetScreenshot {
         super::builder::instances::GetScreenshot::new(self.inner.clone())
     }
 
     /// Returns the last 1 MB of serial port output from the specified instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_serial_port_output()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_serial_port_output(&self) -> super::builder::instances::GetSerialPortOutput {
         super::builder::instances::GetSerialPortOutput::new(self.inner.clone())
     }
 
     /// Returns the Shielded Instance Identity of an instance
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_shielded_instance_identity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_shielded_instance_identity(
         &self,
     ) -> super::builder::instances::GetShieldedInstanceIdentity {
@@ -5312,6 +6797,21 @@ impl Instances {
     }
 
     /// Sends diagnostic interrupt to the instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .send_diagnostic_interrupt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn send_diagnostic_interrupt(&self) -> super::builder::instances::SendDiagnosticInterrupt {
         super::builder::instances::SendDiagnosticInterrupt::new(self.inner.clone())
     }
@@ -5328,6 +6828,22 @@ impl Instances {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::instances::SetIamPolicy {
         super::builder::instances::SetIamPolicy::new(self.inner.clone())
     }
@@ -5453,6 +6969,22 @@ impl Instances {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::instances::TestIamPermissions {
         super::builder::instances::TestIamPermissions::new(self.inner.clone())
     }
@@ -5502,6 +7034,22 @@ impl Instances {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Instances;
+    /// async fn sample(
+    ///    client: &Instances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instances::GetOperation {
         super::builder::instances::GetOperation::new(self.inner.clone())
     }
@@ -5636,12 +7184,44 @@ impl InstantSnapshots {
     }
 
     /// Returns the specified InstantSnapshot resource in the specified zone.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstantSnapshots;
+    /// async fn sample(
+    ///    client: &InstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::instant_snapshots::Get {
         super::builder::instant_snapshots::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstantSnapshots;
+    /// async fn sample(
+    ///    client: &InstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::instant_snapshots::GetIamPolicy {
         super::builder::instant_snapshots::GetIamPolicy::new(self.inner.clone())
     }
@@ -5659,6 +7239,22 @@ impl InstantSnapshots {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstantSnapshots;
+    /// async fn sample(
+    ///    client: &InstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::instant_snapshots::SetIamPolicy {
         super::builder::instant_snapshots::SetIamPolicy::new(self.inner.clone())
     }
@@ -5671,11 +7267,43 @@ impl InstantSnapshots {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstantSnapshots;
+    /// async fn sample(
+    ///    client: &InstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::instant_snapshots::TestIamPermissions {
         super::builder::instant_snapshots::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InstantSnapshots;
+    /// async fn sample(
+    ///    client: &InstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instant_snapshots::GetOperation {
         super::builder::instant_snapshots::GetOperation::new(self.inner.clone())
     }
@@ -5797,18 +7425,66 @@ impl InterconnectAttachmentGroups {
 
     /// Returns the specified InterconnectAttachmentGroup resource in the given
     /// scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnect_attachment_groups::Get {
         super::builder::interconnect_attachment_groups::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::interconnect_attachment_groups::GetIamPolicy {
         super::builder::interconnect_attachment_groups::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the InterconnectAttachmentStatuses for the specified
     /// InterconnectAttachmentGroup resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operational_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operational_status(
         &self,
     ) -> super::builder::interconnect_attachment_groups::GetOperationalStatus {
@@ -5838,11 +7514,43 @@ impl InterconnectAttachmentGroups {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::interconnect_attachment_groups::SetIamPolicy {
         super::builder::interconnect_attachment_groups::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::interconnect_attachment_groups::TestIamPermissions {
@@ -5850,6 +7558,22 @@ impl InterconnectAttachmentGroups {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
+    /// async fn sample(
+    ///    client: &InterconnectAttachmentGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::interconnect_attachment_groups::GetOperation {
         super::builder::interconnect_attachment_groups::GetOperation::new(self.inner.clone())
     }
@@ -5978,6 +7702,22 @@ impl InterconnectAttachments {
     }
 
     /// Returns the specified interconnect attachment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachments;
+    /// async fn sample(
+    ///    client: &InterconnectAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnect_attachments::Get {
         super::builder::interconnect_attachments::Get::new(self.inner.clone())
     }
@@ -6010,6 +7750,22 @@ impl InterconnectAttachments {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectAttachments;
+    /// async fn sample(
+    ///    client: &InterconnectAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::interconnect_attachments::GetOperation {
         super::builder::interconnect_attachments::GetOperation::new(self.inner.clone())
     }
@@ -6135,18 +7891,66 @@ impl InterconnectGroups {
     }
 
     /// Returns the specified InterconnectGroup resource in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnect_groups::Get {
         super::builder::interconnect_groups::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::interconnect_groups::GetIamPolicy {
         super::builder::interconnect_groups::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns the interconnectStatuses for the specified
     /// InterconnectGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operational_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operational_status(
         &self,
     ) -> super::builder::interconnect_groups::GetOperationalStatus {
@@ -6174,16 +7978,64 @@ impl InterconnectGroups {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::interconnect_groups::SetIamPolicy {
         super::builder::interconnect_groups::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::interconnect_groups::TestIamPermissions {
         super::builder::interconnect_groups::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectGroups;
+    /// async fn sample(
+    ///    client: &InterconnectGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::interconnect_groups::GetOperation {
         super::builder::interconnect_groups::GetOperation::new(self.inner.clone())
     }
@@ -6299,6 +8151,22 @@ impl InterconnectLocations {
 
     /// Returns the details for the specified interconnect location. Gets a list of
     /// available interconnect locations by making a list() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectLocations;
+    /// async fn sample(
+    ///    client: &InterconnectLocations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnect_locations::Get {
         super::builder::interconnect_locations::Get::new(self.inner.clone())
     }
@@ -6421,6 +8289,22 @@ impl InterconnectRemoteLocations {
 
     /// Returns the details for the specified interconnect remote location. Gets a
     /// list of available interconnect remote locations by making alist() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::InterconnectRemoteLocations;
+    /// async fn sample(
+    ///    client: &InterconnectRemoteLocations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnect_remote_locations::Get {
         super::builder::interconnect_remote_locations::Get::new(self.inner.clone())
     }
@@ -6544,6 +8428,22 @@ impl Interconnects {
 
     /// Returns the specified Interconnect. Get a list of available Interconnects
     /// by making a list() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Interconnects;
+    /// async fn sample(
+    ///    client: &Interconnects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::interconnects::Get {
         super::builder::interconnects::Get::new(self.inner.clone())
     }
@@ -6558,12 +8458,44 @@ impl Interconnects {
     /// Unlike a VLAN attachment, which is regional, a Cloud Interconnect
     /// connection is a global resource. A global outage can prevent this
     /// API from functioning properly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Interconnects;
+    /// async fn sample(
+    ///    client: &Interconnects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_diagnostics()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_diagnostics(&self) -> super::builder::interconnects::GetDiagnostics {
         super::builder::interconnects::GetDiagnostics::new(self.inner.clone())
     }
 
     /// Returns the interconnectMacsecConfig for the specified
     /// Interconnect.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Interconnects;
+    /// async fn sample(
+    ///    client: &Interconnects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_macsec_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_macsec_config(&self) -> super::builder::interconnects::GetMacsecConfig {
         super::builder::interconnects::GetMacsecConfig::new(self.inner.clone())
     }
@@ -6595,6 +8527,22 @@ impl Interconnects {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Interconnects;
+    /// async fn sample(
+    ///    client: &Interconnects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::interconnects::GetOperation {
         super::builder::interconnects::GetOperation::new(self.inner.clone())
     }
@@ -6710,6 +8658,22 @@ impl LicenseCodes {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::LicenseCodes;
+    /// async fn sample(
+    ///    client: &LicenseCodes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::license_codes::Get {
         super::builder::license_codes::Get::new(self.inner.clone())
     }
@@ -6718,6 +8682,22 @@ impl LicenseCodes {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::LicenseCodes;
+    /// async fn sample(
+    ///    client: &LicenseCodes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::license_codes::TestIamPermissions {
         super::builder::license_codes::TestIamPermissions::new(self.inner.clone())
     }
@@ -6840,6 +8820,22 @@ impl Licenses {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Licenses;
+    /// async fn sample(
+    ///    client: &Licenses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::licenses::Get {
         super::builder::licenses::Get::new(self.inner.clone())
     }
@@ -6849,6 +8845,22 @@ impl Licenses {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Licenses;
+    /// async fn sample(
+    ///    client: &Licenses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::licenses::GetIamPolicy {
         super::builder::licenses::GetIamPolicy::new(self.inner.clone())
     }
@@ -6879,6 +8891,22 @@ impl Licenses {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Licenses;
+    /// async fn sample(
+    ///    client: &Licenses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::licenses::SetIamPolicy {
         super::builder::licenses::SetIamPolicy::new(self.inner.clone())
     }
@@ -6887,6 +8915,22 @@ impl Licenses {
     /// *Caution* This resource is intended
     /// for use only by third-party partners who are creatingCloud Marketplace
     /// images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Licenses;
+    /// async fn sample(
+    ///    client: &Licenses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::licenses::TestIamPermissions {
         super::builder::licenses::TestIamPermissions::new(self.inner.clone())
     }
@@ -6900,6 +8944,22 @@ impl Licenses {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Licenses;
+    /// async fn sample(
+    ///    client: &Licenses
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::licenses::GetOperation {
         super::builder::licenses::GetOperation::new(self.inner.clone())
     }
@@ -7017,12 +9077,44 @@ impl MachineImages {
     }
 
     /// Returns the specified machine image.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineImages;
+    /// async fn sample(
+    ///    client: &MachineImages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::machine_images::Get {
         super::builder::machine_images::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineImages;
+    /// async fn sample(
+    ///    client: &MachineImages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::machine_images::GetIamPolicy {
         super::builder::machine_images::GetIamPolicy::new(self.inner.clone())
     }
@@ -7044,6 +9136,22 @@ impl MachineImages {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineImages;
+    /// async fn sample(
+    ///    client: &MachineImages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::machine_images::SetIamPolicy {
         super::builder::machine_images::SetIamPolicy::new(self.inner.clone())
     }
@@ -7055,11 +9163,43 @@ impl MachineImages {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineImages;
+    /// async fn sample(
+    ///    client: &MachineImages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::machine_images::TestIamPermissions {
         super::builder::machine_images::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineImages;
+    /// async fn sample(
+    ///    client: &MachineImages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::machine_images::GetOperation {
         super::builder::machine_images::GetOperation::new(self.inner.clone())
     }
@@ -7179,6 +9319,22 @@ impl MachineTypes {
     }
 
     /// Returns the specified machine type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::MachineTypes;
+    /// async fn sample(
+    ///    client: &MachineTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::machine_types::Get {
         super::builder::machine_types::Get::new(self.inner.clone())
     }
@@ -7313,12 +9469,44 @@ impl NetworkAttachments {
     }
 
     /// Returns the specified NetworkAttachment resource in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkAttachments;
+    /// async fn sample(
+    ///    client: &NetworkAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::network_attachments::Get {
         super::builder::network_attachments::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkAttachments;
+    /// async fn sample(
+    ///    client: &NetworkAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::network_attachments::GetIamPolicy {
         super::builder::network_attachments::GetIamPolicy::new(self.inner.clone())
     }
@@ -7344,16 +9532,64 @@ impl NetworkAttachments {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkAttachments;
+    /// async fn sample(
+    ///    client: &NetworkAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::network_attachments::SetIamPolicy {
         super::builder::network_attachments::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkAttachments;
+    /// async fn sample(
+    ///    client: &NetworkAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::network_attachments::TestIamPermissions {
         super::builder::network_attachments::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkAttachments;
+    /// async fn sample(
+    ///    client: &NetworkAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_attachments::GetOperation {
         super::builder::network_attachments::GetOperation::new(self.inner.clone())
     }
@@ -7485,6 +9721,22 @@ impl NetworkEdgeSecurityServices {
     }
 
     /// Gets a specified NetworkEdgeSecurityService.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkEdgeSecurityServices;
+    /// async fn sample(
+    ///    client: &NetworkEdgeSecurityServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::network_edge_security_services::Get {
         super::builder::network_edge_security_services::Get::new(self.inner.clone())
     }
@@ -7501,6 +9753,22 @@ impl NetworkEdgeSecurityServices {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkEdgeSecurityServices;
+    /// async fn sample(
+    ///    client: &NetworkEdgeSecurityServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_edge_security_services::GetOperation {
         super::builder::network_edge_security_services::GetOperation::new(self.inner.clone())
     }
@@ -7646,6 +9914,22 @@ impl NetworkEndpointGroups {
     }
 
     /// Returns the specified network endpoint group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &NetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::network_endpoint_groups::Get {
         super::builder::network_endpoint_groups::Get::new(self.inner.clone())
     }
@@ -7670,6 +9954,22 @@ impl NetworkEndpointGroups {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &NetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::network_endpoint_groups::TestIamPermissions {
@@ -7677,6 +9977,22 @@ impl NetworkEndpointGroups {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &NetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_endpoint_groups::GetOperation {
         super::builder::network_endpoint_groups::GetOperation::new(self.inner.clone())
     }
@@ -7829,22 +10145,86 @@ impl NetworkFirewallPolicies {
     }
 
     /// Returns the specified network firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::network_firewall_policies::Get {
         super::builder::network_firewall_policies::Get::new(self.inner.clone())
     }
 
     /// Gets an association with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_association()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_association(&self) -> super::builder::network_firewall_policies::GetAssociation {
         super::builder::network_firewall_policies::GetAssociation::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::network_firewall_policies::GetIamPolicy {
         super::builder::network_firewall_policies::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets a packet mirroring rule of the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_packet_mirroring_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_packet_mirroring_rule(
         &self,
     ) -> super::builder::network_firewall_policies::GetPacketMirroringRule {
@@ -7852,6 +10232,22 @@ impl NetworkFirewallPolicies {
     }
 
     /// Gets a rule of the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::network_firewall_policies::GetRule {
         super::builder::network_firewall_policies::GetRule::new(self.inner.clone())
     }
@@ -7907,11 +10303,43 @@ impl NetworkFirewallPolicies {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::network_firewall_policies::SetIamPolicy {
         super::builder::network_firewall_policies::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::network_firewall_policies::TestIamPermissions {
@@ -7919,6 +10347,22 @@ impl NetworkFirewallPolicies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &NetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_firewall_policies::GetOperation {
         super::builder::network_firewall_policies::GetOperation::new(self.inner.clone())
     }
@@ -8033,6 +10477,22 @@ impl NetworkProfiles {
     }
 
     /// Returns the specified network profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NetworkProfiles;
+    /// async fn sample(
+    ///    client: &NetworkProfiles
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::network_profiles::Get {
         super::builder::network_profiles::Get::new(self.inner.clone())
     }
@@ -8160,11 +10620,43 @@ impl Networks {
     }
 
     /// Returns the specified network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Networks;
+    /// async fn sample(
+    ///    client: &Networks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::networks::Get {
         super::builder::networks::Get::new(self.inner.clone())
     }
 
     /// Returns the effective firewalls on a given network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Networks;
+    /// async fn sample(
+    ///    client: &Networks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_effective_firewalls()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_effective_firewalls(&self) -> super::builder::networks::GetEffectiveFirewalls {
         super::builder::networks::GetEffectiveFirewalls::new(self.inner.clone())
     }
@@ -8215,6 +10707,22 @@ impl Networks {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Networks;
+    /// async fn sample(
+    ///    client: &Networks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::networks::GetOperation {
         super::builder::networks::GetOperation::new(self.inner.clone())
     }
@@ -8353,12 +10861,44 @@ impl NodeGroups {
     /// by making a list() request.
     /// Note: the "nodes" field should not be used. Use nodeGroups.listNodes
     /// instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeGroups;
+    /// async fn sample(
+    ///    client: &NodeGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::node_groups::Get {
         super::builder::node_groups::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeGroups;
+    /// async fn sample(
+    ///    client: &NodeGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::node_groups::GetIamPolicy {
         super::builder::node_groups::GetIamPolicy::new(self.inner.clone())
     }
@@ -8392,6 +10932,22 @@ impl NodeGroups {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeGroups;
+    /// async fn sample(
+    ///    client: &NodeGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::node_groups::SetIamPolicy {
         super::builder::node_groups::SetIamPolicy::new(self.inner.clone())
     }
@@ -8409,11 +10965,43 @@ impl NodeGroups {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeGroups;
+    /// async fn sample(
+    ///    client: &NodeGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::node_groups::TestIamPermissions {
         super::builder::node_groups::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeGroups;
+    /// async fn sample(
+    ///    client: &NodeGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::node_groups::GetOperation {
         super::builder::node_groups::GetOperation::new(self.inner.clone())
     }
@@ -8538,12 +11126,44 @@ impl NodeTemplates {
     }
 
     /// Returns the specified node template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTemplates;
+    /// async fn sample(
+    ///    client: &NodeTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::node_templates::Get {
         super::builder::node_templates::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTemplates;
+    /// async fn sample(
+    ///    client: &NodeTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::node_templates::GetIamPolicy {
         super::builder::node_templates::GetIamPolicy::new(self.inner.clone())
     }
@@ -8562,16 +11182,64 @@ impl NodeTemplates {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTemplates;
+    /// async fn sample(
+    ///    client: &NodeTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::node_templates::SetIamPolicy {
         super::builder::node_templates::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTemplates;
+    /// async fn sample(
+    ///    client: &NodeTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::node_templates::TestIamPermissions {
         super::builder::node_templates::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTemplates;
+    /// async fn sample(
+    ///    client: &NodeTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::node_templates::GetOperation {
         super::builder::node_templates::GetOperation::new(self.inner.clone())
     }
@@ -8691,6 +11359,22 @@ impl NodeTypes {
     }
 
     /// Returns the specified node type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::NodeTypes;
+    /// async fn sample(
+    ///    client: &NodeTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::node_types::Get {
         super::builder::node_types::Get::new(self.inner.clone())
     }
@@ -8860,6 +11544,22 @@ impl OrganizationSecurityPolicies {
     /// Use this API to read Cloud Armor policies. Previously, alpha and beta
     /// versions of this API were used to read firewall policies. This usage is now
     /// disabled for most organizations. Use firewallPolicies.get instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::organization_security_policies::Get {
         super::builder::organization_security_policies::Get::new(self.inner.clone())
     }
@@ -8870,6 +11570,22 @@ impl OrganizationSecurityPolicies {
     /// versions of this API were used to read firewall policies. This usage is
     /// now disabled for most organizations. Use firewallPolicies.getAssociation
     /// instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_association()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_association(
         &self,
     ) -> super::builder::organization_security_policies::GetAssociation {
@@ -8881,6 +11597,22 @@ impl OrganizationSecurityPolicies {
     /// Use this API to read Cloud Armor policies. Previously, alpha and beta
     /// versions of this API were used to read firewall policies. This usage is now
     /// disabled for most organizations. Use firewallPolicies.getRule instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::organization_security_policies::GetRule {
         super::builder::organization_security_policies::GetRule::new(self.inner.clone())
     }
@@ -8911,6 +11643,22 @@ impl OrganizationSecurityPolicies {
     /// versions of this API were used to read firewall policies. This usage is
     /// now disabled for most organizations. Use firewallPolicies.listAssociations
     /// instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_associations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_associations(
         &self,
     ) -> super::builder::organization_security_policies::ListAssociations {
@@ -8919,6 +11667,22 @@ impl OrganizationSecurityPolicies {
 
     /// Gets the current list of preconfigured Web Application Firewall (WAF)
     /// expressions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_preconfigured_expression_sets()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_preconfigured_expression_sets(
         &self,
     ) -> super::builder::organization_security_policies::ListPreconfiguredExpressionSets {
@@ -8979,6 +11743,22 @@ impl OrganizationSecurityPolicies {
 
     /// Retrieves the specified Operations resource. Gets a list of operations
     /// by making a `list()` request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
+    /// async fn sample(
+    ///    client: &OrganizationSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::organization_security_policies::GetOperation {
         super::builder::organization_security_policies::GetOperation::new(self.inner.clone())
     }
@@ -9106,6 +11886,22 @@ impl PacketMirrorings {
     }
 
     /// Returns the specified PacketMirroring resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PacketMirrorings;
+    /// async fn sample(
+    ///    client: &PacketMirrorings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::packet_mirrorings::Get {
         super::builder::packet_mirrorings::Get::new(self.inner.clone())
     }
@@ -9131,11 +11927,43 @@ impl PacketMirrorings {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PacketMirrorings;
+    /// async fn sample(
+    ///    client: &PacketMirrorings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::packet_mirrorings::TestIamPermissions {
         super::builder::packet_mirrorings::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PacketMirrorings;
+    /// async fn sample(
+    ///    client: &PacketMirrorings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::packet_mirrorings::GetOperation {
         super::builder::packet_mirrorings::GetOperation::new(self.inner.clone())
     }
@@ -9250,6 +12078,22 @@ impl PreviewFeatures {
     }
 
     /// Returns the details of the given PreviewFeature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PreviewFeatures;
+    /// async fn sample(
+    ///    client: &PreviewFeatures
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::preview_features::Get {
         super::builder::preview_features::Get::new(self.inner.clone())
     }
@@ -9266,6 +12110,22 @@ impl PreviewFeatures {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PreviewFeatures;
+    /// async fn sample(
+    ///    client: &PreviewFeatures
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::preview_features::GetOperation {
         super::builder::preview_features::GetOperation::new(self.inner.clone())
     }
@@ -9408,12 +12268,44 @@ impl Projects {
     /// to only include the fields you need. For example, to only include the `id`
     /// and `selfLink` fields, add the query parameter `?fields=id,selfLink` to
     /// your request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::projects::Get {
         super::builder::projects::Get::new(self.inner.clone())
     }
 
     /// Gets the shared VPC host project that this project links to. May be empty
     /// if no link exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_xpn_host()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_xpn_host(&self) -> super::builder::projects::GetXpnHost {
         super::builder::projects::GetXpnHost::new(self.inner.clone())
     }
@@ -9491,6 +12383,22 @@ impl Projects {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::projects::GetOperation {
         super::builder::projects::GetOperation::new(self.inner.clone())
     }
@@ -9616,6 +12524,22 @@ impl PublicAdvertisedPrefixes {
     }
 
     /// Returns the specified PublicAdvertisedPrefix resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PublicAdvertisedPrefixes;
+    /// async fn sample(
+    ///    client: &PublicAdvertisedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::public_advertised_prefixes::Get {
         super::builder::public_advertised_prefixes::Get::new(self.inner.clone())
     }
@@ -9645,6 +12569,22 @@ impl PublicAdvertisedPrefixes {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PublicAdvertisedPrefixes;
+    /// async fn sample(
+    ///    client: &PublicAdvertisedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::public_advertised_prefixes::GetOperation {
         super::builder::public_advertised_prefixes::GetOperation::new(self.inner.clone())
     }
@@ -9779,6 +12719,22 @@ impl PublicDelegatedPrefixes {
     }
 
     /// Returns the specified PublicDelegatedPrefix resource in the given region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PublicDelegatedPrefixes;
+    /// async fn sample(
+    ///    client: &PublicDelegatedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::public_delegated_prefixes::Get {
         super::builder::public_delegated_prefixes::Get::new(self.inner.clone())
     }
@@ -9808,6 +12764,22 @@ impl PublicDelegatedPrefixes {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::PublicDelegatedPrefixes;
+    /// async fn sample(
+    ///    client: &PublicDelegatedPrefixes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::public_delegated_prefixes::GetOperation {
         super::builder::public_delegated_prefixes::GetOperation::new(self.inner.clone())
     }
@@ -9927,6 +12899,22 @@ impl RegionAutoscalers {
     }
 
     /// Returns the specified autoscaler.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionAutoscalers;
+    /// async fn sample(
+    ///    client: &RegionAutoscalers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_autoscalers::Get {
         super::builder::region_autoscalers::Get::new(self.inner.clone())
     }
@@ -9958,6 +12946,22 @@ impl RegionAutoscalers {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionAutoscalers;
+    /// async fn sample(
+    ///    client: &RegionAutoscalers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_autoscalers::GetOperation {
         super::builder::region_autoscalers::GetOperation::new(self.inner.clone())
     }
@@ -10077,18 +13081,66 @@ impl RegionBackendServices {
     }
 
     /// Returns the specified regional BackendService resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_backend_services::Get {
         super::builder::region_backend_services::Get::new(self.inner.clone())
     }
 
     /// Gets the most recent health check results for this
     /// regional BackendService.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_health()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_health(&self) -> super::builder::region_backend_services::GetHealth {
         super::builder::region_backend_services::GetHealth::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::region_backend_services::GetIamPolicy {
         super::builder::region_backend_services::GetIamPolicy::new(self.inner.clone())
     }
@@ -10123,6 +13175,22 @@ impl RegionBackendServices {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::region_backend_services::SetIamPolicy {
         super::builder::region_backend_services::SetIamPolicy::new(self.inner.clone())
     }
@@ -10137,6 +13205,22 @@ impl RegionBackendServices {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::region_backend_services::TestIamPermissions {
@@ -10152,6 +13236,22 @@ impl RegionBackendServices {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionBackendServices;
+    /// async fn sample(
+    ///    client: &RegionBackendServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_backend_services::GetOperation {
         super::builder::region_backend_services::GetOperation::new(self.inner.clone())
     }
@@ -10274,6 +13374,22 @@ impl RegionCommitments {
     }
 
     /// Returns the specified commitment resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionCommitments;
+    /// async fn sample(
+    ///    client: &RegionCommitments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_commitments::Get {
         super::builder::region_commitments::Get::new(self.inner.clone())
     }
@@ -10298,6 +13414,22 @@ impl RegionCommitments {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionCommitments;
+    /// async fn sample(
+    ///    client: &RegionCommitments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_commitments::GetOperation {
         super::builder::region_commitments::GetOperation::new(self.inner.clone())
     }
@@ -10412,6 +13544,22 @@ impl RegionDiskTypes {
     }
 
     /// Returns the specified regional disk type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDiskTypes;
+    /// async fn sample(
+    ///    client: &RegionDiskTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_disk_types::Get {
         super::builder::region_disk_types::Get::new(self.inner.clone())
     }
@@ -10557,12 +13705,44 @@ impl RegionDisks {
     }
 
     /// Returns a specified regional persistent disk.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDisks;
+    /// async fn sample(
+    ///    client: &RegionDisks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_disks::Get {
         super::builder::region_disks::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDisks;
+    /// async fn sample(
+    ///    client: &RegionDisks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::region_disks::GetIamPolicy {
         super::builder::region_disks::GetIamPolicy::new(self.inner.clone())
     }
@@ -10591,6 +13771,22 @@ impl RegionDisks {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDisks;
+    /// async fn sample(
+    ///    client: &RegionDisks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::region_disks::SetIamPolicy {
         super::builder::region_disks::SetIamPolicy::new(self.inner.clone())
     }
@@ -10621,6 +13817,22 @@ impl RegionDisks {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDisks;
+    /// async fn sample(
+    ///    client: &RegionDisks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::region_disks::TestIamPermissions {
         super::builder::region_disks::TestIamPermissions::new(self.inner.clone())
     }
@@ -10633,6 +13845,22 @@ impl RegionDisks {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionDisks;
+    /// async fn sample(
+    ///    client: &RegionDisks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_disks::GetOperation {
         super::builder::region_disks::GetOperation::new(self.inner.clone())
     }
@@ -10753,6 +13981,22 @@ impl RegionHealthCheckServices {
     }
 
     /// Returns the specified regional HealthCheckService resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionHealthCheckServices;
+    /// async fn sample(
+    ///    client: &RegionHealthCheckServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_health_check_services::Get {
         super::builder::region_health_check_services::Get::new(self.inner.clone())
     }
@@ -10778,6 +14022,22 @@ impl RegionHealthCheckServices {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionHealthCheckServices;
+    /// async fn sample(
+    ///    client: &RegionHealthCheckServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_health_check_services::GetOperation {
         super::builder::region_health_check_services::GetOperation::new(self.inner.clone())
     }
@@ -10897,6 +14157,22 @@ impl RegionHealthChecks {
     }
 
     /// Returns the specified HealthCheck resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionHealthChecks;
+    /// async fn sample(
+    ///    client: &RegionHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_health_checks::Get {
         super::builder::region_health_checks::Get::new(self.inner.clone())
     }
@@ -10928,6 +14204,22 @@ impl RegionHealthChecks {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionHealthChecks;
+    /// async fn sample(
+    ///    client: &RegionHealthChecks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_health_checks::GetOperation {
         super::builder::region_health_checks::GetOperation::new(self.inner.clone())
     }
@@ -11122,6 +14414,22 @@ impl RegionInstanceGroupManagers {
     }
 
     /// Returns all of the details about the specified managed instance group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceGroupManagers;
+    /// async fn sample(
+    ///    client: &RegionInstanceGroupManagers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_instance_group_managers::Get {
         super::builder::region_instance_group_managers::Get::new(self.inner.clone())
     }
@@ -11373,6 +14681,22 @@ impl RegionInstanceGroupManagers {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceGroupManagers;
+    /// async fn sample(
+    ///    client: &RegionInstanceGroupManagers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_instance_group_managers::GetOperation {
         super::builder::region_instance_group_managers::GetOperation::new(self.inner.clone())
     }
@@ -11487,6 +14811,22 @@ impl RegionInstanceGroups {
     }
 
     /// Returns the specified instance group resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceGroups;
+    /// async fn sample(
+    ///    client: &RegionInstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_instance_groups::Get {
         super::builder::region_instance_groups::Get::new(self.inner.clone())
     }
@@ -11511,6 +14851,22 @@ impl RegionInstanceGroups {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceGroups;
+    /// async fn sample(
+    ///    client: &RegionInstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::region_instance_groups::TestIamPermissions {
@@ -11518,6 +14874,22 @@ impl RegionInstanceGroups {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceGroups;
+    /// async fn sample(
+    ///    client: &RegionInstanceGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_instance_groups::GetOperation {
         super::builder::region_instance_groups::GetOperation::new(self.inner.clone())
     }
@@ -11639,6 +15011,22 @@ impl RegionInstanceTemplates {
     }
 
     /// Returns the specified instance template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceTemplates;
+    /// async fn sample(
+    ///    client: &RegionInstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_instance_templates::Get {
         super::builder::region_instance_templates::Get::new(self.inner.clone())
     }
@@ -11656,6 +15044,22 @@ impl RegionInstanceTemplates {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstanceTemplates;
+    /// async fn sample(
+    ///    client: &RegionInstanceTemplates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_instance_templates::GetOperation {
         super::builder::region_instance_templates::GetOperation::new(self.inner.clone())
     }
@@ -11776,6 +15180,22 @@ impl RegionInstances {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstances;
+    /// async fn sample(
+    ///    client: &RegionInstances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_instances::GetOperation {
         super::builder::region_instances::GetOperation::new(self.inner.clone())
     }
@@ -11902,12 +15322,44 @@ impl RegionInstantSnapshots {
     }
 
     /// Returns the specified InstantSnapshot resource in the specified region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
+    /// async fn sample(
+    ///    client: &RegionInstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_instant_snapshots::Get {
         super::builder::region_instant_snapshots::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
+    /// async fn sample(
+    ///    client: &RegionInstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::region_instant_snapshots::GetIamPolicy {
         super::builder::region_instant_snapshots::GetIamPolicy::new(self.inner.clone())
     }
@@ -11925,6 +15377,22 @@ impl RegionInstantSnapshots {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
+    /// async fn sample(
+    ///    client: &RegionInstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::region_instant_snapshots::SetIamPolicy {
         super::builder::region_instant_snapshots::SetIamPolicy::new(self.inner.clone())
     }
@@ -11937,6 +15405,22 @@ impl RegionInstantSnapshots {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
+    /// async fn sample(
+    ///    client: &RegionInstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::region_instant_snapshots::TestIamPermissions {
@@ -11944,6 +15428,22 @@ impl RegionInstantSnapshots {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
+    /// async fn sample(
+    ///    client: &RegionInstantSnapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_instant_snapshots::GetOperation {
         super::builder::region_instant_snapshots::GetOperation::new(self.inner.clone())
     }
@@ -12083,6 +15583,22 @@ impl RegionNetworkEndpointGroups {
     }
 
     /// Returns the specified network endpoint group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &RegionNetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_network_endpoint_groups::Get {
         super::builder::region_network_endpoint_groups::Get::new(self.inner.clone())
     }
@@ -12109,6 +15625,22 @@ impl RegionNetworkEndpointGroups {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkEndpointGroups;
+    /// async fn sample(
+    ///    client: &RegionNetworkEndpointGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_network_endpoint_groups::GetOperation {
         super::builder::region_network_endpoint_groups::GetOperation::new(self.inner.clone())
     }
@@ -12246,11 +15778,43 @@ impl RegionNetworkFirewallPolicies {
     }
 
     /// Returns the specified network firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_network_firewall_policies::Get {
         super::builder::region_network_firewall_policies::Get::new(self.inner.clone())
     }
 
     /// Gets an association with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_association()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_association(
         &self,
     ) -> super::builder::region_network_firewall_policies::GetAssociation {
@@ -12258,6 +15822,22 @@ impl RegionNetworkFirewallPolicies {
     }
 
     /// Returns the effective firewalls on a given network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_effective_firewalls()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_effective_firewalls(
         &self,
     ) -> super::builder::region_network_firewall_policies::GetEffectiveFirewalls {
@@ -12268,11 +15848,43 @@ impl RegionNetworkFirewallPolicies {
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::region_network_firewall_policies::GetIamPolicy {
         super::builder::region_network_firewall_policies::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets a rule of the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::region_network_firewall_policies::GetRule {
         super::builder::region_network_firewall_policies::GetRule::new(self.inner.clone())
     }
@@ -12312,11 +15924,43 @@ impl RegionNetworkFirewallPolicies {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::region_network_firewall_policies::SetIamPolicy {
         super::builder::region_network_firewall_policies::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::region_network_firewall_policies::TestIamPermissions {
@@ -12326,6 +15970,22 @@ impl RegionNetworkFirewallPolicies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
+    /// async fn sample(
+    ///    client: &RegionNetworkFirewallPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_network_firewall_policies::GetOperation {
         super::builder::region_network_firewall_policies::GetOperation::new(self.inner.clone())
     }
@@ -12446,6 +16106,22 @@ impl RegionNotificationEndpoints {
     }
 
     /// Returns the specified NotificationEndpoint resource in the given region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNotificationEndpoints;
+    /// async fn sample(
+    ///    client: &RegionNotificationEndpoints
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_notification_endpoints::Get {
         super::builder::region_notification_endpoints::Get::new(self.inner.clone())
     }
@@ -12462,6 +16138,22 @@ impl RegionNotificationEndpoints {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionNotificationEndpoints;
+    /// async fn sample(
+    ///    client: &RegionNotificationEndpoints
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_notification_endpoints::GetOperation {
         super::builder::region_notification_endpoints::GetOperation::new(self.inner.clone())
     }
@@ -12576,11 +16268,42 @@ impl RegionOperations {
     }
 
     /// Deletes the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionOperations;
+    /// async fn sample(
+    ///    client: &RegionOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::region_operations::Delete {
         super::builder::region_operations::Delete::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionOperations;
+    /// async fn sample(
+    ///    client: &RegionOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_operations::Get {
         super::builder::region_operations::Get::new(self.inner.clone())
     }
@@ -12609,6 +16332,22 @@ impl RegionOperations {
     /// - If the default deadline is reached, there is no guarantee that the
     ///   operation is actually done when the method returns. Be prepared to retry
     ///   if the operation is not `DONE`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionOperations;
+    /// async fn sample(
+    ///    client: &RegionOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait(&self) -> super::builder::region_operations::Wait {
         super::builder::region_operations::Wait::new(self.inner.clone())
     }
@@ -12733,11 +16472,43 @@ impl RegionSecurityPolicies {
     }
 
     /// List all of the ordered rules present in a single specified policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSecurityPolicies;
+    /// async fn sample(
+    ///    client: &RegionSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_security_policies::Get {
         super::builder::region_security_policies::Get::new(self.inner.clone())
     }
 
     /// Gets a rule at the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSecurityPolicies;
+    /// async fn sample(
+    ///    client: &RegionSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::region_security_policies::GetRule {
         super::builder::region_security_policies::GetRule::new(self.inner.clone())
     }
@@ -12782,6 +16553,22 @@ impl RegionSecurityPolicies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSecurityPolicies;
+    /// async fn sample(
+    ///    client: &RegionSecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_security_policies::GetOperation {
         super::builder::region_security_policies::GetOperation::new(self.inner.clone())
     }
@@ -12903,6 +16690,22 @@ impl RegionSslCertificates {
     /// Returns the specified SslCertificate resource in the specified region. Get
     /// a list of available SSL certificates by making a list()
     /// request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSslCertificates;
+    /// async fn sample(
+    ///    client: &RegionSslCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_ssl_certificates::Get {
         super::builder::region_ssl_certificates::Get::new(self.inner.clone())
     }
@@ -12920,6 +16723,22 @@ impl RegionSslCertificates {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSslCertificates;
+    /// async fn sample(
+    ///    client: &RegionSslCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_ssl_certificates::GetOperation {
         super::builder::region_ssl_certificates::GetOperation::new(self.inner.clone())
     }
@@ -13041,6 +16860,22 @@ impl RegionSslPolicies {
     }
 
     /// Lists all of the ordered rules present in a single specified policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSslPolicies;
+    /// async fn sample(
+    ///    client: &RegionSslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_ssl_policies::Get {
         super::builder::region_ssl_policies::Get::new(self.inner.clone())
     }
@@ -13059,6 +16894,22 @@ impl RegionSslPolicies {
 
     /// Lists all features that can be specified in the SSL policy when using
     /// custom profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSslPolicies;
+    /// async fn sample(
+    ///    client: &RegionSslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_available_features()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_available_features(
         &self,
     ) -> super::builder::region_ssl_policies::ListAvailableFeatures {
@@ -13071,6 +16922,22 @@ impl RegionSslPolicies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionSslPolicies;
+    /// async fn sample(
+    ///    client: &RegionSslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_ssl_policies::GetOperation {
         super::builder::region_ssl_policies::GetOperation::new(self.inner.clone())
     }
@@ -13191,6 +17058,22 @@ impl RegionTargetHttpProxies {
     }
 
     /// Returns the specified TargetHttpProxy resource in the specified region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetHttpProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetHttpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_target_http_proxies::Get {
         super::builder::region_target_http_proxies::Get::new(self.inner.clone())
     }
@@ -13213,6 +17096,22 @@ impl RegionTargetHttpProxies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetHttpProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetHttpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_target_http_proxies::GetOperation {
         super::builder::region_target_http_proxies::GetOperation::new(self.inner.clone())
     }
@@ -13333,6 +17232,22 @@ impl RegionTargetHttpsProxies {
     }
 
     /// Returns the specified TargetHttpsProxy resource in the specified region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetHttpsProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetHttpsProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_target_https_proxies::Get {
         super::builder::region_target_https_proxies::Get::new(self.inner.clone())
     }
@@ -13370,6 +17285,22 @@ impl RegionTargetHttpsProxies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetHttpsProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetHttpsProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_target_https_proxies::GetOperation {
         super::builder::region_target_https_proxies::GetOperation::new(self.inner.clone())
     }
@@ -13489,6 +17420,22 @@ impl RegionTargetTcpProxies {
     }
 
     /// Returns the specified TargetTcpProxy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetTcpProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetTcpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_target_tcp_proxies::Get {
         super::builder::region_target_tcp_proxies::Get::new(self.inner.clone())
     }
@@ -13506,6 +17453,22 @@ impl RegionTargetTcpProxies {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionTargetTcpProxies;
+    /// async fn sample(
+    ///    client: &RegionTargetTcpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_target_tcp_proxies::GetOperation {
         super::builder::region_target_tcp_proxies::GetOperation::new(self.inner.clone())
     }
@@ -13622,6 +17585,22 @@ impl RegionUrlMaps {
     }
 
     /// Returns the specified UrlMap resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionUrlMaps;
+    /// async fn sample(
+    ///    client: &RegionUrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::region_url_maps::Get {
         super::builder::region_url_maps::Get::new(self.inner.clone())
     }
@@ -13655,11 +17634,43 @@ impl RegionUrlMaps {
     /// Runs static validation for the UrlMap. In particular, the tests of the
     /// provided UrlMap will be run. Calling this method does NOT create the
     /// UrlMap.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionUrlMaps;
+    /// async fn sample(
+    ///    client: &RegionUrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate(&self) -> super::builder::region_url_maps::Validate {
         super::builder::region_url_maps::Validate::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::RegionUrlMaps;
+    /// async fn sample(
+    ///    client: &RegionUrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::region_url_maps::GetOperation {
         super::builder::region_url_maps::GetOperation::new(self.inner.clone())
     }
@@ -13900,6 +17911,22 @@ impl Regions {
     /// It is recommended to use the default setting
     /// for the constraint unless your application requires the fail-closed
     /// behaviour for this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Regions;
+    /// async fn sample(
+    ///    client: &Regions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::regions::Get {
         super::builder::regions::Get::new(self.inner.clone())
     }
@@ -14037,12 +18064,44 @@ impl ReservationBlocks {
     }
 
     /// Retrieves information about the specified reservation block.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationBlocks;
+    /// async fn sample(
+    ///    client: &ReservationBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::reservation_blocks::Get {
         super::builder::reservation_blocks::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationBlocks;
+    /// async fn sample(
+    ///    client: &ReservationBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reservation_blocks::GetIamPolicy {
         super::builder::reservation_blocks::GetIamPolicy::new(self.inner.clone())
     }
@@ -14059,16 +18118,64 @@ impl ReservationBlocks {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationBlocks;
+    /// async fn sample(
+    ///    client: &ReservationBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reservation_blocks::SetIamPolicy {
         super::builder::reservation_blocks::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationBlocks;
+    /// async fn sample(
+    ///    client: &ReservationBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::reservation_blocks::TestIamPermissions {
         super::builder::reservation_blocks::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationBlocks;
+    /// async fn sample(
+    ///    client: &ReservationBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reservation_blocks::GetOperation {
         super::builder::reservation_blocks::GetOperation::new(self.inner.clone())
     }
@@ -14183,12 +18290,44 @@ impl ReservationSubBlocks {
     }
 
     /// Retrieves information about the specified reservation subBlock.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
+    /// async fn sample(
+    ///    client: &ReservationSubBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::reservation_sub_blocks::Get {
         super::builder::reservation_sub_blocks::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
+    /// async fn sample(
+    ///    client: &ReservationSubBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reservation_sub_blocks::GetIamPolicy {
         super::builder::reservation_sub_blocks::GetIamPolicy::new(self.inner.clone())
     }
@@ -14212,11 +18351,43 @@ impl ReservationSubBlocks {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
+    /// async fn sample(
+    ///    client: &ReservationSubBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reservation_sub_blocks::SetIamPolicy {
         super::builder::reservation_sub_blocks::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
+    /// async fn sample(
+    ///    client: &ReservationSubBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::reservation_sub_blocks::TestIamPermissions {
@@ -14224,6 +18395,22 @@ impl ReservationSubBlocks {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
+    /// async fn sample(
+    ///    client: &ReservationSubBlocks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reservation_sub_blocks::GetOperation {
         super::builder::reservation_sub_blocks::GetOperation::new(self.inner.clone())
     }
@@ -14348,12 +18535,44 @@ impl Reservations {
     }
 
     /// Retrieves information about the specified reservation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Reservations;
+    /// async fn sample(
+    ///    client: &Reservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::reservations::Get {
         super::builder::reservations::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Reservations;
+    /// async fn sample(
+    ///    client: &Reservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reservations::GetIamPolicy {
         super::builder::reservations::GetIamPolicy::new(self.inner.clone())
     }
@@ -14384,11 +18603,43 @@ impl Reservations {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Reservations;
+    /// async fn sample(
+    ///    client: &Reservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reservations::SetIamPolicy {
         super::builder::reservations::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Reservations;
+    /// async fn sample(
+    ///    client: &Reservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::reservations::TestIamPermissions {
         super::builder::reservations::TestIamPermissions::new(self.inner.clone())
     }
@@ -14399,6 +18650,22 @@ impl Reservations {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Reservations;
+    /// async fn sample(
+    ///    client: &Reservations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reservations::GetOperation {
         super::builder::reservations::GetOperation::new(self.inner.clone())
     }
@@ -14526,12 +18793,44 @@ impl ResourcePolicies {
     }
 
     /// Retrieves all information of the specified resource policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ResourcePolicies;
+    /// async fn sample(
+    ///    client: &ResourcePolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::resource_policies::Get {
         super::builder::resource_policies::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ResourcePolicies;
+    /// async fn sample(
+    ///    client: &ResourcePolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::resource_policies::GetIamPolicy {
         super::builder::resource_policies::GetIamPolicy::new(self.inner.clone())
     }
@@ -14554,16 +18853,64 @@ impl ResourcePolicies {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ResourcePolicies;
+    /// async fn sample(
+    ///    client: &ResourcePolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::resource_policies::SetIamPolicy {
         super::builder::resource_policies::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ResourcePolicies;
+    /// async fn sample(
+    ///    client: &ResourcePolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::resource_policies::TestIamPermissions {
         super::builder::resource_policies::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ResourcePolicies;
+    /// async fn sample(
+    ///    client: &ResourcePolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::resource_policies::GetOperation {
         super::builder::resource_policies::GetOperation::new(self.inner.clone())
     }
@@ -14693,11 +19040,43 @@ impl Routers {
     }
 
     /// Returns the specified Router resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::routers::Get {
         super::builder::routers::Get::new(self.inner.clone())
     }
 
     /// Retrieves runtime NAT IP information.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_nat_ip_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_nat_ip_info(&self) -> super::builder::routers::GetNatIpInfo {
         super::builder::routers::GetNatIpInfo::new(self.inner.clone())
     }
@@ -14708,11 +19087,43 @@ impl Routers {
     }
 
     /// Returns specified Route Policy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_route_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_route_policy(&self) -> super::builder::routers::GetRoutePolicy {
         super::builder::routers::GetRoutePolicy::new(self.inner.clone())
     }
 
     /// Retrieves runtime information of the specified router.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_router_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_router_status(&self) -> super::builder::routers::GetRouterStatus {
         super::builder::routers::GetRouterStatus::new(self.inner.clone())
     }
@@ -14754,6 +19165,22 @@ impl Routers {
 
     /// Preview fields auto-generated during router create andupdate operations.
     /// Calling this method does NOT create or update the router.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .preview()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn preview(&self) -> super::builder::routers::Preview {
         super::builder::routers::Preview::new(self.inner.clone())
     }
@@ -14772,6 +19199,22 @@ impl Routers {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routers;
+    /// async fn sample(
+    ///    client: &Routers
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::routers::GetOperation {
         super::builder::routers::GetOperation::new(self.inner.clone())
     }
@@ -14888,6 +19331,22 @@ impl Routes {
     }
 
     /// Returns the specified Route resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routes;
+    /// async fn sample(
+    ///    client: &Routes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::routes::Get {
         super::builder::routes::Get::new(self.inner.clone())
     }
@@ -14904,6 +19363,22 @@ impl Routes {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Routes;
+    /// async fn sample(
+    ///    client: &Routes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::routes::GetOperation {
         super::builder::routes::GetOperation::new(self.inner.clone())
     }
@@ -15037,11 +19512,43 @@ impl SecurityPolicies {
     }
 
     /// List all of the ordered rules present in a single specified policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SecurityPolicies;
+    /// async fn sample(
+    ///    client: &SecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::security_policies::Get {
         super::builder::security_policies::Get::new(self.inner.clone())
     }
 
     /// Gets a rule at the specified priority.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SecurityPolicies;
+    /// async fn sample(
+    ///    client: &SecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::security_policies::GetRule {
         super::builder::security_policies::GetRule::new(self.inner.clone())
     }
@@ -15059,6 +19566,22 @@ impl SecurityPolicies {
 
     /// Gets the current list of preconfigured Web Application Firewall (WAF)
     /// expressions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SecurityPolicies;
+    /// async fn sample(
+    ///    client: &SecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_preconfigured_expression_sets()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_preconfigured_expression_sets(
         &self,
     ) -> super::builder::security_policies::ListPreconfiguredExpressionSets {
@@ -15093,6 +19616,22 @@ impl SecurityPolicies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SecurityPolicies;
+    /// async fn sample(
+    ///    client: &SecurityPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::security_policies::GetOperation {
         super::builder::security_policies::GetOperation::new(self.inner.clone())
     }
@@ -15221,12 +19760,44 @@ impl ServiceAttachments {
     }
 
     /// Returns the specified ServiceAttachment resource in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ServiceAttachments;
+    /// async fn sample(
+    ///    client: &ServiceAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::service_attachments::Get {
         super::builder::service_attachments::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ServiceAttachments;
+    /// async fn sample(
+    ///    client: &ServiceAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::service_attachments::GetIamPolicy {
         super::builder::service_attachments::GetIamPolicy::new(self.inner.clone())
     }
@@ -15252,16 +19823,64 @@ impl ServiceAttachments {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ServiceAttachments;
+    /// async fn sample(
+    ///    client: &ServiceAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::service_attachments::SetIamPolicy {
         super::builder::service_attachments::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ServiceAttachments;
+    /// async fn sample(
+    ///    client: &ServiceAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::service_attachments::TestIamPermissions {
         super::builder::service_attachments::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ServiceAttachments;
+    /// async fn sample(
+    ///    client: &ServiceAttachments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::service_attachments::GetOperation {
         super::builder::service_attachments::GetOperation::new(self.inner.clone())
     }
@@ -15376,6 +19995,22 @@ impl SnapshotSettings {
     }
 
     /// Get snapshot settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SnapshotSettings;
+    /// async fn sample(
+    ///    client: &SnapshotSettings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::snapshot_settings::Get {
         super::builder::snapshot_settings::Get::new(self.inner.clone())
     }
@@ -15386,6 +20021,22 @@ impl SnapshotSettings {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SnapshotSettings;
+    /// async fn sample(
+    ///    client: &SnapshotSettings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::snapshot_settings::GetOperation {
         super::builder::snapshot_settings::GetOperation::new(self.inner.clone())
     }
@@ -15509,12 +20160,44 @@ impl Snapshots {
     }
 
     /// Returns the specified Snapshot resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Snapshots;
+    /// async fn sample(
+    ///    client: &Snapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::snapshots::Get {
         super::builder::snapshots::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Snapshots;
+    /// async fn sample(
+    ///    client: &Snapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::snapshots::GetIamPolicy {
         super::builder::snapshots::GetIamPolicy::new(self.inner.clone())
     }
@@ -15536,6 +20219,22 @@ impl Snapshots {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Snapshots;
+    /// async fn sample(
+    ///    client: &Snapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::snapshots::SetIamPolicy {
         super::builder::snapshots::SetIamPolicy::new(self.inner.clone())
     }
@@ -15547,11 +20246,43 @@ impl Snapshots {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Snapshots;
+    /// async fn sample(
+    ///    client: &Snapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::snapshots::TestIamPermissions {
         super::builder::snapshots::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Snapshots;
+    /// async fn sample(
+    ///    client: &Snapshots
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::snapshots::GetOperation {
         super::builder::snapshots::GetOperation::new(self.inner.clone())
     }
@@ -15680,6 +20411,22 @@ impl SslCertificates {
     }
 
     /// Returns the specified SslCertificate resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SslCertificates;
+    /// async fn sample(
+    ///    client: &SslCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::ssl_certificates::Get {
         super::builder::ssl_certificates::Get::new(self.inner.clone())
     }
@@ -15697,6 +20444,22 @@ impl SslCertificates {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SslCertificates;
+    /// async fn sample(
+    ///    client: &SslCertificates
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::ssl_certificates::GetOperation {
         super::builder::ssl_certificates::GetOperation::new(self.inner.clone())
     }
@@ -15824,6 +20587,22 @@ impl SslPolicies {
     }
 
     /// Lists all of the ordered rules present in a single specified policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SslPolicies;
+    /// async fn sample(
+    ///    client: &SslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::ssl_policies::Get {
         super::builder::ssl_policies::Get::new(self.inner.clone())
     }
@@ -15841,6 +20620,22 @@ impl SslPolicies {
 
     /// Lists all features that can be specified in the SSL policy when using
     /// custom profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SslPolicies;
+    /// async fn sample(
+    ///    client: &SslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_available_features()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_available_features(&self) -> super::builder::ssl_policies::ListAvailableFeatures {
         super::builder::ssl_policies::ListAvailableFeatures::new(self.inner.clone())
     }
@@ -15851,6 +20646,22 @@ impl SslPolicies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::SslPolicies;
+    /// async fn sample(
+    ///    client: &SslPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::ssl_policies::GetOperation {
         super::builder::ssl_policies::GetOperation::new(self.inner.clone())
     }
@@ -15973,6 +20784,22 @@ impl StoragePoolTypes {
     }
 
     /// Returns the specified storage pool type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePoolTypes;
+    /// async fn sample(
+    ///    client: &StoragePoolTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::storage_pool_types::Get {
         super::builder::storage_pool_types::Get::new(self.inner.clone())
     }
@@ -16108,12 +20935,44 @@ impl StoragePools {
 
     /// Returns a specified storage pool. Gets a list of available
     /// storage pools by making a list() request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePools;
+    /// async fn sample(
+    ///    client: &StoragePools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::storage_pools::Get {
         super::builder::storage_pools::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePools;
+    /// async fn sample(
+    ///    client: &StoragePools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::storage_pools::GetIamPolicy {
         super::builder::storage_pools::GetIamPolicy::new(self.inner.clone())
     }
@@ -16137,11 +20996,43 @@ impl StoragePools {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePools;
+    /// async fn sample(
+    ///    client: &StoragePools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::storage_pools::SetIamPolicy {
         super::builder::storage_pools::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePools;
+    /// async fn sample(
+    ///    client: &StoragePools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::storage_pools::TestIamPermissions {
         super::builder::storage_pools::TestIamPermissions::new(self.inner.clone())
     }
@@ -16156,6 +21047,22 @@ impl StoragePools {
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::StoragePools;
+    /// async fn sample(
+    ///    client: &StoragePools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::storage_pools::GetOperation {
         super::builder::storage_pools::GetOperation::new(self.inner.clone())
     }
@@ -16285,12 +21192,44 @@ impl Subnetworks {
     }
 
     /// Returns the specified subnetwork.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Subnetworks;
+    /// async fn sample(
+    ///    client: &Subnetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::subnetworks::Get {
         super::builder::subnetworks::Get::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. May be empty if no such
     /// policy or resource exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Subnetworks;
+    /// async fn sample(
+    ///    client: &Subnetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::subnetworks::GetIamPolicy {
         super::builder::subnetworks::GetIamPolicy::new(self.inner.clone())
     }
@@ -16323,6 +21262,22 @@ impl Subnetworks {
 
     /// Sets the access control policy on the specified resource.
     /// Replaces any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Subnetworks;
+    /// async fn sample(
+    ///    client: &Subnetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::subnetworks::SetIamPolicy {
         super::builder::subnetworks::SetIamPolicy::new(self.inner.clone())
     }
@@ -16336,11 +21291,43 @@ impl Subnetworks {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Subnetworks;
+    /// async fn sample(
+    ///    client: &Subnetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::subnetworks::TestIamPermissions {
         super::builder::subnetworks::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Subnetworks;
+    /// async fn sample(
+    ///    client: &Subnetworks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::subnetworks::GetOperation {
         super::builder::subnetworks::GetOperation::new(self.inner.clone())
     }
@@ -16460,6 +21447,22 @@ impl TargetGrpcProxies {
     }
 
     /// Returns the specified TargetGrpcProxy resource in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetGrpcProxies;
+    /// async fn sample(
+    ///    client: &TargetGrpcProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_grpc_proxies::Get {
         super::builder::target_grpc_proxies::Get::new(self.inner.clone())
     }
@@ -16484,6 +21487,22 @@ impl TargetGrpcProxies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetGrpcProxies;
+    /// async fn sample(
+    ///    client: &TargetGrpcProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_grpc_proxies::GetOperation {
         super::builder::target_grpc_proxies::GetOperation::new(self.inner.clone())
     }
@@ -16612,6 +21631,22 @@ impl TargetHttpProxies {
     }
 
     /// Returns the specified TargetHttpProxy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetHttpProxies;
+    /// async fn sample(
+    ///    client: &TargetHttpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_http_proxies::Get {
         super::builder::target_http_proxies::Get::new(self.inner.clone())
     }
@@ -16642,6 +21677,22 @@ impl TargetHttpProxies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetHttpProxies;
+    /// async fn sample(
+    ///    client: &TargetHttpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_http_proxies::GetOperation {
         super::builder::target_http_proxies::GetOperation::new(self.inner.clone())
     }
@@ -16770,6 +21821,22 @@ impl TargetHttpsProxies {
     }
 
     /// Returns the specified TargetHttpsProxy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetHttpsProxies;
+    /// async fn sample(
+    ///    client: &TargetHttpsProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_https_proxies::Get {
         super::builder::target_https_proxies::Get::new(self.inner.clone())
     }
@@ -16823,6 +21890,22 @@ impl TargetHttpsProxies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetHttpsProxies;
+    /// async fn sample(
+    ///    client: &TargetHttpsProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_https_proxies::GetOperation {
         super::builder::target_https_proxies::GetOperation::new(self.inner.clone())
     }
@@ -16950,6 +22033,22 @@ impl TargetInstances {
     }
 
     /// Returns the specified TargetInstance resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetInstances;
+    /// async fn sample(
+    ///    client: &TargetInstances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_instances::Get {
         super::builder::target_instances::Get::new(self.inner.clone())
     }
@@ -16974,11 +22073,43 @@ impl TargetInstances {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetInstances;
+    /// async fn sample(
+    ///    client: &TargetInstances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::target_instances::TestIamPermissions {
         super::builder::target_instances::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetInstances;
+    /// async fn sample(
+    ///    client: &TargetInstances
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_instances::GetOperation {
         super::builder::target_instances::GetOperation::new(self.inner.clone())
     }
@@ -17113,12 +22244,44 @@ impl TargetPools {
     }
 
     /// Returns the specified target pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetPools;
+    /// async fn sample(
+    ///    client: &TargetPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_pools::Get {
         super::builder::target_pools::Get::new(self.inner.clone())
     }
 
     /// Gets the most recent health check results for each IP for the
     /// instance that is referenced by the given target pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetPools;
+    /// async fn sample(
+    ///    client: &TargetPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_health()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_health(&self) -> super::builder::target_pools::GetHealth {
         super::builder::target_pools::GetHealth::new(self.inner.clone())
     }
@@ -17158,11 +22321,43 @@ impl TargetPools {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetPools;
+    /// async fn sample(
+    ///    client: &TargetPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::target_pools::TestIamPermissions {
         super::builder::target_pools::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetPools;
+    /// async fn sample(
+    ///    client: &TargetPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_pools::GetOperation {
         super::builder::target_pools::GetOperation::new(self.inner.clone())
     }
@@ -17282,6 +22477,22 @@ impl TargetSslProxies {
     }
 
     /// Returns the specified TargetSslProxy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetSslProxies;
+    /// async fn sample(
+    ///    client: &TargetSslProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_ssl_proxies::Get {
         super::builder::target_ssl_proxies::Get::new(self.inner.clone())
     }
@@ -17327,6 +22538,22 @@ impl TargetSslProxies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetSslProxies;
+    /// async fn sample(
+    ///    client: &TargetSslProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_ssl_proxies::GetOperation {
         super::builder::target_ssl_proxies::GetOperation::new(self.inner.clone())
     }
@@ -17455,6 +22682,22 @@ impl TargetTcpProxies {
     }
 
     /// Returns the specified TargetTcpProxy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetTcpProxies;
+    /// async fn sample(
+    ///    client: &TargetTcpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_tcp_proxies::Get {
         super::builder::target_tcp_proxies::Get::new(self.inner.clone())
     }
@@ -17482,6 +22725,22 @@ impl TargetTcpProxies {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetTcpProxies;
+    /// async fn sample(
+    ///    client: &TargetTcpProxies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_tcp_proxies::GetOperation {
         super::builder::target_tcp_proxies::GetOperation::new(self.inner.clone())
     }
@@ -17609,6 +22868,22 @@ impl TargetVpnGateways {
     }
 
     /// Returns the specified target VPN gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetVpnGateways;
+    /// async fn sample(
+    ///    client: &TargetVpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::target_vpn_gateways::Get {
         super::builder::target_vpn_gateways::Get::new(self.inner.clone())
     }
@@ -17632,6 +22907,22 @@ impl TargetVpnGateways {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::TargetVpnGateways;
+    /// async fn sample(
+    ///    client: &TargetVpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::target_vpn_gateways::GetOperation {
         super::builder::target_vpn_gateways::GetOperation::new(self.inner.clone())
     }
@@ -17757,6 +23048,22 @@ impl UrlMaps {
     }
 
     /// Returns the specified UrlMap resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::UrlMaps;
+    /// async fn sample(
+    ///    client: &UrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::url_maps::Get {
         super::builder::url_maps::Get::new(self.inner.clone())
     }
@@ -17799,11 +23106,43 @@ impl UrlMaps {
     /// Runs static validation for the UrlMap. In particular, the tests of the
     /// provided UrlMap will be run. Calling this method does NOT create the
     /// UrlMap.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::UrlMaps;
+    /// async fn sample(
+    ///    client: &UrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate(&self) -> super::builder::url_maps::Validate {
         super::builder::url_maps::Validate::new(self.inner.clone())
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::UrlMaps;
+    /// async fn sample(
+    ///    client: &UrlMaps
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::url_maps::GetOperation {
         super::builder::url_maps::GetOperation::new(self.inner.clone())
     }
@@ -17928,11 +23267,43 @@ impl VpnGateways {
     }
 
     /// Returns the specified VPN gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnGateways;
+    /// async fn sample(
+    ///    client: &VpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::vpn_gateways::Get {
         super::builder::vpn_gateways::Get::new(self.inner.clone())
     }
 
     /// Returns the status for the specified VPN gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnGateways;
+    /// async fn sample(
+    ///    client: &VpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_status(&self) -> super::builder::vpn_gateways::GetStatus {
         super::builder::vpn_gateways::GetStatus::new(self.inner.clone())
     }
@@ -17956,11 +23327,43 @@ impl VpnGateways {
     }
 
     /// Returns permissions that a caller has on the specified resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnGateways;
+    /// async fn sample(
+    ///    client: &VpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::vpn_gateways::TestIamPermissions {
         super::builder::vpn_gateways::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnGateways;
+    /// async fn sample(
+    ///    client: &VpnGateways
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vpn_gateways::GetOperation {
         super::builder::vpn_gateways::GetOperation::new(self.inner.clone())
     }
@@ -18085,6 +23488,22 @@ impl VpnTunnels {
     }
 
     /// Returns the specified VpnTunnel resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnTunnels;
+    /// async fn sample(
+    ///    client: &VpnTunnels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::vpn_tunnels::Get {
         super::builder::vpn_tunnels::Get::new(self.inner.clone())
     }
@@ -18108,6 +23527,22 @@ impl VpnTunnels {
     }
 
     /// Retrieves the specified region-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::VpnTunnels;
+    /// async fn sample(
+    ///    client: &VpnTunnels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vpn_tunnels::GetOperation {
         super::builder::vpn_tunnels::GetOperation::new(self.inner.clone())
     }
@@ -18224,6 +23659,22 @@ impl WireGroups {
     }
 
     /// Gets the specified wire group resource in the given scope.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::WireGroups;
+    /// async fn sample(
+    ///    client: &WireGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::wire_groups::Get {
         super::builder::wire_groups::Get::new(self.inner.clone())
     }
@@ -18248,6 +23699,22 @@ impl WireGroups {
     }
 
     /// Retrieves the specified Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::WireGroups;
+    /// async fn sample(
+    ///    client: &WireGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::wire_groups::GetOperation {
         super::builder::wire_groups::GetOperation::new(self.inner.clone())
     }
@@ -18359,11 +23826,42 @@ impl ZoneOperations {
     }
 
     /// Deletes the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ZoneOperations;
+    /// async fn sample(
+    ///    client: &ZoneOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::zone_operations::Delete {
         super::builder::zone_operations::Delete::new(self.inner.clone())
     }
 
     /// Retrieves the specified zone-specific Operations resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ZoneOperations;
+    /// async fn sample(
+    ///    client: &ZoneOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::zone_operations::Get {
         super::builder::zone_operations::Get::new(self.inner.clone())
     }
@@ -18391,6 +23889,22 @@ impl ZoneOperations {
     /// - If the default deadline is reached, there is no guarantee that the
     ///   operation is actually done when the method returns. Be prepared to retry
     ///   if the operation is not `DONE`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::ZoneOperations;
+    /// async fn sample(
+    ///    client: &ZoneOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait(&self) -> super::builder::zone_operations::Wait {
         super::builder::zone_operations::Wait::new(self.inner.clone())
     }
@@ -18502,6 +24016,22 @@ impl Zones {
     }
 
     /// Returns the specified Zone resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_compute_v1::client::Zones;
+    /// async fn sample(
+    ///    client: &Zones
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::zones::Get {
         super::builder::zones::Get::new(self.inner.clone())
     }

--- a/src/generated/cloud/confidentialcomputing/v1/src/client.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/client.rs
@@ -122,18 +122,66 @@ impl ConfidentialComputing {
     }
 
     /// Creates a new Challenge in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// async fn sample(
+    ///    client: &ConfidentialComputing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_challenge()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_challenge(&self) -> super::builder::confidential_computing::CreateChallenge {
         super::builder::confidential_computing::CreateChallenge::new(self.inner.clone())
     }
 
     /// Verifies the provided attestation info, returning a signed attestation
     /// token.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// async fn sample(
+    ///    client: &ConfidentialComputing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_attestation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_attestation(&self) -> super::builder::confidential_computing::VerifyAttestation {
         super::builder::confidential_computing::VerifyAttestation::new(self.inner.clone())
     }
 
     /// Verifies whether the provided attestation info is valid, returning a signed
     /// attestation token if so.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// async fn sample(
+    ///    client: &ConfidentialComputing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_confidential_space()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_confidential_space(
         &self,
     ) -> super::builder::confidential_computing::VerifyConfidentialSpace {
@@ -142,6 +190,22 @@ impl ConfidentialComputing {
 
     /// Verifies the provided Confidential GKE attestation info, returning a signed
     /// OIDC token.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// async fn sample(
+    ///    client: &ConfidentialComputing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_confidential_gke()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_confidential_gke(
         &self,
     ) -> super::builder::confidential_computing::VerifyConfidentialGke {
@@ -154,6 +218,22 @@ impl ConfidentialComputing {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+    /// async fn sample(
+    ///    client: &ConfidentialComputing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::confidential_computing::GetLocation {
         super::builder::confidential_computing::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/config/v1/src/client.rs
+++ b/src/generated/cloud/config/v1/src/client.rs
@@ -130,6 +130,23 @@ impl Config {
     /// Gets details about a [Deployment][google.cloud.config.v1.Deployment].
     ///
     /// [google.cloud.config.v1.Deployment]: crate::model::Deployment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment(&self) -> super::builder::config::GetDeployment {
         super::builder::config::GetDeployment::new(self.inner.clone())
     }
@@ -195,6 +212,23 @@ impl Config {
     /// Gets details about a [Revision][google.cloud.config.v1.Revision].
     ///
     /// [google.cloud.config.v1.Revision]: crate::model::Revision
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_revision()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_revision(&self) -> super::builder::config::GetRevision {
         super::builder::config::GetRevision::new(self.inner.clone())
     }
@@ -203,6 +237,23 @@ impl Config {
     /// by Infra Manager.
     ///
     /// [google.cloud.config.v1.Resource]: crate::model::Resource
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource(&self) -> super::builder::config::GetResource {
         super::builder::config::GetResource::new(self.inner.clone())
     }
@@ -215,22 +266,85 @@ impl Config {
     }
 
     /// Exports Terraform state file from a given deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_deployment_statefile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_deployment_statefile(&self) -> super::builder::config::ExportDeploymentStatefile {
         super::builder::config::ExportDeploymentStatefile::new(self.inner.clone())
     }
 
     /// Exports Terraform state file from a given revision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_revision_statefile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_revision_statefile(&self) -> super::builder::config::ExportRevisionStatefile {
         super::builder::config::ExportRevisionStatefile::new(self.inner.clone())
     }
 
     /// Imports Terraform state file in a given deployment. The state file does not
     /// take effect until the Deployment has been unlocked.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_statefile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_statefile(&self) -> super::builder::config::ImportStatefile {
         super::builder::config::ImportStatefile::new(self.inner.clone())
     }
 
     /// Deletes Terraform state file in a given deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_statefile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_statefile(&self) -> super::builder::config::DeleteStatefile {
         super::builder::config::DeleteStatefile::new(self.inner.clone())
     }
@@ -266,6 +380,22 @@ impl Config {
     }
 
     /// Exports the lock info on a locked deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_lock_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_lock_info(&self) -> super::builder::config::ExportLockInfo {
         super::builder::config::ExportLockInfo::new(self.inner.clone())
     }
@@ -290,6 +420,23 @@ impl Config {
     /// Gets details about a [Preview][google.cloud.config.v1.Preview].
     ///
     /// [google.cloud.config.v1.Preview]: crate::model::Preview
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_preview()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_preview(&self) -> super::builder::config::GetPreview {
         super::builder::config::GetPreview::new(self.inner.clone())
     }
@@ -322,6 +469,22 @@ impl Config {
     /// Export [Preview][google.cloud.config.v1.Preview] results.
     ///
     /// [google.cloud.config.v1.Preview]: crate::model::Preview
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_preview_result()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_preview_result(&self) -> super::builder::config::ExportPreviewResult {
         super::builder::config::ExportPreviewResult::new(self.inner.clone())
     }
@@ -338,6 +501,23 @@ impl Config {
     /// [TerraformVersion][google.cloud.config.v1.TerraformVersion].
     ///
     /// [google.cloud.config.v1.TerraformVersion]: crate::model::TerraformVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_terraform_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_terraform_version(&self) -> super::builder::config::GetTerraformVersion {
         super::builder::config::GetTerraformVersion::new(self.inner.clone())
     }
@@ -348,6 +528,23 @@ impl Config {
     }
 
     /// Get a ResourceChange for a given preview.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource_change()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource_change(&self) -> super::builder::config::GetResourceChange {
         super::builder::config::GetResourceChange::new(self.inner.clone())
     }
@@ -358,6 +555,23 @@ impl Config {
     }
 
     /// Get a ResourceDrift for a given preview.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource_drift()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource_drift(&self) -> super::builder::config::GetResourceDrift {
         super::builder::config::GetResourceDrift::new(self.inner.clone())
     }
@@ -368,6 +582,22 @@ impl Config {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::config::GetLocation {
         super::builder::config::GetLocation::new(self.inner.clone())
     }
@@ -377,12 +607,44 @@ impl Config {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::config::SetIamPolicy {
         super::builder::config::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::config::GetIamPolicy {
         super::builder::config::GetIamPolicy::new(self.inner.clone())
     }
@@ -394,6 +656,22 @@ impl Config {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::config::TestIamPermissions {
         super::builder::config::TestIamPermissions::new(self.inner.clone())
     }
@@ -408,6 +686,22 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::config::GetOperation {
         super::builder::config::GetOperation::new(self.inner.clone())
     }
@@ -415,6 +709,21 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::config::DeleteOperation {
         super::builder::config::DeleteOperation::new(self.inner.clone())
     }
@@ -422,6 +731,21 @@ impl Config {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_config_v1::client::Config;
+    /// async fn sample(
+    ///    client: &Config
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::config::CancelOperation {
         super::builder::config::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/configdelivery/v1/src/client.rs
+++ b/src/generated/cloud/configdelivery/v1/src/client.rs
@@ -125,6 +125,23 @@ impl ConfigDelivery {
     }
 
     /// Gets details of a single ResourceBundle.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource_bundle()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource_bundle(&self) -> super::builder::config_delivery::GetResourceBundle {
         super::builder::config_delivery::GetResourceBundle::new(self.inner.clone())
     }
@@ -180,6 +197,23 @@ impl ConfigDelivery {
     }
 
     /// Gets details of a single FleetPackage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_fleet_package()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_fleet_package(&self) -> super::builder::config_delivery::GetFleetPackage {
         super::builder::config_delivery::GetFleetPackage::new(self.inner.clone())
     }
@@ -235,6 +269,23 @@ impl ConfigDelivery {
     }
 
     /// Gets details of a single Release.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_release()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_release(&self) -> super::builder::config_delivery::GetRelease {
         super::builder::config_delivery::GetRelease::new(self.inner.clone())
     }
@@ -290,6 +341,23 @@ impl ConfigDelivery {
     }
 
     /// Gets details of a single Variant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_variant()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_variant(&self) -> super::builder::config_delivery::GetVariant {
         super::builder::config_delivery::GetVariant::new(self.inner.clone())
     }
@@ -346,6 +414,23 @@ impl ConfigDelivery {
     }
 
     /// Gets details of a single Rollout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rollout()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rollout(&self) -> super::builder::config_delivery::GetRollout {
         super::builder::config_delivery::GetRollout::new(self.inner.clone())
     }
@@ -401,6 +486,22 @@ impl ConfigDelivery {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::config_delivery::GetLocation {
         super::builder::config_delivery::GetLocation::new(self.inner.clone())
     }
@@ -415,6 +516,22 @@ impl ConfigDelivery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::config_delivery::GetOperation {
         super::builder::config_delivery::GetOperation::new(self.inner.clone())
     }
@@ -422,6 +539,21 @@ impl ConfigDelivery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::config_delivery::DeleteOperation {
         super::builder::config_delivery::DeleteOperation::new(self.inner.clone())
     }
@@ -429,6 +561,21 @@ impl ConfigDelivery {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+    /// async fn sample(
+    ///    client: &ConfigDelivery
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::config_delivery::CancelOperation {
         super::builder::config_delivery::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/connectors/v1/src/client.rs
+++ b/src/generated/cloud/connectors/v1/src/client.rs
@@ -124,6 +124,23 @@ impl Connectors {
     }
 
     /// Gets details of a single Connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection(&self) -> super::builder::connectors::GetConnection {
         super::builder::connectors::GetConnection::new(self.inner.clone())
     }
@@ -179,6 +196,23 @@ impl Connectors {
     }
 
     /// Gets details of a provider.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_provider()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_provider(&self) -> super::builder::connectors::GetProvider {
         super::builder::connectors::GetProvider::new(self.inner.clone())
     }
@@ -189,6 +223,23 @@ impl Connectors {
     }
 
     /// Gets details of a single Connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connector(&self) -> super::builder::connectors::GetConnector {
         super::builder::connectors::GetConnector::new(self.inner.clone())
     }
@@ -199,12 +250,46 @@ impl Connectors {
     }
 
     /// Gets details of a single connector version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connector_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connector_version(&self) -> super::builder::connectors::GetConnectorVersion {
         super::builder::connectors::GetConnectorVersion::new(self.inner.clone())
     }
 
     /// Gets schema metadata of a connection.
     /// SchemaMetadata is a singleton resource for each connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection_schema_metadata()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection_schema_metadata(
         &self,
     ) -> super::builder::connectors::GetConnectionSchemaMetadata {
@@ -244,12 +329,46 @@ impl Connectors {
 
     /// Gets the runtimeConfig of a location.
     /// RuntimeConfig is a singleton resource for each location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_runtime_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_runtime_config(&self) -> super::builder::connectors::GetRuntimeConfig {
         super::builder::connectors::GetRuntimeConfig::new(self.inner.clone())
     }
 
     /// GetGlobalSettings gets settings of a project.
     /// GlobalSettings is a singleton resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_global_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_global_settings(&self) -> super::builder::connectors::GetGlobalSettings {
         super::builder::connectors::GetGlobalSettings::new(self.inner.clone())
     }
@@ -260,6 +379,22 @@ impl Connectors {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::connectors::GetLocation {
         super::builder::connectors::GetLocation::new(self.inner.clone())
     }
@@ -269,12 +404,44 @@ impl Connectors {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::connectors::SetIamPolicy {
         super::builder::connectors::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::connectors::GetIamPolicy {
         super::builder::connectors::GetIamPolicy::new(self.inner.clone())
     }
@@ -286,6 +453,22 @@ impl Connectors {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::connectors::TestIamPermissions {
         super::builder::connectors::TestIamPermissions::new(self.inner.clone())
     }
@@ -299,6 +482,22 @@ impl Connectors {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::connectors::GetOperation {
         super::builder::connectors::GetOperation::new(self.inner.clone())
     }
@@ -306,6 +505,21 @@ impl Connectors {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::connectors::DeleteOperation {
         super::builder::connectors::DeleteOperation::new(self.inner.clone())
     }
@@ -313,6 +527,21 @@ impl Connectors {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_connectors_v1::client::Connectors;
+    /// async fn sample(
+    ///    client: &Connectors
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::connectors::CancelOperation {
         super::builder::connectors::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/contactcenterinsights/v1/src/client.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/client.rs
@@ -124,6 +124,22 @@ impl ContactCenterInsights {
     /// Creates a conversation.
     /// Note that this method does not support audio transcription or redaction.
     /// Use `conversations.upload` instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_conversation(
         &self,
     ) -> super::builder::contact_center_insights::CreateConversation {
@@ -150,6 +166,22 @@ impl ContactCenterInsights {
     }
 
     /// Updates a conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_conversation(
         &self,
     ) -> super::builder::contact_center_insights::UpdateConversation {
@@ -157,6 +189,23 @@ impl ContactCenterInsights {
     }
 
     /// Gets a conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation(&self) -> super::builder::contact_center_insights::GetConversation {
         super::builder::contact_center_insights::GetConversation::new(self.inner.clone())
     }
@@ -167,6 +216,22 @@ impl ContactCenterInsights {
     }
 
     /// Deletes a conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_conversation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_conversation(
         &self,
     ) -> super::builder::contact_center_insights::DeleteConversation {
@@ -190,6 +255,23 @@ impl ContactCenterInsights {
     }
 
     /// Gets an analysis.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_analysis()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_analysis(&self) -> super::builder::contact_center_insights::GetAnalysis {
         super::builder::contact_center_insights::GetAnalysis::new(self.inner.clone())
     }
@@ -200,6 +282,22 @@ impl ContactCenterInsights {
     }
 
     /// Deletes an analysis.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_analysis()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_analysis(&self) -> super::builder::contact_center_insights::DeleteAnalysis {
         super::builder::contact_center_insights::DeleteAnalysis::new(self.inner.clone())
     }
@@ -289,16 +387,65 @@ impl ContactCenterInsights {
     }
 
     /// Updates an issue model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_issue_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_issue_model(&self) -> super::builder::contact_center_insights::UpdateIssueModel {
         super::builder::contact_center_insights::UpdateIssueModel::new(self.inner.clone())
     }
 
     /// Gets an issue model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_issue_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_issue_model(&self) -> super::builder::contact_center_insights::GetIssueModel {
         super::builder::contact_center_insights::GetIssueModel::new(self.inner.clone())
     }
 
     /// Lists issue models.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_issue_models()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_issue_models(&self) -> super::builder::contact_center_insights::ListIssueModels {
         super::builder::contact_center_insights::ListIssueModels::new(self.inner.clone())
     }
@@ -383,26 +530,106 @@ impl ContactCenterInsights {
     }
 
     /// Gets an issue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_issue()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_issue(&self) -> super::builder::contact_center_insights::GetIssue {
         super::builder::contact_center_insights::GetIssue::new(self.inner.clone())
     }
 
     /// Lists issues.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_issues()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_issues(&self) -> super::builder::contact_center_insights::ListIssues {
         super::builder::contact_center_insights::ListIssues::new(self.inner.clone())
     }
 
     /// Updates an issue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_issue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_issue(&self) -> super::builder::contact_center_insights::UpdateIssue {
         super::builder::contact_center_insights::UpdateIssue::new(self.inner.clone())
     }
 
     /// Deletes an issue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_issue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_issue(&self) -> super::builder::contact_center_insights::DeleteIssue {
         super::builder::contact_center_insights::DeleteIssue::new(self.inner.clone())
     }
 
     /// Gets an issue model's statistics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .calculate_issue_model_stats()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn calculate_issue_model_stats(
         &self,
     ) -> super::builder::contact_center_insights::CalculateIssueModelStats {
@@ -410,6 +637,22 @@ impl ContactCenterInsights {
     }
 
     /// Creates a phrase matcher.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_phrase_matcher()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_phrase_matcher(
         &self,
     ) -> super::builder::contact_center_insights::CreatePhraseMatcher {
@@ -417,6 +660,23 @@ impl ContactCenterInsights {
     }
 
     /// Gets a phrase matcher.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_phrase_matcher()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_phrase_matcher(&self) -> super::builder::contact_center_insights::GetPhraseMatcher {
         super::builder::contact_center_insights::GetPhraseMatcher::new(self.inner.clone())
     }
@@ -429,6 +689,21 @@ impl ContactCenterInsights {
     }
 
     /// Deletes a phrase matcher.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_phrase_matcher()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_phrase_matcher(
         &self,
     ) -> super::builder::contact_center_insights::DeletePhraseMatcher {
@@ -436,6 +711,22 @@ impl ContactCenterInsights {
     }
 
     /// Updates a phrase matcher.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_phrase_matcher()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_phrase_matcher(
         &self,
     ) -> super::builder::contact_center_insights::UpdatePhraseMatcher {
@@ -443,21 +734,86 @@ impl ContactCenterInsights {
     }
 
     /// Gets conversation statistics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .calculate_stats()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn calculate_stats(&self) -> super::builder::contact_center_insights::CalculateStats {
         super::builder::contact_center_insights::CalculateStats::new(self.inner.clone())
     }
 
     /// Gets project-level settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_settings(&self) -> super::builder::contact_center_insights::GetSettings {
         super::builder::contact_center_insights::GetSettings::new(self.inner.clone())
     }
 
     /// Updates project-level settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_settings(&self) -> super::builder::contact_center_insights::UpdateSettings {
         super::builder::contact_center_insights::UpdateSettings::new(self.inner.clone())
     }
 
     /// Creates a analysis rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_analysis_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_analysis_rule(
         &self,
     ) -> super::builder::contact_center_insights::CreateAnalysisRule {
@@ -465,6 +821,23 @@ impl ContactCenterInsights {
     }
 
     /// Get a analysis rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_analysis_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_analysis_rule(&self) -> super::builder::contact_center_insights::GetAnalysisRule {
         super::builder::contact_center_insights::GetAnalysisRule::new(self.inner.clone())
     }
@@ -477,6 +850,22 @@ impl ContactCenterInsights {
     }
 
     /// Updates a analysis rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_analysis_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_analysis_rule(
         &self,
     ) -> super::builder::contact_center_insights::UpdateAnalysisRule {
@@ -484,6 +873,22 @@ impl ContactCenterInsights {
     }
 
     /// Deletes a analysis rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_analysis_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_analysis_rule(
         &self,
     ) -> super::builder::contact_center_insights::DeleteAnalysisRule {
@@ -491,6 +896,23 @@ impl ContactCenterInsights {
     }
 
     /// Gets location-level encryption key specification.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_encryption_spec()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_encryption_spec(
         &self,
     ) -> super::builder::contact_center_insights::GetEncryptionSpec {
@@ -519,11 +941,44 @@ impl ContactCenterInsights {
     }
 
     /// Creates a view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_view(&self) -> super::builder::contact_center_insights::CreateView {
         super::builder::contact_center_insights::CreateView::new(self.inner.clone())
     }
 
     /// Gets a view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_view(&self) -> super::builder::contact_center_insights::GetView {
         super::builder::contact_center_insights::GetView::new(self.inner.clone())
     }
@@ -534,11 +989,42 @@ impl ContactCenterInsights {
     }
 
     /// Updates a view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_view(&self) -> super::builder::contact_center_insights::UpdateView {
         super::builder::contact_center_insights::UpdateView::new(self.inner.clone())
     }
 
     /// Deletes a view.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_view(&self) -> super::builder::contact_center_insights::DeleteView {
         super::builder::contact_center_insights::DeleteView::new(self.inner.clone())
     }
@@ -559,21 +1045,86 @@ impl ContactCenterInsights {
     }
 
     /// Create a QaQuestion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_qa_question()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_qa_question(&self) -> super::builder::contact_center_insights::CreateQaQuestion {
         super::builder::contact_center_insights::CreateQaQuestion::new(self.inner.clone())
     }
 
     /// Gets a QaQuestion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_qa_question()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_qa_question(&self) -> super::builder::contact_center_insights::GetQaQuestion {
         super::builder::contact_center_insights::GetQaQuestion::new(self.inner.clone())
     }
 
     /// Updates a QaQuestion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_qa_question()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_qa_question(&self) -> super::builder::contact_center_insights::UpdateQaQuestion {
         super::builder::contact_center_insights::UpdateQaQuestion::new(self.inner.clone())
     }
 
     /// Deletes a QaQuestion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_qa_question()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_qa_question(&self) -> super::builder::contact_center_insights::DeleteQaQuestion {
         super::builder::contact_center_insights::DeleteQaQuestion::new(self.inner.clone())
     }
@@ -584,6 +1135,22 @@ impl ContactCenterInsights {
     }
 
     /// Create a QaScorecard.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_qa_scorecard()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_qa_scorecard(
         &self,
     ) -> super::builder::contact_center_insights::CreateQaScorecard {
@@ -591,11 +1158,44 @@ impl ContactCenterInsights {
     }
 
     /// Gets a QaScorecard.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_qa_scorecard()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_qa_scorecard(&self) -> super::builder::contact_center_insights::GetQaScorecard {
         super::builder::contact_center_insights::GetQaScorecard::new(self.inner.clone())
     }
 
     /// Updates a QaScorecard.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_qa_scorecard()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_qa_scorecard(
         &self,
     ) -> super::builder::contact_center_insights::UpdateQaScorecard {
@@ -603,6 +1203,22 @@ impl ContactCenterInsights {
     }
 
     /// Deletes a QaScorecard.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_qa_scorecard()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_qa_scorecard(
         &self,
     ) -> super::builder::contact_center_insights::DeleteQaScorecard {
@@ -615,6 +1231,22 @@ impl ContactCenterInsights {
     }
 
     /// Creates a QaScorecardRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_qa_scorecard_revision()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_qa_scorecard_revision(
         &self,
     ) -> super::builder::contact_center_insights::CreateQaScorecardRevision {
@@ -622,6 +1254,23 @@ impl ContactCenterInsights {
     }
 
     /// Gets a QaScorecardRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_qa_scorecard_revision()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_qa_scorecard_revision(
         &self,
     ) -> super::builder::contact_center_insights::GetQaScorecardRevision {
@@ -646,6 +1295,22 @@ impl ContactCenterInsights {
     }
 
     /// Deploy a QaScorecardRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .deploy_qa_scorecard_revision()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn deploy_qa_scorecard_revision(
         &self,
     ) -> super::builder::contact_center_insights::DeployQaScorecardRevision {
@@ -653,6 +1318,22 @@ impl ContactCenterInsights {
     }
 
     /// Undeploy a QaScorecardRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .undeploy_qa_scorecard_revision()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn undeploy_qa_scorecard_revision(
         &self,
     ) -> super::builder::contact_center_insights::UndeployQaScorecardRevision {
@@ -662,6 +1343,22 @@ impl ContactCenterInsights {
     }
 
     /// Deletes a QaScorecardRevision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_qa_scorecard_revision()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_qa_scorecard_revision(
         &self,
     ) -> super::builder::contact_center_insights::DeleteQaScorecardRevision {
@@ -676,6 +1373,22 @@ impl ContactCenterInsights {
     }
 
     /// Create feedback label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_feedback_label()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_feedback_label(
         &self,
     ) -> super::builder::contact_center_insights::CreateFeedbackLabel {
@@ -690,11 +1403,44 @@ impl ContactCenterInsights {
     }
 
     /// Get feedback label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feedback_label()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feedback_label(&self) -> super::builder::contact_center_insights::GetFeedbackLabel {
         super::builder::contact_center_insights::GetFeedbackLabel::new(self.inner.clone())
     }
 
     /// Update feedback label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_feedback_label()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_feedback_label(
         &self,
     ) -> super::builder::contact_center_insights::UpdateFeedbackLabel {
@@ -702,6 +1448,22 @@ impl ContactCenterInsights {
     }
 
     /// Delete feedback label.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_feedback_label()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_feedback_label(
         &self,
     ) -> super::builder::contact_center_insights::DeleteFeedbackLabel {
@@ -759,6 +1521,22 @@ impl ContactCenterInsights {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::contact_center_insights::GetOperation {
         super::builder::contact_center_insights::GetOperation::new(self.inner.clone())
     }
@@ -766,6 +1544,21 @@ impl ContactCenterInsights {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+    /// async fn sample(
+    ///    client: &ContactCenterInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::contact_center_insights::CancelOperation {
         super::builder::contact_center_insights::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
@@ -127,6 +127,22 @@ impl Lineage {
     /// Updates the process and run if they already exist.
     /// Mapped from Open Lineage specification:
     /// <https://github.com/OpenLineage/OpenLineage/blob/main/spec/OpenLineage.json>.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .process_open_lineage_run_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn process_open_lineage_run_event(
         &self,
     ) -> super::builder::lineage::ProcessOpenLineageRunEvent {
@@ -134,16 +150,65 @@ impl Lineage {
     }
 
     /// Creates a new process.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_process()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_process(&self) -> super::builder::lineage::CreateProcess {
         super::builder::lineage::CreateProcess::new(self.inner.clone())
     }
 
     /// Updates a process.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_process()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_process(&self) -> super::builder::lineage::UpdateProcess {
         super::builder::lineage::UpdateProcess::new(self.inner.clone())
     }
 
     /// Gets the details of the specified process.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_process()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_process(&self) -> super::builder::lineage::GetProcess {
         super::builder::lineage::GetProcess::new(self.inner.clone())
     }
@@ -170,16 +235,65 @@ impl Lineage {
     }
 
     /// Creates a new run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_run(&self) -> super::builder::lineage::CreateRun {
         super::builder::lineage::CreateRun::new(self.inner.clone())
     }
 
     /// Updates a run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_run(&self) -> super::builder::lineage::UpdateRun {
         super::builder::lineage::UpdateRun::new(self.inner.clone())
     }
 
     /// Gets the details of the specified run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_run()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_run(&self) -> super::builder::lineage::GetRun {
         super::builder::lineage::GetRun::new(self.inner.clone())
     }
@@ -206,11 +320,44 @@ impl Lineage {
     }
 
     /// Creates a new lineage event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_lineage_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_lineage_event(&self) -> super::builder::lineage::CreateLineageEvent {
         super::builder::lineage::CreateLineageEvent::new(self.inner.clone())
     }
 
     /// Gets details of a specified lineage event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lineage_event()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lineage_event(&self) -> super::builder::lineage::GetLineageEvent {
         super::builder::lineage::GetLineageEvent::new(self.inner.clone())
     }
@@ -222,6 +369,21 @@ impl Lineage {
     }
 
     /// Deletes the lineage event with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_lineage_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_lineage_event(&self) -> super::builder::lineage::DeleteLineageEvent {
         super::builder::lineage::DeleteLineageEvent::new(self.inner.clone())
     }
@@ -269,6 +431,22 @@ impl Lineage {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::lineage::GetOperation {
         super::builder::lineage::GetOperation::new(self.inner.clone())
     }
@@ -276,6 +454,21 @@ impl Lineage {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::lineage::DeleteOperation {
         super::builder::lineage::DeleteOperation::new(self.inner.clone())
     }
@@ -283,6 +476,21 @@ impl Lineage {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+    /// async fn sample(
+    ///    client: &Lineage
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::lineage::CancelOperation {
         super::builder::lineage::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/datacatalog/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/v1/src/client.rs
@@ -169,12 +169,45 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `parent` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entry_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn create_entry_group(&self) -> super::builder::data_catalog::CreateEntryGroup {
         super::builder::data_catalog::CreateEntryGroup::new(self.inner.clone())
     }
 
     /// Gets an entry group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_entry_group(&self) -> super::builder::data_catalog::GetEntryGroup {
         super::builder::data_catalog::GetEntryGroup::new(self.inner.clone())
@@ -186,6 +219,22 @@ impl DataCatalog {
     /// the `entry_group.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entry_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn update_entry_group(&self) -> super::builder::data_catalog::UpdateEntryGroup {
         super::builder::data_catalog::UpdateEntryGroup::new(self.inner.clone())
@@ -197,6 +246,21 @@ impl DataCatalog {
     /// identified by the `name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_entry_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn delete_entry_group(&self) -> super::builder::data_catalog::DeleteEntryGroup {
         super::builder::data_catalog::DeleteEntryGroup::new(self.inner.clone())
@@ -219,6 +283,22 @@ impl DataCatalog {
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     ///
     /// An entry group can have a maximum of 100,000 entries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn create_entry(&self) -> super::builder::data_catalog::CreateEntry {
         super::builder::data_catalog::CreateEntry::new(self.inner.clone())
@@ -230,6 +310,22 @@ impl DataCatalog {
     /// the `entry.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn update_entry(&self) -> super::builder::data_catalog::UpdateEntry {
         super::builder::data_catalog::UpdateEntry::new(self.inner.clone())
@@ -247,12 +343,44 @@ impl DataCatalog {
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
     ///
     /// [google.cloud.datacatalog.v1.DataCatalog.CreateEntry]: crate::client::DataCatalog::create_entry
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn delete_entry(&self) -> super::builder::data_catalog::DeleteEntry {
         super::builder::data_catalog::DeleteEntry::new(self.inner.clone())
     }
 
     /// Gets an entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_entry(&self) -> super::builder::data_catalog::GetEntry {
         super::builder::data_catalog::GetEntry::new(self.inner.clone())
@@ -261,6 +389,22 @@ impl DataCatalog {
     /// Gets an entry by its target resource name.
     ///
     /// The resource name comes from the source Google Cloud Platform service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn lookup_entry(&self) -> super::builder::data_catalog::LookupEntry {
         super::builder::data_catalog::LookupEntry::new(self.inner.clone())
@@ -285,6 +429,22 @@ impl DataCatalog {
     /// IAM permission on the corresponding project.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .modify_entry_overview()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn modify_entry_overview(&self) -> super::builder::data_catalog::ModifyEntryOverview {
         super::builder::data_catalog::ModifyEntryOverview::new(self.inner.clone())
@@ -297,6 +457,22 @@ impl DataCatalog {
     /// IAM permission on the corresponding project.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .modify_entry_contacts()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn modify_entry_contacts(&self) -> super::builder::data_catalog::ModifyEntryContacts {
         super::builder::data_catalog::ModifyEntryContacts::new(self.inner.clone())
@@ -308,12 +484,45 @@ impl DataCatalog {
     /// `parent` parameter.
     /// For more information, see [Data Catalog resource project]
     /// (<https://cloud.google.com/data-catalog/docs/concepts/resource-project>).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tag_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn create_tag_template(&self) -> super::builder::data_catalog::CreateTagTemplate {
         super::builder::data_catalog::CreateTagTemplate::new(self.inner.clone())
     }
 
     /// Gets a tag template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tag_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_tag_template(&self) -> super::builder::data_catalog::GetTagTemplate {
         super::builder::data_catalog::GetTagTemplate::new(self.inner.clone())
@@ -328,6 +537,22 @@ impl DataCatalog {
     /// the `tag_template.name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tag_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn update_tag_template(&self) -> super::builder::data_catalog::UpdateTagTemplate {
         super::builder::data_catalog::UpdateTagTemplate::new(self.inner.clone())
@@ -338,6 +563,21 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `name` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tag_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn delete_tag_template(&self) -> super::builder::data_catalog::DeleteTagTemplate {
         super::builder::data_catalog::DeleteTagTemplate::new(self.inner.clone())
@@ -348,6 +588,22 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `parent` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tag_template_field()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn create_tag_template_field(
         &self,
@@ -363,6 +619,22 @@ impl DataCatalog {
     /// identified by the `name` parameter. For more information, see [Data Catalog
     /// resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tag_template_field()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn update_tag_template_field(
         &self,
@@ -375,6 +647,22 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by the
     /// `name` parameter. For more information, see [Data Catalog resource project]
     /// (<https://cloud.google.com/data-catalog/docs/concepts/resource-project>).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_tag_template_field()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn rename_tag_template_field(
         &self,
@@ -385,6 +673,22 @@ impl DataCatalog {
     /// Renames an enum value in a tag template.
     ///
     /// Within a single enum field, enum values must be unique.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rename_tag_template_field_enum_value()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn rename_tag_template_field_enum_value(
         &self,
@@ -398,6 +702,21 @@ impl DataCatalog {
     /// You must enable the Data Catalog API in the project identified by
     /// the `name` parameter. For more information, see [Data Catalog resource
     /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tag_template_field()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn delete_tag_template_field(
         &self,
@@ -420,18 +739,65 @@ impl DataCatalog {
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
     /// [google.cloud.datacatalog.v1.EntryGroup]: crate::model::EntryGroup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn create_tag(&self) -> super::builder::data_catalog::CreateTag {
         super::builder::data_catalog::CreateTag::new(self.inner.clone())
     }
 
     /// Updates an existing tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn update_tag(&self) -> super::builder::data_catalog::UpdateTag {
         super::builder::data_catalog::UpdateTag::new(self.inner.clone())
     }
 
     /// Deletes a tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn delete_tag(&self) -> super::builder::data_catalog::DeleteTag {
         super::builder::data_catalog::DeleteTag::new(self.inner.clone())
@@ -482,6 +848,22 @@ impl DataCatalog {
     /// the current user. Starring information is private to each user.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .star_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn star_entry(&self) -> super::builder::data_catalog::StarEntry {
         super::builder::data_catalog::StarEntry::new(self.inner.clone())
@@ -491,6 +873,22 @@ impl DataCatalog {
     /// the current user. Starring information is private to each user.
     ///
     /// [google.cloud.datacatalog.v1.Entry]: crate::model::Entry
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .unstar_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn unstar_entry(&self) -> super::builder::data_catalog::UnstarEntry {
         super::builder::data_catalog::UnstarEntry::new(self.inner.clone())
@@ -513,6 +911,22 @@ impl DataCatalog {
     /// - `datacatalog.tagTemplates.setIamPolicy` to set policies on tag
     ///   templates.
     /// - `datacatalog.entryGroups.setIamPolicy` to set policies on entry groups.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn set_iam_policy(&self) -> super::builder::data_catalog::SetIamPolicy {
         super::builder::data_catalog::SetIamPolicy::new(self.inner.clone())
@@ -539,6 +953,22 @@ impl DataCatalog {
     /// - `datacatalog.tagTemplates.getIamPolicy` to get policies on tag
     ///   templates.
     /// - `datacatalog.entryGroups.getIamPolicy` to get policies on entry groups.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_iam_policy(&self) -> super::builder::data_catalog::GetIamPolicy {
         super::builder::data_catalog::GetIamPolicy::new(self.inner.clone())
@@ -558,6 +988,22 @@ impl DataCatalog {
     /// external Google Cloud Platform resources ingested into Data Catalog.
     ///
     /// No Google IAM permissions are required to call this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn test_iam_permissions(&self) -> super::builder::data_catalog::TestIamPermissions {
         super::builder::data_catalog::TestIamPermissions::new(self.inner.clone())
@@ -602,6 +1048,22 @@ impl DataCatalog {
 
     /// Sets the configuration related to the migration to Dataplex for an
     /// organization or project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn set_config(&self) -> super::builder::data_catalog::SetConfig {
         super::builder::data_catalog::SetConfig::new(self.inner.clone())
@@ -610,6 +1072,22 @@ impl DataCatalog {
     /// Retrieves the configuration related to the migration from Data Catalog to
     /// Dataplex for a specific organization, including all the projects under it
     /// which have a separate configuration set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn retrieve_config(&self) -> super::builder::data_catalog::RetrieveConfig {
         super::builder::data_catalog::RetrieveConfig::new(self.inner.clone())
@@ -620,6 +1098,22 @@ impl DataCatalog {
     /// specific configuration set for the resource, the setting is checked
     /// hierarchicahlly through the ancestors of the resource, starting from the
     /// resource itself.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_effective_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn retrieve_effective_config(
         &self,
@@ -637,6 +1131,22 @@ impl DataCatalog {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_catalog::GetOperation {
         super::builder::data_catalog::GetOperation::new(self.inner.clone())
     }
@@ -644,6 +1154,21 @@ impl DataCatalog {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_catalog::DeleteOperation {
         super::builder::data_catalog::DeleteOperation::new(self.inner.clone())
     }
@@ -651,6 +1176,21 @@ impl DataCatalog {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::DataCatalog;
+    /// async fn sample(
+    ///    client: &DataCatalog
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_catalog::CancelOperation {
         super::builder::data_catalog::CancelOperation::new(self.inner.clone())
     }
@@ -769,6 +1309,22 @@ impl PolicyTagManager {
     /// Creates a taxonomy in a specified project.
     ///
     /// The taxonomy is initially empty, that is, it doesn't contain policy tags.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_taxonomy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_taxonomy(&self) -> super::builder::policy_tag_manager::CreateTaxonomy {
         super::builder::policy_tag_manager::CreateTaxonomy::new(self.inner.clone())
     }
@@ -776,12 +1332,43 @@ impl PolicyTagManager {
     /// Deletes a taxonomy, including all policy tags in this
     /// taxonomy, their associated policies, and the policy tags references from
     /// BigQuery columns.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_taxonomy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_taxonomy(&self) -> super::builder::policy_tag_manager::DeleteTaxonomy {
         super::builder::policy_tag_manager::DeleteTaxonomy::new(self.inner.clone())
     }
 
     /// Updates a taxonomy, including its display name,
     /// description, and activated policy types.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_taxonomy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_taxonomy(&self) -> super::builder::policy_tag_manager::UpdateTaxonomy {
         super::builder::policy_tag_manager::UpdateTaxonomy::new(self.inner.clone())
     }
@@ -793,11 +1380,44 @@ impl PolicyTagManager {
     }
 
     /// Gets a taxonomy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_taxonomy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_taxonomy(&self) -> super::builder::policy_tag_manager::GetTaxonomy {
         super::builder::policy_tag_manager::GetTaxonomy::new(self.inner.clone())
     }
 
     /// Creates a policy tag in a taxonomy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_policy_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_policy_tag(&self) -> super::builder::policy_tag_manager::CreatePolicyTag {
         super::builder::policy_tag_manager::CreatePolicyTag::new(self.inner.clone())
     }
@@ -808,12 +1428,43 @@ impl PolicyTagManager {
     /// * Policies associated with the policy tag and its descendants
     /// * References from BigQuery table schema of the policy tag and its
     ///   descendants
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_policy_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_policy_tag(&self) -> super::builder::policy_tag_manager::DeletePolicyTag {
         super::builder::policy_tag_manager::DeletePolicyTag::new(self.inner.clone())
     }
 
     /// Updates a policy tag, including its display
     /// name, description, and parent policy tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_policy_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_policy_tag(&self) -> super::builder::policy_tag_manager::UpdatePolicyTag {
         super::builder::policy_tag_manager::UpdatePolicyTag::new(self.inner.clone())
     }
@@ -824,22 +1475,87 @@ impl PolicyTagManager {
     }
 
     /// Gets a policy tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy_tag()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy_tag(&self) -> super::builder::policy_tag_manager::GetPolicyTag {
         super::builder::policy_tag_manager::GetPolicyTag::new(self.inner.clone())
     }
 
     /// Gets the IAM policy for a policy tag or a taxonomy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::policy_tag_manager::GetIamPolicy {
         super::builder::policy_tag_manager::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM policy for a policy tag or a taxonomy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::policy_tag_manager::SetIamPolicy {
         super::builder::policy_tag_manager::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns your permissions on a specified policy tag or
     /// taxonomy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::policy_tag_manager::TestIamPermissions {
         super::builder::policy_tag_manager::TestIamPermissions::new(self.inner.clone())
     }
@@ -854,6 +1570,22 @@ impl PolicyTagManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::policy_tag_manager::GetOperation {
         super::builder::policy_tag_manager::GetOperation::new(self.inner.clone())
     }
@@ -861,6 +1593,21 @@ impl PolicyTagManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::policy_tag_manager::DeleteOperation {
         super::builder::policy_tag_manager::DeleteOperation::new(self.inner.clone())
     }
@@ -868,6 +1615,21 @@ impl PolicyTagManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+    /// async fn sample(
+    ///    client: &PolicyTagManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::policy_tag_manager::CancelOperation {
         super::builder::policy_tag_manager::CancelOperation::new(self.inner.clone())
     }
@@ -995,6 +1757,22 @@ impl PolicyTagManagerSerialization {
     /// - Creates policy tags that don't have resource names. They are considered
     ///   new.
     /// - Updates policy tags with valid resources names accordingly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .replace_taxonomy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn replace_taxonomy(
         &self,
     ) -> super::builder::policy_tag_manager_serialization::ReplaceTaxonomy {
@@ -1009,6 +1787,22 @@ impl PolicyTagManagerSerialization {
     ///
     /// For an inlined source, taxonomies and policy tags are created in bulk using
     /// nested protocol buffer structures.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_taxonomies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_taxonomies(
         &self,
     ) -> super::builder::policy_tag_manager_serialization::ImportTaxonomies {
@@ -1021,6 +1815,22 @@ impl PolicyTagManagerSerialization {
     ///
     /// This method generates `SerializedTaxonomy` protocol buffers with nested
     /// policy tags that can be used as input for `ImportTaxonomies` calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_taxonomies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_taxonomies(
         &self,
     ) -> super::builder::policy_tag_manager_serialization::ExportTaxonomies {
@@ -1039,6 +1849,22 @@ impl PolicyTagManagerSerialization {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::policy_tag_manager_serialization::GetOperation {
         super::builder::policy_tag_manager_serialization::GetOperation::new(self.inner.clone())
     }
@@ -1046,6 +1872,21 @@ impl PolicyTagManagerSerialization {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::policy_tag_manager_serialization::DeleteOperation {
@@ -1055,6 +1896,21 @@ impl PolicyTagManagerSerialization {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
+    /// async fn sample(
+    ///    client: &PolicyTagManagerSerialization
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::policy_tag_manager_serialization::CancelOperation {

--- a/src/generated/cloud/dataform/v1/src/client.rs
+++ b/src/generated/cloud/dataform/v1/src/client.rs
@@ -128,11 +128,44 @@ impl Dataform {
     }
 
     /// Fetches a single Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_repository()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_repository(&self) -> super::builder::dataform::GetRepository {
         super::builder::dataform::GetRepository::new(self.inner.clone())
     }
 
     /// Creates a new Repository in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_repository()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_repository(&self) -> super::builder::dataform::CreateRepository {
         super::builder::dataform::CreateRepository::new(self.inner.clone())
     }
@@ -143,23 +176,87 @@ impl Dataform {
     /// [AIP/134](https://google.aip.dev/134). The wildcard entry (\*) is treated
     /// as a bad request, and when the `field_mask` is omitted, the request is
     /// treated as a full update on all modifiable fields.*
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_repository()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_repository(&self) -> super::builder::dataform::UpdateRepository {
         super::builder::dataform::UpdateRepository::new(self.inner.clone())
     }
 
     /// Deletes a single Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_repository()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_repository(&self) -> super::builder::dataform::DeleteRepository {
         super::builder::dataform::DeleteRepository::new(self.inner.clone())
     }
 
     /// Applies a Git commit to a Repository. The Repository must not have a value
     /// for `git_remote_settings.url`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .commit_repository_changes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn commit_repository_changes(&self) -> super::builder::dataform::CommitRepositoryChanges {
         super::builder::dataform::CommitRepositoryChanges::new(self.inner.clone())
     }
 
     /// Returns the contents of a file (inside a Repository). The Repository
     /// must not have a value for `git_remote_settings.url`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_repository_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_repository_file(&self) -> super::builder::dataform::ReadRepositoryFile {
         super::builder::dataform::ReadRepositoryFile::new(self.inner.clone())
     }
@@ -179,6 +276,22 @@ impl Dataform {
     }
 
     /// Computes a Repository's Git access token status.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compute_repository_access_token_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compute_repository_access_token_status(
         &self,
     ) -> super::builder::dataform::ComputeRepositoryAccessTokenStatus {
@@ -186,6 +299,22 @@ impl Dataform {
     }
 
     /// Fetches a Repository's remote branches.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_remote_branches()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_remote_branches(&self) -> super::builder::dataform::FetchRemoteBranches {
         super::builder::dataform::FetchRemoteBranches::new(self.inner.clone())
     }
@@ -196,56 +325,233 @@ impl Dataform {
     }
 
     /// Fetches a single Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workspace()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workspace(&self) -> super::builder::dataform::GetWorkspace {
         super::builder::dataform::GetWorkspace::new(self.inner.clone())
     }
 
     /// Creates a new Workspace in a given Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_workspace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_workspace(&self) -> super::builder::dataform::CreateWorkspace {
         super::builder::dataform::CreateWorkspace::new(self.inner.clone())
     }
 
     /// Deletes a single Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_workspace()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_workspace(&self) -> super::builder::dataform::DeleteWorkspace {
         super::builder::dataform::DeleteWorkspace::new(self.inner.clone())
     }
 
     /// Installs dependency NPM packages (inside a Workspace).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .install_npm_packages()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn install_npm_packages(&self) -> super::builder::dataform::InstallNpmPackages {
         super::builder::dataform::InstallNpmPackages::new(self.inner.clone())
     }
 
     /// Pulls Git commits from the Repository's remote into a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pull_git_commits()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pull_git_commits(&self) -> super::builder::dataform::PullGitCommits {
         super::builder::dataform::PullGitCommits::new(self.inner.clone())
     }
 
     /// Pushes Git commits from a Workspace to the Repository's remote.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .push_git_commits()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn push_git_commits(&self) -> super::builder::dataform::PushGitCommits {
         super::builder::dataform::PushGitCommits::new(self.inner.clone())
     }
 
     /// Fetches Git statuses for the files in a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_file_git_statuses()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_file_git_statuses(&self) -> super::builder::dataform::FetchFileGitStatuses {
         super::builder::dataform::FetchFileGitStatuses::new(self.inner.clone())
     }
 
     /// Fetches Git ahead/behind against a remote branch.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_git_ahead_behind()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_git_ahead_behind(&self) -> super::builder::dataform::FetchGitAheadBehind {
         super::builder::dataform::FetchGitAheadBehind::new(self.inner.clone())
     }
 
     /// Applies a Git commit for uncommitted files in a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .commit_workspace_changes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn commit_workspace_changes(&self) -> super::builder::dataform::CommitWorkspaceChanges {
         super::builder::dataform::CommitWorkspaceChanges::new(self.inner.clone())
     }
 
     /// Performs a Git reset for uncommitted files in a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_workspace_changes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_workspace_changes(&self) -> super::builder::dataform::ResetWorkspaceChanges {
         super::builder::dataform::ResetWorkspaceChanges::new(self.inner.clone())
     }
 
     /// Fetches Git diff for an uncommitted file in a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_file_diff()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_file_diff(&self) -> super::builder::dataform::FetchFileDiff {
         super::builder::dataform::FetchFileDiff::new(self.inner.clone())
     }
@@ -261,37 +567,149 @@ impl Dataform {
     }
 
     /// Creates a directory inside a Workspace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .make_directory()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn make_directory(&self) -> super::builder::dataform::MakeDirectory {
         super::builder::dataform::MakeDirectory::new(self.inner.clone())
     }
 
     /// Deletes a directory (inside a Workspace) and all of its contents.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_directory()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_directory(&self) -> super::builder::dataform::RemoveDirectory {
         super::builder::dataform::RemoveDirectory::new(self.inner.clone())
     }
 
     /// Moves a directory (inside a Workspace), and all of its contents, to a new
     /// location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_directory()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_directory(&self) -> super::builder::dataform::MoveDirectory {
         super::builder::dataform::MoveDirectory::new(self.inner.clone())
     }
 
     /// Returns the contents of a file (inside a Workspace).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .read_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn read_file(&self) -> super::builder::dataform::ReadFile {
         super::builder::dataform::ReadFile::new(self.inner.clone())
     }
 
     /// Deletes a file (inside a Workspace).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_file(&self) -> super::builder::dataform::RemoveFile {
         super::builder::dataform::RemoveFile::new(self.inner.clone())
     }
 
     /// Moves a file (inside a Workspace) to a new location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_file(&self) -> super::builder::dataform::MoveFile {
         super::builder::dataform::MoveFile::new(self.inner.clone())
     }
 
     /// Writes to a file (inside a Workspace).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_file(&self) -> super::builder::dataform::WriteFile {
         super::builder::dataform::WriteFile::new(self.inner.clone())
     }
@@ -302,11 +720,44 @@ impl Dataform {
     }
 
     /// Fetches a single ReleaseConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_release_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_release_config(&self) -> super::builder::dataform::GetReleaseConfig {
         super::builder::dataform::GetReleaseConfig::new(self.inner.clone())
     }
 
     /// Creates a new ReleaseConfig in a given Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_release_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_release_config(&self) -> super::builder::dataform::CreateReleaseConfig {
         super::builder::dataform::CreateReleaseConfig::new(self.inner.clone())
     }
@@ -317,11 +768,43 @@ impl Dataform {
     /// [AIP/134](https://google.aip.dev/134). The wildcard entry (\*) is treated
     /// as a bad request, and when the `field_mask` is omitted, the request is
     /// treated as a full update on all modifiable fields.*
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_release_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_release_config(&self) -> super::builder::dataform::UpdateReleaseConfig {
         super::builder::dataform::UpdateReleaseConfig::new(self.inner.clone())
     }
 
     /// Deletes a single ReleaseConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_release_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_release_config(&self) -> super::builder::dataform::DeleteReleaseConfig {
         super::builder::dataform::DeleteReleaseConfig::new(self.inner.clone())
     }
@@ -332,11 +815,44 @@ impl Dataform {
     }
 
     /// Fetches a single CompilationResult.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_compilation_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_compilation_result(&self) -> super::builder::dataform::GetCompilationResult {
         super::builder::dataform::GetCompilationResult::new(self.inner.clone())
     }
 
     /// Creates a new CompilationResult in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_compilation_result()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_compilation_result(&self) -> super::builder::dataform::CreateCompilationResult {
         super::builder::dataform::CreateCompilationResult::new(self.inner.clone())
     }
@@ -354,11 +870,44 @@ impl Dataform {
     }
 
     /// Fetches a single WorkflowConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workflow_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workflow_config(&self) -> super::builder::dataform::GetWorkflowConfig {
         super::builder::dataform::GetWorkflowConfig::new(self.inner.clone())
     }
 
     /// Creates a new WorkflowConfig in a given Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_workflow_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_workflow_config(&self) -> super::builder::dataform::CreateWorkflowConfig {
         super::builder::dataform::CreateWorkflowConfig::new(self.inner.clone())
     }
@@ -369,11 +918,43 @@ impl Dataform {
     /// [AIP/134](https://google.aip.dev/134). The wildcard entry (\*) is treated
     /// as a bad request, and when the `field_mask` is omitted, the request is
     /// treated as a full update on all modifiable fields.*
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_workflow_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_workflow_config(&self) -> super::builder::dataform::UpdateWorkflowConfig {
         super::builder::dataform::UpdateWorkflowConfig::new(self.inner.clone())
     }
 
     /// Deletes a single WorkflowConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_workflow_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_workflow_config(&self) -> super::builder::dataform::DeleteWorkflowConfig {
         super::builder::dataform::DeleteWorkflowConfig::new(self.inner.clone())
     }
@@ -384,21 +965,86 @@ impl Dataform {
     }
 
     /// Fetches a single WorkflowInvocation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workflow_invocation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workflow_invocation(&self) -> super::builder::dataform::GetWorkflowInvocation {
         super::builder::dataform::GetWorkflowInvocation::new(self.inner.clone())
     }
 
     /// Creates a new WorkflowInvocation in a given Repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_workflow_invocation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_workflow_invocation(&self) -> super::builder::dataform::CreateWorkflowInvocation {
         super::builder::dataform::CreateWorkflowInvocation::new(self.inner.clone())
     }
 
     /// Deletes a single WorkflowInvocation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_workflow_invocation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_workflow_invocation(&self) -> super::builder::dataform::DeleteWorkflowInvocation {
         super::builder::dataform::DeleteWorkflowInvocation::new(self.inner.clone())
     }
 
     /// Requests cancellation of a running WorkflowInvocation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_workflow_invocation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_workflow_invocation(&self) -> super::builder::dataform::CancelWorkflowInvocation {
         super::builder::dataform::CancelWorkflowInvocation::new(self.inner.clone())
     }
@@ -411,6 +1057,23 @@ impl Dataform {
     }
 
     /// Get default config for a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_config(&self) -> super::builder::dataform::GetConfig {
         super::builder::dataform::GetConfig::new(self.inner.clone())
     }
@@ -421,6 +1084,22 @@ impl Dataform {
     /// [AIP/134](https://google.aip.dev/134). The wildcard entry (\*) is treated
     /// as a bad request, and when the `field_mask` is omitted, the request is
     /// treated as a full update on all modifiable fields.*
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_config(&self) -> super::builder::dataform::UpdateConfig {
         super::builder::dataform::UpdateConfig::new(self.inner.clone())
     }
@@ -431,6 +1110,22 @@ impl Dataform {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dataform::GetLocation {
         super::builder::dataform::GetLocation::new(self.inner.clone())
     }
@@ -440,12 +1135,44 @@ impl Dataform {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dataform::SetIamPolicy {
         super::builder::dataform::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dataform::GetIamPolicy {
         super::builder::dataform::GetIamPolicy::new(self.inner.clone())
     }
@@ -457,6 +1184,22 @@ impl Dataform {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataform_v1::client::Dataform;
+    /// async fn sample(
+    ///    client: &Dataform
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::dataform::TestIamPermissions {
         super::builder::dataform::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/generated/cloud/datafusion/v1/src/client.rs
+++ b/src/generated/cloud/datafusion/v1/src/client.rs
@@ -132,6 +132,23 @@ impl DataFusion {
     }
 
     /// Gets details of a single Data Fusion instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datafusion_v1::client::DataFusion;
+    /// async fn sample(
+    ///    client: &DataFusion,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::data_fusion::GetInstance {
         super::builder::data_fusion::GetInstance::new(self.inner.clone())
     }
@@ -207,6 +224,22 @@ impl DataFusion {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datafusion_v1::client::DataFusion;
+    /// async fn sample(
+    ///    client: &DataFusion
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_fusion::GetOperation {
         super::builder::data_fusion::GetOperation::new(self.inner.clone())
     }
@@ -214,6 +247,21 @@ impl DataFusion {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datafusion_v1::client::DataFusion;
+    /// async fn sample(
+    ///    client: &DataFusion
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_fusion::DeleteOperation {
         super::builder::data_fusion::DeleteOperation::new(self.inner.clone())
     }
@@ -221,6 +269,21 @@ impl DataFusion {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datafusion_v1::client::DataFusion;
+    /// async fn sample(
+    ///    client: &DataFusion
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_fusion::CancelOperation {
         super::builder::data_fusion::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/dataplex/v1/src/client.rs
+++ b/src/generated/cloud/dataplex/v1/src/client.rs
@@ -175,6 +175,23 @@ impl BusinessGlossaryService {
     }
 
     /// Gets a Glossary resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_glossary()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_glossary(&self) -> super::builder::business_glossary_service::GetGlossary {
         super::builder::business_glossary_service::GetGlossary::new(self.inner.clone())
     }
@@ -185,6 +202,22 @@ impl BusinessGlossaryService {
     }
 
     /// Creates a new GlossaryCategory resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_glossary_category()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_glossary_category(
         &self,
     ) -> super::builder::business_glossary_service::CreateGlossaryCategory {
@@ -192,6 +225,22 @@ impl BusinessGlossaryService {
     }
 
     /// Updates a GlossaryCategory resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_glossary_category()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_glossary_category(
         &self,
     ) -> super::builder::business_glossary_service::UpdateGlossaryCategory {
@@ -201,6 +250,21 @@ impl BusinessGlossaryService {
     /// Deletes a GlossaryCategory resource. All the GlossaryCategories and
     /// GlossaryTerms nested directly under the specified GlossaryCategory will be
     /// moved one level up to the parent in the hierarchy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_glossary_category()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_glossary_category(
         &self,
     ) -> super::builder::business_glossary_service::DeleteGlossaryCategory {
@@ -208,6 +272,22 @@ impl BusinessGlossaryService {
     }
 
     /// Gets a GlossaryCategory resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_glossary_category()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_glossary_category(
         &self,
     ) -> super::builder::business_glossary_service::GetGlossaryCategory {
@@ -222,6 +302,22 @@ impl BusinessGlossaryService {
     }
 
     /// Creates a new GlossaryTerm resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_glossary_term()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_glossary_term(
         &self,
     ) -> super::builder::business_glossary_service::CreateGlossaryTerm {
@@ -229,6 +325,22 @@ impl BusinessGlossaryService {
     }
 
     /// Updates a GlossaryTerm resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_glossary_term()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_glossary_term(
         &self,
     ) -> super::builder::business_glossary_service::UpdateGlossaryTerm {
@@ -236,6 +348,21 @@ impl BusinessGlossaryService {
     }
 
     /// Deletes a GlossaryTerm resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_glossary_term()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_glossary_term(
         &self,
     ) -> super::builder::business_glossary_service::DeleteGlossaryTerm {
@@ -243,6 +370,22 @@ impl BusinessGlossaryService {
     }
 
     /// Gets a GlossaryTerm resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_glossary_term()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_glossary_term(&self) -> super::builder::business_glossary_service::GetGlossaryTerm {
         super::builder::business_glossary_service::GetGlossaryTerm::new(self.inner.clone())
     }
@@ -260,6 +403,22 @@ impl BusinessGlossaryService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::business_glossary_service::GetLocation {
         super::builder::business_glossary_service::GetLocation::new(self.inner.clone())
     }
@@ -269,12 +428,44 @@ impl BusinessGlossaryService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::business_glossary_service::SetIamPolicy {
         super::builder::business_glossary_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::business_glossary_service::GetIamPolicy {
         super::builder::business_glossary_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -286,6 +477,22 @@ impl BusinessGlossaryService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::business_glossary_service::TestIamPermissions {
@@ -302,6 +509,22 @@ impl BusinessGlossaryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::business_glossary_service::GetOperation {
         super::builder::business_glossary_service::GetOperation::new(self.inner.clone())
     }
@@ -309,6 +532,21 @@ impl BusinessGlossaryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::business_glossary_service::DeleteOperation {
         super::builder::business_glossary_service::DeleteOperation::new(self.inner.clone())
     }
@@ -316,6 +554,21 @@ impl BusinessGlossaryService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
+    /// async fn sample(
+    ///    client: &BusinessGlossaryService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::business_glossary_service::CancelOperation {
         super::builder::business_glossary_service::CancelOperation::new(self.inner.clone())
     }
@@ -478,6 +731,23 @@ impl CatalogService {
     }
 
     /// Gets an EntryType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entry_type(&self) -> super::builder::catalog_service::GetEntryType {
         super::builder::catalog_service::GetEntryType::new(self.inner.clone())
     }
@@ -533,6 +803,23 @@ impl CatalogService {
     }
 
     /// Gets an AspectType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aspect_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_aspect_type(&self) -> super::builder::catalog_service::GetAspectType {
         super::builder::catalog_service::GetAspectType::new(self.inner.clone())
     }
@@ -588,21 +875,87 @@ impl CatalogService {
     }
 
     /// Gets an EntryGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entry_group(&self) -> super::builder::catalog_service::GetEntryGroup {
         super::builder::catalog_service::GetEntryGroup::new(self.inner.clone())
     }
 
     /// Creates an Entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_entry(&self) -> super::builder::catalog_service::CreateEntry {
         super::builder::catalog_service::CreateEntry::new(self.inner.clone())
     }
 
     /// Updates an Entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_entry(&self) -> super::builder::catalog_service::UpdateEntry {
         super::builder::catalog_service::UpdateEntry::new(self.inner.clone())
     }
 
     /// Deletes an Entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_entry(&self) -> super::builder::catalog_service::DeleteEntry {
         super::builder::catalog_service::DeleteEntry::new(self.inner.clone())
     }
@@ -623,6 +976,23 @@ impl CatalogService {
     /// changing. For more information, see [Changes to metadata stored in
     /// Dataplex Universal
     /// Catalog](https://cloud.google.com/dataplex/docs/metadata-changes).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entry(&self) -> super::builder::catalog_service::GetEntry {
         super::builder::catalog_service::GetEntry::new(self.inner.clone())
     }
@@ -633,6 +1003,22 @@ impl CatalogService {
     /// changing. For more information, see [Changes to metadata stored in
     /// Dataplex Universal
     /// Catalog](https://cloud.google.com/dataplex/docs/metadata-changes).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_entry(&self) -> super::builder::catalog_service::LookupEntry {
         super::builder::catalog_service::LookupEntry::new(self.inner.clone())
     }
@@ -659,6 +1045,23 @@ impl CatalogService {
     }
 
     /// Gets a metadata job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metadata_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metadata_job(&self) -> super::builder::catalog_service::GetMetadataJob {
         super::builder::catalog_service::GetMetadataJob::new(self.inner.clone())
     }
@@ -674,21 +1077,86 @@ impl CatalogService {
     /// job might be partially applied. We recommend that you reset the state of
     /// the entry groups in your project by running another metadata job that
     /// reverts the changes from the canceled job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_metadata_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_metadata_job(&self) -> super::builder::catalog_service::CancelMetadataJob {
         super::builder::catalog_service::CancelMetadataJob::new(self.inner.clone())
     }
 
     /// Creates an Entry Link.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entry_link()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_entry_link(&self) -> super::builder::catalog_service::CreateEntryLink {
         super::builder::catalog_service::CreateEntryLink::new(self.inner.clone())
     }
 
     /// Deletes an Entry Link.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_entry_link()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_entry_link(&self) -> super::builder::catalog_service::DeleteEntryLink {
         super::builder::catalog_service::DeleteEntryLink::new(self.inner.clone())
     }
 
     /// Gets an Entry Link.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entry_link()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entry_link(&self) -> super::builder::catalog_service::GetEntryLink {
         super::builder::catalog_service::GetEntryLink::new(self.inner.clone())
     }
@@ -699,6 +1167,22 @@ impl CatalogService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::catalog_service::GetLocation {
         super::builder::catalog_service::GetLocation::new(self.inner.clone())
     }
@@ -708,12 +1192,44 @@ impl CatalogService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::catalog_service::SetIamPolicy {
         super::builder::catalog_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::catalog_service::GetIamPolicy {
         super::builder::catalog_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -725,6 +1241,22 @@ impl CatalogService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::catalog_service::TestIamPermissions {
         super::builder::catalog_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -739,6 +1271,22 @@ impl CatalogService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::catalog_service::GetOperation {
         super::builder::catalog_service::GetOperation::new(self.inner.clone())
     }
@@ -746,6 +1294,21 @@ impl CatalogService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::catalog_service::DeleteOperation {
         super::builder::catalog_service::DeleteOperation::new(self.inner.clone())
     }
@@ -753,6 +1316,21 @@ impl CatalogService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::catalog_service::CancelOperation {
         super::builder::catalog_service::CancelOperation::new(self.inner.clone())
     }
@@ -911,6 +1489,23 @@ impl CmekService {
     }
 
     /// Get an EncryptionConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_encryption_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_encryption_config(&self) -> super::builder::cmek_service::GetEncryptionConfig {
         super::builder::cmek_service::GetEncryptionConfig::new(self.inner.clone())
     }
@@ -921,6 +1516,22 @@ impl CmekService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cmek_service::GetLocation {
         super::builder::cmek_service::GetLocation::new(self.inner.clone())
     }
@@ -930,12 +1541,44 @@ impl CmekService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cmek_service::SetIamPolicy {
         super::builder::cmek_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cmek_service::GetIamPolicy {
         super::builder::cmek_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -947,6 +1590,22 @@ impl CmekService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::cmek_service::TestIamPermissions {
         super::builder::cmek_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -961,6 +1620,22 @@ impl CmekService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cmek_service::GetOperation {
         super::builder::cmek_service::GetOperation::new(self.inner.clone())
     }
@@ -968,6 +1643,21 @@ impl CmekService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cmek_service::DeleteOperation {
         super::builder::cmek_service::DeleteOperation::new(self.inner.clone())
     }
@@ -975,6 +1665,21 @@ impl CmekService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::CmekService;
+    /// async fn sample(
+    ///    client: &CmekService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cmek_service::CancelOperation {
         super::builder::cmek_service::CancelOperation::new(self.inner.clone())
     }
@@ -1084,21 +1789,85 @@ impl ContentService {
     }
 
     /// Create a content.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_content(&self) -> super::builder::content_service::CreateContent {
         super::builder::content_service::CreateContent::new(self.inner.clone())
     }
 
     /// Update a content. Only supports full resource update.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_content(&self) -> super::builder::content_service::UpdateContent {
         super::builder::content_service::UpdateContent::new(self.inner.clone())
     }
 
     /// Delete a content.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_content(&self) -> super::builder::content_service::DeleteContent {
         super::builder::content_service::DeleteContent::new(self.inner.clone())
     }
 
     /// Get a content resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_content()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_content(&self) -> super::builder::content_service::GetContent {
         super::builder::content_service::GetContent::new(self.inner.clone())
     }
@@ -1109,6 +1878,22 @@ impl ContentService {
     ///
     /// Caller must have Google IAM `dataplex.content.getIamPolicy` permission
     /// on the resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::content_service::GetIamPolicy {
         super::builder::content_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1118,6 +1903,22 @@ impl ContentService {
     ///
     /// Caller must have Google IAM `dataplex.content.setIamPolicy` permission
     /// on the resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::content_service::SetIamPolicy {
         super::builder::content_service::SetIamPolicy::new(self.inner.clone())
     }
@@ -1132,6 +1933,22 @@ impl ContentService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::content_service::TestIamPermissions {
         super::builder::content_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1147,6 +1964,22 @@ impl ContentService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::content_service::GetLocation {
         super::builder::content_service::GetLocation::new(self.inner.clone())
     }
@@ -1161,6 +1994,22 @@ impl ContentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::content_service::GetOperation {
         super::builder::content_service::GetOperation::new(self.inner.clone())
     }
@@ -1168,6 +2017,21 @@ impl ContentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::content_service::DeleteOperation {
         super::builder::content_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1175,6 +2039,21 @@ impl ContentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::ContentService;
+    /// async fn sample(
+    ///    client: &ContentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::content_service::CancelOperation {
         super::builder::content_service::CancelOperation::new(self.inner.clone())
     }
@@ -1351,6 +2230,23 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a DataTaxonomy resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_taxonomy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_data_taxonomy(&self) -> super::builder::data_taxonomy_service::GetDataTaxonomy {
         super::builder::data_taxonomy_service::GetDataTaxonomy::new(self.inner.clone())
@@ -1421,6 +2317,23 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a DataAttributeBinding resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_attribute_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_data_attribute_binding(
         &self,
@@ -1491,6 +2404,23 @@ impl DataTaxonomyService {
     }
 
     /// Retrieves a Data Attribute resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_attribute()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_data_attribute(&self) -> super::builder::data_taxonomy_service::GetDataAttribute {
         super::builder::data_taxonomy_service::GetDataAttribute::new(self.inner.clone())
@@ -1502,6 +2432,22 @@ impl DataTaxonomyService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_taxonomy_service::GetLocation {
         super::builder::data_taxonomy_service::GetLocation::new(self.inner.clone())
     }
@@ -1511,12 +2457,44 @@ impl DataTaxonomyService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_taxonomy_service::SetIamPolicy {
         super::builder::data_taxonomy_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_taxonomy_service::GetIamPolicy {
         super::builder::data_taxonomy_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1528,6 +2506,22 @@ impl DataTaxonomyService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::data_taxonomy_service::TestIamPermissions {
@@ -1544,6 +2538,22 @@ impl DataTaxonomyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_taxonomy_service::GetOperation {
         super::builder::data_taxonomy_service::GetOperation::new(self.inner.clone())
     }
@@ -1551,6 +2561,21 @@ impl DataTaxonomyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_taxonomy_service::DeleteOperation {
         super::builder::data_taxonomy_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1558,6 +2583,21 @@ impl DataTaxonomyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
+    /// async fn sample(
+    ///    client: &DataTaxonomyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_taxonomy_service::CancelOperation {
         super::builder::data_taxonomy_service::CancelOperation::new(self.inner.clone())
     }
@@ -1716,6 +2756,23 @@ impl DataScanService {
     }
 
     /// Gets a DataScan resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_scan()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_scan(&self) -> super::builder::data_scan_service::GetDataScan {
         super::builder::data_scan_service::GetDataScan::new(self.inner.clone())
     }
@@ -1726,11 +2783,44 @@ impl DataScanService {
     }
 
     /// Runs an on-demand execution of a DataScan
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .run_data_scan()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn run_data_scan(&self) -> super::builder::data_scan_service::RunDataScan {
         super::builder::data_scan_service::RunDataScan::new(self.inner.clone())
     }
 
     /// Gets a DataScanJob resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_scan_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_scan_job(&self) -> super::builder::data_scan_service::GetDataScanJob {
         super::builder::data_scan_service::GetDataScanJob::new(self.inner.clone())
     }
@@ -1744,6 +2834,22 @@ impl DataScanService {
     /// profiling scan.
     ///
     /// Use the recommendations to build rules for a data quality scan.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_data_quality_rules()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_data_quality_rules(
         &self,
     ) -> super::builder::data_scan_service::GenerateDataQualityRules {
@@ -1756,6 +2862,22 @@ impl DataScanService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_scan_service::GetLocation {
         super::builder::data_scan_service::GetLocation::new(self.inner.clone())
     }
@@ -1765,12 +2887,44 @@ impl DataScanService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_scan_service::SetIamPolicy {
         super::builder::data_scan_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_scan_service::GetIamPolicy {
         super::builder::data_scan_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1782,6 +2936,22 @@ impl DataScanService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::data_scan_service::TestIamPermissions {
         super::builder::data_scan_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1796,6 +2966,22 @@ impl DataScanService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_scan_service::GetOperation {
         super::builder::data_scan_service::GetOperation::new(self.inner.clone())
     }
@@ -1803,6 +2989,21 @@ impl DataScanService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_scan_service::DeleteOperation {
         super::builder::data_scan_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1810,6 +3011,21 @@ impl DataScanService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataScanService;
+    /// async fn sample(
+    ///    client: &DataScanService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_scan_service::CancelOperation {
         super::builder::data_scan_service::CancelOperation::new(self.inner.clone())
     }
@@ -1922,21 +3138,85 @@ impl MetadataService {
     }
 
     /// Create a metadata entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_entity(&self) -> super::builder::metadata_service::CreateEntity {
         super::builder::metadata_service::CreateEntity::new(self.inner.clone())
     }
 
     /// Update a metadata entity. Only supports full resource update.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_entity(&self) -> super::builder::metadata_service::UpdateEntity {
         super::builder::metadata_service::UpdateEntity::new(self.inner.clone())
     }
 
     /// Delete a metadata entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_entity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_entity(&self) -> super::builder::metadata_service::DeleteEntity {
         super::builder::metadata_service::DeleteEntity::new(self.inner.clone())
     }
 
     /// Get a metadata entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entity()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entity(&self) -> super::builder::metadata_service::GetEntity {
         super::builder::metadata_service::GetEntity::new(self.inner.clone())
     }
@@ -1947,16 +3227,64 @@ impl MetadataService {
     }
 
     /// Create a metadata partition.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_partition()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_partition(&self) -> super::builder::metadata_service::CreatePartition {
         super::builder::metadata_service::CreatePartition::new(self.inner.clone())
     }
 
     /// Delete a metadata partition.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_partition()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_partition(&self) -> super::builder::metadata_service::DeletePartition {
         super::builder::metadata_service::DeletePartition::new(self.inner.clone())
     }
 
     /// Get a metadata partition of an entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_partition()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_partition(&self) -> super::builder::metadata_service::GetPartition {
         super::builder::metadata_service::GetPartition::new(self.inner.clone())
     }
@@ -1972,6 +3300,22 @@ impl MetadataService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::metadata_service::GetLocation {
         super::builder::metadata_service::GetLocation::new(self.inner.clone())
     }
@@ -1981,12 +3325,44 @@ impl MetadataService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::metadata_service::SetIamPolicy {
         super::builder::metadata_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::metadata_service::GetIamPolicy {
         super::builder::metadata_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1998,6 +3374,22 @@ impl MetadataService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::metadata_service::TestIamPermissions {
         super::builder::metadata_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -2012,6 +3404,22 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::metadata_service::GetOperation {
         super::builder::metadata_service::GetOperation::new(self.inner.clone())
     }
@@ -2019,6 +3427,21 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::metadata_service::DeleteOperation {
         super::builder::metadata_service::DeleteOperation::new(self.inner.clone())
     }
@@ -2026,6 +3449,21 @@ impl MetadataService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::MetadataService;
+    /// async fn sample(
+    ///    client: &MetadataService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::metadata_service::CancelOperation {
         super::builder::metadata_service::CancelOperation::new(self.inner.clone())
     }
@@ -2192,6 +3630,23 @@ impl DataplexService {
     }
 
     /// Retrieves a lake resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lake()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lake(&self) -> super::builder::dataplex_service::GetLake {
         super::builder::dataplex_service::GetLake::new(self.inner.clone())
     }
@@ -2253,6 +3708,23 @@ impl DataplexService {
     }
 
     /// Retrieves a zone resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_zone()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_zone(&self) -> super::builder::dataplex_service::GetZone {
         super::builder::dataplex_service::GetZone::new(self.inner.clone())
     }
@@ -2314,6 +3786,23 @@ impl DataplexService {
     }
 
     /// Retrieves an asset resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_asset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_asset(&self) -> super::builder::dataplex_service::GetAsset {
         super::builder::dataplex_service::GetAsset::new(self.inner.clone())
     }
@@ -2374,6 +3863,23 @@ impl DataplexService {
     }
 
     /// Get task resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_task()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_task(&self) -> super::builder::dataplex_service::GetTask {
         super::builder::dataplex_service::GetTask::new(self.inner.clone())
     }
@@ -2384,16 +3890,64 @@ impl DataplexService {
     }
 
     /// Run an on demand execution of a Task.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .run_task()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn run_task(&self) -> super::builder::dataplex_service::RunTask {
         super::builder::dataplex_service::RunTask::new(self.inner.clone())
     }
 
     /// Get job resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::dataplex_service::GetJob {
         super::builder::dataplex_service::GetJob::new(self.inner.clone())
     }
 
     /// Cancel jobs running for the task resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_job(&self) -> super::builder::dataplex_service::CancelJob {
         super::builder::dataplex_service::CancelJob::new(self.inner.clone())
     }
@@ -2450,6 +4004,23 @@ impl DataplexService {
     }
 
     /// Get environment resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_environment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_environment(&self) -> super::builder::dataplex_service::GetEnvironment {
         super::builder::dataplex_service::GetEnvironment::new(self.inner.clone())
     }
@@ -2465,6 +4036,22 @@ impl DataplexService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dataplex_service::GetLocation {
         super::builder::dataplex_service::GetLocation::new(self.inner.clone())
     }
@@ -2474,12 +4061,44 @@ impl DataplexService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dataplex_service::SetIamPolicy {
         super::builder::dataplex_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dataplex_service::GetIamPolicy {
         super::builder::dataplex_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -2491,6 +4110,22 @@ impl DataplexService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::dataplex_service::TestIamPermissions {
         super::builder::dataplex_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -2505,6 +4140,22 @@ impl DataplexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::dataplex_service::GetOperation {
         super::builder::dataplex_service::GetOperation::new(self.inner.clone())
     }
@@ -2512,6 +4163,21 @@ impl DataplexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::dataplex_service::DeleteOperation {
         super::builder::dataplex_service::DeleteOperation::new(self.inner.clone())
     }
@@ -2519,6 +4185,21 @@ impl DataplexService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataplex_v1::client::DataplexService;
+    /// async fn sample(
+    ///    client: &DataplexService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::dataplex_service::CancelOperation {
         super::builder::dataplex_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/dataproc/v1/src/client.rs
+++ b/src/generated/cloud/dataproc/v1/src/client.rs
@@ -124,6 +124,22 @@ impl AutoscalingPolicyService {
     }
 
     /// Creates new autoscaling policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_autoscaling_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_autoscaling_policy(
         &self,
     ) -> super::builder::autoscaling_policy_service::CreateAutoscalingPolicy {
@@ -134,6 +150,22 @@ impl AutoscalingPolicyService {
     ///
     /// Disabled check for update_mask, because all updates will be full
     /// replacements.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_autoscaling_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_autoscaling_policy(
         &self,
     ) -> super::builder::autoscaling_policy_service::UpdateAutoscalingPolicy {
@@ -141,6 +173,23 @@ impl AutoscalingPolicyService {
     }
 
     /// Retrieves autoscaling policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_autoscaling_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_autoscaling_policy(
         &self,
     ) -> super::builder::autoscaling_policy_service::GetAutoscalingPolicy {
@@ -156,6 +205,21 @@ impl AutoscalingPolicyService {
 
     /// Deletes an autoscaling policy. It is an error to delete an autoscaling
     /// policy that is in use by one or more clusters.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_autoscaling_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_autoscaling_policy(
         &self,
     ) -> super::builder::autoscaling_policy_service::DeleteAutoscalingPolicy {
@@ -167,12 +231,44 @@ impl AutoscalingPolicyService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::autoscaling_policy_service::SetIamPolicy {
         super::builder::autoscaling_policy_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::autoscaling_policy_service::GetIamPolicy {
         super::builder::autoscaling_policy_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -184,6 +280,22 @@ impl AutoscalingPolicyService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::autoscaling_policy_service::TestIamPermissions {
@@ -200,6 +312,22 @@ impl AutoscalingPolicyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::autoscaling_policy_service::GetOperation {
         super::builder::autoscaling_policy_service::GetOperation::new(self.inner.clone())
     }
@@ -207,6 +335,21 @@ impl AutoscalingPolicyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::autoscaling_policy_service::DeleteOperation {
         super::builder::autoscaling_policy_service::DeleteOperation::new(self.inner.clone())
     }
@@ -214,6 +357,21 @@ impl AutoscalingPolicyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+    /// async fn sample(
+    ///    client: &AutoscalingPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::autoscaling_policy_service::CancelOperation {
         super::builder::autoscaling_policy_service::CancelOperation::new(self.inner.clone())
     }
@@ -340,6 +498,23 @@ impl BatchController {
     }
 
     /// Gets the batch workload resource representation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_batch()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_batch(&self) -> super::builder::batch_controller::GetBatch {
         super::builder::batch_controller::GetBatch::new(self.inner.clone())
     }
@@ -351,6 +526,21 @@ impl BatchController {
 
     /// Deletes the batch workload resource. If the batch is not in terminal state,
     /// the delete fails and the response returns `FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_batch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_batch(&self) -> super::builder::batch_controller::DeleteBatch {
         super::builder::batch_controller::DeleteBatch::new(self.inner.clone())
     }
@@ -360,12 +550,44 @@ impl BatchController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::batch_controller::SetIamPolicy {
         super::builder::batch_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::batch_controller::GetIamPolicy {
         super::builder::batch_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -377,6 +599,22 @@ impl BatchController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::batch_controller::TestIamPermissions {
         super::builder::batch_controller::TestIamPermissions::new(self.inner.clone())
     }
@@ -391,6 +629,22 @@ impl BatchController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::batch_controller::GetOperation {
         super::builder::batch_controller::GetOperation::new(self.inner.clone())
     }
@@ -398,6 +652,21 @@ impl BatchController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::batch_controller::DeleteOperation {
         super::builder::batch_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -405,6 +674,21 @@ impl BatchController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::BatchController;
+    /// async fn sample(
+    ///    client: &BatchController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::batch_controller::CancelOperation {
         super::builder::batch_controller::CancelOperation::new(self.inner.clone())
     }
@@ -608,6 +892,22 @@ impl ClusterController {
     }
 
     /// Gets the resource representation for a cluster in a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::cluster_controller::GetCluster {
         super::builder::cluster_controller::GetCluster::new(self.inner.clone())
     }
@@ -646,12 +946,44 @@ impl ClusterController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cluster_controller::SetIamPolicy {
         super::builder::cluster_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cluster_controller::GetIamPolicy {
         super::builder::cluster_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -663,6 +995,22 @@ impl ClusterController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::cluster_controller::TestIamPermissions {
         super::builder::cluster_controller::TestIamPermissions::new(self.inner.clone())
     }
@@ -677,6 +1025,22 @@ impl ClusterController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cluster_controller::GetOperation {
         super::builder::cluster_controller::GetOperation::new(self.inner.clone())
     }
@@ -684,6 +1048,21 @@ impl ClusterController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cluster_controller::DeleteOperation {
         super::builder::cluster_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -691,6 +1070,21 @@ impl ClusterController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::ClusterController;
+    /// async fn sample(
+    ///    client: &ClusterController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cluster_controller::CancelOperation {
         super::builder::cluster_controller::CancelOperation::new(self.inner.clone())
     }
@@ -799,6 +1193,22 @@ impl JobController {
     }
 
     /// Submits a job to a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .submit_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn submit_job(&self) -> super::builder::job_controller::SubmitJob {
         super::builder::job_controller::SubmitJob::new(self.inner.clone())
     }
@@ -819,6 +1229,22 @@ impl JobController {
     }
 
     /// Gets the resource representation for a job in a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::job_controller::GetJob {
         super::builder::job_controller::GetJob::new(self.inner.clone())
     }
@@ -829,6 +1255,22 @@ impl JobController {
     }
 
     /// Updates a job in a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_job(&self) -> super::builder::job_controller::UpdateJob {
         super::builder::job_controller::UpdateJob::new(self.inner.clone())
     }
@@ -838,12 +1280,43 @@ impl JobController {
     /// [regions/{region}/jobs.list](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/list)
     /// or
     /// [regions/{region}/jobs.get](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.jobs/get).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_job(&self) -> super::builder::job_controller::CancelJob {
         super::builder::job_controller::CancelJob::new(self.inner.clone())
     }
 
     /// Deletes the job from the project. If the job is active, the delete fails,
     /// and the response returns `FAILED_PRECONDITION`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::job_controller::DeleteJob {
         super::builder::job_controller::DeleteJob::new(self.inner.clone())
     }
@@ -853,12 +1326,44 @@ impl JobController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::job_controller::SetIamPolicy {
         super::builder::job_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::job_controller::GetIamPolicy {
         super::builder::job_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -870,6 +1375,22 @@ impl JobController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::job_controller::TestIamPermissions {
         super::builder::job_controller::TestIamPermissions::new(self.inner.clone())
     }
@@ -884,6 +1405,22 @@ impl JobController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::job_controller::GetOperation {
         super::builder::job_controller::GetOperation::new(self.inner.clone())
     }
@@ -891,6 +1428,21 @@ impl JobController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::job_controller::DeleteOperation {
         super::builder::job_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -898,6 +1450,21 @@ impl JobController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::JobController;
+    /// async fn sample(
+    ///    client: &JobController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::job_controller::CancelOperation {
         super::builder::job_controller::CancelOperation::new(self.inner.clone())
     }
@@ -1049,6 +1616,23 @@ impl NodeGroupController {
 
     /// Gets the resource representation for a node group in a
     /// cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node_group(&self) -> super::builder::node_group_controller::GetNodeGroup {
         super::builder::node_group_controller::GetNodeGroup::new(self.inner.clone())
     }
@@ -1058,12 +1642,44 @@ impl NodeGroupController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::node_group_controller::SetIamPolicy {
         super::builder::node_group_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::node_group_controller::GetIamPolicy {
         super::builder::node_group_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -1075,6 +1691,22 @@ impl NodeGroupController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::node_group_controller::TestIamPermissions {
@@ -1091,6 +1723,22 @@ impl NodeGroupController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::node_group_controller::GetOperation {
         super::builder::node_group_controller::GetOperation::new(self.inner.clone())
     }
@@ -1098,6 +1746,21 @@ impl NodeGroupController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::node_group_controller::DeleteOperation {
         super::builder::node_group_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -1105,6 +1768,21 @@ impl NodeGroupController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::NodeGroupController;
+    /// async fn sample(
+    ///    client: &NodeGroupController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::node_group_controller::CancelOperation {
         super::builder::node_group_controller::CancelOperation::new(self.inner.clone())
     }
@@ -1217,6 +1895,22 @@ impl SessionTemplateController {
     }
 
     /// Create a session template synchronously.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session_template(
         &self,
     ) -> super::builder::session_template_controller::CreateSessionTemplate {
@@ -1224,6 +1918,22 @@ impl SessionTemplateController {
     }
 
     /// Updates the session template synchronously.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_session_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_session_template(
         &self,
     ) -> super::builder::session_template_controller::UpdateSessionTemplate {
@@ -1231,6 +1941,23 @@ impl SessionTemplateController {
     }
 
     /// Gets the resource representation for a session template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session_template(
         &self,
     ) -> super::builder::session_template_controller::GetSessionTemplate {
@@ -1245,6 +1972,21 @@ impl SessionTemplateController {
     }
 
     /// Deletes a session template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session_template(
         &self,
     ) -> super::builder::session_template_controller::DeleteSessionTemplate {
@@ -1256,12 +1998,44 @@ impl SessionTemplateController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::session_template_controller::SetIamPolicy {
         super::builder::session_template_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::session_template_controller::GetIamPolicy {
         super::builder::session_template_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -1273,6 +2047,22 @@ impl SessionTemplateController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::session_template_controller::TestIamPermissions {
@@ -1289,6 +2079,22 @@ impl SessionTemplateController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::session_template_controller::GetOperation {
         super::builder::session_template_controller::GetOperation::new(self.inner.clone())
     }
@@ -1296,6 +2102,21 @@ impl SessionTemplateController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::session_template_controller::DeleteOperation {
         super::builder::session_template_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -1303,6 +2124,21 @@ impl SessionTemplateController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
+    /// async fn sample(
+    ///    client: &SessionTemplateController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::session_template_controller::CancelOperation {
         super::builder::session_template_controller::CancelOperation::new(self.inner.clone())
     }
@@ -1429,6 +2265,23 @@ impl SessionController {
     }
 
     /// Gets the resource representation for an interactive session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session(&self) -> super::builder::session_controller::GetSession {
         super::builder::session_controller::GetSession::new(self.inner.clone())
     }
@@ -1474,12 +2327,44 @@ impl SessionController {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::session_controller::SetIamPolicy {
         super::builder::session_controller::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::session_controller::GetIamPolicy {
         super::builder::session_controller::GetIamPolicy::new(self.inner.clone())
     }
@@ -1491,6 +2376,22 @@ impl SessionController {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::session_controller::TestIamPermissions {
         super::builder::session_controller::TestIamPermissions::new(self.inner.clone())
     }
@@ -1505,6 +2406,22 @@ impl SessionController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::session_controller::GetOperation {
         super::builder::session_controller::GetOperation::new(self.inner.clone())
     }
@@ -1512,6 +2429,21 @@ impl SessionController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::session_controller::DeleteOperation {
         super::builder::session_controller::DeleteOperation::new(self.inner.clone())
     }
@@ -1519,6 +2451,21 @@ impl SessionController {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::SessionController;
+    /// async fn sample(
+    ///    client: &SessionController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::session_controller::CancelOperation {
         super::builder::session_controller::CancelOperation::new(self.inner.clone())
     }
@@ -1632,6 +2579,22 @@ impl WorkflowTemplateService {
     }
 
     /// Creates new workflow template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_workflow_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_workflow_template(
         &self,
     ) -> super::builder::workflow_template_service::CreateWorkflowTemplate {
@@ -1642,6 +2605,23 @@ impl WorkflowTemplateService {
     ///
     /// Can retrieve previously instantiated template by specifying optional
     /// version parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workflow_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workflow_template(
         &self,
     ) -> super::builder::workflow_template_service::GetWorkflowTemplate {
@@ -1742,6 +2722,22 @@ impl WorkflowTemplateService {
 
     /// Updates (replaces) workflow template. The updated template
     /// must contain version that matches the current server version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_workflow_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_workflow_template(
         &self,
     ) -> super::builder::workflow_template_service::UpdateWorkflowTemplate {
@@ -1756,6 +2752,21 @@ impl WorkflowTemplateService {
     }
 
     /// Deletes a workflow template. It does not cancel in-progress workflows.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_workflow_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_workflow_template(
         &self,
     ) -> super::builder::workflow_template_service::DeleteWorkflowTemplate {
@@ -1767,12 +2778,44 @@ impl WorkflowTemplateService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::workflow_template_service::SetIamPolicy {
         super::builder::workflow_template_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::workflow_template_service::GetIamPolicy {
         super::builder::workflow_template_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1784,6 +2827,22 @@ impl WorkflowTemplateService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::workflow_template_service::TestIamPermissions {
@@ -1800,6 +2859,22 @@ impl WorkflowTemplateService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::workflow_template_service::GetOperation {
         super::builder::workflow_template_service::GetOperation::new(self.inner.clone())
     }
@@ -1807,6 +2882,21 @@ impl WorkflowTemplateService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::workflow_template_service::DeleteOperation {
         super::builder::workflow_template_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1814,6 +2904,21 @@ impl WorkflowTemplateService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
+    /// async fn sample(
+    ///    client: &WorkflowTemplateService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::workflow_template_service::CancelOperation {
         super::builder::workflow_template_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/datastream/v1/src/client.rs
+++ b/src/generated/cloud/datastream/v1/src/client.rs
@@ -125,6 +125,23 @@ impl Datastream {
     }
 
     /// Use this method to get details about a connection profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection_profile(&self) -> super::builder::datastream::GetConnectionProfile {
         super::builder::datastream::GetConnectionProfile::new(self.inner.clone())
     }
@@ -178,6 +195,22 @@ impl Datastream {
     /// The discover API call exposes the data objects and metadata belonging to
     /// the profile. Typically, a request returns children data objects of a
     /// parent data object that's optionally supplied in the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .discover_connection_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn discover_connection_profile(
         &self,
     ) -> super::builder::datastream::DiscoverConnectionProfile {
@@ -190,6 +223,23 @@ impl Datastream {
     }
 
     /// Use this method to get details about a stream.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_stream()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_stream(&self) -> super::builder::datastream::GetStream {
         super::builder::datastream::GetStream::new(self.inner.clone())
     }
@@ -256,11 +306,44 @@ impl Datastream {
     }
 
     /// Use this method to get details about a stream object.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_stream_object()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_stream_object(&self) -> super::builder::datastream::GetStreamObject {
         super::builder::datastream::GetStreamObject::new(self.inner.clone())
     }
 
     /// Use this method to look up a stream object by its source object identifier.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_stream_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_stream_object(&self) -> super::builder::datastream::LookupStreamObject {
         super::builder::datastream::LookupStreamObject::new(self.inner.clone())
     }
@@ -271,17 +354,65 @@ impl Datastream {
     }
 
     /// Use this method to start a backfill job for the specified stream object.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_backfill_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_backfill_job(&self) -> super::builder::datastream::StartBackfillJob {
         super::builder::datastream::StartBackfillJob::new(self.inner.clone())
     }
 
     /// Use this method to stop a backfill job for the specified stream object.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_backfill_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_backfill_job(&self) -> super::builder::datastream::StopBackfillJob {
         super::builder::datastream::StopBackfillJob::new(self.inner.clone())
     }
 
     /// The FetchStaticIps API call exposes the static IP addresses used by
     /// Datastream.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_static_ips()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_static_ips(&self) -> super::builder::datastream::FetchStaticIps {
         super::builder::datastream::FetchStaticIps::new(self.inner.clone())
     }
@@ -302,6 +433,23 @@ impl Datastream {
     }
 
     /// Use this method to get details about a private connectivity configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_private_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_private_connection(&self) -> super::builder::datastream::GetPrivateConnection {
         super::builder::datastream::GetPrivateConnection::new(self.inner.clone())
     }
@@ -344,6 +492,23 @@ impl Datastream {
     }
 
     /// Use this method to get details about a route.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_route(&self) -> super::builder::datastream::GetRoute {
         super::builder::datastream::GetRoute::new(self.inner.clone())
     }
@@ -375,6 +540,22 @@ impl Datastream {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::datastream::GetLocation {
         super::builder::datastream::GetLocation::new(self.inner.clone())
     }
@@ -389,6 +570,22 @@ impl Datastream {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::datastream::GetOperation {
         super::builder::datastream::GetOperation::new(self.inner.clone())
     }
@@ -396,6 +593,21 @@ impl Datastream {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::datastream::DeleteOperation {
         super::builder::datastream::DeleteOperation::new(self.inner.clone())
     }
@@ -403,6 +615,21 @@ impl Datastream {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastream_v1::client::Datastream;
+    /// async fn sample(
+    ///    client: &Datastream
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::datastream::CancelOperation {
         super::builder::datastream::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/deploy/v1/src/client.rs
+++ b/src/generated/cloud/deploy/v1/src/client.rs
@@ -125,6 +125,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single DeliveryPipeline.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_delivery_pipeline()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_delivery_pipeline(&self) -> super::builder::cloud_deploy::GetDeliveryPipeline {
         super::builder::cloud_deploy::GetDeliveryPipeline::new(self.inner.clone())
     }
@@ -180,11 +197,44 @@ impl CloudDeploy {
     }
 
     /// Creates a `Rollout` to roll back the specified target.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rollback_target()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rollback_target(&self) -> super::builder::cloud_deploy::RollbackTarget {
         super::builder::cloud_deploy::RollbackTarget::new(self.inner.clone())
     }
 
     /// Gets details of a single Target.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_target()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_target(&self) -> super::builder::cloud_deploy::GetTarget {
         super::builder::cloud_deploy::GetTarget::new(self.inner.clone())
     }
@@ -240,6 +290,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single CustomTargetType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_custom_target_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_custom_target_type(&self) -> super::builder::cloud_deploy::GetCustomTargetType {
         super::builder::cloud_deploy::GetCustomTargetType::new(self.inner.clone())
     }
@@ -301,6 +368,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single Release.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_release()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_release(&self) -> super::builder::cloud_deploy::GetRelease {
         super::builder::cloud_deploy::GetRelease::new(self.inner.clone())
     }
@@ -321,6 +405,22 @@ impl CloudDeploy {
     }
 
     /// Abandons a Release in the Delivery Pipeline.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .abandon_release()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn abandon_release(&self) -> super::builder::cloud_deploy::AbandonRelease {
         super::builder::cloud_deploy::AbandonRelease::new(self.inner.clone())
     }
@@ -376,21 +476,86 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single DeployPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deploy_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deploy_policy(&self) -> super::builder::cloud_deploy::GetDeployPolicy {
         super::builder::cloud_deploy::GetDeployPolicy::new(self.inner.clone())
     }
 
     /// Approves a Rollout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .approve_rollout()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn approve_rollout(&self) -> super::builder::cloud_deploy::ApproveRollout {
         super::builder::cloud_deploy::ApproveRollout::new(self.inner.clone())
     }
 
     /// Advances a Rollout in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .advance_rollout()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn advance_rollout(&self) -> super::builder::cloud_deploy::AdvanceRollout {
         super::builder::cloud_deploy::AdvanceRollout::new(self.inner.clone())
     }
 
     /// Cancels a Rollout in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_rollout()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_rollout(&self) -> super::builder::cloud_deploy::CancelRollout {
         super::builder::cloud_deploy::CancelRollout::new(self.inner.clone())
     }
@@ -401,6 +566,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single Rollout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rollout()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rollout(&self) -> super::builder::cloud_deploy::GetRollout {
         super::builder::cloud_deploy::GetRollout::new(self.inner.clone())
     }
@@ -421,11 +603,43 @@ impl CloudDeploy {
     }
 
     /// Ignores the specified Job in a Rollout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .ignore_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn ignore_job(&self) -> super::builder::cloud_deploy::IgnoreJob {
         super::builder::cloud_deploy::IgnoreJob::new(self.inner.clone())
     }
 
     /// Retries the specified Job in a Rollout.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retry_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retry_job(&self) -> super::builder::cloud_deploy::RetryJob {
         super::builder::cloud_deploy::RetryJob::new(self.inner.clone())
     }
@@ -436,16 +650,66 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single JobRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job_run()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job_run(&self) -> super::builder::cloud_deploy::GetJobRun {
         super::builder::cloud_deploy::GetJobRun::new(self.inner.clone())
     }
 
     /// Terminates a Job Run in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .terminate_job_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn terminate_job_run(&self) -> super::builder::cloud_deploy::TerminateJobRun {
         super::builder::cloud_deploy::TerminateJobRun::new(self.inner.clone())
     }
 
     /// Gets the configuration for a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_config(&self) -> super::builder::cloud_deploy::GetConfig {
         super::builder::cloud_deploy::GetConfig::new(self.inner.clone())
     }
@@ -496,6 +760,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single Automation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_automation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_automation(&self) -> super::builder::cloud_deploy::GetAutomation {
         super::builder::cloud_deploy::GetAutomation::new(self.inner.clone())
     }
@@ -506,6 +787,23 @@ impl CloudDeploy {
     }
 
     /// Gets details of a single AutomationRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_automation_run()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_automation_run(&self) -> super::builder::cloud_deploy::GetAutomationRun {
         super::builder::cloud_deploy::GetAutomationRun::new(self.inner.clone())
     }
@@ -519,6 +817,22 @@ impl CloudDeploy {
     /// cancelling is `CANCELLED`. `CancelAutomationRun` can be called on
     /// AutomationRun in the state `IN_PROGRESS` and `PENDING`; AutomationRun
     /// in a different state returns an `FAILED_PRECONDITION` error.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_automation_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_automation_run(&self) -> super::builder::cloud_deploy::CancelAutomationRun {
         super::builder::cloud_deploy::CancelAutomationRun::new(self.inner.clone())
     }
@@ -529,6 +843,22 @@ impl CloudDeploy {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_deploy::GetLocation {
         super::builder::cloud_deploy::GetLocation::new(self.inner.clone())
     }
@@ -538,12 +868,44 @@ impl CloudDeploy {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cloud_deploy::SetIamPolicy {
         super::builder::cloud_deploy::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cloud_deploy::GetIamPolicy {
         super::builder::cloud_deploy::GetIamPolicy::new(self.inner.clone())
     }
@@ -555,6 +917,22 @@ impl CloudDeploy {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::cloud_deploy::TestIamPermissions {
         super::builder::cloud_deploy::TestIamPermissions::new(self.inner.clone())
     }
@@ -569,6 +947,22 @@ impl CloudDeploy {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_deploy::GetOperation {
         super::builder::cloud_deploy::GetOperation::new(self.inner.clone())
     }
@@ -576,6 +970,21 @@ impl CloudDeploy {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cloud_deploy::DeleteOperation {
         super::builder::cloud_deploy::DeleteOperation::new(self.inner.clone())
     }
@@ -583,6 +992,21 @@ impl CloudDeploy {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_deploy_v1::client::CloudDeploy;
+    /// async fn sample(
+    ///    client: &CloudDeploy
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_deploy::CancelOperation {
         super::builder::cloud_deploy::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/developerconnect/v1/src/client.rs
+++ b/src/generated/cloud/developerconnect/v1/src/client.rs
@@ -127,6 +127,23 @@ impl DeveloperConnect {
     }
 
     /// Gets details of a single Connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection(&self) -> super::builder::developer_connect::GetConnection {
         super::builder::developer_connect::GetConnection::new(self.inner.clone())
     }
@@ -222,6 +239,23 @@ impl DeveloperConnect {
     }
 
     /// Gets details of a single GitRepositoryLink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_git_repository_link()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_git_repository_link(
         &self,
     ) -> super::builder::developer_connect::GetGitRepositoryLink {
@@ -229,11 +263,43 @@ impl DeveloperConnect {
     }
 
     /// Fetches read/write token of a given gitRepositoryLink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_read_write_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_read_write_token(&self) -> super::builder::developer_connect::FetchReadWriteToken {
         super::builder::developer_connect::FetchReadWriteToken::new(self.inner.clone())
     }
 
     /// Fetches read token of a given gitRepositoryLink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_read_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_read_token(&self) -> super::builder::developer_connect::FetchReadToken {
         super::builder::developer_connect::FetchReadToken::new(self.inner.clone())
     }
@@ -250,6 +316,22 @@ impl DeveloperConnect {
     /// are available to be added to a Connection.
     /// For github.com, only installations accessible to the authorizer token
     /// are returned. For GitHub Enterprise, all installations are returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_git_hub_installations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_git_hub_installations(
         &self,
     ) -> super::builder::developer_connect::FetchGitHubInstallations {
@@ -257,6 +339,22 @@ impl DeveloperConnect {
     }
 
     /// Fetch the list of branches or tags for a given repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_git_refs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_git_refs(&self) -> super::builder::developer_connect::FetchGitRefs {
         super::builder::developer_connect::FetchGitRefs::new(self.inner.clone())
     }
@@ -269,6 +367,23 @@ impl DeveloperConnect {
     }
 
     /// Gets details of a single AccountConnector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_account_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_account_connector(&self) -> super::builder::developer_connect::GetAccountConnector {
         super::builder::developer_connect::GetAccountConnector::new(self.inner.clone())
     }
@@ -325,6 +440,22 @@ impl DeveloperConnect {
     }
 
     /// Fetches OAuth access token based on end user credentials.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_access_token(&self) -> super::builder::developer_connect::FetchAccessToken {
         super::builder::developer_connect::FetchAccessToken::new(self.inner.clone())
     }
@@ -350,6 +481,22 @@ impl DeveloperConnect {
     }
 
     /// Fetch the User based on the user credentials.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_self()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_self(&self) -> super::builder::developer_connect::FetchSelf {
         super::builder::developer_connect::FetchSelf::new(self.inner.clone())
     }
@@ -375,6 +522,22 @@ impl DeveloperConnect {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::developer_connect::GetLocation {
         super::builder::developer_connect::GetLocation::new(self.inner.clone())
     }
@@ -389,6 +552,22 @@ impl DeveloperConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::developer_connect::GetOperation {
         super::builder::developer_connect::GetOperation::new(self.inner.clone())
     }
@@ -396,6 +575,21 @@ impl DeveloperConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::developer_connect::DeleteOperation {
         super::builder::developer_connect::DeleteOperation::new(self.inner.clone())
     }
@@ -403,6 +597,21 @@ impl DeveloperConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+    /// async fn sample(
+    ///    client: &DeveloperConnect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::developer_connect::CancelOperation {
         super::builder::developer_connect::CancelOperation::new(self.inner.clone())
     }
@@ -546,6 +755,23 @@ impl InsightsConfigService {
     }
 
     /// Gets details of a single Insight.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
+    /// async fn sample(
+    ///    client: &InsightsConfigService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_insights_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_insights_config(
         &self,
     ) -> super::builder::insights_config_service::GetInsightsConfig {
@@ -592,6 +818,22 @@ impl InsightsConfigService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
+    /// async fn sample(
+    ///    client: &InsightsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::insights_config_service::GetLocation {
         super::builder::insights_config_service::GetLocation::new(self.inner.clone())
     }
@@ -606,6 +848,22 @@ impl InsightsConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
+    /// async fn sample(
+    ///    client: &InsightsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::insights_config_service::GetOperation {
         super::builder::insights_config_service::GetOperation::new(self.inner.clone())
     }
@@ -613,6 +871,21 @@ impl InsightsConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
+    /// async fn sample(
+    ///    client: &InsightsConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::insights_config_service::DeleteOperation {
         super::builder::insights_config_service::DeleteOperation::new(self.inner.clone())
     }
@@ -620,6 +893,21 @@ impl InsightsConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
+    /// async fn sample(
+    ///    client: &InsightsConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::insights_config_service::CancelOperation {
         super::builder::insights_config_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/devicestreaming/v1/src/client.rs
+++ b/src/generated/cloud/devicestreaming/v1/src/client.rs
@@ -131,6 +131,22 @@ impl DirectAccessService {
     }
 
     /// Creates a DeviceSession.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
+    /// async fn sample(
+    ///    client: &DirectAccessService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_device_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_device_session(
         &self,
     ) -> super::builder::direct_access_service::CreateDeviceSession {
@@ -147,6 +163,23 @@ impl DirectAccessService {
     /// Gets a DeviceSession, which documents the allocation status and
     /// whether the device is allocated. Clients making requests from this API
     /// must poll GetDeviceSession.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
+    /// async fn sample(
+    ///    client: &DirectAccessService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_device_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_device_session(&self) -> super::builder::direct_access_service::GetDeviceSession {
         super::builder::direct_access_service::GetDeviceSession::new(self.inner.clone())
     }
@@ -156,6 +189,21 @@ impl DirectAccessService {
     /// connections.
     /// Canceled sessions are not deleted and can be retrieved or
     /// listed by the user until they expire based on the 28 day deletion policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
+    /// async fn sample(
+    ///    client: &DirectAccessService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_device_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_device_session(
         &self,
     ) -> super::builder::direct_access_service::CancelDeviceSession {
@@ -164,6 +212,22 @@ impl DirectAccessService {
 
     /// Updates the current DeviceSession to the fields described by the
     /// update_mask.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
+    /// async fn sample(
+    ///    client: &DirectAccessService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_device_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_device_session(
         &self,
     ) -> super::builder::direct_access_service::UpdateDeviceSession {

--- a/src/generated/cloud/dialogflow/cx/v3/src/client.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/client.rs
@@ -129,6 +129,23 @@ impl Agents {
     }
 
     /// Retrieves the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_agent()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_agent(&self) -> super::builder::agents::GetAgent {
         super::builder::agents::GetAgent::new(self.inner.clone())
     }
@@ -138,6 +155,22 @@ impl Agents {
     /// Note: You should always train flows prior to sending them queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_agent(&self) -> super::builder::agents::CreateAgent {
         super::builder::agents::CreateAgent::new(self.inner.clone())
     }
@@ -147,11 +180,42 @@ impl Agents {
     /// Note: You should always train flows prior to sending them queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_agent(&self) -> super::builder::agents::UpdateAgent {
         super::builder::agents::UpdateAgent::new(self.inner.clone())
     }
 
     /// Deletes the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_agent(&self) -> super::builder::agents::DeleteAgent {
         super::builder::agents::DeleteAgent::new(self.inner.clone())
     }
@@ -216,22 +280,88 @@ impl Agents {
     /// Validates the specified agent and creates or updates validation results.
     /// The agent in draft version is validated. Please call this API after the
     /// training is completed to get the complete validation results.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_agent(&self) -> super::builder::agents::ValidateAgent {
         super::builder::agents::ValidateAgent::new(self.inner.clone())
     }
 
     /// Gets the latest agent validation result. Agent validation is performed
     /// when ValidateAgent is called.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_agent_validation_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_agent_validation_result(&self) -> super::builder::agents::GetAgentValidationResult {
         super::builder::agents::GetAgentValidationResult::new(self.inner.clone())
     }
 
     /// Gets the generative settings for the agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_generative_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_generative_settings(&self) -> super::builder::agents::GetGenerativeSettings {
         super::builder::agents::GetGenerativeSettings::new(self.inner.clone())
     }
 
     /// Updates the generative settings for the agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_generative_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_generative_settings(&self) -> super::builder::agents::UpdateGenerativeSettings {
         super::builder::agents::UpdateGenerativeSettings::new(self.inner.clone())
     }
@@ -242,6 +372,22 @@ impl Agents {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::agents::GetLocation {
         super::builder::agents::GetLocation::new(self.inner.clone())
     }
@@ -256,6 +402,22 @@ impl Agents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::agents::GetOperation {
         super::builder::agents::GetOperation::new(self.inner.clone())
     }
@@ -263,6 +425,21 @@ impl Agents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::agents::CancelOperation {
         super::builder::agents::CancelOperation::new(self.inner.clone())
     }
@@ -381,6 +558,23 @@ impl Changelogs {
     }
 
     /// Retrieves the specified Changelog.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+    /// async fn sample(
+    ///    client: &Changelogs,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_changelog()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_changelog(&self) -> super::builder::changelogs::GetChangelog {
         super::builder::changelogs::GetChangelog::new(self.inner.clone())
     }
@@ -391,6 +585,22 @@ impl Changelogs {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+    /// async fn sample(
+    ///    client: &Changelogs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::changelogs::GetLocation {
         super::builder::changelogs::GetLocation::new(self.inner.clone())
     }
@@ -405,6 +615,22 @@ impl Changelogs {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+    /// async fn sample(
+    ///    client: &Changelogs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::changelogs::GetOperation {
         super::builder::changelogs::GetOperation::new(self.inner.clone())
     }
@@ -412,6 +638,21 @@ impl Changelogs {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
+    /// async fn sample(
+    ///    client: &Changelogs
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::changelogs::CancelOperation {
         super::builder::changelogs::CancelOperation::new(self.inner.clone())
     }
@@ -536,6 +777,23 @@ impl Deployments {
     /// [Deployment][google.cloud.dialogflow.cx.v3.Deployment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Deployment]: crate::model::Deployment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+    /// async fn sample(
+    ///    client: &Deployments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment(&self) -> super::builder::deployments::GetDeployment {
         super::builder::deployments::GetDeployment::new(self.inner.clone())
     }
@@ -546,6 +804,22 @@ impl Deployments {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+    /// async fn sample(
+    ///    client: &Deployments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::deployments::GetLocation {
         super::builder::deployments::GetLocation::new(self.inner.clone())
     }
@@ -560,6 +834,22 @@ impl Deployments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+    /// async fn sample(
+    ///    client: &Deployments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::deployments::GetOperation {
         super::builder::deployments::GetOperation::new(self.inner.clone())
     }
@@ -567,6 +857,21 @@ impl Deployments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
+    /// async fn sample(
+    ///    client: &Deployments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::deployments::CancelOperation {
         super::builder::deployments::CancelOperation::new(self.inner.clone())
     }
@@ -680,6 +985,23 @@ impl EntityTypes {
     }
 
     /// Retrieves the specified entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entity_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entity_type(&self) -> super::builder::entity_types::GetEntityType {
         super::builder::entity_types::GetEntityType::new(self.inner.clone())
     }
@@ -689,6 +1011,22 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_entity_type(&self) -> super::builder::entity_types::CreateEntityType {
         super::builder::entity_types::CreateEntityType::new(self.inner.clone())
     }
@@ -698,6 +1036,22 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_entity_type(&self) -> super::builder::entity_types::UpdateEntityType {
         super::builder::entity_types::UpdateEntityType::new(self.inner.clone())
     }
@@ -707,6 +1061,21 @@ impl EntityTypes {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_entity_type(&self) -> super::builder::entity_types::DeleteEntityType {
         super::builder::entity_types::DeleteEntityType::new(self.inner.clone())
     }
@@ -752,6 +1121,22 @@ impl EntityTypes {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::entity_types::GetLocation {
         super::builder::entity_types::GetLocation::new(self.inner.clone())
     }
@@ -766,6 +1151,22 @@ impl EntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::entity_types::GetOperation {
         super::builder::entity_types::GetOperation::new(self.inner.clone())
     }
@@ -773,6 +1174,21 @@ impl EntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::entity_types::CancelOperation {
         super::builder::entity_types::CancelOperation::new(self.inner.clone())
     }
@@ -898,6 +1314,23 @@ impl Environments {
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_environment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
         super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
@@ -959,6 +1392,21 @@ impl Environments {
     /// [Environment][google.cloud.dialogflow.cx.v3.Environment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_environment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_environment(&self) -> super::builder::environments::DeleteEnvironment {
         super::builder::environments::DeleteEnvironment::new(self.inner.clone())
     }
@@ -1044,6 +1492,22 @@ impl Environments {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::environments::GetLocation {
         super::builder::environments::GetLocation::new(self.inner.clone())
     }
@@ -1058,6 +1522,22 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::environments::GetOperation {
         super::builder::environments::GetOperation::new(self.inner.clone())
     }
@@ -1065,6 +1545,21 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::environments::CancelOperation {
         super::builder::environments::CancelOperation::new(self.inner.clone())
     }
@@ -1189,6 +1684,23 @@ impl Experiments {
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_experiment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_experiment(&self) -> super::builder::experiments::GetExperiment {
         super::builder::experiments::GetExperiment::new(self.inner.clone())
     }
@@ -1198,6 +1710,22 @@ impl Experiments {
     ///
     /// [google.cloud.dialogflow.cx.v3.Environment]: crate::model::Environment
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_experiment(&self) -> super::builder::experiments::CreateExperiment {
         super::builder::experiments::CreateExperiment::new(self.inner.clone())
     }
@@ -1206,6 +1734,22 @@ impl Experiments {
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_experiment(&self) -> super::builder::experiments::UpdateExperiment {
         super::builder::experiments::UpdateExperiment::new(self.inner.clone())
     }
@@ -1214,6 +1758,21 @@ impl Experiments {
     /// [Experiment][google.cloud.dialogflow.cx.v3.Experiment].
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_experiment(&self) -> super::builder::experiments::DeleteExperiment {
         super::builder::experiments::DeleteExperiment::new(self.inner.clone())
     }
@@ -1223,6 +1782,22 @@ impl Experiments {
     /// changes the state of experiment from PENDING to RUNNING.
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_experiment(&self) -> super::builder::experiments::StartExperiment {
         super::builder::experiments::StartExperiment::new(self.inner.clone())
     }
@@ -1231,6 +1806,22 @@ impl Experiments {
     /// This rpc only changes the state of experiment from RUNNING to DONE.
     ///
     /// [google.cloud.dialogflow.cx.v3.Experiment]: crate::model::Experiment
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_experiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_experiment(&self) -> super::builder::experiments::StopExperiment {
         super::builder::experiments::StopExperiment::new(self.inner.clone())
     }
@@ -1241,6 +1832,22 @@ impl Experiments {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::experiments::GetLocation {
         super::builder::experiments::GetLocation::new(self.inner.clone())
     }
@@ -1255,6 +1862,22 @@ impl Experiments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::experiments::GetOperation {
         super::builder::experiments::GetOperation::new(self.inner.clone())
     }
@@ -1262,6 +1885,21 @@ impl Experiments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
+    /// async fn sample(
+    ///    client: &Experiments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::experiments::CancelOperation {
         super::builder::experiments::CancelOperation::new(self.inner.clone())
     }
@@ -1379,11 +2017,42 @@ impl Flows {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_flow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_flow(&self) -> super::builder::flows::CreateFlow {
         super::builder::flows::CreateFlow::new(self.inner.clone())
     }
 
     /// Deletes a specified flow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_flow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_flow(&self) -> super::builder::flows::DeleteFlow {
         super::builder::flows::DeleteFlow::new(self.inner.clone())
     }
@@ -1394,6 +2063,23 @@ impl Flows {
     }
 
     /// Retrieves the specified flow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_flow()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_flow(&self) -> super::builder::flows::GetFlow {
         super::builder::flows::GetFlow::new(self.inner.clone())
     }
@@ -1403,6 +2089,22 @@ impl Flows {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_flow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_flow(&self) -> super::builder::flows::UpdateFlow {
         super::builder::flows::UpdateFlow::new(self.inner.clone())
     }
@@ -1439,12 +2141,45 @@ impl Flows {
     /// Validates the specified flow and creates or updates validation results.
     /// Please call this API after the training is completed to get the complete
     /// validation results.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_flow()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_flow(&self) -> super::builder::flows::ValidateFlow {
         super::builder::flows::ValidateFlow::new(self.inner.clone())
     }
 
     /// Gets the latest flow validation result. Flow validation is performed
     /// when ValidateFlow is called.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_flow_validation_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_flow_validation_result(&self) -> super::builder::flows::GetFlowValidationResult {
         super::builder::flows::GetFlowValidationResult::new(self.inner.clone())
     }
@@ -1514,6 +2249,22 @@ impl Flows {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::flows::GetLocation {
         super::builder::flows::GetLocation::new(self.inner.clone())
     }
@@ -1528,6 +2279,22 @@ impl Flows {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::flows::GetOperation {
         super::builder::flows::GetOperation::new(self.inner.clone())
     }
@@ -1535,6 +2302,21 @@ impl Flows {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Flows;
+    /// async fn sample(
+    ///    client: &Flows
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::flows::CancelOperation {
         super::builder::flows::CancelOperation::new(self.inner.clone())
     }
@@ -1653,21 +2435,85 @@ impl Generators {
     }
 
     /// Retrieves the specified generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_generator()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_generator(&self) -> super::builder::generators::GetGenerator {
         super::builder::generators::GetGenerator::new(self.inner.clone())
     }
 
     /// Creates a generator in the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_generator()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_generator(&self) -> super::builder::generators::CreateGenerator {
         super::builder::generators::CreateGenerator::new(self.inner.clone())
     }
 
     /// Update the specified generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_generator()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_generator(&self) -> super::builder::generators::UpdateGenerator {
         super::builder::generators::UpdateGenerator::new(self.inner.clone())
     }
 
     /// Deletes the specified generators.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_generator()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_generator(&self) -> super::builder::generators::DeleteGenerator {
         super::builder::generators::DeleteGenerator::new(self.inner.clone())
     }
@@ -1678,6 +2524,22 @@ impl Generators {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::generators::GetLocation {
         super::builder::generators::GetLocation::new(self.inner.clone())
     }
@@ -1692,6 +2554,22 @@ impl Generators {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::generators::GetOperation {
         super::builder::generators::GetOperation::new(self.inner.clone())
     }
@@ -1699,6 +2577,21 @@ impl Generators {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::generators::CancelOperation {
         super::builder::generators::CancelOperation::new(self.inner.clone())
     }
@@ -1817,6 +2710,23 @@ impl Intents {
     }
 
     /// Retrieves the specified intent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_intent()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_intent(&self) -> super::builder::intents::GetIntent {
         super::builder::intents::GetIntent::new(self.inner.clone())
     }
@@ -1826,6 +2736,22 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_intent(&self) -> super::builder::intents::CreateIntent {
         super::builder::intents::CreateIntent::new(self.inner.clone())
     }
@@ -1835,6 +2761,22 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_intent(&self) -> super::builder::intents::UpdateIntent {
         super::builder::intents::UpdateIntent::new(self.inner.clone())
     }
@@ -1844,6 +2786,21 @@ impl Intents {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_intent(&self) -> super::builder::intents::DeleteIntent {
         super::builder::intents::DeleteIntent::new(self.inner.clone())
     }
@@ -1908,6 +2865,22 @@ impl Intents {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::intents::GetLocation {
         super::builder::intents::GetLocation::new(self.inner.clone())
     }
@@ -1922,6 +2895,22 @@ impl Intents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::intents::GetOperation {
         super::builder::intents::GetOperation::new(self.inner.clone())
     }
@@ -1929,6 +2918,21 @@ impl Intents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::intents::CancelOperation {
         super::builder::intents::CancelOperation::new(self.inner.clone())
     }
@@ -2047,6 +3051,23 @@ impl Pages {
     }
 
     /// Retrieves the specified page.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_page()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_page(&self) -> super::builder::pages::GetPage {
         super::builder::pages::GetPage::new(self.inner.clone())
     }
@@ -2056,6 +3077,22 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_page()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_page(&self) -> super::builder::pages::CreatePage {
         super::builder::pages::CreatePage::new(self.inner.clone())
     }
@@ -2065,6 +3102,22 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_page()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_page(&self) -> super::builder::pages::UpdatePage {
         super::builder::pages::UpdatePage::new(self.inner.clone())
     }
@@ -2074,6 +3127,21 @@ impl Pages {
     /// Note: You should always train a flow prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_page()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_page(&self) -> super::builder::pages::DeletePage {
         super::builder::pages::DeletePage::new(self.inner.clone())
     }
@@ -2084,6 +3152,22 @@ impl Pages {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::pages::GetLocation {
         super::builder::pages::GetLocation::new(self.inner.clone())
     }
@@ -2098,6 +3182,22 @@ impl Pages {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::pages::GetOperation {
         super::builder::pages::GetOperation::new(self.inner.clone())
     }
@@ -2105,6 +3205,21 @@ impl Pages {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Pages;
+    /// async fn sample(
+    ///    client: &Pages
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::pages::CancelOperation {
         super::builder::pages::CancelOperation::new(self.inner.clone())
     }
@@ -2220,6 +3335,22 @@ impl SecuritySettingsService {
     }
 
     /// Create security settings in the specified location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_security_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_security_settings(
         &self,
     ) -> super::builder::security_settings_service::CreateSecuritySettings {
@@ -2231,6 +3362,23 @@ impl SecuritySettingsService {
     /// returned settings may be stale by up to 1 minute.
     ///
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_security_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_security_settings(
         &self,
     ) -> super::builder::security_settings_service::GetSecuritySettings {
@@ -2241,6 +3389,22 @@ impl SecuritySettingsService {
     /// [SecuritySettings][google.cloud.dialogflow.cx.v3.SecuritySettings].
     ///
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_security_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_security_settings(
         &self,
     ) -> super::builder::security_settings_service::UpdateSecuritySettings {
@@ -2258,6 +3422,21 @@ impl SecuritySettingsService {
     /// [SecuritySettings][google.cloud.dialogflow.cx.v3.SecuritySettings].
     ///
     /// [google.cloud.dialogflow.cx.v3.SecuritySettings]: crate::model::SecuritySettings
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_security_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_security_settings(
         &self,
     ) -> super::builder::security_settings_service::DeleteSecuritySettings {
@@ -2270,6 +3449,22 @@ impl SecuritySettingsService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::security_settings_service::GetLocation {
         super::builder::security_settings_service::GetLocation::new(self.inner.clone())
     }
@@ -2284,6 +3479,22 @@ impl SecuritySettingsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::security_settings_service::GetOperation {
         super::builder::security_settings_service::GetOperation::new(self.inner.clone())
     }
@@ -2291,6 +3502,21 @@ impl SecuritySettingsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
+    /// async fn sample(
+    ///    client: &SecuritySettingsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::security_settings_service::CancelOperation {
         super::builder::security_settings_service::CancelOperation::new(self.inner.clone())
     }
@@ -2414,12 +3640,44 @@ impl Sessions {
     /// Note: Always use agent versions for production traffic.
     /// See [Versions and
     /// environments](https://cloud.google.com/dialogflow/cx/docs/concept/version).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .detect_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn detect_intent(&self) -> super::builder::sessions::DetectIntent {
         super::builder::sessions::DetectIntent::new(self.inner.clone())
     }
 
     /// Returns preliminary intent match results, doesn't change the session
     /// status.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .match_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn match_intent(&self) -> super::builder::sessions::MatchIntent {
         super::builder::sessions::MatchIntent::new(self.inner.clone())
     }
@@ -2434,12 +3692,44 @@ impl Sessions {
     ///
     /// [google.cloud.dialogflow.cx.v3.MatchIntentResponse]: crate::model::MatchIntentResponse
     /// [google.cloud.dialogflow.cx.v3.Sessions.MatchIntent]: crate::client::Sessions::match_intent
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fulfill_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fulfill_intent(&self) -> super::builder::sessions::FulfillIntent {
         super::builder::sessions::FulfillIntent::new(self.inner.clone())
     }
 
     /// Updates the feedback received from the user for a single turn of the bot
     /// response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .submit_answer_feedback()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn submit_answer_feedback(&self) -> super::builder::sessions::SubmitAnswerFeedback {
         super::builder::sessions::SubmitAnswerFeedback::new(self.inner.clone())
     }
@@ -2450,6 +3740,22 @@ impl Sessions {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::sessions::GetLocation {
         super::builder::sessions::GetLocation::new(self.inner.clone())
     }
@@ -2464,6 +3770,22 @@ impl Sessions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::sessions::GetOperation {
         super::builder::sessions::GetOperation::new(self.inner.clone())
     }
@@ -2471,6 +3793,21 @@ impl Sessions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::sessions::CancelOperation {
         super::builder::sessions::CancelOperation::new(self.inner.clone())
     }
@@ -2595,6 +3932,23 @@ impl SessionEntityTypes {
     }
 
     /// Retrieves the specified session entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session_entity_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::GetSessionEntityType {
@@ -2602,6 +3956,22 @@ impl SessionEntityTypes {
     }
 
     /// Creates a session entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::CreateSessionEntityType {
@@ -2609,6 +3979,22 @@ impl SessionEntityTypes {
     }
 
     /// Updates the specified session entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::UpdateSessionEntityType {
@@ -2616,6 +4002,21 @@ impl SessionEntityTypes {
     }
 
     /// Deletes the specified session entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::DeleteSessionEntityType {
@@ -2628,6 +4029,22 @@ impl SessionEntityTypes {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::session_entity_types::GetLocation {
         super::builder::session_entity_types::GetLocation::new(self.inner.clone())
     }
@@ -2642,6 +4059,22 @@ impl SessionEntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::session_entity_types::GetOperation {
         super::builder::session_entity_types::GetOperation::new(self.inner.clone())
     }
@@ -2649,6 +4082,21 @@ impl SessionEntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::session_entity_types::CancelOperation {
         super::builder::session_entity_types::CancelOperation::new(self.inner.clone())
     }
@@ -2769,21 +4217,85 @@ impl TestCases {
     }
 
     /// Batch deletes test cases.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .batch_delete_test_cases()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_delete_test_cases(&self) -> super::builder::test_cases::BatchDeleteTestCases {
         super::builder::test_cases::BatchDeleteTestCases::new(self.inner.clone())
     }
 
     /// Gets a test case.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_test_case()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_test_case(&self) -> super::builder::test_cases::GetTestCase {
         super::builder::test_cases::GetTestCase::new(self.inner.clone())
     }
 
     /// Creates a test case for the given agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_test_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_test_case(&self) -> super::builder::test_cases::CreateTestCase {
         super::builder::test_cases::CreateTestCase::new(self.inner.clone())
     }
 
     /// Updates the specified test case.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_test_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_test_case(&self) -> super::builder::test_cases::UpdateTestCase {
         super::builder::test_cases::UpdateTestCase::new(self.inner.clone())
     }
@@ -2843,6 +4355,22 @@ impl TestCases {
     }
 
     /// Calculates the test coverage for an agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .calculate_coverage()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn calculate_coverage(&self) -> super::builder::test_cases::CalculateCoverage {
         super::builder::test_cases::CalculateCoverage::new(self.inner.clone())
     }
@@ -2911,6 +4439,23 @@ impl TestCases {
     }
 
     /// Gets a test case result.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_test_case_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_test_case_result(&self) -> super::builder::test_cases::GetTestCaseResult {
         super::builder::test_cases::GetTestCaseResult::new(self.inner.clone())
     }
@@ -2921,6 +4466,22 @@ impl TestCases {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::test_cases::GetLocation {
         super::builder::test_cases::GetLocation::new(self.inner.clone())
     }
@@ -2935,6 +4496,22 @@ impl TestCases {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::test_cases::GetOperation {
         super::builder::test_cases::GetOperation::new(self.inner.clone())
     }
@@ -2942,6 +4519,21 @@ impl TestCases {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
+    /// async fn sample(
+    ///    client: &TestCases
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::test_cases::CancelOperation {
         super::builder::test_cases::CancelOperation::new(self.inner.clone())
     }
@@ -3069,6 +4661,23 @@ impl TransitionRouteGroups {
     /// [TransitionRouteGroup][google.cloud.dialogflow.cx.v3.TransitionRouteGroup].
     ///
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_transition_route_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_transition_route_group(
         &self,
     ) -> super::builder::transition_route_groups::GetTransitionRouteGroup {
@@ -3084,6 +4693,22 @@ impl TransitionRouteGroups {
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
     ///
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_transition_route_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_transition_route_group(
         &self,
     ) -> super::builder::transition_route_groups::CreateTransitionRouteGroup {
@@ -3098,6 +4723,22 @@ impl TransitionRouteGroups {
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
     ///
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_transition_route_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_transition_route_group(
         &self,
     ) -> super::builder::transition_route_groups::UpdateTransitionRouteGroup {
@@ -3112,6 +4753,22 @@ impl TransitionRouteGroups {
     /// documentation](https://cloud.google.com/dialogflow/cx/docs/concept/training).
     ///
     /// [google.cloud.dialogflow.cx.v3.TransitionRouteGroup]: crate::model::TransitionRouteGroup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_transition_route_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_transition_route_group(
         &self,
     ) -> super::builder::transition_route_groups::DeleteTransitionRouteGroup {
@@ -3124,6 +4781,22 @@ impl TransitionRouteGroups {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::transition_route_groups::GetLocation {
         super::builder::transition_route_groups::GetLocation::new(self.inner.clone())
     }
@@ -3138,6 +4811,22 @@ impl TransitionRouteGroups {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::transition_route_groups::GetOperation {
         super::builder::transition_route_groups::GetOperation::new(self.inner.clone())
     }
@@ -3145,6 +4834,21 @@ impl TransitionRouteGroups {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
+    /// async fn sample(
+    ///    client: &TransitionRouteGroups
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::transition_route_groups::CancelOperation {
         super::builder::transition_route_groups::CancelOperation::new(self.inner.clone())
     }
@@ -3268,6 +4972,23 @@ impl Versions {
     /// Retrieves the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::versions::GetVersion {
         super::builder::versions::GetVersion::new(self.inner.clone())
     }
@@ -3303,6 +5024,22 @@ impl Versions {
     /// Updates the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_version(&self) -> super::builder::versions::UpdateVersion {
         super::builder::versions::UpdateVersion::new(self.inner.clone())
     }
@@ -3310,6 +5047,21 @@ impl Versions {
     /// Deletes the specified [Version][google.cloud.dialogflow.cx.v3.Version].
     ///
     /// [google.cloud.dialogflow.cx.v3.Version]: crate::model::Version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_version(&self) -> super::builder::versions::DeleteVersion {
         super::builder::versions::DeleteVersion::new(self.inner.clone())
     }
@@ -3339,6 +5091,22 @@ impl Versions {
     }
 
     /// Compares the specified base version with target version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compare_versions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compare_versions(&self) -> super::builder::versions::CompareVersions {
         super::builder::versions::CompareVersions::new(self.inner.clone())
     }
@@ -3349,6 +5117,22 @@ impl Versions {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::versions::GetLocation {
         super::builder::versions::GetLocation::new(self.inner.clone())
     }
@@ -3363,6 +5147,22 @@ impl Versions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::versions::GetOperation {
         super::builder::versions::GetOperation::new(self.inner.clone())
     }
@@ -3370,6 +5170,21 @@ impl Versions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::versions::CancelOperation {
         super::builder::versions::CancelOperation::new(self.inner.clone())
     }
@@ -3488,21 +5303,85 @@ impl Webhooks {
     }
 
     /// Retrieves the specified webhook.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_webhook()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_webhook(&self) -> super::builder::webhooks::GetWebhook {
         super::builder::webhooks::GetWebhook::new(self.inner.clone())
     }
 
     /// Creates a webhook in the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_webhook()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_webhook(&self) -> super::builder::webhooks::CreateWebhook {
         super::builder::webhooks::CreateWebhook::new(self.inner.clone())
     }
 
     /// Updates the specified webhook.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_webhook()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_webhook(&self) -> super::builder::webhooks::UpdateWebhook {
         super::builder::webhooks::UpdateWebhook::new(self.inner.clone())
     }
 
     /// Deletes the specified webhook.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_webhook()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_webhook(&self) -> super::builder::webhooks::DeleteWebhook {
         super::builder::webhooks::DeleteWebhook::new(self.inner.clone())
     }
@@ -3513,6 +5392,22 @@ impl Webhooks {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::webhooks::GetLocation {
         super::builder::webhooks::GetLocation::new(self.inner.clone())
     }
@@ -3527,6 +5422,22 @@ impl Webhooks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::webhooks::GetOperation {
         super::builder::webhooks::GetOperation::new(self.inner.clone())
     }
@@ -3534,6 +5445,21 @@ impl Webhooks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
+    /// async fn sample(
+    ///    client: &Webhooks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::webhooks::CancelOperation {
         super::builder::webhooks::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/dialogflow/v2/src/client.rs
+++ b/src/generated/cloud/dialogflow/v2/src/client.rs
@@ -124,6 +124,22 @@ impl Agents {
     }
 
     /// Retrieves the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_agent(&self) -> super::builder::agents::GetAgent {
         super::builder::agents::GetAgent::new(self.inner.clone())
     }
@@ -133,11 +149,42 @@ impl Agents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_agent(&self) -> super::builder::agents::SetAgent {
         super::builder::agents::SetAgent::new(self.inner.clone())
     }
 
     /// Deletes the specified agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_agent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_agent(&self) -> super::builder::agents::DeleteAgent {
         super::builder::agents::DeleteAgent::new(self.inner.clone())
     }
@@ -294,6 +341,22 @@ impl Agents {
 
     /// Gets agent validation result. Agent validation is performed during
     /// training time and is updated automatically when training is completed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_validation_result()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_validation_result(&self) -> super::builder::agents::GetValidationResult {
         super::builder::agents::GetValidationResult::new(self.inner.clone())
     }
@@ -304,6 +367,22 @@ impl Agents {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::agents::GetLocation {
         super::builder::agents::GetLocation::new(self.inner.clone())
     }
@@ -318,6 +397,22 @@ impl Agents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::agents::GetOperation {
         super::builder::agents::GetOperation::new(self.inner.clone())
     }
@@ -325,6 +420,21 @@ impl Agents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Agents;
+    /// async fn sample(
+    ///    client: &Agents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::agents::CancelOperation {
         super::builder::agents::CancelOperation::new(self.inner.clone())
     }
@@ -445,6 +555,22 @@ impl AnswerRecords {
     }
 
     /// Updates the specified answer record.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+    /// async fn sample(
+    ///    client: &AnswerRecords
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_answer_record()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_answer_record(&self) -> super::builder::answer_records::UpdateAnswerRecord {
         super::builder::answer_records::UpdateAnswerRecord::new(self.inner.clone())
     }
@@ -455,6 +581,22 @@ impl AnswerRecords {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+    /// async fn sample(
+    ///    client: &AnswerRecords
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::answer_records::GetLocation {
         super::builder::answer_records::GetLocation::new(self.inner.clone())
     }
@@ -469,6 +611,22 @@ impl AnswerRecords {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+    /// async fn sample(
+    ///    client: &AnswerRecords
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::answer_records::GetOperation {
         super::builder::answer_records::GetOperation::new(self.inner.clone())
     }
@@ -476,6 +634,21 @@ impl AnswerRecords {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+    /// async fn sample(
+    ///    client: &AnswerRecords
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::answer_records::CancelOperation {
         super::builder::answer_records::CancelOperation::new(self.inner.clone())
     }
@@ -594,6 +767,23 @@ impl Contexts {
     }
 
     /// Retrieves the specified context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_context()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_context(&self) -> super::builder::contexts::GetContext {
         super::builder::contexts::GetContext::new(self.inner.clone())
     }
@@ -601,21 +791,83 @@ impl Contexts {
     /// Creates a context.
     ///
     /// If the specified context already exists, overrides the context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_context()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_context(&self) -> super::builder::contexts::CreateContext {
         super::builder::contexts::CreateContext::new(self.inner.clone())
     }
 
     /// Updates the specified context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_context()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_context(&self) -> super::builder::contexts::UpdateContext {
         super::builder::contexts::UpdateContext::new(self.inner.clone())
     }
 
     /// Deletes the specified context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_context()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_context(&self) -> super::builder::contexts::DeleteContext {
         super::builder::contexts::DeleteContext::new(self.inner.clone())
     }
 
     /// Deletes all active contexts in the specified session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_all_contexts()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_all_contexts(&self) -> super::builder::contexts::DeleteAllContexts {
         super::builder::contexts::DeleteAllContexts::new(self.inner.clone())
     }
@@ -626,6 +878,22 @@ impl Contexts {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::contexts::GetLocation {
         super::builder::contexts::GetLocation::new(self.inner.clone())
     }
@@ -640,6 +908,22 @@ impl Contexts {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::contexts::GetOperation {
         super::builder::contexts::GetOperation::new(self.inner.clone())
     }
@@ -647,6 +931,21 @@ impl Contexts {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Contexts;
+    /// async fn sample(
+    ///    client: &Contexts
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::contexts::CancelOperation {
         super::builder::contexts::CancelOperation::new(self.inner.clone())
     }
@@ -785,6 +1084,22 @@ impl Conversations {
     /// [google.cloud.dialogflow.v2.Conversation.conversation_profile]: crate::model::Conversation::conversation_profile
     /// [google.cloud.dialogflow.v2.Intent]: crate::model::Intent
     /// [google.cloud.dialogflow.v2.Intent.live_agent_handoff]: crate::model::Intent::live_agent_handoff
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_conversation(&self) -> super::builder::conversations::CreateConversation {
         super::builder::conversations::CreateConversation::new(self.inner.clone())
     }
@@ -795,18 +1110,67 @@ impl Conversations {
     }
 
     /// Retrieves the specific conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation(&self) -> super::builder::conversations::GetConversation {
         super::builder::conversations::GetConversation::new(self.inner.clone())
     }
 
     /// Completes the specified conversation. Finished conversations are purged
     /// from the database after 30 days.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_conversation(&self) -> super::builder::conversations::CompleteConversation {
         super::builder::conversations::CompleteConversation::new(self.inner.clone())
     }
 
     /// Data ingestion API.
     /// Ingests context references for an existing conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .ingest_context_references()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn ingest_context_references(
         &self,
     ) -> super::builder::conversations::IngestContextReferences {
@@ -825,6 +1189,22 @@ impl Conversations {
     /// Suggests summary for a conversation based on specific historical messages.
     /// The range of the messages to be used for summary can be specified in the
     /// request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .suggest_conversation_summary()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn suggest_conversation_summary(
         &self,
     ) -> super::builder::conversations::SuggestConversationSummary {
@@ -833,6 +1213,22 @@ impl Conversations {
 
     /// Generates and returns a summary for a conversation that does not have a
     /// resource created for it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_stateless_summary()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_stateless_summary(
         &self,
     ) -> super::builder::conversations::GenerateStatelessSummary {
@@ -841,6 +1237,22 @@ impl Conversations {
 
     /// Generates and returns a suggestion for a conversation that does not have a
     /// resource created for it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_stateless_suggestion()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_stateless_suggestion(
         &self,
     ) -> super::builder::conversations::GenerateStatelessSuggestion {
@@ -848,6 +1260,22 @@ impl Conversations {
     }
 
     /// Get answers for the given query based on knowledge documents.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_knowledge()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_knowledge(&self) -> super::builder::conversations::SearchKnowledge {
         super::builder::conversations::SearchKnowledge::new(self.inner.clone())
     }
@@ -855,6 +1283,22 @@ impl Conversations {
     /// Generates all the suggestions using generators configured in the
     /// conversation profile. A generator is used only if its trigger event is
     /// matched.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_suggestions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_suggestions(&self) -> super::builder::conversations::GenerateSuggestions {
         super::builder::conversations::GenerateSuggestions::new(self.inner.clone())
     }
@@ -865,6 +1309,22 @@ impl Conversations {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::conversations::GetLocation {
         super::builder::conversations::GetLocation::new(self.inner.clone())
     }
@@ -879,6 +1339,22 @@ impl Conversations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversations::GetOperation {
         super::builder::conversations::GetOperation::new(self.inner.clone())
     }
@@ -886,6 +1362,21 @@ impl Conversations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Conversations;
+    /// async fn sample(
+    ///    client: &Conversations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::conversations::CancelOperation {
         super::builder::conversations::CancelOperation::new(self.inner.clone())
     }
@@ -1032,6 +1523,23 @@ impl ConversationDatasets {
     }
 
     /// Retrieves the specified conversation dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+    /// async fn sample(
+    ///    client: &ConversationDatasets,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation_dataset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation_dataset(
         &self,
     ) -> super::builder::conversation_datasets::GetConversationDataset {
@@ -1111,6 +1619,22 @@ impl ConversationDatasets {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+    /// async fn sample(
+    ///    client: &ConversationDatasets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::conversation_datasets::GetLocation {
         super::builder::conversation_datasets::GetLocation::new(self.inner.clone())
     }
@@ -1125,6 +1649,22 @@ impl ConversationDatasets {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+    /// async fn sample(
+    ///    client: &ConversationDatasets
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversation_datasets::GetOperation {
         super::builder::conversation_datasets::GetOperation::new(self.inner.clone())
     }
@@ -1132,6 +1672,21 @@ impl ConversationDatasets {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
+    /// async fn sample(
+    ///    client: &ConversationDatasets
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::conversation_datasets::CancelOperation {
         super::builder::conversation_datasets::CancelOperation::new(self.inner.clone())
     }
@@ -1275,6 +1830,22 @@ impl ConversationModels {
     }
 
     /// Gets conversation model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// async fn sample(
+    ///    client: &ConversationModels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation_model(
         &self,
     ) -> super::builder::conversation_models::GetConversationModel {
@@ -1380,6 +1951,22 @@ impl ConversationModels {
     }
 
     /// Gets an evaluation of conversation model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// async fn sample(
+    ///    client: &ConversationModels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation_model_evaluation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation_model_evaluation(
         &self,
     ) -> super::builder::conversation_models::GetConversationModelEvaluation {
@@ -1420,6 +2007,22 @@ impl ConversationModels {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// async fn sample(
+    ///    client: &ConversationModels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::conversation_models::GetLocation {
         super::builder::conversation_models::GetLocation::new(self.inner.clone())
     }
@@ -1434,6 +2037,22 @@ impl ConversationModels {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// async fn sample(
+    ///    client: &ConversationModels
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversation_models::GetOperation {
         super::builder::conversation_models::GetOperation::new(self.inner.clone())
     }
@@ -1441,6 +2060,21 @@ impl ConversationModels {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationModels;
+    /// async fn sample(
+    ///    client: &ConversationModels
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::conversation_models::CancelOperation {
         super::builder::conversation_models::CancelOperation::new(self.inner.clone())
     }
@@ -1565,6 +2199,23 @@ impl ConversationProfiles {
     }
 
     /// Retrieves the specified conversation profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation_profile(
         &self,
     ) -> super::builder::conversation_profiles::GetConversationProfile {
@@ -1583,6 +2234,22 @@ impl ConversationProfiles {
     /// [google.cloud.dialogflow.v2.ConversationProfile.create_time]: crate::model::ConversationProfile::create_time
     /// [google.cloud.dialogflow.v2.ConversationProfile.update_time]: crate::model::ConversationProfile::update_time
     /// [google.cloud.dialogflow.v2.ConversationProfiles.GetConversationProfile]: crate::client::ConversationProfiles::get_conversation_profile
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_conversation_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_conversation_profile(
         &self,
     ) -> super::builder::conversation_profiles::CreateConversationProfile {
@@ -1601,6 +2268,22 @@ impl ConversationProfiles {
     /// [google.cloud.dialogflow.v2.ConversationProfile.create_time]: crate::model::ConversationProfile::create_time
     /// [google.cloud.dialogflow.v2.ConversationProfile.update_time]: crate::model::ConversationProfile::update_time
     /// [google.cloud.dialogflow.v2.ConversationProfiles.GetConversationProfile]: crate::client::ConversationProfiles::get_conversation_profile
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_conversation_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_conversation_profile(
         &self,
     ) -> super::builder::conversation_profiles::UpdateConversationProfile {
@@ -1608,6 +2291,21 @@ impl ConversationProfiles {
     }
 
     /// Deletes the specified conversation profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_conversation_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_conversation_profile(
         &self,
     ) -> super::builder::conversation_profiles::DeleteConversationProfile {
@@ -1687,6 +2385,22 @@ impl ConversationProfiles {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::conversation_profiles::GetLocation {
         super::builder::conversation_profiles::GetLocation::new(self.inner.clone())
     }
@@ -1701,6 +2415,22 @@ impl ConversationProfiles {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversation_profiles::GetOperation {
         super::builder::conversation_profiles::GetOperation::new(self.inner.clone())
     }
@@ -1708,6 +2438,21 @@ impl ConversationProfiles {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
+    /// async fn sample(
+    ///    client: &ConversationProfiles
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::conversation_profiles::CancelOperation {
         super::builder::conversation_profiles::CancelOperation::new(self.inner.clone())
     }
@@ -1827,6 +2572,23 @@ impl Documents {
     }
 
     /// Retrieves the specified document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Documents;
+    /// async fn sample(
+    ///    client: &Documents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_document()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_document(&self) -> super::builder::documents::GetDocument {
         super::builder::documents::GetDocument::new(self.inner.clone())
     }
@@ -2003,6 +2765,22 @@ impl Documents {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Documents;
+    /// async fn sample(
+    ///    client: &Documents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::documents::GetLocation {
         super::builder::documents::GetLocation::new(self.inner.clone())
     }
@@ -2017,6 +2795,22 @@ impl Documents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Documents;
+    /// async fn sample(
+    ///    client: &Documents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::documents::GetOperation {
         super::builder::documents::GetOperation::new(self.inner.clone())
     }
@@ -2024,6 +2818,21 @@ impl Documents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Documents;
+    /// async fn sample(
+    ///    client: &Documents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::documents::CancelOperation {
         super::builder::documents::CancelOperation::new(self.inner.clone())
     }
@@ -2138,6 +2947,23 @@ impl EncryptionSpecService {
     }
 
     /// Gets location-level encryption key specification.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+    /// async fn sample(
+    ///    client: &EncryptionSpecService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_encryption_spec()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_encryption_spec(
         &self,
     ) -> super::builder::encryption_spec_service::GetEncryptionSpec {
@@ -2171,6 +2997,22 @@ impl EncryptionSpecService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+    /// async fn sample(
+    ///    client: &EncryptionSpecService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::encryption_spec_service::GetLocation {
         super::builder::encryption_spec_service::GetLocation::new(self.inner.clone())
     }
@@ -2185,6 +3027,22 @@ impl EncryptionSpecService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+    /// async fn sample(
+    ///    client: &EncryptionSpecService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::encryption_spec_service::GetOperation {
         super::builder::encryption_spec_service::GetOperation::new(self.inner.clone())
     }
@@ -2192,6 +3050,21 @@ impl EncryptionSpecService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
+    /// async fn sample(
+    ///    client: &EncryptionSpecService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::encryption_spec_service::CancelOperation {
         super::builder::encryption_spec_service::CancelOperation::new(self.inner.clone())
     }
@@ -2310,6 +3183,23 @@ impl EntityTypes {
     }
 
     /// Retrieves the specified entity type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entity_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entity_type(&self) -> super::builder::entity_types::GetEntityType {
         super::builder::entity_types::GetEntityType::new(self.inner.clone())
     }
@@ -2319,6 +3209,22 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_entity_type(&self) -> super::builder::entity_types::CreateEntityType {
         super::builder::entity_types::CreateEntityType::new(self.inner.clone())
     }
@@ -2328,6 +3234,22 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_entity_type(&self) -> super::builder::entity_types::UpdateEntityType {
         super::builder::entity_types::UpdateEntityType::new(self.inner.clone())
     }
@@ -2337,6 +3259,21 @@ impl EntityTypes {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_entity_type(&self) -> super::builder::entity_types::DeleteEntityType {
         super::builder::entity_types::DeleteEntityType::new(self.inner.clone())
     }
@@ -2495,6 +3432,22 @@ impl EntityTypes {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::entity_types::GetLocation {
         super::builder::entity_types::GetLocation::new(self.inner.clone())
     }
@@ -2509,6 +3462,22 @@ impl EntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::entity_types::GetOperation {
         super::builder::entity_types::GetOperation::new(self.inner.clone())
     }
@@ -2516,6 +3485,21 @@ impl EntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::EntityTypes;
+    /// async fn sample(
+    ///    client: &EntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::entity_types::CancelOperation {
         super::builder::entity_types::CancelOperation::new(self.inner.clone())
     }
@@ -2634,11 +3618,44 @@ impl Environments {
     }
 
     /// Retrieves the specified agent environment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_environment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
         super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
 
     /// Creates an agent environment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_environment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_environment(&self) -> super::builder::environments::CreateEnvironment {
         super::builder::environments::CreateEnvironment::new(self.inner.clone())
     }
@@ -2655,11 +3672,42 @@ impl Environments {
     /// version in the default environment. WARNING: this will negate all recent
     /// changes to the draft agent and can't be undone. You may want to save the
     /// draft agent to a version before calling this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_environment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_environment(&self) -> super::builder::environments::UpdateEnvironment {
         super::builder::environments::UpdateEnvironment::new(self.inner.clone())
     }
 
     /// Deletes the specified agent environment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_environment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_environment(&self) -> super::builder::environments::DeleteEnvironment {
         super::builder::environments::DeleteEnvironment::new(self.inner.clone())
     }
@@ -2675,6 +3723,22 @@ impl Environments {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::environments::GetLocation {
         super::builder::environments::GetLocation::new(self.inner.clone())
     }
@@ -2689,6 +3753,22 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::environments::GetOperation {
         super::builder::environments::GetOperation::new(self.inner.clone())
     }
@@ -2696,6 +3776,21 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::environments::CancelOperation {
         super::builder::environments::CancelOperation::new(self.inner.clone())
     }
@@ -2809,11 +3904,44 @@ impl Fulfillments {
     }
 
     /// Retrieves the fulfillment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// async fn sample(
+    ///    client: &Fulfillments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_fulfillment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_fulfillment(&self) -> super::builder::fulfillments::GetFulfillment {
         super::builder::fulfillments::GetFulfillment::new(self.inner.clone())
     }
 
     /// Updates the fulfillment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// async fn sample(
+    ///    client: &Fulfillments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_fulfillment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_fulfillment(&self) -> super::builder::fulfillments::UpdateFulfillment {
         super::builder::fulfillments::UpdateFulfillment::new(self.inner.clone())
     }
@@ -2824,6 +3952,22 @@ impl Fulfillments {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// async fn sample(
+    ///    client: &Fulfillments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::fulfillments::GetLocation {
         super::builder::fulfillments::GetLocation::new(self.inner.clone())
     }
@@ -2838,6 +3982,22 @@ impl Fulfillments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// async fn sample(
+    ///    client: &Fulfillments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::fulfillments::GetOperation {
         super::builder::fulfillments::GetOperation::new(self.inner.clone())
     }
@@ -2845,6 +4005,21 @@ impl Fulfillments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Fulfillments;
+    /// async fn sample(
+    ///    client: &Fulfillments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::fulfillments::CancelOperation {
         super::builder::fulfillments::CancelOperation::new(self.inner.clone())
     }
@@ -2960,11 +4135,44 @@ impl Generators {
     }
 
     /// Creates a generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_generator()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_generator(&self) -> super::builder::generators::CreateGenerator {
         super::builder::generators::CreateGenerator::new(self.inner.clone())
     }
 
     /// Retrieves a generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_generator()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_generator(&self) -> super::builder::generators::GetGenerator {
         super::builder::generators::GetGenerator::new(self.inner.clone())
     }
@@ -2975,11 +4183,43 @@ impl Generators {
     }
 
     /// Deletes a generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_generator()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_generator(&self) -> super::builder::generators::DeleteGenerator {
         super::builder::generators::DeleteGenerator::new(self.inner.clone())
     }
 
     /// Updates a generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_generator()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_generator(&self) -> super::builder::generators::UpdateGenerator {
         super::builder::generators::UpdateGenerator::new(self.inner.clone())
     }
@@ -2990,6 +4230,22 @@ impl Generators {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::generators::GetLocation {
         super::builder::generators::GetLocation::new(self.inner.clone())
     }
@@ -3004,6 +4260,22 @@ impl Generators {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::generators::GetOperation {
         super::builder::generators::GetOperation::new(self.inner.clone())
     }
@@ -3011,6 +4283,21 @@ impl Generators {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Generators;
+    /// async fn sample(
+    ///    client: &Generators
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::generators::CancelOperation {
         super::builder::generators::CancelOperation::new(self.inner.clone())
     }
@@ -3142,6 +4429,23 @@ impl GeneratorEvaluations {
     }
 
     /// Gets an evaluation of generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
+    /// async fn sample(
+    ///    client: &GeneratorEvaluations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_generator_evaluation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_generator_evaluation(
         &self,
     ) -> super::builder::generator_evaluations::GetGeneratorEvaluation {
@@ -3156,6 +4460,22 @@ impl GeneratorEvaluations {
     }
 
     /// Deletes an evaluation of generator.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
+    /// async fn sample(
+    ///    client: &GeneratorEvaluations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_generator_evaluation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_generator_evaluation(
         &self,
     ) -> super::builder::generator_evaluations::DeleteGeneratorEvaluation {
@@ -3168,6 +4488,22 @@ impl GeneratorEvaluations {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
+    /// async fn sample(
+    ///    client: &GeneratorEvaluations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::generator_evaluations::GetLocation {
         super::builder::generator_evaluations::GetLocation::new(self.inner.clone())
     }
@@ -3182,6 +4518,22 @@ impl GeneratorEvaluations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
+    /// async fn sample(
+    ///    client: &GeneratorEvaluations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::generator_evaluations::GetOperation {
         super::builder::generator_evaluations::GetOperation::new(self.inner.clone())
     }
@@ -3189,6 +4541,21 @@ impl GeneratorEvaluations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
+    /// async fn sample(
+    ///    client: &GeneratorEvaluations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::generator_evaluations::CancelOperation {
         super::builder::generator_evaluations::CancelOperation::new(self.inner.clone())
     }
@@ -3307,6 +4674,23 @@ impl Intents {
     }
 
     /// Retrieves the specified intent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_intent()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_intent(&self) -> super::builder::intents::GetIntent {
         super::builder::intents::GetIntent::new(self.inner.clone())
     }
@@ -3316,6 +4700,22 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_intent(&self) -> super::builder::intents::CreateIntent {
         super::builder::intents::CreateIntent::new(self.inner.clone())
     }
@@ -3325,6 +4725,22 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_intent(&self) -> super::builder::intents::UpdateIntent {
         super::builder::intents::UpdateIntent::new(self.inner.clone())
     }
@@ -3334,6 +4750,21 @@ impl Intents {
     /// Note: You should always train an agent prior to sending it queries. See the
     /// [training
     /// documentation](https://cloud.google.com/dialogflow/es/docs/training).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_intent(&self) -> super::builder::intents::DeleteIntent {
         super::builder::intents::DeleteIntent::new(self.inner.clone())
     }
@@ -3402,6 +4833,22 @@ impl Intents {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::intents::GetLocation {
         super::builder::intents::GetLocation::new(self.inner.clone())
     }
@@ -3416,6 +4863,22 @@ impl Intents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::intents::GetOperation {
         super::builder::intents::GetOperation::new(self.inner.clone())
     }
@@ -3423,6 +4886,21 @@ impl Intents {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Intents;
+    /// async fn sample(
+    ///    client: &Intents
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::intents::CancelOperation {
         super::builder::intents::CancelOperation::new(self.inner.clone())
     }
@@ -3542,21 +5020,85 @@ impl KnowledgeBases {
     }
 
     /// Retrieves the specified knowledge base.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_knowledge_base()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_knowledge_base(&self) -> super::builder::knowledge_bases::GetKnowledgeBase {
         super::builder::knowledge_bases::GetKnowledgeBase::new(self.inner.clone())
     }
 
     /// Creates a knowledge base.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_knowledge_base()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_knowledge_base(&self) -> super::builder::knowledge_bases::CreateKnowledgeBase {
         super::builder::knowledge_bases::CreateKnowledgeBase::new(self.inner.clone())
     }
 
     /// Deletes the specified knowledge base.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_knowledge_base()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_knowledge_base(&self) -> super::builder::knowledge_bases::DeleteKnowledgeBase {
         super::builder::knowledge_bases::DeleteKnowledgeBase::new(self.inner.clone())
     }
 
     /// Updates the specified knowledge base.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_knowledge_base()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_knowledge_base(&self) -> super::builder::knowledge_bases::UpdateKnowledgeBase {
         super::builder::knowledge_bases::UpdateKnowledgeBase::new(self.inner.clone())
     }
@@ -3567,6 +5109,22 @@ impl KnowledgeBases {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::knowledge_bases::GetLocation {
         super::builder::knowledge_bases::GetLocation::new(self.inner.clone())
     }
@@ -3581,6 +5139,22 @@ impl KnowledgeBases {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::knowledge_bases::GetOperation {
         super::builder::knowledge_bases::GetOperation::new(self.inner.clone())
     }
@@ -3588,6 +5162,21 @@ impl KnowledgeBases {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
+    /// async fn sample(
+    ///    client: &KnowledgeBases
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::knowledge_bases::CancelOperation {
         super::builder::knowledge_bases::CancelOperation::new(self.inner.clone())
     }
@@ -3701,11 +5290,44 @@ impl Participants {
     }
 
     /// Creates a new participant in a conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_participant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_participant(&self) -> super::builder::participants::CreateParticipant {
         super::builder::participants::CreateParticipant::new(self.inner.clone())
     }
 
     /// Retrieves a conversation participant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_participant()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_participant(&self) -> super::builder::participants::GetParticipant {
         super::builder::participants::GetParticipant::new(self.inner.clone())
     }
@@ -3716,6 +5338,22 @@ impl Participants {
     }
 
     /// Updates the specified participant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_participant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_participant(&self) -> super::builder::participants::UpdateParticipant {
         super::builder::participants::UpdateParticipant::new(self.inner.clone())
     }
@@ -3726,29 +5364,109 @@ impl Participants {
     /// Note: Always use agent versions for production traffic
     /// sent to virtual agents. See [Versions and
     /// environments](https://cloud.google.com/dialogflow/es/docs/agents-versions).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .analyze_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn analyze_content(&self) -> super::builder::participants::AnalyzeContent {
         super::builder::participants::AnalyzeContent::new(self.inner.clone())
     }
 
     /// Gets suggested articles for a participant based on specific historical
     /// messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .suggest_articles()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn suggest_articles(&self) -> super::builder::participants::SuggestArticles {
         super::builder::participants::SuggestArticles::new(self.inner.clone())
     }
 
     /// Gets suggested faq answers for a participant based on specific historical
     /// messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .suggest_faq_answers()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn suggest_faq_answers(&self) -> super::builder::participants::SuggestFaqAnswers {
         super::builder::participants::SuggestFaqAnswers::new(self.inner.clone())
     }
 
     /// Gets smart replies for a participant based on specific historical
     /// messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .suggest_smart_replies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn suggest_smart_replies(&self) -> super::builder::participants::SuggestSmartReplies {
         super::builder::participants::SuggestSmartReplies::new(self.inner.clone())
     }
 
     /// Gets knowledge assist suggestions based on historical messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .suggest_knowledge_assist()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn suggest_knowledge_assist(&self) -> super::builder::participants::SuggestKnowledgeAssist {
         super::builder::participants::SuggestKnowledgeAssist::new(self.inner.clone())
     }
@@ -3759,6 +5477,22 @@ impl Participants {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::participants::GetLocation {
         super::builder::participants::GetLocation::new(self.inner.clone())
     }
@@ -3773,6 +5507,22 @@ impl Participants {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::participants::GetOperation {
         super::builder::participants::GetOperation::new(self.inner.clone())
     }
@@ -3780,6 +5530,21 @@ impl Participants {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Participants;
+    /// async fn sample(
+    ///    client: &Participants
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::participants::CancelOperation {
         super::builder::participants::CancelOperation::new(self.inner.clone())
     }
@@ -3910,6 +5675,22 @@ impl Sessions {
     /// environments](https://cloud.google.com/dialogflow/es/docs/agents-versions).
     ///
     /// [google.cloud.dialogflow.v2.Participants.AnalyzeContent]: crate::client::Participants::analyze_content
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .detect_intent()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn detect_intent(&self) -> super::builder::sessions::DetectIntent {
         super::builder::sessions::DetectIntent::new(self.inner.clone())
     }
@@ -3920,6 +5701,22 @@ impl Sessions {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::sessions::GetLocation {
         super::builder::sessions::GetLocation::new(self.inner.clone())
     }
@@ -3934,6 +5731,22 @@ impl Sessions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::sessions::GetOperation {
         super::builder::sessions::GetOperation::new(self.inner.clone())
     }
@@ -3941,6 +5754,21 @@ impl Sessions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Sessions;
+    /// async fn sample(
+    ///    client: &Sessions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::sessions::CancelOperation {
         super::builder::sessions::CancelOperation::new(self.inner.clone())
     }
@@ -4073,6 +5901,23 @@ impl SessionEntityTypes {
     /// This method doesn't work with Google Assistant integration.
     /// Contact Dialogflow support if you need to use session entities
     /// with Google Assistant integration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session_entity_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::GetSessionEntityType {
@@ -4087,6 +5932,22 @@ impl SessionEntityTypes {
     /// This method doesn't work with Google Assistant integration.
     /// Contact Dialogflow support if you need to use session entities
     /// with Google Assistant integration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::CreateSessionEntityType {
@@ -4098,6 +5959,22 @@ impl SessionEntityTypes {
     /// This method doesn't work with Google Assistant integration.
     /// Contact Dialogflow support if you need to use session entities
     /// with Google Assistant integration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::UpdateSessionEntityType {
@@ -4109,6 +5986,21 @@ impl SessionEntityTypes {
     /// This method doesn't work with Google Assistant integration.
     /// Contact Dialogflow support if you need to use session entities
     /// with Google Assistant integration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session_entity_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session_entity_type(
         &self,
     ) -> super::builder::session_entity_types::DeleteSessionEntityType {
@@ -4121,6 +6013,22 @@ impl SessionEntityTypes {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::session_entity_types::GetLocation {
         super::builder::session_entity_types::GetLocation::new(self.inner.clone())
     }
@@ -4135,6 +6043,22 @@ impl SessionEntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::session_entity_types::GetOperation {
         super::builder::session_entity_types::GetOperation::new(self.inner.clone())
     }
@@ -4142,6 +6066,21 @@ impl SessionEntityTypes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
+    /// async fn sample(
+    ///    client: &SessionEntityTypes
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::session_entity_types::CancelOperation {
         super::builder::session_entity_types::CancelOperation::new(self.inner.clone())
     }
@@ -4255,11 +6194,43 @@ impl SipTrunks {
     }
 
     /// Creates a SipTrunk for a specified location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_sip_trunk()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_sip_trunk(&self) -> super::builder::sip_trunks::CreateSipTrunk {
         super::builder::sip_trunks::CreateSipTrunk::new(self.inner.clone())
     }
 
     /// Deletes a specified SipTrunk.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_sip_trunk()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_sip_trunk(&self) -> super::builder::sip_trunks::DeleteSipTrunk {
         super::builder::sip_trunks::DeleteSipTrunk::new(self.inner.clone())
     }
@@ -4270,11 +6241,44 @@ impl SipTrunks {
     }
 
     /// Retrieves the specified SipTrunk.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_sip_trunk()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_sip_trunk(&self) -> super::builder::sip_trunks::GetSipTrunk {
         super::builder::sip_trunks::GetSipTrunk::new(self.inner.clone())
     }
 
     /// Updates the specified SipTrunk.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_sip_trunk()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_sip_trunk(&self) -> super::builder::sip_trunks::UpdateSipTrunk {
         super::builder::sip_trunks::UpdateSipTrunk::new(self.inner.clone())
     }
@@ -4285,6 +6289,22 @@ impl SipTrunks {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::sip_trunks::GetLocation {
         super::builder::sip_trunks::GetLocation::new(self.inner.clone())
     }
@@ -4299,6 +6319,22 @@ impl SipTrunks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::sip_trunks::GetOperation {
         super::builder::sip_trunks::GetOperation::new(self.inner.clone())
     }
@@ -4306,6 +6342,21 @@ impl SipTrunks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::SipTrunks;
+    /// async fn sample(
+    ///    client: &SipTrunks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::sip_trunks::CancelOperation {
         super::builder::sip_trunks::CancelOperation::new(self.inner.clone())
     }
@@ -4419,11 +6470,44 @@ impl Tools {
     }
 
     /// Creates a tool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tool(&self) -> super::builder::tools::CreateTool {
         super::builder::tools::CreateTool::new(self.inner.clone())
     }
 
     /// Retrieves a tool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tool(&self) -> super::builder::tools::GetTool {
         super::builder::tools::GetTool::new(self.inner.clone())
     }
@@ -4434,11 +6518,43 @@ impl Tools {
     }
 
     /// Deletes a tool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_tool(&self) -> super::builder::tools::DeleteTool {
         super::builder::tools::DeleteTool::new(self.inner.clone())
     }
 
     /// Updates a tool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tool(&self) -> super::builder::tools::UpdateTool {
         super::builder::tools::UpdateTool::new(self.inner.clone())
     }
@@ -4449,6 +6565,22 @@ impl Tools {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::tools::GetLocation {
         super::builder::tools::GetLocation::new(self.inner.clone())
     }
@@ -4463,6 +6595,22 @@ impl Tools {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tools::GetOperation {
         super::builder::tools::GetOperation::new(self.inner.clone())
     }
@@ -4470,6 +6618,21 @@ impl Tools {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Tools;
+    /// async fn sample(
+    ///    client: &Tools
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::tools::CancelOperation {
         super::builder::tools::CancelOperation::new(self.inner.clone())
     }
@@ -4588,6 +6751,23 @@ impl Versions {
     }
 
     /// Retrieves the specified agent version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::versions::GetVersion {
         super::builder::versions::GetVersion::new(self.inner.clone())
     }
@@ -4595,6 +6775,22 @@ impl Versions {
     /// Creates an agent version.
     ///
     /// The new version points to the agent instance in the "default" environment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_version(&self) -> super::builder::versions::CreateVersion {
         super::builder::versions::CreateVersion::new(self.inner.clone())
     }
@@ -4604,11 +6800,42 @@ impl Versions {
     /// Note that this method does not allow you to update the state of the agent
     /// the given version points to. It allows you to update only mutable
     /// properties of the version resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_version(&self) -> super::builder::versions::UpdateVersion {
         super::builder::versions::UpdateVersion::new(self.inner.clone())
     }
 
     /// Delete the specified agent version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_version(&self) -> super::builder::versions::DeleteVersion {
         super::builder::versions::DeleteVersion::new(self.inner.clone())
     }
@@ -4619,6 +6846,22 @@ impl Versions {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::versions::GetLocation {
         super::builder::versions::GetLocation::new(self.inner.clone())
     }
@@ -4633,6 +6876,22 @@ impl Versions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::versions::GetOperation {
         super::builder::versions::GetOperation::new(self.inner.clone())
     }
@@ -4640,6 +6899,21 @@ impl Versions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_dialogflow_v2::client::Versions;
+    /// async fn sample(
+    ///    client: &Versions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::versions::CancelOperation {
         super::builder::versions::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/discoveryengine/v1/src/client.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/client.rs
@@ -134,6 +134,22 @@ impl AssistantService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::AssistantService;
+    /// async fn sample(
+    ///    client: &AssistantService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::assistant_service::GetOperation {
         super::builder::assistant_service::GetOperation::new(self.inner.clone())
     }
@@ -141,6 +157,21 @@ impl AssistantService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::AssistantService;
+    /// async fn sample(
+    ///    client: &AssistantService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::assistant_service::CancelOperation {
         super::builder::assistant_service::CancelOperation::new(self.inner.clone())
     }
@@ -275,6 +306,23 @@ impl CmekConfigService {
     /// Gets the [CmekConfig][google.cloud.discoveryengine.v1.CmekConfig].
     ///
     /// [google.cloud.discoveryengine.v1.CmekConfig]: crate::model::CmekConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
+    /// async fn sample(
+    ///    client: &CmekConfigService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cmek_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cmek_config(&self) -> super::builder::cmek_config_service::GetCmekConfig {
         super::builder::cmek_config_service::GetCmekConfig::new(self.inner.clone())
     }
@@ -283,6 +331,22 @@ impl CmekConfigService {
     /// with the project.
     ///
     /// [google.cloud.discoveryengine.v1.CmekConfig]: crate::model::CmekConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
+    /// async fn sample(
+    ///    client: &CmekConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_cmek_configs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_cmek_configs(&self) -> super::builder::cmek_config_service::ListCmekConfigs {
         super::builder::cmek_config_service::ListCmekConfigs::new(self.inner.clone())
     }
@@ -312,6 +376,22 @@ impl CmekConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
+    /// async fn sample(
+    ///    client: &CmekConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cmek_config_service::GetOperation {
         super::builder::cmek_config_service::GetOperation::new(self.inner.clone())
     }
@@ -319,6 +399,21 @@ impl CmekConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
+    /// async fn sample(
+    ///    client: &CmekConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cmek_config_service::CancelOperation {
         super::builder::cmek_config_service::CancelOperation::new(self.inner.clone())
     }
@@ -433,6 +528,22 @@ impl CompletionService {
     }
 
     /// Completes the specified user input with keyword suggestions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CompletionService;
+    /// async fn sample(
+    ///    client: &CompletionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_query(&self) -> super::builder::completion_service::CompleteQuery {
         super::builder::completion_service::CompleteQuery::new(self.inner.clone())
     }
@@ -531,6 +642,22 @@ impl CompletionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CompletionService;
+    /// async fn sample(
+    ///    client: &CompletionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::completion_service::GetOperation {
         super::builder::completion_service::GetOperation::new(self.inner.clone())
     }
@@ -538,6 +665,21 @@ impl CompletionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::CompletionService;
+    /// async fn sample(
+    ///    client: &CompletionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::completion_service::CancelOperation {
         super::builder::completion_service::CancelOperation::new(self.inner.clone())
     }
@@ -659,6 +801,22 @@ impl ControlService {
     /// exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_control(&self) -> super::builder::control_service::CreateControl {
         super::builder::control_service::CreateControl::new(self.inner.clone())
     }
@@ -669,6 +827,21 @@ impl ControlService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_control(&self) -> super::builder::control_service::DeleteControl {
         super::builder::control_service::DeleteControl::new(self.inner.clone())
     }
@@ -680,11 +853,44 @@ impl ControlService {
     /// update does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_control(&self) -> super::builder::control_service::UpdateControl {
         super::builder::control_service::UpdateControl::new(self.inner.clone())
     }
 
     /// Gets a Control.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_control()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_control(&self) -> super::builder::control_service::GetControl {
         super::builder::control_service::GetControl::new(self.inner.clone())
     }
@@ -707,6 +913,22 @@ impl ControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::control_service::GetOperation {
         super::builder::control_service::GetOperation::new(self.inner.clone())
     }
@@ -714,6 +936,21 @@ impl ControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::control_service::CancelOperation {
         super::builder::control_service::CancelOperation::new(self.inner.clone())
     }
@@ -829,6 +1066,22 @@ impl ConversationalSearchService {
     }
 
     /// Converses a conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .converse_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn converse_conversation(
         &self,
     ) -> super::builder::conversational_search_service::ConverseConversation {
@@ -841,6 +1094,22 @@ impl ConversationalSearchService {
     /// create already exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_conversation(
         &self,
     ) -> super::builder::conversational_search_service::CreateConversation {
@@ -853,6 +1122,21 @@ impl ConversationalSearchService {
     /// delete does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_conversation(
         &self,
     ) -> super::builder::conversational_search_service::DeleteConversation {
@@ -867,6 +1151,22 @@ impl ConversationalSearchService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Conversation]: crate::model::Conversation
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_conversation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_conversation(
         &self,
     ) -> super::builder::conversational_search_service::UpdateConversation {
@@ -874,6 +1174,23 @@ impl ConversationalSearchService {
     }
 
     /// Gets a Conversation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_conversation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_conversation(
         &self,
     ) -> super::builder::conversational_search_service::GetConversation {
@@ -891,11 +1208,44 @@ impl ConversationalSearchService {
     }
 
     /// Answer query method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .answer_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn answer_query(&self) -> super::builder::conversational_search_service::AnswerQuery {
         super::builder::conversational_search_service::AnswerQuery::new(self.inner.clone())
     }
 
     /// Gets a Answer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_answer()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_answer(&self) -> super::builder::conversational_search_service::GetAnswer {
         super::builder::conversational_search_service::GetAnswer::new(self.inner.clone())
     }
@@ -906,6 +1256,22 @@ impl ConversationalSearchService {
     /// exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session(&self) -> super::builder::conversational_search_service::CreateSession {
         super::builder::conversational_search_service::CreateSession::new(self.inner.clone())
     }
@@ -916,6 +1282,22 @@ impl ConversationalSearchService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session(&self) -> super::builder::conversational_search_service::DeleteSession {
         super::builder::conversational_search_service::DeleteSession::new(self.inner.clone())
     }
@@ -927,11 +1309,44 @@ impl ConversationalSearchService {
     /// update does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_session(&self) -> super::builder::conversational_search_service::UpdateSession {
         super::builder::conversational_search_service::UpdateSession::new(self.inner.clone())
     }
 
     /// Gets a Session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session(&self) -> super::builder::conversational_search_service::GetSession {
         super::builder::conversational_search_service::GetSession::new(self.inner.clone())
     }
@@ -954,6 +1369,22 @@ impl ConversationalSearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversational_search_service::GetOperation {
         super::builder::conversational_search_service::GetOperation::new(self.inner.clone())
     }
@@ -961,6 +1392,21 @@ impl ConversationalSearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::conversational_search_service::CancelOperation {
@@ -1107,6 +1553,23 @@ impl DataStoreService {
     /// Gets a [DataStore][google.cloud.discoveryengine.v1.DataStore].
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+    /// async fn sample(
+    ///    client: &DataStoreService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_data_store()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_data_store(&self) -> super::builder::data_store_service::GetDataStore {
         super::builder::data_store_service::GetDataStore::new(self.inner.clone())
     }
@@ -1139,6 +1602,22 @@ impl DataStoreService {
     /// Updates a [DataStore][google.cloud.discoveryengine.v1.DataStore]
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+    /// async fn sample(
+    ///    client: &DataStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_data_store()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_data_store(&self) -> super::builder::data_store_service::UpdateDataStore {
         super::builder::data_store_service::UpdateDataStore::new(self.inner.clone())
     }
@@ -1153,6 +1632,22 @@ impl DataStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+    /// async fn sample(
+    ///    client: &DataStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_store_service::GetOperation {
         super::builder::data_store_service::GetOperation::new(self.inner.clone())
     }
@@ -1160,6 +1655,21 @@ impl DataStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
+    /// async fn sample(
+    ///    client: &DataStoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_store_service::CancelOperation {
         super::builder::data_store_service::CancelOperation::new(self.inner.clone())
     }
@@ -1279,6 +1789,23 @@ impl DocumentService {
     /// Gets a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_document()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_document(&self) -> super::builder::document_service::GetDocument {
         super::builder::document_service::GetDocument::new(self.inner.clone())
     }
@@ -1293,6 +1820,22 @@ impl DocumentService {
     /// Creates a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_document(&self) -> super::builder::document_service::CreateDocument {
         super::builder::document_service::CreateDocument::new(self.inner.clone())
     }
@@ -1300,6 +1843,22 @@ impl DocumentService {
     /// Updates a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_document(&self) -> super::builder::document_service::UpdateDocument {
         super::builder::document_service::UpdateDocument::new(self.inner.clone())
     }
@@ -1307,6 +1866,21 @@ impl DocumentService {
     /// Deletes a [Document][google.cloud.discoveryengine.v1.Document].
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_document(&self) -> super::builder::document_service::DeleteDocument {
         super::builder::document_service::DeleteDocument::new(self.inner.clone())
     }
@@ -1374,6 +1948,22 @@ impl DocumentService {
     /// website search only.
     ///
     /// [google.cloud.discoveryengine.v1.Document]: crate::model::Document
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_get_documents_metadata()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_get_documents_metadata(
         &self,
     ) -> super::builder::document_service::BatchGetDocumentsMetadata {
@@ -1390,6 +1980,22 @@ impl DocumentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::document_service::GetOperation {
         super::builder::document_service::GetOperation::new(self.inner.clone())
     }
@@ -1397,6 +2003,21 @@ impl DocumentService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::DocumentService;
+    /// async fn sample(
+    ///    client: &DocumentService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::document_service::CancelOperation {
         super::builder::document_service::CancelOperation::new(self.inner.clone())
     }
@@ -1547,6 +2168,22 @@ impl EngineService {
     /// Updates an [Engine][google.cloud.discoveryengine.v1.Engine]
     ///
     /// [google.cloud.discoveryengine.v1.Engine]: crate::model::Engine
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::EngineService;
+    /// async fn sample(
+    ///    client: &EngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_engine()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_engine(&self) -> super::builder::engine_service::UpdateEngine {
         super::builder::engine_service::UpdateEngine::new(self.inner.clone())
     }
@@ -1554,6 +2191,23 @@ impl EngineService {
     /// Gets a [Engine][google.cloud.discoveryengine.v1.Engine].
     ///
     /// [google.cloud.discoveryengine.v1.Engine]: crate::model::Engine
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::EngineService;
+    /// async fn sample(
+    ///    client: &EngineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_engine()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_engine(&self) -> super::builder::engine_service::GetEngine {
         super::builder::engine_service::GetEngine::new(self.inner.clone())
     }
@@ -1576,6 +2230,22 @@ impl EngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::EngineService;
+    /// async fn sample(
+    ///    client: &EngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::engine_service::GetOperation {
         super::builder::engine_service::GetOperation::new(self.inner.clone())
     }
@@ -1583,6 +2253,21 @@ impl EngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::EngineService;
+    /// async fn sample(
+    ///    client: &EngineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::engine_service::CancelOperation {
         super::builder::engine_service::CancelOperation::new(self.inner.clone())
     }
@@ -1698,6 +2383,22 @@ impl GroundedGenerationService {
     }
 
     /// Generates grounded content.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+    /// async fn sample(
+    ///    client: &GroundedGenerationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_grounded_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_grounded_content(
         &self,
     ) -> super::builder::grounded_generation_service::GenerateGroundedContent {
@@ -1707,6 +2408,22 @@ impl GroundedGenerationService {
     }
 
     /// Performs a grounding check.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+    /// async fn sample(
+    ///    client: &GroundedGenerationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_grounding()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_grounding(&self) -> super::builder::grounded_generation_service::CheckGrounding {
         super::builder::grounded_generation_service::CheckGrounding::new(self.inner.clone())
     }
@@ -1721,6 +2438,22 @@ impl GroundedGenerationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+    /// async fn sample(
+    ///    client: &GroundedGenerationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::grounded_generation_service::GetOperation {
         super::builder::grounded_generation_service::GetOperation::new(self.inner.clone())
     }
@@ -1728,6 +2461,21 @@ impl GroundedGenerationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
+    /// async fn sample(
+    ///    client: &GroundedGenerationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::grounded_generation_service::CancelOperation {
         super::builder::grounded_generation_service::CancelOperation::new(self.inner.clone())
     }
@@ -1843,6 +2591,22 @@ impl IdentityMappingStoreService {
     }
 
     /// Creates a new Identity Mapping Store.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::IdentityMappingStoreService;
+    /// async fn sample(
+    ///    client: &IdentityMappingStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_identity_mapping_store()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_identity_mapping_store(
         &self,
     ) -> super::builder::identity_mapping_store_service::CreateIdentityMappingStore {
@@ -1852,6 +2616,23 @@ impl IdentityMappingStoreService {
     }
 
     /// Gets the Identity Mapping Store.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::IdentityMappingStoreService;
+    /// async fn sample(
+    ///    client: &IdentityMappingStoreService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_identity_mapping_store()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_identity_mapping_store(
         &self,
     ) -> super::builder::identity_mapping_store_service::GetIdentityMappingStore {
@@ -1948,6 +2729,22 @@ impl IdentityMappingStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::IdentityMappingStoreService;
+    /// async fn sample(
+    ///    client: &IdentityMappingStoreService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::identity_mapping_store_service::GetOperation {
         super::builder::identity_mapping_store_service::GetOperation::new(self.inner.clone())
     }
@@ -1955,6 +2752,21 @@ impl IdentityMappingStoreService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::IdentityMappingStoreService;
+    /// async fn sample(
+    ///    client: &IdentityMappingStoreService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::identity_mapping_store_service::CancelOperation {
@@ -2100,6 +2912,22 @@ impl ProjectService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ProjectService;
+    /// async fn sample(
+    ///    client: &ProjectService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::project_service::GetOperation {
         super::builder::project_service::GetOperation::new(self.inner.clone())
     }
@@ -2107,6 +2935,21 @@ impl ProjectService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ProjectService;
+    /// async fn sample(
+    ///    client: &ProjectService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::project_service::CancelOperation {
         super::builder::project_service::CancelOperation::new(self.inner.clone())
     }
@@ -2218,6 +3061,22 @@ impl RankService {
     }
 
     /// Ranks a list of text records based on the given input query.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RankService;
+    /// async fn sample(
+    ///    client: &RankService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rank()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rank(&self) -> super::builder::rank_service::Rank {
         super::builder::rank_service::Rank::new(self.inner.clone())
     }
@@ -2232,6 +3091,22 @@ impl RankService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RankService;
+    /// async fn sample(
+    ///    client: &RankService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::rank_service::GetOperation {
         super::builder::rank_service::GetOperation::new(self.inner.clone())
     }
@@ -2239,6 +3114,21 @@ impl RankService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RankService;
+    /// async fn sample(
+    ///    client: &RankService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::rank_service::CancelOperation {
         super::builder::rank_service::CancelOperation::new(self.inner.clone())
     }
@@ -2353,6 +3243,22 @@ impl RecommendationService {
     }
 
     /// Makes a recommendation, which requires a contextual user event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RecommendationService;
+    /// async fn sample(
+    ///    client: &RecommendationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .recommend()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn recommend(&self) -> super::builder::recommendation_service::Recommend {
         super::builder::recommendation_service::Recommend::new(self.inner.clone())
     }
@@ -2367,6 +3273,22 @@ impl RecommendationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RecommendationService;
+    /// async fn sample(
+    ///    client: &RecommendationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::recommendation_service::GetOperation {
         super::builder::recommendation_service::GetOperation::new(self.inner.clone())
     }
@@ -2374,6 +3296,21 @@ impl RecommendationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::RecommendationService;
+    /// async fn sample(
+    ///    client: &RecommendationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::recommendation_service::CancelOperation {
         super::builder::recommendation_service::CancelOperation::new(self.inner.clone())
     }
@@ -2489,6 +3426,23 @@ impl SchemaService {
     /// Gets a [Schema][google.cloud.discoveryengine.v1.Schema].
     ///
     /// [google.cloud.discoveryengine.v1.Schema]: crate::model::Schema
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema(&self) -> super::builder::schema_service::GetSchema {
         super::builder::schema_service::GetSchema::new(self.inner.clone())
     }
@@ -2561,6 +3515,22 @@ impl SchemaService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::schema_service::GetOperation {
         super::builder::schema_service::GetOperation::new(self.inner.clone())
     }
@@ -2568,6 +3538,21 @@ impl SchemaService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::schema_service::CancelOperation {
         super::builder::schema_service::CancelOperation::new(self.inner.clone())
     }
@@ -2712,6 +3697,22 @@ impl SearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SearchService;
+    /// async fn sample(
+    ///    client: &SearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::search_service::GetOperation {
         super::builder::search_service::GetOperation::new(self.inner.clone())
     }
@@ -2719,6 +3720,21 @@ impl SearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SearchService;
+    /// async fn sample(
+    ///    client: &SearchService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::search_service::CancelOperation {
         super::builder::search_service::CancelOperation::new(self.inner.clone())
     }
@@ -2848,6 +3864,22 @@ impl SearchTuningService {
     }
 
     /// Gets a list of all the custom models.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
+    /// async fn sample(
+    ///    client: &SearchTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_custom_models()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_custom_models(&self) -> super::builder::search_tuning_service::ListCustomModels {
         super::builder::search_tuning_service::ListCustomModels::new(self.inner.clone())
     }
@@ -2862,6 +3894,22 @@ impl SearchTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
+    /// async fn sample(
+    ///    client: &SearchTuningService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::search_tuning_service::GetOperation {
         super::builder::search_tuning_service::GetOperation::new(self.inner.clone())
     }
@@ -2869,6 +3917,21 @@ impl SearchTuningService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
+    /// async fn sample(
+    ///    client: &SearchTuningService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::search_tuning_service::CancelOperation {
         super::builder::search_tuning_service::CancelOperation::new(self.inner.clone())
     }
@@ -2988,6 +4051,22 @@ impl ServingConfigService {
     /// Updates a ServingConfig.
     ///
     /// Returns a NOT_FOUND error if the ServingConfig does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_serving_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_serving_config(
         &self,
     ) -> super::builder::serving_config_service::UpdateServingConfig {
@@ -3004,6 +4083,22 @@ impl ServingConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::serving_config_service::GetOperation {
         super::builder::serving_config_service::GetOperation::new(self.inner.clone())
     }
@@ -3011,6 +4106,21 @@ impl ServingConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::serving_config_service::CancelOperation {
         super::builder::serving_config_service::CancelOperation::new(self.inner.clone())
     }
@@ -3127,6 +4237,22 @@ impl SessionService {
     /// exists, an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session(&self) -> super::builder::session_service::CreateSession {
         super::builder::session_service::CreateSession::new(self.inner.clone())
     }
@@ -3137,6 +4263,22 @@ impl SessionService {
     /// not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session(&self) -> super::builder::session_service::DeleteSession {
         super::builder::session_service::DeleteSession::new(self.inner.clone())
     }
@@ -3148,11 +4290,44 @@ impl SessionService {
     /// update does not exist, a NOT_FOUND error is returned.
     ///
     /// [google.cloud.discoveryengine.v1.Session]: crate::model::Session
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_session(&self) -> super::builder::session_service::UpdateSession {
         super::builder::session_service::UpdateSession::new(self.inner.clone())
     }
 
     /// Gets a Session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session(&self) -> super::builder::session_service::GetSession {
         super::builder::session_service::GetSession::new(self.inner.clone())
     }
@@ -3175,6 +4350,22 @@ impl SessionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::session_service::GetOperation {
         super::builder::session_service::GetOperation::new(self.inner.clone())
     }
@@ -3182,6 +4373,21 @@ impl SessionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SessionService;
+    /// async fn sample(
+    ///    client: &SessionService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::session_service::CancelOperation {
         super::builder::session_service::CancelOperation::new(self.inner.clone())
     }
@@ -3300,6 +4506,23 @@ impl SiteSearchEngineService {
     /// [SiteSearchEngine][google.cloud.discoveryengine.v1.SiteSearchEngine].
     ///
     /// [google.cloud.discoveryengine.v1.SiteSearchEngine]: crate::model::SiteSearchEngine
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// async fn sample(
+    ///    client: &SiteSearchEngineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_site_search_engine()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_site_search_engine(
         &self,
     ) -> super::builder::site_search_engine_service::GetSiteSearchEngine {
@@ -3348,6 +4571,23 @@ impl SiteSearchEngineService {
     /// Gets a [TargetSite][google.cloud.discoveryengine.v1.TargetSite].
     ///
     /// [google.cloud.discoveryengine.v1.TargetSite]: crate::model::TargetSite
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// async fn sample(
+    ///    client: &SiteSearchEngineService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_target_site()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_target_site(&self) -> super::builder::site_search_engine_service::GetTargetSite {
         super::builder::site_search_engine_service::GetTargetSite::new(self.inner.clone())
     }
@@ -3436,6 +4676,22 @@ impl SiteSearchEngineService {
     ///
     /// [google.cloud.discoveryengine.v1.DataStore]: crate::model::DataStore
     /// [google.cloud.discoveryengine.v1.Sitemap]: crate::model::Sitemap
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// async fn sample(
+    ///    client: &SiteSearchEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_sitemaps()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_sitemaps(&self) -> super::builder::site_search_engine_service::FetchSitemaps {
         super::builder::site_search_engine_service::FetchSitemaps::new(self.inner.clone())
     }
@@ -3533,6 +4789,22 @@ impl SiteSearchEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// async fn sample(
+    ///    client: &SiteSearchEngineService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::site_search_engine_service::GetOperation {
         super::builder::site_search_engine_service::GetOperation::new(self.inner.clone())
     }
@@ -3540,6 +4812,21 @@ impl SiteSearchEngineService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
+    /// async fn sample(
+    ///    client: &SiteSearchEngineService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::site_search_engine_service::CancelOperation {
         super::builder::site_search_engine_service::CancelOperation::new(self.inner.clone())
     }
@@ -3654,6 +4941,22 @@ impl UserEventService {
     }
 
     /// Writes a single user event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_user_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_user_event(&self) -> super::builder::user_event_service::WriteUserEvent {
         super::builder::user_event_service::WriteUserEvent::new(self.inner.clone())
     }
@@ -3663,6 +4966,22 @@ impl UserEventService {
     ///
     /// This method is used only by the Discovery Engine API JavaScript pixel and
     /// Google Tag Manager. Users should not call this method directly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .collect_user_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn collect_user_event(&self) -> super::builder::user_event_service::CollectUserEvent {
         super::builder::user_event_service::CollectUserEvent::new(self.inner.clone())
     }
@@ -3716,6 +5035,22 @@ impl UserEventService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::user_event_service::GetOperation {
         super::builder::user_event_service::GetOperation::new(self.inner.clone())
     }
@@ -3723,6 +5058,21 @@ impl UserEventService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::user_event_service::CancelOperation {
         super::builder::user_event_service::CancelOperation::new(self.inner.clone())
     }
@@ -3869,6 +5219,22 @@ impl UserLicenseService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserLicenseService;
+    /// async fn sample(
+    ///    client: &UserLicenseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::user_license_service::GetOperation {
         super::builder::user_license_service::GetOperation::new(self.inner.clone())
     }
@@ -3876,6 +5242,21 @@ impl UserLicenseService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_discoveryengine_v1::client::UserLicenseService;
+    /// async fn sample(
+    ///    client: &UserLicenseService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::user_license_service::CancelOperation {
         super::builder::user_license_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/documentai/v1/src/client.rs
+++ b/src/generated/cloud/documentai/v1/src/client.rs
@@ -126,6 +126,22 @@ impl DocumentProcessorService {
     }
 
     /// Processes a single document.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .process_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn process_document(&self) -> super::builder::document_processor_service::ProcessDocument {
         super::builder::document_processor_service::ProcessDocument::new(self.inner.clone())
     }
@@ -153,6 +169,22 @@ impl DocumentProcessorService {
     /// here, because it isn't paginated.
     ///
     /// [google.cloud.documentai.v1.DocumentProcessorService.ListProcessorTypes]: crate::client::DocumentProcessorService::list_processor_types
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_processor_types()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_processor_types(
         &self,
     ) -> super::builder::document_processor_service::FetchProcessorTypes {
@@ -167,6 +199,23 @@ impl DocumentProcessorService {
     }
 
     /// Gets a processor type detail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_processor_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_processor_type(
         &self,
     ) -> super::builder::document_processor_service::GetProcessorType {
@@ -179,6 +228,23 @@ impl DocumentProcessorService {
     }
 
     /// Gets a processor detail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_processor()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_processor(&self) -> super::builder::document_processor_service::GetProcessor {
         super::builder::document_processor_service::GetProcessor::new(self.inner.clone())
     }
@@ -205,6 +271,23 @@ impl DocumentProcessorService {
     }
 
     /// Gets a processor version detail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_processor_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_processor_version(
         &self,
     ) -> super::builder::document_processor_service::GetProcessorVersion {
@@ -281,6 +364,22 @@ impl DocumentProcessorService {
     /// bucket in your project.
     ///
     /// [google.cloud.documentai.v1.ProcessorType]: crate::model::ProcessorType
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_processor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_processor(&self) -> super::builder::document_processor_service::CreateProcessor {
         super::builder::document_processor_service::CreateProcessor::new(self.inner.clone())
     }
@@ -397,6 +496,23 @@ impl DocumentProcessorService {
     }
 
     /// Retrieves a specific evaluation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_evaluation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_evaluation(&self) -> super::builder::document_processor_service::GetEvaluation {
         super::builder::document_processor_service::GetEvaluation::new(self.inner.clone())
     }
@@ -412,6 +528,22 @@ impl DocumentProcessorService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::document_processor_service::GetLocation {
         super::builder::document_processor_service::GetLocation::new(self.inner.clone())
     }
@@ -426,6 +558,22 @@ impl DocumentProcessorService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::document_processor_service::GetOperation {
         super::builder::document_processor_service::GetOperation::new(self.inner.clone())
     }
@@ -433,6 +581,21 @@ impl DocumentProcessorService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+    /// async fn sample(
+    ///    client: &DocumentProcessorService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::document_processor_service::CancelOperation {
         super::builder::document_processor_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/domains/v1/src/client.rs
+++ b/src/generated/cloud/domains/v1/src/client.rs
@@ -123,12 +123,44 @@ impl Domains {
     /// Availability results from this method are approximate; call
     /// `RetrieveRegisterParameters` on a domain before registering to confirm
     /// availability.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_domains()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_domains(&self) -> super::builder::domains::SearchDomains {
         super::builder::domains::SearchDomains::new(self.inner.clone())
     }
 
     /// Gets parameters needed to register a new domain name, including price and
     /// up-to-date availability. Use the returned values to call `RegisterDomain`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_register_parameters()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retrieve_register_parameters(
         &self,
     ) -> super::builder::domains::RetrieveRegisterParameters {
@@ -167,6 +199,22 @@ impl Domains {
     /// Domains is not supported.
     ///
     /// Use the returned values to call `TransferDomain`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_transfer_parameters()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retrieve_transfer_parameters(
         &self,
     ) -> super::builder::domains::RetrieveTransferParameters {
@@ -213,6 +261,23 @@ impl Domains {
     }
 
     /// Gets the details of a `Registration` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_registration()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_registration(&self) -> super::builder::domains::GetRegistration {
         super::builder::domains::GetRegistration::new(self.inner.clone())
     }
@@ -346,6 +411,22 @@ impl Domains {
     ///
     /// You can call this method only after 60 days have elapsed since the initial
     /// domain registration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_authorization_code()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retrieve_authorization_code(
         &self,
     ) -> super::builder::domains::RetrieveAuthorizationCode {
@@ -356,6 +437,22 @@ impl Domains {
     ///
     /// You can call this method only after 60 days have elapsed since the initial
     /// domain registration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_authorization_code()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_authorization_code(&self) -> super::builder::domains::ResetAuthorizationCode {
         super::builder::domains::ResetAuthorizationCode::new(self.inner.clone())
     }
@@ -370,6 +467,22 @@ impl Domains {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_domains_v1::client::Domains;
+    /// async fn sample(
+    ///    client: &Domains
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::domains::GetOperation {
         super::builder::domains::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/edgecontainer/v1/src/client.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/client.rs
@@ -125,6 +125,23 @@ impl EdgeContainer {
     }
 
     /// Gets details of a single Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::edge_container::GetCluster {
         super::builder::edge_container::GetCluster::new(self.inner.clone())
     }
@@ -190,11 +207,43 @@ impl EdgeContainer {
     }
 
     /// Generates an access token for a Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_access_token(&self) -> super::builder::edge_container::GenerateAccessToken {
         super::builder::edge_container::GenerateAccessToken::new(self.inner.clone())
     }
 
     /// Generates an offline credential for a Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_offline_credential()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_offline_credential(
         &self,
     ) -> super::builder::edge_container::GenerateOfflineCredential {
@@ -207,6 +256,23 @@ impl EdgeContainer {
     }
 
     /// Gets details of a single NodePool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node_pool(&self) -> super::builder::edge_container::GetNodePool {
         super::builder::edge_container::GetNodePool::new(self.inner.clone())
     }
@@ -262,6 +328,23 @@ impl EdgeContainer {
     }
 
     /// Gets details of a single Machine.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_machine()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_machine(&self) -> super::builder::edge_container::GetMachine {
         super::builder::edge_container::GetMachine::new(self.inner.clone())
     }
@@ -272,6 +355,23 @@ impl EdgeContainer {
     }
 
     /// Gets details of a single VPN connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vpn_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vpn_connection(&self) -> super::builder::edge_container::GetVpnConnection {
         super::builder::edge_container::GetVpnConnection::new(self.inner.clone())
     }
@@ -307,6 +407,22 @@ impl EdgeContainer {
     }
 
     /// Gets the server config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_server_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_server_config(&self) -> super::builder::edge_container::GetServerConfig {
         super::builder::edge_container::GetServerConfig::new(self.inner.clone())
     }
@@ -317,6 +433,22 @@ impl EdgeContainer {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::edge_container::GetLocation {
         super::builder::edge_container::GetLocation::new(self.inner.clone())
     }
@@ -331,6 +463,22 @@ impl EdgeContainer {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::edge_container::GetOperation {
         super::builder::edge_container::GetOperation::new(self.inner.clone())
     }
@@ -338,6 +486,21 @@ impl EdgeContainer {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::edge_container::DeleteOperation {
         super::builder::edge_container::DeleteOperation::new(self.inner.clone())
     }
@@ -345,6 +508,21 @@ impl EdgeContainer {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+    /// async fn sample(
+    ///    client: &EdgeContainer
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::edge_container::CancelOperation {
         super::builder::edge_container::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/edgenetwork/v1/src/client.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/client.rs
@@ -122,6 +122,22 @@ impl EdgeNetwork {
     }
 
     /// InitializeZone will initialize resources for a zone in a project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .initialize_zone()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn initialize_zone(&self) -> super::builder::edge_network::InitializeZone {
         super::builder::edge_network::InitializeZone::new(self.inner.clone())
     }
@@ -135,6 +151,23 @@ impl EdgeNetwork {
 
     /// Deprecated: not implemented.
     /// Gets details of a single Zone.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_zone()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_zone(&self) -> super::builder::edge_network::GetZone {
         super::builder::edge_network::GetZone::new(self.inner.clone())
@@ -146,11 +179,44 @@ impl EdgeNetwork {
     }
 
     /// Gets details of a single Network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_network()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_network(&self) -> super::builder::edge_network::GetNetwork {
         super::builder::edge_network::GetNetwork::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single network resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .diagnose_network()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn diagnose_network(&self) -> super::builder::edge_network::DiagnoseNetwork {
         super::builder::edge_network::DiagnoseNetwork::new(self.inner.clone())
     }
@@ -191,6 +257,23 @@ impl EdgeNetwork {
     }
 
     /// Gets details of a single Subnet.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_subnet()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_subnet(&self) -> super::builder::edge_network::GetSubnet {
         super::builder::edge_network::GetSubnet::new(self.inner.clone())
     }
@@ -246,11 +329,44 @@ impl EdgeNetwork {
     }
 
     /// Gets details of a single Interconnect.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_interconnect()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_interconnect(&self) -> super::builder::edge_network::GetInterconnect {
         super::builder::edge_network::GetInterconnect::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single interconnect resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .diagnose_interconnect()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn diagnose_interconnect(&self) -> super::builder::edge_network::DiagnoseInterconnect {
         super::builder::edge_network::DiagnoseInterconnect::new(self.inner.clone())
     }
@@ -263,6 +379,23 @@ impl EdgeNetwork {
     }
 
     /// Gets details of a single InterconnectAttachment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_interconnect_attachment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_interconnect_attachment(
         &self,
     ) -> super::builder::edge_network::GetInterconnectAttachment {
@@ -309,11 +442,44 @@ impl EdgeNetwork {
     }
 
     /// Gets details of a single Router.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_router()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_router(&self) -> super::builder::edge_network::GetRouter {
         super::builder::edge_network::GetRouter::new(self.inner.clone())
     }
 
     /// Get the diagnostics of a single router resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .diagnose_router()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn diagnose_router(&self) -> super::builder::edge_network::DiagnoseRouter {
         super::builder::edge_network::DiagnoseRouter::new(self.inner.clone())
     }
@@ -369,6 +535,22 @@ impl EdgeNetwork {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::edge_network::GetLocation {
         super::builder::edge_network::GetLocation::new(self.inner.clone())
     }
@@ -383,6 +565,22 @@ impl EdgeNetwork {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::edge_network::GetOperation {
         super::builder::edge_network::GetOperation::new(self.inner.clone())
     }
@@ -390,6 +588,21 @@ impl EdgeNetwork {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::edge_network::DeleteOperation {
         super::builder::edge_network::DeleteOperation::new(self.inner.clone())
     }
@@ -397,6 +610,21 @@ impl EdgeNetwork {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+    /// async fn sample(
+    ///    client: &EdgeNetwork
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::edge_network::CancelOperation {
         super::builder::edge_network::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/essentialcontacts/v1/src/client.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/client.rs
@@ -123,12 +123,44 @@ impl EssentialContactsService {
     }
 
     /// Adds a new contact for a resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// async fn sample(
+    ///    client: &EssentialContactsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_contact()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_contact(&self) -> super::builder::essential_contacts_service::CreateContact {
         super::builder::essential_contacts_service::CreateContact::new(self.inner.clone())
     }
 
     /// Updates a contact.
     /// Note: A contact's email address cannot be changed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// async fn sample(
+    ///    client: &EssentialContactsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_contact()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_contact(&self) -> super::builder::essential_contacts_service::UpdateContact {
         super::builder::essential_contacts_service::UpdateContact::new(self.inner.clone())
     }
@@ -139,11 +171,43 @@ impl EssentialContactsService {
     }
 
     /// Gets a single contact.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// async fn sample(
+    ///    client: &EssentialContactsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_contact()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_contact(&self) -> super::builder::essential_contacts_service::GetContact {
         super::builder::essential_contacts_service::GetContact::new(self.inner.clone())
     }
 
     /// Deletes a contact.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// async fn sample(
+    ///    client: &EssentialContactsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_contact()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_contact(&self) -> super::builder::essential_contacts_service::DeleteContact {
         super::builder::essential_contacts_service::DeleteContact::new(self.inner.clone())
     }
@@ -157,6 +221,21 @@ impl EssentialContactsService {
 
     /// Allows a contact admin to send a test message to contact to verify that it
     /// has been configured correctly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+    /// async fn sample(
+    ///    client: &EssentialContactsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .send_test_message()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn send_test_message(&self) -> super::builder::essential_contacts_service::SendTestMessage {
         super::builder::essential_contacts_service::SendTestMessage::new(self.inner.clone())
     }

--- a/src/generated/cloud/eventarc/v1/src/client.rs
+++ b/src/generated/cloud/eventarc/v1/src/client.rs
@@ -120,6 +120,23 @@ impl Eventarc {
     }
 
     /// Get a single trigger.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_trigger()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_trigger(&self) -> super::builder::eventarc::GetTrigger {
         super::builder::eventarc::GetTrigger::new(self.inner.clone())
     }
@@ -175,6 +192,23 @@ impl Eventarc {
     }
 
     /// Get a single Channel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_channel()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_channel(&self) -> super::builder::eventarc::GetChannel {
         super::builder::eventarc::GetChannel::new(self.inner.clone())
     }
@@ -230,6 +264,23 @@ impl Eventarc {
     }
 
     /// Get a single Provider.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_provider()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_provider(&self) -> super::builder::eventarc::GetProvider {
         super::builder::eventarc::GetProvider::new(self.inner.clone())
     }
@@ -240,6 +291,23 @@ impl Eventarc {
     }
 
     /// Get a single ChannelConnection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_channel_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_channel_connection(&self) -> super::builder::eventarc::GetChannelConnection {
         super::builder::eventarc::GetChannelConnection::new(self.inner.clone())
     }
@@ -282,11 +350,44 @@ impl Eventarc {
     /// Get a GoogleChannelConfig.
     /// The name of the GoogleChannelConfig in the response is ALWAYS coded with
     /// projectID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_google_channel_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_google_channel_config(&self) -> super::builder::eventarc::GetGoogleChannelConfig {
         super::builder::eventarc::GetGoogleChannelConfig::new(self.inner.clone())
     }
 
     /// Update a single GoogleChannelConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_google_channel_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_google_channel_config(
         &self,
     ) -> super::builder::eventarc::UpdateGoogleChannelConfig {
@@ -294,6 +395,23 @@ impl Eventarc {
     }
 
     /// Get a single MessageBus.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_message_bus()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_message_bus(&self) -> super::builder::eventarc::GetMessageBus {
         super::builder::eventarc::GetMessageBus::new(self.inner.clone())
     }
@@ -304,6 +422,22 @@ impl Eventarc {
     }
 
     /// List message bus enrollments.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_message_bus_enrollments()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_message_bus_enrollments(
         &self,
     ) -> super::builder::eventarc::ListMessageBusEnrollments {
@@ -356,6 +490,23 @@ impl Eventarc {
     }
 
     /// Get a single Enrollment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_enrollment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_enrollment(&self) -> super::builder::eventarc::GetEnrollment {
         super::builder::eventarc::GetEnrollment::new(self.inner.clone())
     }
@@ -411,6 +562,23 @@ impl Eventarc {
     }
 
     /// Get a single Pipeline.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pipeline()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pipeline(&self) -> super::builder::eventarc::GetPipeline {
         super::builder::eventarc::GetPipeline::new(self.inner.clone())
     }
@@ -466,6 +634,23 @@ impl Eventarc {
     }
 
     /// Get a single GoogleApiSource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_google_api_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_google_api_source(&self) -> super::builder::eventarc::GetGoogleApiSource {
         super::builder::eventarc::GetGoogleApiSource::new(self.inner.clone())
     }
@@ -526,6 +711,22 @@ impl Eventarc {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::eventarc::GetLocation {
         super::builder::eventarc::GetLocation::new(self.inner.clone())
     }
@@ -535,12 +736,44 @@ impl Eventarc {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::eventarc::SetIamPolicy {
         super::builder::eventarc::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::eventarc::GetIamPolicy {
         super::builder::eventarc::GetIamPolicy::new(self.inner.clone())
     }
@@ -552,6 +785,22 @@ impl Eventarc {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::eventarc::TestIamPermissions {
         super::builder::eventarc::TestIamPermissions::new(self.inner.clone())
     }
@@ -566,6 +815,22 @@ impl Eventarc {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::eventarc::GetOperation {
         super::builder::eventarc::GetOperation::new(self.inner.clone())
     }
@@ -573,6 +838,21 @@ impl Eventarc {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::eventarc::DeleteOperation {
         super::builder::eventarc::DeleteOperation::new(self.inner.clone())
     }
@@ -580,6 +860,21 @@ impl Eventarc {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_eventarc_v1::client::Eventarc;
+    /// async fn sample(
+    ///    client: &Eventarc
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::eventarc::CancelOperation {
         super::builder::eventarc::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/filestore/v1/src/client.rs
+++ b/src/generated/cloud/filestore/v1/src/client.rs
@@ -148,6 +148,23 @@ impl CloudFilestoreManager {
     }
 
     /// Gets the details of a specific instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::cloud_filestore_manager::GetInstance {
         super::builder::cloud_filestore_manager::GetInstance::new(self.inner.clone())
     }
@@ -241,6 +258,23 @@ impl CloudFilestoreManager {
     }
 
     /// Gets the details of a specific snapshot.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_snapshot()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_snapshot(&self) -> super::builder::cloud_filestore_manager::GetSnapshot {
         super::builder::cloud_filestore_manager::GetSnapshot::new(self.inner.clone())
     }
@@ -297,6 +331,23 @@ impl CloudFilestoreManager {
     }
 
     /// Gets the details of a specific backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::cloud_filestore_manager::GetBackup {
         super::builder::cloud_filestore_manager::GetBackup::new(self.inner.clone())
     }
@@ -367,6 +418,22 @@ impl CloudFilestoreManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_filestore_manager::GetLocation {
         super::builder::cloud_filestore_manager::GetLocation::new(self.inner.clone())
     }
@@ -381,6 +448,22 @@ impl CloudFilestoreManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_filestore_manager::GetOperation {
         super::builder::cloud_filestore_manager::GetOperation::new(self.inner.clone())
     }
@@ -388,6 +471,21 @@ impl CloudFilestoreManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cloud_filestore_manager::DeleteOperation {
         super::builder::cloud_filestore_manager::DeleteOperation::new(self.inner.clone())
     }
@@ -395,6 +493,21 @@ impl CloudFilestoreManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+    /// async fn sample(
+    ///    client: &CloudFilestoreManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_filestore_manager::CancelOperation {
         super::builder::cloud_filestore_manager::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/financialservices/v1/src/client.rs
+++ b/src/generated/cloud/financialservices/v1/src/client.rs
@@ -125,6 +125,23 @@ impl Aml {
     }
 
     /// Gets an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::aml::GetInstance {
         super::builder::aml::GetInstance::new(self.inner.clone())
     }
@@ -216,6 +233,23 @@ impl Aml {
     }
 
     /// Gets a dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset(&self) -> super::builder::aml::GetDataset {
         super::builder::aml::GetDataset::new(self.inner.clone())
     }
@@ -271,6 +305,23 @@ impl Aml {
     }
 
     /// Gets a model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model(&self) -> super::builder::aml::GetModel {
         super::builder::aml::GetModel::new(self.inner.clone())
     }
@@ -344,6 +395,23 @@ impl Aml {
     }
 
     /// Gets an engine config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_engine_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_engine_config(&self) -> super::builder::aml::GetEngineConfig {
         super::builder::aml::GetEngineConfig::new(self.inner.clone())
     }
@@ -412,6 +480,23 @@ impl Aml {
     }
 
     /// Gets a single EngineVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_engine_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_engine_version(&self) -> super::builder::aml::GetEngineVersion {
         super::builder::aml::GetEngineVersion::new(self.inner.clone())
     }
@@ -427,6 +512,23 @@ impl Aml {
     }
 
     /// Gets a PredictionResult.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_prediction_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_prediction_result(&self) -> super::builder::aml::GetPredictionResult {
         super::builder::aml::GetPredictionResult::new(self.inner.clone())
     }
@@ -502,6 +604,23 @@ impl Aml {
     }
 
     /// Gets a BacktestResult.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backtest_result()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backtest_result(&self) -> super::builder::aml::GetBacktestResult {
         super::builder::aml::GetBacktestResult::new(self.inner.clone())
     }
@@ -577,6 +696,22 @@ impl Aml {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::aml::GetLocation {
         super::builder::aml::GetLocation::new(self.inner.clone())
     }
@@ -591,6 +726,22 @@ impl Aml {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::aml::GetOperation {
         super::builder::aml::GetOperation::new(self.inner.clone())
     }
@@ -598,6 +749,21 @@ impl Aml {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::aml::DeleteOperation {
         super::builder::aml::DeleteOperation::new(self.inner.clone())
     }
@@ -605,6 +771,21 @@ impl Aml {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_financialservices_v1::client::Aml;
+    /// async fn sample(
+    ///    client: &Aml
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::aml::CancelOperation {
         super::builder::aml::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/functions/v2/src/client.rs
+++ b/src/generated/cloud/functions/v2/src/client.rs
@@ -127,6 +127,23 @@ impl FunctionService {
     }
 
     /// Returns a function with the given name from the requested project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_function()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_function(&self) -> super::builder::function_service::GetFunction {
         super::builder::function_service::GetFunction::new(self.inner.clone())
     }
@@ -208,6 +225,22 @@ impl FunctionService {
     /// Do not specify this header:
     ///
     /// * `Authorization: Bearer YOUR_TOKEN`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_upload_url()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_upload_url(&self) -> super::builder::function_service::GenerateUploadUrl {
         super::builder::function_service::GenerateUploadUrl::new(self.inner.clone())
     }
@@ -217,11 +250,43 @@ impl FunctionService {
     /// 30 minutes of generation.
     /// For more information about the signed URL usage see:
     /// <https://cloud.google.com/storage/docs/access-control/signed-urls>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_download_url()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_download_url(&self) -> super::builder::function_service::GenerateDownloadUrl {
         super::builder::function_service::GenerateDownloadUrl::new(self.inner.clone())
     }
 
     /// Returns a list of runtimes that are supported for the requested project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_runtimes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_runtimes(&self) -> super::builder::function_service::ListRuntimes {
         super::builder::function_service::ListRuntimes::new(self.inner.clone())
     }
@@ -236,12 +301,44 @@ impl FunctionService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::function_service::SetIamPolicy {
         super::builder::function_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::function_service::GetIamPolicy {
         super::builder::function_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -253,6 +350,22 @@ impl FunctionService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::function_service::TestIamPermissions {
         super::builder::function_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -267,6 +380,22 @@ impl FunctionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_functions_v2::client::FunctionService;
+    /// async fn sample(
+    ///    client: &FunctionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::function_service::GetOperation {
         super::builder::function_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/gkebackup/v1/src/client.rs
+++ b/src/generated/cloud/gkebackup/v1/src/client.rs
@@ -140,6 +140,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single BackupPlan.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_plan()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_plan(&self) -> super::builder::backup_for_gke::GetBackupPlan {
         super::builder::backup_for_gke::GetBackupPlan::new(self.inner.clone())
     }
@@ -195,6 +212,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single BackupChannel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_channel()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_channel(&self) -> super::builder::backup_for_gke::GetBackupChannel {
         super::builder::backup_for_gke::GetBackupChannel::new(self.inner.clone())
     }
@@ -237,6 +271,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single BackupPlanBinding.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_plan_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_plan_binding(&self) -> super::builder::backup_for_gke::GetBackupPlanBinding {
         super::builder::backup_for_gke::GetBackupPlanBinding::new(self.inner.clone())
     }
@@ -262,6 +313,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single Backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::backup_for_gke::GetBackup {
         super::builder::backup_for_gke::GetBackup::new(self.inner.clone())
     }
@@ -302,6 +370,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single VolumeBackup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_volume_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_volume_backup(&self) -> super::builder::backup_for_gke::GetVolumeBackup {
         super::builder::backup_for_gke::GetVolumeBackup::new(self.inner.clone())
     }
@@ -327,6 +412,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single RestorePlan.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_restore_plan()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_restore_plan(&self) -> super::builder::backup_for_gke::GetRestorePlan {
         super::builder::backup_for_gke::GetRestorePlan::new(self.inner.clone())
     }
@@ -382,6 +484,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single RestoreChannel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_restore_channel()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_restore_channel(&self) -> super::builder::backup_for_gke::GetRestoreChannel {
         super::builder::backup_for_gke::GetRestoreChannel::new(self.inner.clone())
     }
@@ -424,6 +543,23 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single RestorePlanBinding.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_restore_plan_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_restore_plan_binding(
         &self,
     ) -> super::builder::backup_for_gke::GetRestorePlanBinding {
@@ -451,6 +587,23 @@ impl BackupForGKE {
     }
 
     /// Retrieves the details of a single Restore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_restore()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_restore(&self) -> super::builder::backup_for_gke::GetRestore {
         super::builder::backup_for_gke::GetRestore::new(self.inner.clone())
     }
@@ -491,11 +644,44 @@ impl BackupForGKE {
     }
 
     /// Retrieve the details of a single VolumeRestore.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_volume_restore()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_volume_restore(&self) -> super::builder::backup_for_gke::GetVolumeRestore {
         super::builder::backup_for_gke::GetVolumeRestore::new(self.inner.clone())
     }
 
     /// Retrieve the link to the backupIndex.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_index_download_url()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_index_download_url(
         &self,
     ) -> super::builder::backup_for_gke::GetBackupIndexDownloadUrl {
@@ -508,6 +694,22 @@ impl BackupForGKE {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::backup_for_gke::GetLocation {
         super::builder::backup_for_gke::GetLocation::new(self.inner.clone())
     }
@@ -517,12 +719,44 @@ impl BackupForGKE {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::backup_for_gke::SetIamPolicy {
         super::builder::backup_for_gke::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::backup_for_gke::GetIamPolicy {
         super::builder::backup_for_gke::GetIamPolicy::new(self.inner.clone())
     }
@@ -534,6 +768,22 @@ impl BackupForGKE {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::backup_for_gke::TestIamPermissions {
         super::builder::backup_for_gke::TestIamPermissions::new(self.inner.clone())
     }
@@ -548,6 +798,22 @@ impl BackupForGKE {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::backup_for_gke::GetOperation {
         super::builder::backup_for_gke::GetOperation::new(self.inner.clone())
     }
@@ -555,6 +821,21 @@ impl BackupForGKE {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::backup_for_gke::DeleteOperation {
         super::builder::backup_for_gke::DeleteOperation::new(self.inner.clone())
     }
@@ -562,6 +843,21 @@ impl BackupForGKE {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+    /// async fn sample(
+    ///    client: &BackupForGKE
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::backup_for_gke::CancelOperation {
         super::builder::backup_for_gke::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
@@ -120,6 +120,22 @@ impl GatewayControl {
 
     /// GenerateCredentials provides connection information that allows a user to
     /// access the specified membership using Connect Gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkeconnect_gateway_v1::client::GatewayControl;
+    /// async fn sample(
+    ///    client: &GatewayControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_credentials()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_credentials(&self) -> super::builder::gateway_control::GenerateCredentials {
         super::builder::gateway_control::GenerateCredentials::new(self.inner.clone())
     }

--- a/src/generated/cloud/gkehub/v1/src/client.rs
+++ b/src/generated/cloud/gkehub/v1/src/client.rs
@@ -148,11 +148,45 @@ impl GkeHub {
     }
 
     /// Gets the details of a Membership.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_membership()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_membership(&self) -> super::builder::gke_hub::GetMembership {
         super::builder::gke_hub::GetMembership::new(self.inner.clone())
     }
 
     /// Gets details of a single Feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_feature()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_feature(&self) -> super::builder::gke_hub::GetFeature {
         super::builder::gke_hub::GetFeature::new(self.inner.clone())
     }
@@ -259,6 +293,22 @@ impl GkeHub {
     ///
     /// **This method is used internally by Google-provided libraries.**
     /// Most clients should not need to call this method directly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_connect_manifest()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_connect_manifest(&self) -> super::builder::gke_hub::GenerateConnectManifest {
         super::builder::gke_hub::GenerateConnectManifest::new(self.inner.clone())
     }
@@ -273,6 +323,22 @@ impl GkeHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::gke_hub::GetOperation {
         super::builder::gke_hub::GetOperation::new(self.inner.clone())
     }
@@ -280,6 +346,21 @@ impl GkeHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::gke_hub::DeleteOperation {
         super::builder::gke_hub::DeleteOperation::new(self.inner.clone())
     }
@@ -287,6 +368,21 @@ impl GkeHub {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkehub_v1::client::GkeHub;
+    /// async fn sample(
+    ///    client: &GkeHub
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::gke_hub::CancelOperation {
         super::builder::gke_hub::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/gkemulticloud/v1/src/client.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/client.rs
@@ -202,6 +202,23 @@ impl AttachedClusters {
     /// [AttachedCluster][google.cloud.gkemulticloud.v1.AttachedCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AttachedCluster]: crate::model::AttachedCluster
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attached_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attached_cluster(&self) -> super::builder::attached_clusters::GetAttachedCluster {
         super::builder::attached_clusters::GetAttachedCluster::new(self.inner.clone())
     }
@@ -243,6 +260,23 @@ impl AttachedClusters {
 
     /// Returns information, such as supported Kubernetes versions, on a given
     /// Google Cloud location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attached_server_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attached_server_config(
         &self,
     ) -> super::builder::attached_clusters::GetAttachedServerConfig {
@@ -250,6 +284,22 @@ impl AttachedClusters {
     }
 
     /// Generates the install manifest to be installed on the target cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_attached_cluster_install_manifest()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_attached_cluster_install_manifest(
         &self,
     ) -> super::builder::attached_clusters::GenerateAttachedClusterInstallManifest {
@@ -259,6 +309,22 @@ impl AttachedClusters {
     }
 
     /// Generates an access token for a cluster agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_attached_cluster_agent_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_attached_cluster_agent_token(
         &self,
     ) -> super::builder::attached_clusters::GenerateAttachedClusterAgentToken {
@@ -277,6 +343,22 @@ impl AttachedClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::attached_clusters::GetOperation {
         super::builder::attached_clusters::GetOperation::new(self.inner.clone())
     }
@@ -284,6 +366,21 @@ impl AttachedClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::attached_clusters::DeleteOperation {
         super::builder::attached_clusters::DeleteOperation::new(self.inner.clone())
     }
@@ -291,6 +388,21 @@ impl AttachedClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+    /// async fn sample(
+    ///    client: &AttachedClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::attached_clusters::CancelOperation {
         super::builder::attached_clusters::CancelOperation::new(self.inner.clone())
     }
@@ -446,6 +558,23 @@ impl AwsClusters {
     /// resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aws_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_aws_cluster(&self) -> super::builder::aws_clusters::GetAwsCluster {
         super::builder::aws_clusters::GetAwsCluster::new(self.inner.clone())
@@ -489,6 +618,22 @@ impl AwsClusters {
     }
 
     /// Generates an access token for a cluster agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_aws_cluster_agent_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn generate_aws_cluster_agent_token(
         &self,
@@ -500,6 +645,22 @@ impl AwsClusters {
     /// [AwsCluster][google.cloud.gkemulticloud.v1.AwsCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsCluster]: crate::model::AwsCluster
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_aws_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn generate_aws_access_token(
         &self,
@@ -579,6 +740,23 @@ impl AwsClusters {
     /// [AwsNodePool][google.cloud.gkemulticloud.v1.AwsNodePool] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AwsNodePool]: crate::model::AwsNodePool
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aws_node_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_aws_node_pool(&self) -> super::builder::aws_clusters::GetAwsNodePool {
         super::builder::aws_clusters::GetAwsNodePool::new(self.inner.clone())
@@ -624,6 +802,22 @@ impl AwsClusters {
     /// [OpenID Connect Discovery 1.0
     /// specification](https://openid.net/specs/openid-connect-discovery-1_0.html)
     /// for details.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aws_open_id_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_aws_open_id_config(&self) -> super::builder::aws_clusters::GetAwsOpenIdConfig {
         super::builder::aws_clusters::GetAwsOpenIdConfig::new(self.inner.clone())
@@ -631,6 +825,22 @@ impl AwsClusters {
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aws_json_web_keys()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_aws_json_web_keys(&self) -> super::builder::aws_clusters::GetAwsJsonWebKeys {
         super::builder::aws_clusters::GetAwsJsonWebKeys::new(self.inner.clone())
@@ -638,6 +848,23 @@ impl AwsClusters {
 
     /// Returns information, such as supported AWS regions and Kubernetes
     /// versions, on a given Google Cloud location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_aws_server_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_aws_server_config(&self) -> super::builder::aws_clusters::GetAwsServerConfig {
         super::builder::aws_clusters::GetAwsServerConfig::new(self.inner.clone())
@@ -653,6 +880,22 @@ impl AwsClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::aws_clusters::GetOperation {
         super::builder::aws_clusters::GetOperation::new(self.inner.clone())
     }
@@ -660,6 +903,21 @@ impl AwsClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::aws_clusters::DeleteOperation {
         super::builder::aws_clusters::DeleteOperation::new(self.inner.clone())
     }
@@ -667,6 +925,21 @@ impl AwsClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
+    /// async fn sample(
+    ///    client: &AwsClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::aws_clusters::CancelOperation {
         super::builder::aws_clusters::CancelOperation::new(self.inner.clone())
     }
@@ -808,6 +1081,23 @@ impl AzureClusters {
     /// [AzureClient][google.cloud.gkemulticloud.v1.AzureClient] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureClient]: crate::model::AzureClient
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_client()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_client(&self) -> super::builder::azure_clusters::GetAzureClient {
         super::builder::azure_clusters::GetAzureClient::new(self.inner.clone())
@@ -895,6 +1185,23 @@ impl AzureClusters {
     /// [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_cluster(&self) -> super::builder::azure_clusters::GetAzureCluster {
         super::builder::azure_clusters::GetAzureCluster::new(self.inner.clone())
@@ -938,6 +1245,22 @@ impl AzureClusters {
     }
 
     /// Generates an access token for a cluster agent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_azure_cluster_agent_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn generate_azure_cluster_agent_token(
         &self,
@@ -949,6 +1272,22 @@ impl AzureClusters {
     /// [AzureCluster][google.cloud.gkemulticloud.v1.AzureCluster] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureCluster]: crate::model::AzureCluster
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_azure_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn generate_azure_access_token(
         &self,
@@ -1004,6 +1343,23 @@ impl AzureClusters {
     /// [AzureNodePool][google.cloud.gkemulticloud.v1.AzureNodePool] resource.
     ///
     /// [google.cloud.gkemulticloud.v1.AzureNodePool]: crate::model::AzureNodePool
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_node_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_node_pool(&self) -> super::builder::azure_clusters::GetAzureNodePool {
         super::builder::azure_clusters::GetAzureNodePool::new(self.inner.clone())
@@ -1049,6 +1405,22 @@ impl AzureClusters {
     /// [OpenID Connect Discovery 1.0
     /// specification](https://openid.net/specs/openid-connect-discovery-1_0.html)
     /// for details.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_open_id_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_open_id_config(&self) -> super::builder::azure_clusters::GetAzureOpenIdConfig {
         super::builder::azure_clusters::GetAzureOpenIdConfig::new(self.inner.clone())
@@ -1056,6 +1428,22 @@ impl AzureClusters {
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_json_web_keys()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_json_web_keys(&self) -> super::builder::azure_clusters::GetAzureJsonWebKeys {
         super::builder::azure_clusters::GetAzureJsonWebKeys::new(self.inner.clone())
@@ -1063,6 +1451,23 @@ impl AzureClusters {
 
     /// Returns information, such as supported Azure regions and Kubernetes
     /// versions, on a given Google Cloud location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_azure_server_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn get_azure_server_config(&self) -> super::builder::azure_clusters::GetAzureServerConfig {
         super::builder::azure_clusters::GetAzureServerConfig::new(self.inner.clone())
@@ -1078,6 +1483,22 @@ impl AzureClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::azure_clusters::GetOperation {
         super::builder::azure_clusters::GetOperation::new(self.inner.clone())
     }
@@ -1085,6 +1506,21 @@ impl AzureClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::azure_clusters::DeleteOperation {
         super::builder::azure_clusters::DeleteOperation::new(self.inner.clone())
     }
@@ -1092,6 +1528,21 @@ impl AzureClusters {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
+    /// async fn sample(
+    ///    client: &AzureClusters
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::azure_clusters::CancelOperation {
         super::builder::azure_clusters::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/gkerecommender/v1/src/client.rs
+++ b/src/generated/cloud/gkerecommender/v1/src/client.rs
@@ -126,12 +126,44 @@ impl GkeInferenceQuickstart {
 
     /// Fetches available models. Open-source models follow the Huggingface Hub
     /// `owner/model_name` format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+    /// async fn sample(
+    ///    client: &GkeInferenceQuickstart
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_models()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_models(&self) -> super::builder::gke_inference_quickstart::FetchModels {
         super::builder::gke_inference_quickstart::FetchModels::new(self.inner.clone())
     }
 
     /// Fetches available model servers. Open-source model servers use simplified,
     /// lowercase names (e.g., `vllm`).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+    /// async fn sample(
+    ///    client: &GkeInferenceQuickstart
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_model_servers()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_model_servers(
         &self,
     ) -> super::builder::gke_inference_quickstart::FetchModelServers {
@@ -145,6 +177,22 @@ impl GkeInferenceQuickstart {
     /// accelerator. For example, `vllm` uses semver on GPUs, but returns nightly
     /// build tags on TPUs. All available versions will be returned when different
     /// schemas are present.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+    /// async fn sample(
+    ///    client: &GkeInferenceQuickstart
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_model_server_versions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_model_server_versions(
         &self,
     ) -> super::builder::gke_inference_quickstart::FetchModelServerVersions {
@@ -172,6 +220,22 @@ impl GkeInferenceQuickstart {
     /// Quickstart
     /// recipes](https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference/inference-quickstart)
     /// for deployment details.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+    /// async fn sample(
+    ///    client: &GkeInferenceQuickstart
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_optimized_manifest()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_optimized_manifest(
         &self,
     ) -> super::builder::gke_inference_quickstart::GenerateOptimizedManifest {
@@ -181,6 +245,22 @@ impl GkeInferenceQuickstart {
     /// Fetches all of the benchmarking data available for a profile. Benchmarking
     /// data returns all of the performance metrics available for a given model
     /// server setup on a given instance type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+    /// async fn sample(
+    ///    client: &GkeInferenceQuickstart
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_benchmarking_data()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_benchmarking_data(
         &self,
     ) -> super::builder::gke_inference_quickstart::FetchBenchmarkingData {

--- a/src/generated/cloud/gsuiteaddons/v1/src/client.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/client.rs
@@ -146,21 +146,87 @@ impl GSuiteAddOns {
     }
 
     /// Gets the authorization information for deployments in a given project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_authorization()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_authorization(&self) -> super::builder::g_suite_add_ons::GetAuthorization {
         super::builder::g_suite_add_ons::GetAuthorization::new(self.inner.clone())
     }
 
     /// Creates a deployment with the specified name and configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_deployment(&self) -> super::builder::g_suite_add_ons::CreateDeployment {
         super::builder::g_suite_add_ons::CreateDeployment::new(self.inner.clone())
     }
 
     /// Creates or replaces a deployment with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .replace_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn replace_deployment(&self) -> super::builder::g_suite_add_ons::ReplaceDeployment {
         super::builder::g_suite_add_ons::ReplaceDeployment::new(self.inner.clone())
     }
 
     /// Gets the deployment with the specified name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment(&self) -> super::builder::g_suite_add_ons::GetDeployment {
         super::builder::g_suite_add_ons::GetDeployment::new(self.inner.clone())
     }
@@ -171,6 +237,21 @@ impl GSuiteAddOns {
     }
 
     /// Deletes the deployment with the given name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_deployment(&self) -> super::builder::g_suite_add_ons::DeleteDeployment {
         super::builder::g_suite_add_ons::DeleteDeployment::new(self.inner.clone())
     }
@@ -178,6 +259,21 @@ impl GSuiteAddOns {
     /// Installs a deployment in developer mode.
     /// See:
     /// <https://developers.google.com/gsuite/add-ons/how-tos/testing-gsuite-addons>.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .install_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn install_deployment(&self) -> super::builder::g_suite_add_ons::InstallDeployment {
         super::builder::g_suite_add_ons::InstallDeployment::new(self.inner.clone())
     }
@@ -185,11 +281,43 @@ impl GSuiteAddOns {
     /// Uninstalls a developer mode deployment.
     /// See:
     /// <https://developers.google.com/gsuite/add-ons/how-tos/testing-gsuite-addons>.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .uninstall_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn uninstall_deployment(&self) -> super::builder::g_suite_add_ons::UninstallDeployment {
         super::builder::g_suite_add_ons::UninstallDeployment::new(self.inner.clone())
     }
 
     /// Fetches the install status of a developer mode deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+    /// async fn sample(
+    ///    client: &GSuiteAddOns,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_install_status()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_install_status(&self) -> super::builder::g_suite_add_ons::GetInstallStatus {
         super::builder::g_suite_add_ons::GetInstallStatus::new(self.inner.clone())
     }

--- a/src/generated/cloud/iap/v1/src/client.rs
+++ b/src/generated/cloud/iap/v1/src/client.rs
@@ -126,6 +126,22 @@ impl IdentityAwareProxyAdminService {
     /// resource. Replaces any existing policy.
     /// More information about managing access via IAP can be found at:
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::SetIamPolicy {
@@ -136,6 +152,22 @@ impl IdentityAwareProxyAdminService {
     /// resource.
     /// More information about managing access via IAP can be found at:
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::GetIamPolicy {
@@ -146,6 +178,22 @@ impl IdentityAwareProxyAdminService {
     /// resource.
     /// More information about managing access via IAP can be found at:
     /// <https://cloud.google.com/iap/docs/managing-access#managing_access_via_the_api>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::TestIamPermissions {
@@ -155,6 +203,22 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Gets the IAP settings on a particular IAP protected resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iap_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iap_settings(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::GetIapSettings {
@@ -163,6 +227,22 @@ impl IdentityAwareProxyAdminService {
 
     /// Updates the IAP settings on a particular IAP protected resource. It
     /// replaces all fields unless the `update_mask` is set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_iap_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_iap_settings(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::UpdateIapSettings {
@@ -172,6 +252,22 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Validates that a given CEL expression conforms to IAP restrictions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_iap_attribute_expression()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_iap_attribute_expression(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::ValidateIapAttributeExpression {
@@ -192,6 +288,22 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Creates a new TunnelDestGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tunnel_dest_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tunnel_dest_group(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::CreateTunnelDestGroup {
@@ -201,6 +313,23 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Retrieves an existing TunnelDestGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tunnel_dest_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tunnel_dest_group(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::GetTunnelDestGroup {
@@ -210,6 +339,21 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Deletes a TunnelDestGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tunnel_dest_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_tunnel_dest_group(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::DeleteTunnelDestGroup {
@@ -219,6 +363,22 @@ impl IdentityAwareProxyAdminService {
     }
 
     /// Updates a TunnelDestGroup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyAdminService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tunnel_dest_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tunnel_dest_group(
         &self,
     ) -> super::builder::identity_aware_proxy_admin_service::UpdateTunnelDestGroup {
@@ -337,6 +497,22 @@ impl IdentityAwareProxyOAuthService {
     }
 
     /// Lists the existing brands for the project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_brands()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_brands(&self) -> super::builder::identity_aware_proxy_o_auth_service::ListBrands {
         super::builder::identity_aware_proxy_o_auth_service::ListBrands::new(self.inner.clone())
     }
@@ -349,11 +525,43 @@ impl IdentityAwareProxyOAuthService {
     /// changed in the Google Cloud Console. Requires that a brand does not already
     /// exist for the project, and that the specified support email is owned by the
     /// caller.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_brand()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_brand(&self) -> super::builder::identity_aware_proxy_o_auth_service::CreateBrand {
         super::builder::identity_aware_proxy_o_auth_service::CreateBrand::new(self.inner.clone())
     }
 
     /// Retrieves the OAuth brand of the project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_brand()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_brand(&self) -> super::builder::identity_aware_proxy_o_auth_service::GetBrand {
         super::builder::identity_aware_proxy_o_auth_service::GetBrand::new(self.inner.clone())
     }
@@ -361,6 +569,22 @@ impl IdentityAwareProxyOAuthService {
     /// Creates an Identity Aware Proxy (IAP) OAuth client. The client is owned
     /// by IAP. Requires that the brand for the project exists and that it is
     /// set for internal-only use.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_identity_aware_proxy_client()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_identity_aware_proxy_client(
         &self,
     ) -> super::builder::identity_aware_proxy_o_auth_service::CreateIdentityAwareProxyClient {
@@ -380,6 +604,22 @@ impl IdentityAwareProxyOAuthService {
 
     /// Retrieves an Identity Aware Proxy (IAP) OAuth client.
     /// Requires that the client is owned by IAP.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_identity_aware_proxy_client()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_identity_aware_proxy_client(
         &self,
     ) -> super::builder::identity_aware_proxy_o_auth_service::GetIdentityAwareProxyClient {
@@ -390,6 +630,22 @@ impl IdentityAwareProxyOAuthService {
 
     /// Resets an Identity Aware Proxy (IAP) OAuth client secret. Useful if the
     /// secret was compromised. Requires that the client is owned by IAP.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_identity_aware_proxy_client_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_identity_aware_proxy_client_secret(
         &self,
     ) -> super::builder::identity_aware_proxy_o_auth_service::ResetIdentityAwareProxyClientSecret
@@ -400,6 +656,21 @@ impl IdentityAwareProxyOAuthService {
     /// Deletes an Identity Aware Proxy (IAP) OAuth client. Useful for removing
     /// obsolete clients, managing the number of clients in a given project, and
     /// cleaning up after tests. Requires that the client is owned by IAP.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
+    /// async fn sample(
+    ///    client: &IdentityAwareProxyOAuthService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_identity_aware_proxy_client()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_identity_aware_proxy_client(
         &self,
     ) -> super::builder::identity_aware_proxy_o_auth_service::DeleteIdentityAwareProxyClient {

--- a/src/generated/cloud/ids/v1/src/client.rs
+++ b/src/generated/cloud/ids/v1/src/client.rs
@@ -124,6 +124,23 @@ impl Ids {
     }
 
     /// Gets details of a single Endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_ids_v1::client::Ids;
+    /// async fn sample(
+    ///    client: &Ids,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_endpoint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_endpoint(&self) -> super::builder::ids::GetEndpoint {
         super::builder::ids::GetEndpoint::new(self.inner.clone())
     }
@@ -168,6 +185,22 @@ impl Ids {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_ids_v1::client::Ids;
+    /// async fn sample(
+    ///    client: &Ids
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::ids::GetOperation {
         super::builder::ids::GetOperation::new(self.inner.clone())
     }
@@ -175,6 +208,21 @@ impl Ids {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_ids_v1::client::Ids;
+    /// async fn sample(
+    ///    client: &Ids
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::ids::DeleteOperation {
         super::builder::ids::DeleteOperation::new(self.inner.clone())
     }
@@ -182,6 +230,21 @@ impl Ids {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_ids_v1::client::Ids;
+    /// async fn sample(
+    ///    client: &Ids
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::ids::CancelOperation {
         super::builder::ids::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/kms/inventory/v1/src/client.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/client.rs
@@ -242,6 +242,23 @@ impl KeyTrackingService {
     /// succeed.
     ///
     /// [google.cloud.kms.v1.CryptoKey]: kms::model::CryptoKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_inventory_v1::client::KeyTrackingService;
+    /// async fn sample(
+    ///    client: &KeyTrackingService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_protected_resources_summary()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_protected_resources_summary(
         &self,
     ) -> super::builder::key_tracking_service::GetProtectedResourcesSummary {

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -167,6 +167,23 @@ impl Autokey {
     /// Returns the [KeyHandle][google.cloud.kms.v1.KeyHandle].
     ///
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_key_handle()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_key_handle(&self) -> super::builder::autokey::GetKeyHandle {
         super::builder::autokey::GetKeyHandle::new(self.inner.clone())
     }
@@ -184,6 +201,22 @@ impl Autokey {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::autokey::GetLocation {
         super::builder::autokey::GetLocation::new(self.inner.clone())
     }
@@ -193,12 +226,44 @@ impl Autokey {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::autokey::SetIamPolicy {
         super::builder::autokey::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::autokey::GetIamPolicy {
         super::builder::autokey::GetIamPolicy::new(self.inner.clone())
     }
@@ -210,6 +275,22 @@ impl Autokey {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::autokey::TestIamPermissions {
         super::builder::autokey::TestIamPermissions::new(self.inner.clone())
     }
@@ -217,6 +298,22 @@ impl Autokey {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::Autokey;
+    /// async fn sample(
+    ///    client: &Autokey
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::autokey::GetOperation {
         super::builder::autokey::GetOperation::new(self.inner.clone())
     }
@@ -344,6 +441,22 @@ impl AutokeyAdmin {
     /// [google.cloud.kms.v1.AutokeyConfig]: crate::model::AutokeyConfig
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.KeyHandle]: crate::model::KeyHandle
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_autokey_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_autokey_config(&self) -> super::builder::autokey_admin::UpdateAutokeyConfig {
         super::builder::autokey_admin::UpdateAutokeyConfig::new(self.inner.clone())
     }
@@ -352,11 +465,44 @@ impl AutokeyAdmin {
     /// folder.
     ///
     /// [google.cloud.kms.v1.AutokeyConfig]: crate::model::AutokeyConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_autokey_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_autokey_config(&self) -> super::builder::autokey_admin::GetAutokeyConfig {
         super::builder::autokey_admin::GetAutokeyConfig::new(self.inner.clone())
     }
 
     /// Returns the effective Cloud KMS Autokey configuration for a given project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .show_effective_autokey_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn show_effective_autokey_config(
         &self,
     ) -> super::builder::autokey_admin::ShowEffectiveAutokeyConfig {
@@ -369,6 +515,22 @@ impl AutokeyAdmin {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::autokey_admin::GetLocation {
         super::builder::autokey_admin::GetLocation::new(self.inner.clone())
     }
@@ -378,12 +540,44 @@ impl AutokeyAdmin {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::autokey_admin::SetIamPolicy {
         super::builder::autokey_admin::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::autokey_admin::GetIamPolicy {
         super::builder::autokey_admin::GetIamPolicy::new(self.inner.clone())
     }
@@ -395,6 +589,22 @@ impl AutokeyAdmin {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::autokey_admin::TestIamPermissions {
         super::builder::autokey_admin::TestIamPermissions::new(self.inner.clone())
     }
@@ -402,6 +612,22 @@ impl AutokeyAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::AutokeyAdmin;
+    /// async fn sample(
+    ///    client: &AutokeyAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::autokey_admin::GetOperation {
         super::builder::autokey_admin::GetOperation::new(self.inner.clone())
     }
@@ -527,6 +753,23 @@ impl EkmService {
     /// [EkmConnection][google.cloud.kms.v1.EkmConnection].
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ekm_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ekm_connection(&self) -> super::builder::ekm_service::GetEkmConnection {
         super::builder::ekm_service::GetEkmConnection::new(self.inner.clone())
     }
@@ -535,6 +778,22 @@ impl EkmService {
     /// Project and Location.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_ekm_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_ekm_connection(&self) -> super::builder::ekm_service::CreateEkmConnection {
         super::builder::ekm_service::CreateEkmConnection::new(self.inner.clone())
     }
@@ -542,6 +801,22 @@ impl EkmService {
     /// Updates an [EkmConnection][google.cloud.kms.v1.EkmConnection]'s metadata.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_ekm_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_ekm_connection(&self) -> super::builder::ekm_service::UpdateEkmConnection {
         super::builder::ekm_service::UpdateEkmConnection::new(self.inner.clone())
     }
@@ -550,6 +825,23 @@ impl EkmService {
     /// for a given project and location.
     ///
     /// [google.cloud.kms.v1.EkmConfig]: crate::model::EkmConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ekm_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ekm_config(&self) -> super::builder::ekm_service::GetEkmConfig {
         super::builder::ekm_service::GetEkmConfig::new(self.inner.clone())
     }
@@ -558,6 +850,22 @@ impl EkmService {
     /// for a given project and location.
     ///
     /// [google.cloud.kms.v1.EkmConfig]: crate::model::EkmConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_ekm_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_ekm_config(&self) -> super::builder::ekm_service::UpdateEkmConfig {
         super::builder::ekm_service::UpdateEkmConfig::new(self.inner.clone())
     }
@@ -569,6 +877,22 @@ impl EkmService {
     /// at <https://cloud.google.com/kms/docs/reference/ekm_errors>.
     ///
     /// [google.cloud.kms.v1.EkmConnection]: crate::model::EkmConnection
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_connectivity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_connectivity(&self) -> super::builder::ekm_service::VerifyConnectivity {
         super::builder::ekm_service::VerifyConnectivity::new(self.inner.clone())
     }
@@ -579,6 +903,22 @@ impl EkmService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::ekm_service::GetLocation {
         super::builder::ekm_service::GetLocation::new(self.inner.clone())
     }
@@ -588,12 +928,44 @@ impl EkmService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::ekm_service::SetIamPolicy {
         super::builder::ekm_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::ekm_service::GetIamPolicy {
         super::builder::ekm_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -605,6 +977,22 @@ impl EkmService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::ekm_service::TestIamPermissions {
         super::builder::ekm_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -612,6 +1000,22 @@ impl EkmService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::EkmService;
+    /// async fn sample(
+    ///    client: &EkmService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::ekm_service::GetOperation {
         super::builder::ekm_service::GetOperation::new(self.inner.clone())
     }
@@ -771,6 +1175,23 @@ impl KeyManagementService {
     /// Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].
     ///
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_key_ring()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_key_ring(&self) -> super::builder::key_management_service::GetKeyRing {
         super::builder::key_management_service::GetKeyRing::new(self.inner.clone())
     }
@@ -782,6 +1203,23 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.primary]: crate::model::CryptoKey::primary
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_crypto_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_crypto_key(&self) -> super::builder::key_management_service::GetCryptoKey {
         super::builder::key_management_service::GetCryptoKey::new(self.inner.clone())
     }
@@ -790,6 +1228,23 @@ impl KeyManagementService {
     /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion].
     ///
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_crypto_key_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::GetCryptoKeyVersion {
@@ -807,6 +1262,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ASYMMETRIC_SIGN]: crate::model::crypto_key::CryptoKeyPurpose::AsymmetricSign
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_public_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_public_key(&self) -> super::builder::key_management_service::GetPublicKey {
         super::builder::key_management_service::GetPublicKey::new(self.inner.clone())
     }
@@ -814,6 +1285,23 @@ impl KeyManagementService {
     /// Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].
     ///
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_import_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_import_job(&self) -> super::builder::key_management_service::GetImportJob {
         super::builder::key_management_service::GetImportJob::new(self.inner.clone())
     }
@@ -822,6 +1310,22 @@ impl KeyManagementService {
     /// Location.
     ///
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_key_ring()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_key_ring(&self) -> super::builder::key_management_service::CreateKeyRing {
         super::builder::key_management_service::CreateKeyRing::new(self.inner.clone())
     }
@@ -837,6 +1341,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersionTemplate.algorithm]: crate::model::CryptoKeyVersionTemplate::algorithm
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_crypto_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_crypto_key(&self) -> super::builder::key_management_service::CreateCryptoKey {
         super::builder::key_management_service::CreateCryptoKey::new(self.inner.clone())
     }
@@ -852,6 +1372,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.ENABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Enabled
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_crypto_key_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::CreateCryptoKeyVersion {
@@ -869,6 +1405,22 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_crypto_key_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::ImportCryptoKeyVersion {
@@ -884,6 +1436,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.ImportJob]: crate::model::ImportJob
     /// [google.cloud.kms.v1.ImportJob.import_method]: crate::model::ImportJob::import_method
     /// [google.cloud.kms.v1.KeyRing]: crate::model::KeyRing
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_import_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_import_job(&self) -> super::builder::key_management_service::CreateImportJob {
         super::builder::key_management_service::CreateImportJob::new(self.inner.clone())
     }
@@ -891,6 +1459,22 @@ impl KeyManagementService {
     /// Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].
     ///
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_crypto_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_crypto_key(&self) -> super::builder::key_management_service::UpdateCryptoKey {
         super::builder::key_management_service::UpdateCryptoKey::new(self.inner.clone())
     }
@@ -914,6 +1498,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     /// [google.cloud.kms.v1.KeyManagementService.DestroyCryptoKeyVersion]: crate::client::KeyManagementService::destroy_crypto_key_version
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_crypto_key_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::UpdateCryptoKeyVersion {
@@ -930,6 +1530,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey]: crate::model::CryptoKey
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_crypto_key_primary_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_crypto_key_primary_version(
         &self,
     ) -> super::builder::key_management_service::UpdateCryptoKeyPrimaryVersion {
@@ -967,6 +1583,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
     /// [google.cloud.kms.v1.KeyManagementService.RestoreCryptoKeyVersion]: crate::client::KeyManagementService::restore_crypto_key_version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .destroy_crypto_key_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn destroy_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::DestroyCryptoKeyVersion {
@@ -988,6 +1620,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKeyVersion.CryptoKeyVersionState.DISABLED]: crate::model::crypto_key_version::CryptoKeyVersionState::Disabled
     /// [google.cloud.kms.v1.CryptoKeyVersion.destroy_time]: crate::model::CryptoKeyVersion::destroy_time
     /// [google.cloud.kms.v1.CryptoKeyVersion.state]: crate::model::CryptoKeyVersion::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restore_crypto_key_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restore_crypto_key_version(
         &self,
     ) -> super::builder::key_management_service::RestoreCryptoKeyVersion {
@@ -1002,6 +1650,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .encrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn encrypt(&self) -> super::builder::key_management_service::Encrypt {
         super::builder::key_management_service::Encrypt::new(self.inner.clone())
     }
@@ -1014,6 +1678,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::EncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .decrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn decrypt(&self) -> super::builder::key_management_service::Decrypt {
         super::builder::key_management_service::Decrypt::new(self.inner.clone())
     }
@@ -1029,6 +1709,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.KeyManagementService.Decrypt]: crate::client::KeyManagementService::decrypt
     /// [google.cloud.kms.v1.KeyManagementService.Encrypt]: crate::client::KeyManagementService::encrypt
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .raw_encrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn raw_encrypt(&self) -> super::builder::key_management_service::RawEncrypt {
         super::builder::key_management_service::RawEncrypt::new(self.inner.clone())
     }
@@ -1040,6 +1736,22 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose.RAW_ENCRYPT_DECRYPT]: crate::model::crypto_key::CryptoKeyPurpose::RawEncryptDecrypt
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .raw_decrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn raw_decrypt(&self) -> super::builder::key_management_service::RawDecrypt {
         super::builder::key_management_service::RawDecrypt::new(self.inner.clone())
     }
@@ -1053,6 +1765,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .asymmetric_sign()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn asymmetric_sign(&self) -> super::builder::key_management_service::AsymmetricSign {
         super::builder::key_management_service::AsymmetricSign::new(self.inner.clone())
     }
@@ -1066,6 +1794,22 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .asymmetric_decrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn asymmetric_decrypt(&self) -> super::builder::key_management_service::AsymmetricDecrypt {
         super::builder::key_management_service::AsymmetricDecrypt::new(self.inner.clone())
     }
@@ -1076,6 +1820,22 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mac_sign()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mac_sign(&self) -> super::builder::key_management_service::MacSign {
         super::builder::key_management_service::MacSign::new(self.inner.clone())
     }
@@ -1087,6 +1847,22 @@ impl KeyManagementService {
     ///
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mac_verify()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mac_verify(&self) -> super::builder::key_management_service::MacVerify {
         super::builder::key_management_service::MacVerify::new(self.inner.clone())
     }
@@ -1100,12 +1876,44 @@ impl KeyManagementService {
     /// [google.cloud.kms.v1.CryptoKey.purpose]: crate::model::CryptoKey::purpose
     /// [google.cloud.kms.v1.CryptoKeyVersion]: crate::model::CryptoKeyVersion
     /// [google.cloud.kms.v1.KeyManagementService.GetPublicKey]: crate::client::KeyManagementService::get_public_key
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .decapsulate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn decapsulate(&self) -> super::builder::key_management_service::Decapsulate {
         super::builder::key_management_service::Decapsulate::new(self.inner.clone())
     }
 
     /// Generate random bytes using the Cloud KMS randomness source in the provided
     /// location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_random_bytes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_random_bytes(
         &self,
     ) -> super::builder::key_management_service::GenerateRandomBytes {
@@ -1118,6 +1926,22 @@ impl KeyManagementService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::key_management_service::GetLocation {
         super::builder::key_management_service::GetLocation::new(self.inner.clone())
     }
@@ -1127,12 +1951,44 @@ impl KeyManagementService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::key_management_service::SetIamPolicy {
         super::builder::key_management_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::key_management_service::GetIamPolicy {
         super::builder::key_management_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1144,6 +2000,22 @@ impl KeyManagementService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::key_management_service::TestIamPermissions {
@@ -1153,6 +2025,22 @@ impl KeyManagementService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_kms_v1::client::KeyManagementService;
+    /// async fn sample(
+    ///    client: &KeyManagementService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::key_management_service::GetOperation {
         super::builder::key_management_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/language/v2/src/client.rs
+++ b/src/generated/cloud/language/v2/src/client.rs
@@ -123,6 +123,22 @@ impl LanguageService {
     }
 
     /// Analyzes the sentiment of the provided text.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// async fn sample(
+    ///    client: &LanguageService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .analyze_sentiment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn analyze_sentiment(&self) -> super::builder::language_service::AnalyzeSentiment {
         super::builder::language_service::AnalyzeSentiment::new(self.inner.clone())
     }
@@ -130,21 +146,85 @@ impl LanguageService {
     /// Finds named entities (currently proper names and common nouns) in the text
     /// along with entity types, probability, mentions for each entity, and
     /// other properties.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// async fn sample(
+    ///    client: &LanguageService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .analyze_entities()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn analyze_entities(&self) -> super::builder::language_service::AnalyzeEntities {
         super::builder::language_service::AnalyzeEntities::new(self.inner.clone())
     }
 
     /// Classifies a document into categories.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// async fn sample(
+    ///    client: &LanguageService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .classify_text()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn classify_text(&self) -> super::builder::language_service::ClassifyText {
         super::builder::language_service::ClassifyText::new(self.inner.clone())
     }
 
     /// Moderates a document for harmful and sensitive categories.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// async fn sample(
+    ///    client: &LanguageService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .moderate_text()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn moderate_text(&self) -> super::builder::language_service::ModerateText {
         super::builder::language_service::ModerateText::new(self.inner.clone())
     }
 
     /// A convenience method that provides all features in one call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_language_v2::client::LanguageService;
+    /// async fn sample(
+    ///    client: &LanguageService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .annotate_text()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn annotate_text(&self) -> super::builder::language_service::AnnotateText {
         super::builder::language_service::AnnotateText::new(self.inner.clone())
     }

--- a/src/generated/cloud/licensemanager/v1/src/client.rs
+++ b/src/generated/cloud/licensemanager/v1/src/client.rs
@@ -124,6 +124,23 @@ impl LicenseManager {
     }
 
     /// Gets details of a single Configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_configuration()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_configuration(&self) -> super::builder::license_manager::GetConfiguration {
         super::builder::license_manager::GetConfiguration::new(self.inner.clone())
     }
@@ -179,6 +196,23 @@ impl LicenseManager {
     }
 
     /// Gets details of a single Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::license_manager::GetInstance {
         super::builder::license_manager::GetInstance::new(self.inner.clone())
     }
@@ -218,6 +252,22 @@ impl LicenseManager {
     }
 
     /// License Usage information for a Configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_configuration_license_usage()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_configuration_license_usage(
         &self,
     ) -> super::builder::license_manager::QueryConfigurationLicenseUsage {
@@ -235,6 +285,23 @@ impl LicenseManager {
     }
 
     /// Gets details of a single Product.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_product()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_product(&self) -> super::builder::license_manager::GetProduct {
         super::builder::license_manager::GetProduct::new(self.inner.clone())
     }
@@ -245,6 +312,22 @@ impl LicenseManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::license_manager::GetLocation {
         super::builder::license_manager::GetLocation::new(self.inner.clone())
     }
@@ -259,6 +342,22 @@ impl LicenseManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::license_manager::GetOperation {
         super::builder::license_manager::GetOperation::new(self.inner.clone())
     }
@@ -266,6 +365,21 @@ impl LicenseManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::license_manager::DeleteOperation {
         super::builder::license_manager::DeleteOperation::new(self.inner.clone())
     }
@@ -273,6 +387,21 @@ impl LicenseManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_licensemanager_v1::client::LicenseManager;
+    /// async fn sample(
+    ///    client: &LicenseManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::license_manager::CancelOperation {
         super::builder::license_manager::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -128,6 +128,22 @@ impl Locations {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_location::client::Locations;
+    /// async fn sample(
+    ///    client: &Locations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::locations::GetLocation {
         super::builder::locations::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/locationfinder/v1/src/client.rs
+++ b/src/generated/cloud/locationfinder/v1/src/client.rs
@@ -129,6 +129,23 @@ impl CloudLocationFinder {
     }
 
     /// Retrieves a resource containing information about a cloud location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_locationfinder_v1::client::CloudLocationFinder;
+    /// async fn sample(
+    ///    client: &CloudLocationFinder,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cloud_location()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cloud_location(&self) -> super::builder::cloud_location_finder::GetCloudLocation {
         super::builder::cloud_location_finder::GetCloudLocation::new(self.inner.clone())
     }
@@ -146,6 +163,22 @@ impl CloudLocationFinder {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_locationfinder_v1::client::CloudLocationFinder;
+    /// async fn sample(
+    ///    client: &CloudLocationFinder
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_location_finder::GetLocation {
         super::builder::cloud_location_finder::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/lustre/v1/src/client.rs
+++ b/src/generated/cloud/lustre/v1/src/client.rs
@@ -124,6 +124,23 @@ impl Lustre {
     }
 
     /// Gets details of a single instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_lustre_v1::client::Lustre;
+    /// async fn sample(
+    ///    client: &Lustre,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::lustre::GetInstance {
         super::builder::lustre::GetInstance::new(self.inner.clone())
     }
@@ -209,6 +226,22 @@ impl Lustre {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_lustre_v1::client::Lustre;
+    /// async fn sample(
+    ///    client: &Lustre
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::lustre::GetLocation {
         super::builder::lustre::GetLocation::new(self.inner.clone())
     }
@@ -223,6 +256,22 @@ impl Lustre {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_lustre_v1::client::Lustre;
+    /// async fn sample(
+    ///    client: &Lustre
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::lustre::GetOperation {
         super::builder::lustre::GetOperation::new(self.inner.clone())
     }
@@ -230,6 +279,21 @@ impl Lustre {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_lustre_v1::client::Lustre;
+    /// async fn sample(
+    ///    client: &Lustre
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::lustre::DeleteOperation {
         super::builder::lustre::DeleteOperation::new(self.inner.clone())
     }
@@ -237,6 +301,21 @@ impl Lustre {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_lustre_v1::client::Lustre;
+    /// async fn sample(
+    ///    client: &Lustre
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::lustre::CancelOperation {
         super::builder::lustre::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/maintenance/api/v1/src/client.rs
+++ b/src/generated/cloud/maintenance/api/v1/src/client.rs
@@ -131,6 +131,23 @@ impl Maintenance {
     }
 
     /// Retrieve a single resource maintenance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_maintenance_api_v1::client::Maintenance;
+    /// async fn sample(
+    ///    client: &Maintenance,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource_maintenance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource_maintenance(&self) -> super::builder::maintenance::GetResourceMaintenance {
         super::builder::maintenance::GetResourceMaintenance::new(self.inner.clone())
     }
@@ -141,6 +158,22 @@ impl Maintenance {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_maintenance_api_v1::client::Maintenance;
+    /// async fn sample(
+    ///    client: &Maintenance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::maintenance::GetLocation {
         super::builder::maintenance::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/managedidentities/v1/src/client.rs
+++ b/src/generated/cloud/managedidentities/v1/src/client.rs
@@ -172,6 +172,22 @@ impl ManagedIdentitiesService {
     }
 
     /// Resets a domain's administrator password.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// async fn sample(
+    ///    client: &ManagedIdentitiesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_admin_password()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_admin_password(
         &self,
     ) -> super::builder::managed_identities_service::ResetAdminPassword {
@@ -184,6 +200,23 @@ impl ManagedIdentitiesService {
     }
 
     /// Gets information about a domain.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// async fn sample(
+    ///    client: &ManagedIdentitiesService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_domain()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_domain(&self) -> super::builder::managed_identities_service::GetDomain {
         super::builder::managed_identities_service::GetDomain::new(self.inner.clone())
     }
@@ -291,6 +324,22 @@ impl ManagedIdentitiesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// async fn sample(
+    ///    client: &ManagedIdentitiesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::managed_identities_service::GetOperation {
         super::builder::managed_identities_service::GetOperation::new(self.inner.clone())
     }
@@ -298,6 +347,21 @@ impl ManagedIdentitiesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// async fn sample(
+    ///    client: &ManagedIdentitiesService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::managed_identities_service::DeleteOperation {
         super::builder::managed_identities_service::DeleteOperation::new(self.inner.clone())
     }
@@ -305,6 +369,21 @@ impl ManagedIdentitiesService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+    /// async fn sample(
+    ///    client: &ManagedIdentitiesService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::managed_identities_service::CancelOperation {
         super::builder::managed_identities_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/client.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/client.rs
@@ -171,6 +171,23 @@ impl ManagedSchemaRegistry {
     }
 
     /// Get the schema registry instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema_registry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema_registry(
         &self,
     ) -> super::builder::managed_schema_registry::GetSchemaRegistry {
@@ -178,6 +195,22 @@ impl ManagedSchemaRegistry {
     }
 
     /// List schema registries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_schema_registries()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_schema_registries(
         &self,
     ) -> super::builder::managed_schema_registry::ListSchemaRegistries {
@@ -185,6 +218,22 @@ impl ManagedSchemaRegistry {
     }
 
     /// Create a schema registry instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_schema_registry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_schema_registry(
         &self,
     ) -> super::builder::managed_schema_registry::CreateSchemaRegistry {
@@ -192,6 +241,22 @@ impl ManagedSchemaRegistry {
     }
 
     /// Delete a schema registry instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_schema_registry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema_registry(
         &self,
     ) -> super::builder::managed_schema_registry::DeleteSchemaRegistry {
@@ -199,22 +264,88 @@ impl ManagedSchemaRegistry {
     }
 
     /// Get the context.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_context()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_context(&self) -> super::builder::managed_schema_registry::GetContext {
         super::builder::managed_schema_registry::GetContext::new(self.inner.clone())
     }
 
     /// List contexts for a schema registry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_contexts()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_contexts(&self) -> super::builder::managed_schema_registry::ListContexts {
         super::builder::managed_schema_registry::ListContexts::new(self.inner.clone())
     }
 
     /// Get the schema for the given schema id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema(&self) -> super::builder::managed_schema_registry::GetSchema {
         super::builder::managed_schema_registry::GetSchema::new(self.inner.clone())
     }
 
     /// Get the schema string for the given schema id.
     /// The response will be the schema string.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_raw_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_raw_schema(&self) -> super::builder::managed_schema_registry::GetRawSchema {
         super::builder::managed_schema_registry::GetRawSchema::new(self.inner.clone())
     }
@@ -222,6 +353,22 @@ impl ManagedSchemaRegistry {
     /// List the schema versions for the given schema id.
     /// The response will be an array of subject-version pairs as:
     /// [{"subject":"subject1", "version":1}, {"subject":"subject2", "version":2}].
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_schema_versions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_schema_versions(
         &self,
     ) -> super::builder::managed_schema_registry::ListSchemaVersions {
@@ -230,18 +377,66 @@ impl ManagedSchemaRegistry {
 
     /// List the supported schema types.
     /// The response will be an array of schema types.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_schema_types()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_schema_types(&self) -> super::builder::managed_schema_registry::ListSchemaTypes {
         super::builder::managed_schema_registry::ListSchemaTypes::new(self.inner.clone())
     }
 
     /// List subjects in the schema registry.
     /// The response will be an array of subject names.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_subjects()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_subjects(&self) -> super::builder::managed_schema_registry::ListSubjects {
         super::builder::managed_schema_registry::ListSubjects::new(self.inner.clone())
     }
 
     /// List subjects which reference a particular schema id.
     /// The response will be an array of subject names.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_subjects_by_schema_id()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_subjects_by_schema_id(
         &self,
     ) -> super::builder::managed_schema_registry::ListSubjectsBySchemaId {
@@ -250,22 +445,88 @@ impl ManagedSchemaRegistry {
 
     /// Delete a subject.
     /// The response will be an array of versions of the deleted subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_subject()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_subject(&self) -> super::builder::managed_schema_registry::DeleteSubject {
         super::builder::managed_schema_registry::DeleteSubject::new(self.inner.clone())
     }
 
     /// Lookup a schema under the specified subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lookup_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lookup_version(&self) -> super::builder::managed_schema_registry::LookupVersion {
         super::builder::managed_schema_registry::LookupVersion::new(self.inner.clone())
     }
 
     /// Get a versioned schema (schema with subject/version) of a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::managed_schema_registry::GetVersion {
         super::builder::managed_schema_registry::GetVersion::new(self.inner.clone())
     }
 
     /// Get the schema string only for a version of a subject.
     /// The response will be the schema string.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_raw_schema_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_raw_schema_version(
         &self,
     ) -> super::builder::managed_schema_registry::GetRawSchemaVersion {
@@ -274,23 +535,88 @@ impl ManagedSchemaRegistry {
 
     /// Get all versions of a subject.
     /// The response will be an array of versions of the subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_versions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_versions(&self) -> super::builder::managed_schema_registry::ListVersions {
         super::builder::managed_schema_registry::ListVersions::new(self.inner.clone())
     }
 
     /// Register a new version under a given subject with the given schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_version(&self) -> super::builder::managed_schema_registry::CreateVersion {
         super::builder::managed_schema_registry::CreateVersion::new(self.inner.clone())
     }
 
     /// Delete a version of a subject.
     /// The response will be the deleted version id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_version(&self) -> super::builder::managed_schema_registry::DeleteVersion {
         super::builder::managed_schema_registry::DeleteVersion::new(self.inner.clone())
     }
 
     /// Get a list of IDs of schemas that reference the schema with the given
     /// subject and version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_referenced_schemas()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_referenced_schemas(
         &self,
     ) -> super::builder::managed_schema_registry::ListReferencedSchemas {
@@ -299,6 +625,22 @@ impl ManagedSchemaRegistry {
 
     /// Check compatibility of a schema with all versions or a specific version of
     /// a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_compatibility()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_compatibility(
         &self,
     ) -> super::builder::managed_schema_registry::CheckCompatibility {
@@ -306,12 +648,44 @@ impl ManagedSchemaRegistry {
     }
 
     /// Get schema config at global level or for a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema_config(&self) -> super::builder::managed_schema_registry::GetSchemaConfig {
         super::builder::managed_schema_registry::GetSchemaConfig::new(self.inner.clone())
     }
 
     /// Update config at global level or for a subject.
     /// Creates a SchemaSubject-level SchemaConfig if it does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_schema_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_schema_config(
         &self,
     ) -> super::builder::managed_schema_registry::UpdateSchemaConfig {
@@ -319,6 +693,22 @@ impl ManagedSchemaRegistry {
     }
 
     /// Delete schema config for a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_schema_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema_config(
         &self,
     ) -> super::builder::managed_schema_registry::DeleteSchemaConfig {
@@ -326,16 +716,64 @@ impl ManagedSchemaRegistry {
     }
 
     /// Get mode at global level or for a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema_mode()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema_mode(&self) -> super::builder::managed_schema_registry::GetSchemaMode {
         super::builder::managed_schema_registry::GetSchemaMode::new(self.inner.clone())
     }
 
     /// Update mode at global level or for a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_schema_mode()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_schema_mode(&self) -> super::builder::managed_schema_registry::UpdateSchemaMode {
         super::builder::managed_schema_registry::UpdateSchemaMode::new(self.inner.clone())
     }
 
     /// Delete schema mode for a subject.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_schema_mode()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema_mode(&self) -> super::builder::managed_schema_registry::DeleteSchemaMode {
         super::builder::managed_schema_registry::DeleteSchemaMode::new(self.inner.clone())
     }
@@ -346,6 +784,22 @@ impl ManagedSchemaRegistry {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::managed_schema_registry::GetLocation {
         super::builder::managed_schema_registry::GetLocation::new(self.inner.clone())
     }
@@ -360,6 +814,22 @@ impl ManagedSchemaRegistry {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::managed_schema_registry::GetOperation {
         super::builder::managed_schema_registry::GetOperation::new(self.inner.clone())
     }
@@ -367,6 +837,21 @@ impl ManagedSchemaRegistry {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::managed_schema_registry::DeleteOperation {
         super::builder::managed_schema_registry::DeleteOperation::new(self.inner.clone())
     }
@@ -374,6 +859,21 @@ impl ManagedSchemaRegistry {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+    /// async fn sample(
+    ///    client: &ManagedSchemaRegistry
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::managed_schema_registry::CancelOperation {
         super::builder::managed_schema_registry::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/managedkafka/v1/src/client.rs
+++ b/src/generated/cloud/managedkafka/v1/src/client.rs
@@ -125,6 +125,23 @@ impl ManagedKafka {
     }
 
     /// Returns the properties of a single cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::managed_kafka::GetCluster {
         super::builder::managed_kafka::GetCluster::new(self.inner.clone())
     }
@@ -180,21 +197,86 @@ impl ManagedKafka {
     }
 
     /// Returns the properties of a single topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_topic()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_topic(&self) -> super::builder::managed_kafka::GetTopic {
         super::builder::managed_kafka::GetTopic::new(self.inner.clone())
     }
 
     /// Creates a new topic in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_topic()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_topic(&self) -> super::builder::managed_kafka::CreateTopic {
         super::builder::managed_kafka::CreateTopic::new(self.inner.clone())
     }
 
     /// Updates the properties of a single topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_topic()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_topic(&self) -> super::builder::managed_kafka::UpdateTopic {
         super::builder::managed_kafka::UpdateTopic::new(self.inner.clone())
     }
 
     /// Deletes a single topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_topic()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_topic(&self) -> super::builder::managed_kafka::DeleteTopic {
         super::builder::managed_kafka::DeleteTopic::new(self.inner.clone())
     }
@@ -205,16 +287,65 @@ impl ManagedKafka {
     }
 
     /// Returns the properties of a single consumer group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_consumer_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_consumer_group(&self) -> super::builder::managed_kafka::GetConsumerGroup {
         super::builder::managed_kafka::GetConsumerGroup::new(self.inner.clone())
     }
 
     /// Updates the properties of a single consumer group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_consumer_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_consumer_group(&self) -> super::builder::managed_kafka::UpdateConsumerGroup {
         super::builder::managed_kafka::UpdateConsumerGroup::new(self.inner.clone())
     }
 
     /// Deletes a single consumer group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_consumer_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_consumer_group(&self) -> super::builder::managed_kafka::DeleteConsumerGroup {
         super::builder::managed_kafka::DeleteConsumerGroup::new(self.inner.clone())
     }
@@ -225,27 +356,108 @@ impl ManagedKafka {
     }
 
     /// Returns the properties of a single acl.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_acl()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_acl(&self) -> super::builder::managed_kafka::GetAcl {
         super::builder::managed_kafka::GetAcl::new(self.inner.clone())
     }
 
     /// Creates a new acl in the given project, location, and cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_acl()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_acl(&self) -> super::builder::managed_kafka::CreateAcl {
         super::builder::managed_kafka::CreateAcl::new(self.inner.clone())
     }
 
     /// Updates the properties of a single acl.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_acl()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_acl(&self) -> super::builder::managed_kafka::UpdateAcl {
         super::builder::managed_kafka::UpdateAcl::new(self.inner.clone())
     }
 
     /// Deletes an acl.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_acl()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_acl(&self) -> super::builder::managed_kafka::DeleteAcl {
         super::builder::managed_kafka::DeleteAcl::new(self.inner.clone())
     }
 
     /// Incremental update: Adds an acl entry to an acl. Creates the acl if it does
     /// not exist yet.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_acl_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_acl_entry(&self) -> super::builder::managed_kafka::AddAclEntry {
         super::builder::managed_kafka::AddAclEntry::new(self.inner.clone())
     }
@@ -253,6 +465,22 @@ impl ManagedKafka {
     /// Incremental update: Removes an acl entry from an acl. Deletes the acl if
     /// its acl entries become empty (i.e. if the removed entry was the last one in
     /// the acl).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_acl_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_acl_entry(&self) -> super::builder::managed_kafka::RemoveAclEntry {
         super::builder::managed_kafka::RemoveAclEntry::new(self.inner.clone())
     }
@@ -263,6 +491,22 @@ impl ManagedKafka {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::managed_kafka::GetLocation {
         super::builder::managed_kafka::GetLocation::new(self.inner.clone())
     }
@@ -277,6 +521,22 @@ impl ManagedKafka {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::managed_kafka::GetOperation {
         super::builder::managed_kafka::GetOperation::new(self.inner.clone())
     }
@@ -284,6 +544,21 @@ impl ManagedKafka {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::managed_kafka::DeleteOperation {
         super::builder::managed_kafka::DeleteOperation::new(self.inner.clone())
     }
@@ -291,6 +566,21 @@ impl ManagedKafka {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+    /// async fn sample(
+    ///    client: &ManagedKafka
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::managed_kafka::CancelOperation {
         super::builder::managed_kafka::CancelOperation::new(self.inner.clone())
     }
@@ -410,6 +700,23 @@ impl ManagedKafkaConnect {
     }
 
     /// Returns the properties of a single Kafka Connect cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connect_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connect_cluster(&self) -> super::builder::managed_kafka_connect::GetConnectCluster {
         super::builder::managed_kafka_connect::GetConnectCluster::new(self.inner.clone())
     }
@@ -471,41 +778,170 @@ impl ManagedKafkaConnect {
     }
 
     /// Returns the properties of a single connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connector(&self) -> super::builder::managed_kafka_connect::GetConnector {
         super::builder::managed_kafka_connect::GetConnector::new(self.inner.clone())
     }
 
     /// Creates a new connector in a given Connect cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_connector(&self) -> super::builder::managed_kafka_connect::CreateConnector {
         super::builder::managed_kafka_connect::CreateConnector::new(self.inner.clone())
     }
 
     /// Updates the properties of a connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_connector(&self) -> super::builder::managed_kafka_connect::UpdateConnector {
         super::builder::managed_kafka_connect::UpdateConnector::new(self.inner.clone())
     }
 
     /// Deletes a connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_connector(&self) -> super::builder::managed_kafka_connect::DeleteConnector {
         super::builder::managed_kafka_connect::DeleteConnector::new(self.inner.clone())
     }
 
     /// Pauses the connector and its tasks.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_connector(&self) -> super::builder::managed_kafka_connect::PauseConnector {
         super::builder::managed_kafka_connect::PauseConnector::new(self.inner.clone())
     }
 
     /// Resumes the connector and its tasks.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_connector(&self) -> super::builder::managed_kafka_connect::ResumeConnector {
         super::builder::managed_kafka_connect::ResumeConnector::new(self.inner.clone())
     }
 
     /// Restarts the connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restart_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restart_connector(&self) -> super::builder::managed_kafka_connect::RestartConnector {
         super::builder::managed_kafka_connect::RestartConnector::new(self.inner.clone())
     }
 
     /// Stops the connector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_connector()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_connector(&self) -> super::builder::managed_kafka_connect::StopConnector {
         super::builder::managed_kafka_connect::StopConnector::new(self.inner.clone())
     }
@@ -516,6 +952,22 @@ impl ManagedKafkaConnect {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::managed_kafka_connect::GetLocation {
         super::builder::managed_kafka_connect::GetLocation::new(self.inner.clone())
     }
@@ -530,6 +982,22 @@ impl ManagedKafkaConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::managed_kafka_connect::GetOperation {
         super::builder::managed_kafka_connect::GetOperation::new(self.inner.clone())
     }
@@ -537,6 +1005,21 @@ impl ManagedKafkaConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::managed_kafka_connect::DeleteOperation {
         super::builder::managed_kafka_connect::DeleteOperation::new(self.inner.clone())
     }
@@ -544,6 +1027,21 @@ impl ManagedKafkaConnect {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
+    /// async fn sample(
+    ///    client: &ManagedKafkaConnect
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::managed_kafka_connect::CancelOperation {
         super::builder::managed_kafka_connect::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/memcache/v1/src/client.rs
+++ b/src/generated/cloud/memcache/v1/src/client.rs
@@ -139,6 +139,23 @@ impl CloudMemcache {
     }
 
     /// Gets details of a single Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// async fn sample(
+    ///    client: &CloudMemcache,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::cloud_memcache::GetInstance {
         super::builder::cloud_memcache::GetInstance::new(self.inner.clone())
     }
@@ -243,6 +260,22 @@ impl CloudMemcache {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// async fn sample(
+    ///    client: &CloudMemcache
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_memcache::GetLocation {
         super::builder::cloud_memcache::GetLocation::new(self.inner.clone())
     }
@@ -257,6 +290,22 @@ impl CloudMemcache {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// async fn sample(
+    ///    client: &CloudMemcache
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_memcache::GetOperation {
         super::builder::cloud_memcache::GetOperation::new(self.inner.clone())
     }
@@ -264,6 +313,21 @@ impl CloudMemcache {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// async fn sample(
+    ///    client: &CloudMemcache
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cloud_memcache::DeleteOperation {
         super::builder::cloud_memcache::DeleteOperation::new(self.inner.clone())
     }
@@ -271,6 +335,21 @@ impl CloudMemcache {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memcache_v1::client::CloudMemcache;
+    /// async fn sample(
+    ///    client: &CloudMemcache
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_memcache::CancelOperation {
         super::builder::cloud_memcache::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/memorystore/v1/src/client.rs
+++ b/src/generated/cloud/memorystore/v1/src/client.rs
@@ -124,6 +124,23 @@ impl Memorystore {
     }
 
     /// Gets details of a single Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::memorystore::GetInstance {
         super::builder::memorystore::GetInstance::new(self.inner.clone())
     }
@@ -174,6 +191,22 @@ impl Memorystore {
     }
 
     /// Gets details about the certificate authority for an Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_authority()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_authority(
         &self,
     ) -> super::builder::memorystore::GetCertificateAuthority {
@@ -205,6 +238,23 @@ impl Memorystore {
     }
 
     /// Get a backup collection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_collection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_collection(&self) -> super::builder::memorystore::GetBackupCollection {
         super::builder::memorystore::GetBackupCollection::new(self.inner.clone())
     }
@@ -215,6 +265,23 @@ impl Memorystore {
     }
 
     /// Gets the details of a specific backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::memorystore::GetBackup {
         super::builder::memorystore::GetBackup::new(self.inner.clone())
     }
@@ -281,6 +348,22 @@ impl Memorystore {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::memorystore::GetLocation {
         super::builder::memorystore::GetLocation::new(self.inner.clone())
     }
@@ -295,6 +378,22 @@ impl Memorystore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::memorystore::GetOperation {
         super::builder::memorystore::GetOperation::new(self.inner.clone())
     }
@@ -302,6 +401,21 @@ impl Memorystore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::memorystore::DeleteOperation {
         super::builder::memorystore::DeleteOperation::new(self.inner.clone())
     }
@@ -309,6 +423,21 @@ impl Memorystore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_memorystore_v1::client::Memorystore;
+    /// async fn sample(
+    ///    client: &Memorystore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::memorystore::CancelOperation {
         super::builder::memorystore::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/metastore/v1/src/client.rs
+++ b/src/generated/cloud/metastore/v1/src/client.rs
@@ -147,6 +147,23 @@ impl DataprocMetastore {
     }
 
     /// Gets the details of a single service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::dataproc_metastore::GetService {
         super::builder::dataproc_metastore::GetService::new(self.inner.clone())
     }
@@ -202,6 +219,23 @@ impl DataprocMetastore {
     }
 
     /// Gets details of a single import.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metadata_import()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metadata_import(&self) -> super::builder::dataproc_metastore::GetMetadataImport {
         super::builder::dataproc_metastore::GetMetadataImport::new(self.inner.clone())
     }
@@ -277,6 +311,23 @@ impl DataprocMetastore {
     }
 
     /// Gets details of a single backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::dataproc_metastore::GetBackup {
         super::builder::dataproc_metastore::GetBackup::new(self.inner.clone())
     }
@@ -369,6 +420,22 @@ impl DataprocMetastore {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dataproc_metastore::GetLocation {
         super::builder::dataproc_metastore::GetLocation::new(self.inner.clone())
     }
@@ -378,12 +445,44 @@ impl DataprocMetastore {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dataproc_metastore::SetIamPolicy {
         super::builder::dataproc_metastore::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dataproc_metastore::GetIamPolicy {
         super::builder::dataproc_metastore::GetIamPolicy::new(self.inner.clone())
     }
@@ -395,6 +494,22 @@ impl DataprocMetastore {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::dataproc_metastore::TestIamPermissions {
         super::builder::dataproc_metastore::TestIamPermissions::new(self.inner.clone())
     }
@@ -409,6 +524,22 @@ impl DataprocMetastore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::dataproc_metastore::GetOperation {
         super::builder::dataproc_metastore::GetOperation::new(self.inner.clone())
     }
@@ -416,6 +547,21 @@ impl DataprocMetastore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::dataproc_metastore::DeleteOperation {
         super::builder::dataproc_metastore::DeleteOperation::new(self.inner.clone())
     }
@@ -423,6 +569,21 @@ impl DataprocMetastore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastore;
+    /// async fn sample(
+    ///    client: &DataprocMetastore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::dataproc_metastore::CancelOperation {
         super::builder::dataproc_metastore::CancelOperation::new(self.inner.clone())
     }
@@ -555,6 +716,23 @@ impl DataprocMetastoreFederation {
     }
 
     /// Gets the details of a single federation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_federation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_federation(&self) -> super::builder::dataproc_metastore_federation::GetFederation {
         super::builder::dataproc_metastore_federation::GetFederation::new(self.inner.clone())
     }
@@ -616,6 +794,22 @@ impl DataprocMetastoreFederation {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dataproc_metastore_federation::GetLocation {
         super::builder::dataproc_metastore_federation::GetLocation::new(self.inner.clone())
     }
@@ -625,12 +819,44 @@ impl DataprocMetastoreFederation {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dataproc_metastore_federation::SetIamPolicy {
         super::builder::dataproc_metastore_federation::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dataproc_metastore_federation::GetIamPolicy {
         super::builder::dataproc_metastore_federation::GetIamPolicy::new(self.inner.clone())
     }
@@ -642,6 +868,22 @@ impl DataprocMetastoreFederation {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::dataproc_metastore_federation::TestIamPermissions {
@@ -658,6 +900,22 @@ impl DataprocMetastoreFederation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::dataproc_metastore_federation::GetOperation {
         super::builder::dataproc_metastore_federation::GetOperation::new(self.inner.clone())
     }
@@ -665,6 +923,21 @@ impl DataprocMetastoreFederation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::dataproc_metastore_federation::DeleteOperation {
@@ -674,6 +947,21 @@ impl DataprocMetastoreFederation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
+    /// async fn sample(
+    ///    client: &DataprocMetastoreFederation
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::dataproc_metastore_federation::CancelOperation {

--- a/src/generated/cloud/migrationcenter/v1/src/client.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/client.rs
@@ -127,36 +127,147 @@ impl MigrationCenter {
     }
 
     /// Gets the details of an asset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_asset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_asset(&self) -> super::builder::migration_center::GetAsset {
         super::builder::migration_center::GetAsset::new(self.inner.clone())
     }
 
     /// Updates the parameters of an asset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_asset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_asset(&self) -> super::builder::migration_center::UpdateAsset {
         super::builder::migration_center::UpdateAsset::new(self.inner.clone())
     }
 
     /// Updates the parameters of a list of assets.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_update_assets()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_update_assets(&self) -> super::builder::migration_center::BatchUpdateAssets {
         super::builder::migration_center::BatchUpdateAssets::new(self.inner.clone())
     }
 
     /// Deletes an asset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_asset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_asset(&self) -> super::builder::migration_center::DeleteAsset {
         super::builder::migration_center::DeleteAsset::new(self.inner.clone())
     }
 
     /// Deletes list of Assets.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .batch_delete_assets()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_delete_assets(&self) -> super::builder::migration_center::BatchDeleteAssets {
         super::builder::migration_center::BatchDeleteAssets::new(self.inner.clone())
     }
 
     /// Reports a set of frames.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .report_asset_frames()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn report_asset_frames(&self) -> super::builder::migration_center::ReportAssetFrames {
         super::builder::migration_center::ReportAssetFrames::new(self.inner.clone())
     }
 
     /// Aggregates the requested fields based on provided function.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .aggregate_assets_values()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn aggregate_assets_values(
         &self,
     ) -> super::builder::migration_center::AggregateAssetsValues {
@@ -184,6 +295,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of an import job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_import_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_import_job(&self) -> super::builder::migration_center::GetImportJob {
         super::builder::migration_center::GetImportJob::new(self.inner.clone())
     }
@@ -249,6 +377,23 @@ impl MigrationCenter {
     }
 
     /// Gets an import data file.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_import_data_file()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_import_data_file(&self) -> super::builder::migration_center::GetImportDataFile {
         super::builder::migration_center::GetImportDataFile::new(self.inner.clone())
     }
@@ -298,6 +443,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of a group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_group(&self) -> super::builder::migration_center::GetGroup {
         super::builder::migration_center::GetGroup::new(self.inner.clone())
     }
@@ -385,6 +547,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of an error frame.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_error_frame()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_error_frame(&self) -> super::builder::migration_center::GetErrorFrame {
         super::builder::migration_center::GetErrorFrame::new(self.inner.clone())
     }
@@ -395,6 +574,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of a source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_source(&self) -> super::builder::migration_center::GetSource {
         super::builder::migration_center::GetSource::new(self.inner.clone())
     }
@@ -450,6 +646,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of a preference set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_preference_set()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_preference_set(&self) -> super::builder::migration_center::GetPreferenceSet {
         super::builder::migration_center::GetPreferenceSet::new(self.inner.clone())
     }
@@ -500,6 +713,23 @@ impl MigrationCenter {
     }
 
     /// Gets the details of regional settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_settings(&self) -> super::builder::migration_center::GetSettings {
         super::builder::migration_center::GetSettings::new(self.inner.clone())
     }
@@ -535,6 +765,23 @@ impl MigrationCenter {
     }
 
     /// Gets details of a single ReportConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_report_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_report_config(&self) -> super::builder::migration_center::GetReportConfig {
         super::builder::migration_center::GetReportConfig::new(self.inner.clone())
     }
@@ -575,6 +822,23 @@ impl MigrationCenter {
     }
 
     /// Gets details of a single Report.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_report(&self) -> super::builder::migration_center::GetReport {
         super::builder::migration_center::GetReport::new(self.inner.clone())
     }
@@ -605,6 +869,22 @@ impl MigrationCenter {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::migration_center::GetLocation {
         super::builder::migration_center::GetLocation::new(self.inner.clone())
     }
@@ -619,6 +899,22 @@ impl MigrationCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::migration_center::GetOperation {
         super::builder::migration_center::GetOperation::new(self.inner.clone())
     }
@@ -626,6 +922,21 @@ impl MigrationCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::migration_center::DeleteOperation {
         super::builder::migration_center::DeleteOperation::new(self.inner.clone())
     }
@@ -633,6 +944,21 @@ impl MigrationCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+    /// async fn sample(
+    ///    client: &MigrationCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::migration_center::CancelOperation {
         super::builder::migration_center::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/modelarmor/v1/src/client.rs
+++ b/src/generated/cloud/modelarmor/v1/src/client.rs
@@ -124,41 +124,171 @@ impl ModelArmor {
     }
 
     /// Gets details of a single Template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_template(&self) -> super::builder::model_armor::GetTemplate {
         super::builder::model_armor::GetTemplate::new(self.inner.clone())
     }
 
     /// Creates a new Template in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_template(&self) -> super::builder::model_armor::CreateTemplate {
         super::builder::model_armor::CreateTemplate::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single Template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_template(&self) -> super::builder::model_armor::UpdateTemplate {
         super::builder::model_armor::UpdateTemplate::new(self.inner.clone())
     }
 
     /// Deletes a single Template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_template(&self) -> super::builder::model_armor::DeleteTemplate {
         super::builder::model_armor::DeleteTemplate::new(self.inner.clone())
     }
 
     /// Gets details of a single floor setting of a project
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_floor_setting()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_floor_setting(&self) -> super::builder::model_armor::GetFloorSetting {
         super::builder::model_armor::GetFloorSetting::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single floor setting of a project
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_floor_setting()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_floor_setting(&self) -> super::builder::model_armor::UpdateFloorSetting {
         super::builder::model_armor::UpdateFloorSetting::new(self.inner.clone())
     }
 
     /// Sanitizes User Prompt.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sanitize_user_prompt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn sanitize_user_prompt(&self) -> super::builder::model_armor::SanitizeUserPrompt {
         super::builder::model_armor::SanitizeUserPrompt::new(self.inner.clone())
     }
 
     /// Sanitizes Model Response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sanitize_model_response()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn sanitize_model_response(&self) -> super::builder::model_armor::SanitizeModelResponse {
         super::builder::model_armor::SanitizeModelResponse::new(self.inner.clone())
     }
@@ -169,6 +299,22 @@ impl ModelArmor {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_modelarmor_v1::client::ModelArmor;
+    /// async fn sample(
+    ///    client: &ModelArmor
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::model_armor::GetLocation {
         super::builder::model_armor::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/netapp/v1/src/client.rs
+++ b/src/generated/cloud/netapp/v1/src/client.rs
@@ -139,6 +139,23 @@ impl NetApp {
     }
 
     /// Returns the description of the specified storage pool by poolId.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_storage_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_storage_pool(&self) -> super::builder::net_app::GetStoragePool {
         super::builder::net_app::GetStoragePool::new(self.inner.clone())
     }
@@ -211,6 +228,23 @@ impl NetApp {
     }
 
     /// Gets details of a single Volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_volume()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_volume(&self) -> super::builder::net_app::GetVolume {
         super::builder::net_app::GetVolume::new(self.inner.clone())
     }
@@ -283,6 +317,23 @@ impl NetApp {
     }
 
     /// Describe a snapshot for a volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_snapshot()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_snapshot(&self) -> super::builder::net_app::GetSnapshot {
         super::builder::net_app::GetSnapshot::new(self.inner.clone())
     }
@@ -338,6 +389,23 @@ impl NetApp {
     }
 
     /// Describes a specified active directory.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_active_directory()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_active_directory(&self) -> super::builder::net_app::GetActiveDirectory {
         super::builder::net_app::GetActiveDirectory::new(self.inner.clone())
     }
@@ -409,6 +477,23 @@ impl NetApp {
     }
 
     /// Returns the description of the specified KMS config by kms_config_id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_kms_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_kms_config(&self) -> super::builder::net_app::GetKmsConfig {
         super::builder::net_app::GetKmsConfig::new(self.inner.clone())
     }
@@ -445,6 +530,22 @@ impl NetApp {
     }
 
     /// Verifies KMS config reachability.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_kms_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_kms_config(&self) -> super::builder::net_app::VerifyKmsConfig {
         super::builder::net_app::VerifyKmsConfig::new(self.inner.clone())
     }
@@ -470,6 +571,23 @@ impl NetApp {
     }
 
     /// Describe a replication for a volume.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_replication()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_replication(&self) -> super::builder::net_app::GetReplication {
         super::builder::net_app::GetReplication::new(self.inner.clone())
     }
@@ -614,6 +732,23 @@ impl NetApp {
     }
 
     /// Returns the description of the specified backup vault
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_vault()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_vault(&self) -> super::builder::net_app::GetBackupVault {
         super::builder::net_app::GetBackupVault::new(self.inner.clone())
     }
@@ -672,6 +807,23 @@ impl NetApp {
     }
 
     /// Returns the description of the specified backup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::net_app::GetBackup {
         super::builder::net_app::GetBackup::new(self.inner.clone())
     }
@@ -727,6 +879,23 @@ impl NetApp {
     }
 
     /// Returns the description of the specified backup policy by backup_policy_id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_policy(&self) -> super::builder::net_app::GetBackupPolicy {
         super::builder::net_app::GetBackupPolicy::new(self.inner.clone())
     }
@@ -772,6 +941,23 @@ impl NetApp {
     }
 
     /// Returns details of the specified quota rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_quota_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_quota_rule(&self) -> super::builder::net_app::GetQuotaRule {
         super::builder::net_app::GetQuotaRule::new(self.inner.clone())
     }
@@ -827,6 +1013,22 @@ impl NetApp {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::net_app::GetLocation {
         super::builder::net_app::GetLocation::new(self.inner.clone())
     }
@@ -841,6 +1043,22 @@ impl NetApp {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::net_app::GetOperation {
         super::builder::net_app::GetOperation::new(self.inner.clone())
     }
@@ -848,6 +1066,21 @@ impl NetApp {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::net_app::DeleteOperation {
         super::builder::net_app::DeleteOperation::new(self.inner.clone())
     }
@@ -855,6 +1088,21 @@ impl NetApp {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_netapp_v1::client::NetApp;
+    /// async fn sample(
+    ///    client: &NetApp
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::net_app::CancelOperation {
         super::builder::net_app::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/networkconnectivity/v1/src/client.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/client.rs
@@ -132,6 +132,23 @@ impl CrossNetworkAutomationService {
     }
 
     /// Gets details of a single ServiceConnectionMap.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_connection_map()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_connection_map(
         &self,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionMap {
@@ -207,6 +224,23 @@ impl CrossNetworkAutomationService {
     }
 
     /// Gets details of a single ServiceConnectionPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_connection_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_connection_policy(
         &self,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionPolicy {
@@ -282,6 +316,23 @@ impl CrossNetworkAutomationService {
     }
 
     /// Gets details of a single ServiceClass.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_class()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_class(
         &self,
     ) -> super::builder::cross_network_automation_service::GetServiceClass {
@@ -327,6 +378,23 @@ impl CrossNetworkAutomationService {
     }
 
     /// Gets details of a single ServiceConnectionToken.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_connection_token()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_connection_token(
         &self,
     ) -> super::builder::cross_network_automation_service::GetServiceConnectionToken {
@@ -390,6 +458,22 @@ impl CrossNetworkAutomationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cross_network_automation_service::GetLocation {
         super::builder::cross_network_automation_service::GetLocation::new(self.inner.clone())
     }
@@ -399,12 +483,44 @@ impl CrossNetworkAutomationService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cross_network_automation_service::SetIamPolicy {
         super::builder::cross_network_automation_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cross_network_automation_service::GetIamPolicy {
         super::builder::cross_network_automation_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -416,6 +532,22 @@ impl CrossNetworkAutomationService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::cross_network_automation_service::TestIamPermissions {
@@ -436,6 +568,22 @@ impl CrossNetworkAutomationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cross_network_automation_service::GetOperation {
         super::builder::cross_network_automation_service::GetOperation::new(self.inner.clone())
     }
@@ -443,6 +591,21 @@ impl CrossNetworkAutomationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::cross_network_automation_service::DeleteOperation {
@@ -452,6 +615,21 @@ impl CrossNetworkAutomationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+    /// async fn sample(
+    ///    client: &CrossNetworkAutomationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::cross_network_automation_service::CancelOperation {
@@ -575,6 +753,23 @@ impl DataTransferService {
     }
 
     /// Gets the details of a `MulticloudDataTransferConfig` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_multicloud_data_transfer_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_multicloud_data_transfer_config(
         &self,
     ) -> super::builder::data_transfer_service::GetMulticloudDataTransferConfig {
@@ -648,6 +843,23 @@ impl DataTransferService {
     }
 
     /// Gets the details of a `Destination` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_destination()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_destination(&self) -> super::builder::data_transfer_service::GetDestination {
         super::builder::data_transfer_service::GetDestination::new(self.inner.clone())
     }
@@ -699,6 +911,23 @@ impl DataTransferService {
 
     /// Gets the details of a service that is supported for Data Transfer
     /// Essentials.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_multicloud_data_transfer_supported_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_multicloud_data_transfer_supported_service(
         &self,
     ) -> super::builder::data_transfer_service::GetMulticloudDataTransferSupportedService {
@@ -723,6 +952,22 @@ impl DataTransferService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::data_transfer_service::GetLocation {
         super::builder::data_transfer_service::GetLocation::new(self.inner.clone())
     }
@@ -732,12 +977,44 @@ impl DataTransferService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::data_transfer_service::SetIamPolicy {
         super::builder::data_transfer_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::data_transfer_service::GetIamPolicy {
         super::builder::data_transfer_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -749,6 +1026,22 @@ impl DataTransferService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::data_transfer_service::TestIamPermissions {
@@ -765,6 +1058,22 @@ impl DataTransferService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::data_transfer_service::GetOperation {
         super::builder::data_transfer_service::GetOperation::new(self.inner.clone())
     }
@@ -772,6 +1081,21 @@ impl DataTransferService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::data_transfer_service::DeleteOperation {
         super::builder::data_transfer_service::DeleteOperation::new(self.inner.clone())
     }
@@ -779,6 +1103,21 @@ impl DataTransferService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
+    /// async fn sample(
+    ///    client: &DataTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::data_transfer_service::CancelOperation {
         super::builder::data_transfer_service::CancelOperation::new(self.inner.clone())
     }
@@ -894,6 +1233,23 @@ impl HubService {
     }
 
     /// Gets details about a Network Connectivity Center hub.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_hub()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_hub(&self) -> super::builder::hub_service::GetHub {
         super::builder::hub_service::GetHub::new(self.inner.clone())
     }
@@ -964,6 +1320,23 @@ impl HubService {
     }
 
     /// Gets details about a Network Connectivity Center spoke.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_spoke()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_spoke(&self) -> super::builder::hub_service::GetSpoke {
         super::builder::hub_service::GetSpoke::new(self.inner.clone())
     }
@@ -1078,11 +1451,45 @@ impl HubService {
     }
 
     /// Gets details about a Network Connectivity Center route table.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_route_table()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_route_table(&self) -> super::builder::hub_service::GetRouteTable {
         super::builder::hub_service::GetRouteTable::new(self.inner.clone())
     }
 
     /// Gets details about the specified route.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_route(&self) -> super::builder::hub_service::GetRoute {
         super::builder::hub_service::GetRoute::new(self.inner.clone())
     }
@@ -1098,6 +1505,23 @@ impl HubService {
     }
 
     /// Gets details about a Network Connectivity Center group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_group(&self) -> super::builder::hub_service::GetGroup {
         super::builder::hub_service::GetGroup::new(self.inner.clone())
     }
@@ -1128,6 +1552,22 @@ impl HubService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::hub_service::GetLocation {
         super::builder::hub_service::GetLocation::new(self.inner.clone())
     }
@@ -1137,12 +1577,44 @@ impl HubService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::hub_service::SetIamPolicy {
         super::builder::hub_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::hub_service::GetIamPolicy {
         super::builder::hub_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1154,6 +1626,22 @@ impl HubService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::hub_service::TestIamPermissions {
         super::builder::hub_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1168,6 +1656,22 @@ impl HubService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::hub_service::GetOperation {
         super::builder::hub_service::GetOperation::new(self.inner.clone())
     }
@@ -1175,6 +1679,21 @@ impl HubService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::hub_service::DeleteOperation {
         super::builder::hub_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1182,6 +1701,21 @@ impl HubService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::HubService;
+    /// async fn sample(
+    ///    client: &HubService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::hub_service::CancelOperation {
         super::builder::hub_service::CancelOperation::new(self.inner.clone())
     }
@@ -1301,6 +1835,23 @@ impl InternalRangeService {
     }
 
     /// Gets details of a single internal range.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_internal_range()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_internal_range(&self) -> super::builder::internal_range_service::GetInternalRange {
         super::builder::internal_range_service::GetInternalRange::new(self.inner.clone())
     }
@@ -1362,6 +1913,22 @@ impl InternalRangeService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::internal_range_service::GetLocation {
         super::builder::internal_range_service::GetLocation::new(self.inner.clone())
     }
@@ -1371,12 +1938,44 @@ impl InternalRangeService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::internal_range_service::SetIamPolicy {
         super::builder::internal_range_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::internal_range_service::GetIamPolicy {
         super::builder::internal_range_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1388,6 +1987,22 @@ impl InternalRangeService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::internal_range_service::TestIamPermissions {
@@ -1404,6 +2019,22 @@ impl InternalRangeService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::internal_range_service::GetOperation {
         super::builder::internal_range_service::GetOperation::new(self.inner.clone())
     }
@@ -1411,6 +2042,21 @@ impl InternalRangeService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::internal_range_service::DeleteOperation {
         super::builder::internal_range_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1418,6 +2064,21 @@ impl InternalRangeService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
+    /// async fn sample(
+    ///    client: &InternalRangeService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::internal_range_service::CancelOperation {
         super::builder::internal_range_service::CancelOperation::new(self.inner.clone())
     }
@@ -1538,6 +2199,23 @@ impl PolicyBasedRoutingService {
     }
 
     /// Gets details of a single policy-based route.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy_based_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy_based_route(
         &self,
     ) -> super::builder::policy_based_routing_service::GetPolicyBasedRoute {
@@ -1588,6 +2266,22 @@ impl PolicyBasedRoutingService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::policy_based_routing_service::GetLocation {
         super::builder::policy_based_routing_service::GetLocation::new(self.inner.clone())
     }
@@ -1597,12 +2291,44 @@ impl PolicyBasedRoutingService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::policy_based_routing_service::SetIamPolicy {
         super::builder::policy_based_routing_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::policy_based_routing_service::GetIamPolicy {
         super::builder::policy_based_routing_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1614,6 +2340,22 @@ impl PolicyBasedRoutingService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::policy_based_routing_service::TestIamPermissions {
@@ -1630,6 +2372,22 @@ impl PolicyBasedRoutingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::policy_based_routing_service::GetOperation {
         super::builder::policy_based_routing_service::GetOperation::new(self.inner.clone())
     }
@@ -1637,6 +2395,21 @@ impl PolicyBasedRoutingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::policy_based_routing_service::DeleteOperation {
@@ -1646,6 +2419,21 @@ impl PolicyBasedRoutingService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
+    /// async fn sample(
+    ///    client: &PolicyBasedRoutingService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::policy_based_routing_service::CancelOperation {

--- a/src/generated/cloud/networkmanagement/v1/src/client.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/client.rs
@@ -136,6 +136,23 @@ impl ReachabilityService {
     }
 
     /// Gets the details of a specific Connectivity Test.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connectivity_test()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connectivity_test(
         &self,
     ) -> super::builder::reachability_service::GetConnectivityTest {
@@ -252,6 +269,22 @@ impl ReachabilityService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::reachability_service::GetLocation {
         super::builder::reachability_service::GetLocation::new(self.inner.clone())
     }
@@ -261,12 +294,44 @@ impl ReachabilityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::reachability_service::SetIamPolicy {
         super::builder::reachability_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::reachability_service::GetIamPolicy {
         super::builder::reachability_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -278,6 +343,22 @@ impl ReachabilityService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::reachability_service::TestIamPermissions {
         super::builder::reachability_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -292,6 +373,22 @@ impl ReachabilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::reachability_service::GetOperation {
         super::builder::reachability_service::GetOperation::new(self.inner.clone())
     }
@@ -299,6 +396,21 @@ impl ReachabilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::reachability_service::DeleteOperation {
         super::builder::reachability_service::DeleteOperation::new(self.inner.clone())
     }
@@ -306,6 +418,21 @@ impl ReachabilityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+    /// async fn sample(
+    ///    client: &ReachabilityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::reachability_service::CancelOperation {
         super::builder::reachability_service::CancelOperation::new(self.inner.clone())
     }
@@ -426,6 +553,23 @@ impl VpcFlowLogsService {
     }
 
     /// Gets the details of a specific `VpcFlowLogsConfig`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vpc_flow_logs_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vpc_flow_logs_config(
         &self,
     ) -> super::builder::vpc_flow_logs_service::GetVpcFlowLogsConfig {
@@ -533,6 +677,22 @@ impl VpcFlowLogsService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vpc_flow_logs_service::GetLocation {
         super::builder::vpc_flow_logs_service::GetLocation::new(self.inner.clone())
     }
@@ -542,12 +702,44 @@ impl VpcFlowLogsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::vpc_flow_logs_service::SetIamPolicy {
         super::builder::vpc_flow_logs_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::vpc_flow_logs_service::GetIamPolicy {
         super::builder::vpc_flow_logs_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -559,6 +751,22 @@ impl VpcFlowLogsService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::vpc_flow_logs_service::TestIamPermissions {
@@ -575,6 +783,22 @@ impl VpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vpc_flow_logs_service::GetOperation {
         super::builder::vpc_flow_logs_service::GetOperation::new(self.inner.clone())
     }
@@ -582,6 +806,21 @@ impl VpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vpc_flow_logs_service::DeleteOperation {
         super::builder::vpc_flow_logs_service::DeleteOperation::new(self.inner.clone())
     }
@@ -589,6 +828,21 @@ impl VpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &VpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::vpc_flow_logs_service::CancelOperation {
         super::builder::vpc_flow_logs_service::CancelOperation::new(self.inner.clone())
     }
@@ -713,6 +967,23 @@ impl OrganizationVpcFlowLogsService {
     }
 
     /// Gets the details of a specific `VpcFlowLogsConfig`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vpc_flow_logs_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vpc_flow_logs_config(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::GetVpcFlowLogsConfig {
@@ -814,6 +1085,22 @@ impl OrganizationVpcFlowLogsService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::organization_vpc_flow_logs_service::GetLocation {
         super::builder::organization_vpc_flow_logs_service::GetLocation::new(self.inner.clone())
     }
@@ -823,6 +1110,22 @@ impl OrganizationVpcFlowLogsService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::SetIamPolicy {
@@ -831,6 +1134,22 @@ impl OrganizationVpcFlowLogsService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::GetIamPolicy {
@@ -844,6 +1163,22 @@ impl OrganizationVpcFlowLogsService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::TestIamPermissions {
@@ -864,6 +1199,22 @@ impl OrganizationVpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::GetOperation {
@@ -873,6 +1224,21 @@ impl OrganizationVpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::DeleteOperation {
@@ -882,6 +1248,21 @@ impl OrganizationVpcFlowLogsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
+    /// async fn sample(
+    ///    client: &OrganizationVpcFlowLogsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::organization_vpc_flow_logs_service::CancelOperation {

--- a/src/generated/cloud/networksecurity/v1/src/client.rs
+++ b/src/generated/cloud/networksecurity/v1/src/client.rs
@@ -129,6 +129,23 @@ impl AddressGroupService {
     }
 
     /// Gets details of a single address group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_address_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_address_group(&self) -> super::builder::address_group_service::GetAddressGroup {
         super::builder::address_group_service::GetAddressGroup::new(self.inner.clone())
     }
@@ -248,6 +265,22 @@ impl AddressGroupService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::address_group_service::GetLocation {
         super::builder::address_group_service::GetLocation::new(self.inner.clone())
     }
@@ -257,12 +290,44 @@ impl AddressGroupService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::address_group_service::SetIamPolicy {
         super::builder::address_group_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::address_group_service::GetIamPolicy {
         super::builder::address_group_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -274,6 +339,22 @@ impl AddressGroupService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::address_group_service::TestIamPermissions {
@@ -290,6 +371,22 @@ impl AddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::address_group_service::GetOperation {
         super::builder::address_group_service::GetOperation::new(self.inner.clone())
     }
@@ -297,6 +394,21 @@ impl AddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::address_group_service::DeleteOperation {
         super::builder::address_group_service::DeleteOperation::new(self.inner.clone())
     }
@@ -304,6 +416,21 @@ impl AddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
+    /// async fn sample(
+    ///    client: &AddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::address_group_service::CancelOperation {
         super::builder::address_group_service::CancelOperation::new(self.inner.clone())
     }
@@ -427,6 +554,23 @@ impl OrganizationAddressGroupService {
     }
 
     /// Gets details of a single address group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_address_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_address_group(
         &self,
     ) -> super::builder::organization_address_group_service::GetAddressGroup {
@@ -564,6 +708,22 @@ impl OrganizationAddressGroupService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::organization_address_group_service::GetLocation {
         super::builder::organization_address_group_service::GetLocation::new(self.inner.clone())
     }
@@ -573,6 +733,22 @@ impl OrganizationAddressGroupService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(
         &self,
     ) -> super::builder::organization_address_group_service::SetIamPolicy {
@@ -581,6 +757,22 @@ impl OrganizationAddressGroupService {
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(
         &self,
     ) -> super::builder::organization_address_group_service::GetIamPolicy {
@@ -594,6 +786,22 @@ impl OrganizationAddressGroupService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::organization_address_group_service::TestIamPermissions {
@@ -614,6 +822,22 @@ impl OrganizationAddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::organization_address_group_service::GetOperation {
@@ -623,6 +847,21 @@ impl OrganizationAddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::organization_address_group_service::DeleteOperation {
@@ -632,6 +871,21 @@ impl OrganizationAddressGroupService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
+    /// async fn sample(
+    ///    client: &OrganizationAddressGroupService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::organization_address_group_service::CancelOperation {
@@ -754,6 +1008,23 @@ impl NetworkSecurity {
     }
 
     /// Gets details of a single AuthorizationPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_authorization_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_authorization_policy(
         &self,
     ) -> super::builder::network_security::GetAuthorizationPolicy {
@@ -819,6 +1090,23 @@ impl NetworkSecurity {
     }
 
     /// Gets details of a single ServerTlsPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_server_tls_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_server_tls_policy(&self) -> super::builder::network_security::GetServerTlsPolicy {
         super::builder::network_security::GetServerTlsPolicy::new(self.inner.clone())
     }
@@ -882,6 +1170,23 @@ impl NetworkSecurity {
     }
 
     /// Gets details of a single ClientTlsPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_client_tls_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_client_tls_policy(&self) -> super::builder::network_security::GetClientTlsPolicy {
         super::builder::network_security::GetClientTlsPolicy::new(self.inner.clone())
     }
@@ -943,6 +1248,22 @@ impl NetworkSecurity {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::network_security::GetLocation {
         super::builder::network_security::GetLocation::new(self.inner.clone())
     }
@@ -952,12 +1273,44 @@ impl NetworkSecurity {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::network_security::SetIamPolicy {
         super::builder::network_security::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::network_security::GetIamPolicy {
         super::builder::network_security::GetIamPolicy::new(self.inner.clone())
     }
@@ -969,6 +1322,22 @@ impl NetworkSecurity {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::network_security::TestIamPermissions {
         super::builder::network_security::TestIamPermissions::new(self.inner.clone())
     }
@@ -983,6 +1352,22 @@ impl NetworkSecurity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_security::GetOperation {
         super::builder::network_security::GetOperation::new(self.inner.clone())
     }
@@ -990,6 +1375,21 @@ impl NetworkSecurity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::network_security::DeleteOperation {
         super::builder::network_security::DeleteOperation::new(self.inner.clone())
     }
@@ -997,6 +1397,21 @@ impl NetworkSecurity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+    /// async fn sample(
+    ///    client: &NetworkSecurity
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::network_security::CancelOperation {
         super::builder::network_security::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/networkservices/v1/src/client.rs
+++ b/src/generated/cloud/networkservices/v1/src/client.rs
@@ -126,6 +126,23 @@ impl DepService {
     }
 
     /// Gets details of the specified `LbTrafficExtension` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lb_traffic_extension()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lb_traffic_extension(&self) -> super::builder::dep_service::GetLbTrafficExtension {
         super::builder::dep_service::GetLbTrafficExtension::new(self.inner.clone())
     }
@@ -188,6 +205,23 @@ impl DepService {
     }
 
     /// Gets details of the specified `LbRouteExtension` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lb_route_extension()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lb_route_extension(&self) -> super::builder::dep_service::GetLbRouteExtension {
         super::builder::dep_service::GetLbRouteExtension::new(self.inner.clone())
     }
@@ -243,6 +277,23 @@ impl DepService {
     }
 
     /// Gets details of the specified `LbEdgeExtension` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_lb_edge_extension()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_lb_edge_extension(&self) -> super::builder::dep_service::GetLbEdgeExtension {
         super::builder::dep_service::GetLbEdgeExtension::new(self.inner.clone())
     }
@@ -298,6 +349,23 @@ impl DepService {
     }
 
     /// Gets details of the specified `AuthzExtension` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_authz_extension()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_authz_extension(&self) -> super::builder::dep_service::GetAuthzExtension {
         super::builder::dep_service::GetAuthzExtension::new(self.inner.clone())
     }
@@ -355,6 +423,22 @@ impl DepService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::dep_service::GetLocation {
         super::builder::dep_service::GetLocation::new(self.inner.clone())
     }
@@ -364,12 +448,44 @@ impl DepService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::dep_service::SetIamPolicy {
         super::builder::dep_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::dep_service::GetIamPolicy {
         super::builder::dep_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -381,6 +497,22 @@ impl DepService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::dep_service::TestIamPermissions {
         super::builder::dep_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -395,6 +527,22 @@ impl DepService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::dep_service::GetOperation {
         super::builder::dep_service::GetOperation::new(self.inner.clone())
     }
@@ -402,6 +550,21 @@ impl DepService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::dep_service::DeleteOperation {
         super::builder::dep_service::DeleteOperation::new(self.inner.clone())
     }
@@ -409,6 +572,21 @@ impl DepService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::DepService;
+    /// async fn sample(
+    ///    client: &DepService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::dep_service::CancelOperation {
         super::builder::dep_service::CancelOperation::new(self.inner.clone())
     }
@@ -525,6 +703,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single EndpointPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_endpoint_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_endpoint_policy(&self) -> super::builder::network_services::GetEndpointPolicy {
         super::builder::network_services::GetEndpointPolicy::new(self.inner.clone())
     }
@@ -583,6 +778,23 @@ impl NetworkServices {
     }
 
     /// Gets details of the specified `WasmPluginVersion` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_wasm_plugin_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_wasm_plugin_version(
         &self,
     ) -> super::builder::network_services::GetWasmPluginVersion {
@@ -631,6 +843,23 @@ impl NetworkServices {
     }
 
     /// Gets details of the specified `WasmPlugin` resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_wasm_plugin()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_wasm_plugin(&self) -> super::builder::network_services::GetWasmPlugin {
         super::builder::network_services::GetWasmPlugin::new(self.inner.clone())
     }
@@ -687,6 +916,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single Gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_gateway()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_gateway(&self) -> super::builder::network_services::GetGateway {
         super::builder::network_services::GetGateway::new(self.inner.clone())
     }
@@ -742,6 +988,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single GrpcRoute.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_grpc_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_grpc_route(&self) -> super::builder::network_services::GetGrpcRoute {
         super::builder::network_services::GetGrpcRoute::new(self.inner.clone())
     }
@@ -797,6 +1060,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single HttpRoute.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_http_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_http_route(&self) -> super::builder::network_services::GetHttpRoute {
         super::builder::network_services::GetHttpRoute::new(self.inner.clone())
     }
@@ -852,6 +1132,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single TcpRoute.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tcp_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tcp_route(&self) -> super::builder::network_services::GetTcpRoute {
         super::builder::network_services::GetTcpRoute::new(self.inner.clone())
     }
@@ -907,6 +1204,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single TlsRoute.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tls_route()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tls_route(&self) -> super::builder::network_services::GetTlsRoute {
         super::builder::network_services::GetTlsRoute::new(self.inner.clone())
     }
@@ -962,6 +1276,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single ServiceBinding.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_binding(&self) -> super::builder::network_services::GetServiceBinding {
         super::builder::network_services::GetServiceBinding::new(self.inner.clone())
     }
@@ -1017,6 +1348,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single Mesh.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_mesh()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_mesh(&self) -> super::builder::network_services::GetMesh {
         super::builder::network_services::GetMesh::new(self.inner.clone())
     }
@@ -1074,6 +1422,23 @@ impl NetworkServices {
     }
 
     /// Gets details of a single ServiceLbPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_lb_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_lb_policy(&self) -> super::builder::network_services::GetServiceLbPolicy {
         super::builder::network_services::GetServiceLbPolicy::new(self.inner.clone())
     }
@@ -1130,11 +1495,45 @@ impl NetworkServices {
     }
 
     /// Get a single RouteView of a Gateway.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_gateway_route_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_gateway_route_view(&self) -> super::builder::network_services::GetGatewayRouteView {
         super::builder::network_services::GetGatewayRouteView::new(self.inner.clone())
     }
 
     /// Get a single RouteView of a Mesh.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_mesh_route_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_mesh_route_view(&self) -> super::builder::network_services::GetMeshRouteView {
         super::builder::network_services::GetMeshRouteView::new(self.inner.clone())
     }
@@ -1157,6 +1556,22 @@ impl NetworkServices {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::network_services::GetLocation {
         super::builder::network_services::GetLocation::new(self.inner.clone())
     }
@@ -1166,12 +1581,44 @@ impl NetworkServices {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::network_services::SetIamPolicy {
         super::builder::network_services::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::network_services::GetIamPolicy {
         super::builder::network_services::GetIamPolicy::new(self.inner.clone())
     }
@@ -1183,6 +1630,22 @@ impl NetworkServices {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::network_services::TestIamPermissions {
         super::builder::network_services::TestIamPermissions::new(self.inner.clone())
     }
@@ -1197,6 +1660,22 @@ impl NetworkServices {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::network_services::GetOperation {
         super::builder::network_services::GetOperation::new(self.inner.clone())
     }
@@ -1204,6 +1683,21 @@ impl NetworkServices {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::network_services::DeleteOperation {
         super::builder::network_services::DeleteOperation::new(self.inner.clone())
     }
@@ -1211,6 +1705,21 @@ impl NetworkServices {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_networkservices_v1::client::NetworkServices;
+    /// async fn sample(
+    ///    client: &NetworkServices
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::network_services::CancelOperation {
         super::builder::network_services::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/notebooks/v2/src/client.rs
+++ b/src/generated/cloud/notebooks/v2/src/client.rs
@@ -127,6 +127,23 @@ impl NotebookService {
     }
 
     /// Gets details of a single Instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::notebook_service::GetInstance {
         super::builder::notebook_service::GetInstance::new(self.inner.clone())
     }
@@ -222,6 +239,22 @@ impl NotebookService {
     }
 
     /// Checks whether a notebook instance is upgradable.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_instance_upgradability()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_instance_upgradability(
         &self,
     ) -> super::builder::notebook_service::CheckInstanceUpgradability {
@@ -279,6 +312,22 @@ impl NotebookService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::notebook_service::GetLocation {
         super::builder::notebook_service::GetLocation::new(self.inner.clone())
     }
@@ -288,12 +337,44 @@ impl NotebookService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::notebook_service::SetIamPolicy {
         super::builder::notebook_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::notebook_service::GetIamPolicy {
         super::builder::notebook_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -305,6 +386,22 @@ impl NotebookService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::notebook_service::TestIamPermissions {
         super::builder::notebook_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -319,6 +416,22 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::notebook_service::GetOperation {
         super::builder::notebook_service::GetOperation::new(self.inner.clone())
     }
@@ -326,6 +439,21 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::notebook_service::DeleteOperation {
         super::builder::notebook_service::DeleteOperation::new(self.inner.clone())
     }
@@ -333,6 +461,21 @@ impl NotebookService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_notebooks_v2::client::NotebookService;
+    /// async fn sample(
+    ///    client: &NotebookService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::notebook_service::CancelOperation {
         super::builder::notebook_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/optimization/v1/src/client.rs
+++ b/src/generated/cloud/optimization/v1/src/client.rs
@@ -148,6 +148,22 @@ impl FleetRouting {
     /// The goal is to provide an assignment of `ShipmentRoute`s to `Vehicle`s that
     /// minimizes the total cost where cost has many components defined in the
     /// `ShipmentModel`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_optimization_v1::client::FleetRouting;
+    /// async fn sample(
+    ///    client: &FleetRouting
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .optimize_tours()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn optimize_tours(&self) -> super::builder::fleet_routing::OptimizeTours {
         super::builder::fleet_routing::OptimizeTours::new(self.inner.clone())
     }
@@ -179,6 +195,22 @@ impl FleetRouting {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_optimization_v1::client::FleetRouting;
+    /// async fn sample(
+    ///    client: &FleetRouting
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::fleet_routing::GetOperation {
         super::builder::fleet_routing::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/oracledatabase/v1/src/client.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/client.rs
@@ -126,6 +126,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single Exadata Infrastructure.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cloud_exadata_infrastructure()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cloud_exadata_infrastructure(
         &self,
     ) -> super::builder::oracle_database::GetCloudExadataInfrastructure {
@@ -172,6 +189,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single VM Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cloud_vm_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cloud_vm_cluster(&self) -> super::builder::oracle_database::GetCloudVmCluster {
         super::builder::oracle_database::GetCloudVmCluster::new(self.inner.clone())
     }
@@ -246,6 +280,23 @@ impl OracleDatabase {
     }
 
     /// Gets the details of a single Autonomous Database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_autonomous_database()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_autonomous_database(
         &self,
     ) -> super::builder::oracle_database::GetAutonomousDatabase {
@@ -321,6 +372,22 @@ impl OracleDatabase {
     }
 
     /// Generates a wallet for an Autonomous Database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_autonomous_database_wallet()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_autonomous_database_wallet(
         &self,
     ) -> super::builder::oracle_database::GenerateAutonomousDatabaseWallet {
@@ -444,6 +511,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single ODB Network.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_odb_network()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_odb_network(&self) -> super::builder::oracle_database::GetOdbNetwork {
         super::builder::oracle_database::GetOdbNetwork::new(self.inner.clone())
     }
@@ -484,6 +568,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single ODB Subnet.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_odb_subnet()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_odb_subnet(&self) -> super::builder::oracle_database::GetOdbSubnet {
         super::builder::oracle_database::GetOdbSubnet::new(self.inner.clone())
     }
@@ -525,6 +626,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single Exadb (Exascale) VM Cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_exadb_vm_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_exadb_vm_cluster(&self) -> super::builder::oracle_database::GetExadbVmCluster {
         super::builder::oracle_database::GetExadbVmCluster::new(self.inner.clone())
     }
@@ -601,6 +719,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single ExascaleDB Storage Vault.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_exascale_db_storage_vault()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_exascale_db_storage_vault(
         &self,
     ) -> super::builder::oracle_database::GetExascaleDbStorageVault {
@@ -655,6 +790,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single Database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_database()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_database(&self) -> super::builder::oracle_database::GetDatabase {
         super::builder::oracle_database::GetDatabase::new(self.inner.clone())
     }
@@ -668,6 +820,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single PluggableDatabase.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pluggable_database()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pluggable_database(&self) -> super::builder::oracle_database::GetPluggableDatabase {
         super::builder::oracle_database::GetPluggableDatabase::new(self.inner.clone())
     }
@@ -678,6 +847,23 @@ impl OracleDatabase {
     }
 
     /// Gets details of a single DbSystem.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_db_system()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_db_system(&self) -> super::builder::oracle_database::GetDbSystem {
         super::builder::oracle_database::GetDbSystem::new(self.inner.clone())
     }
@@ -730,6 +916,22 @@ impl OracleDatabase {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::oracle_database::GetLocation {
         super::builder::oracle_database::GetLocation::new(self.inner.clone())
     }
@@ -744,6 +946,22 @@ impl OracleDatabase {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::oracle_database::GetOperation {
         super::builder::oracle_database::GetOperation::new(self.inner.clone())
     }
@@ -751,6 +969,21 @@ impl OracleDatabase {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::oracle_database::DeleteOperation {
         super::builder::oracle_database::DeleteOperation::new(self.inner.clone())
     }
@@ -758,6 +991,21 @@ impl OracleDatabase {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+    /// async fn sample(
+    ///    client: &OracleDatabase
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::oracle_database::CancelOperation {
         super::builder::oracle_database::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
@@ -134,6 +134,22 @@ impl Environments {
     }
 
     /// Get an existing environment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_environment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_environment(&self) -> super::builder::environments::GetEnvironment {
         super::builder::environments::GetEnvironment::new(self.inner.clone())
     }
@@ -174,16 +190,64 @@ impl Environments {
     }
 
     /// Executes Airflow CLI command.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .execute_airflow_command()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn execute_airflow_command(&self) -> super::builder::environments::ExecuteAirflowCommand {
         super::builder::environments::ExecuteAirflowCommand::new(self.inner.clone())
     }
 
     /// Stops Airflow CLI command execution.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_airflow_command()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_airflow_command(&self) -> super::builder::environments::StopAirflowCommand {
         super::builder::environments::StopAirflowCommand::new(self.inner.clone())
     }
 
     /// Polls Airflow CLI command execution and fetches logs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .poll_airflow_command()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn poll_airflow_command(&self) -> super::builder::environments::PollAirflowCommand {
         super::builder::environments::PollAirflowCommand::new(self.inner.clone())
     }
@@ -218,6 +282,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_user_workloads_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_user_workloads_secret(
         &self,
     ) -> super::builder::environments::CreateUserWorkloadsSecret {
@@ -229,6 +309,23 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_user_workloads_secret()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_user_workloads_secret(
         &self,
     ) -> super::builder::environments::GetUserWorkloadsSecret {
@@ -249,6 +346,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_user_workloads_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_user_workloads_secret(
         &self,
     ) -> super::builder::environments::UpdateUserWorkloadsSecret {
@@ -259,6 +372,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_user_workloads_secret()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_user_workloads_secret(
         &self,
     ) -> super::builder::environments::DeleteUserWorkloadsSecret {
@@ -269,6 +398,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_user_workloads_config_map()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_user_workloads_config_map(
         &self,
     ) -> super::builder::environments::CreateUserWorkloadsConfigMap {
@@ -279,6 +424,23 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_user_workloads_config_map()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_user_workloads_config_map(
         &self,
     ) -> super::builder::environments::GetUserWorkloadsConfigMap {
@@ -299,6 +461,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_user_workloads_config_map()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_user_workloads_config_map(
         &self,
     ) -> super::builder::environments::UpdateUserWorkloadsConfigMap {
@@ -309,6 +487,22 @@ impl Environments {
     ///
     /// This method is supported for Cloud Composer environments in versions
     /// composer-3-airflow-*.*.*-build.* and newer.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_user_workloads_config_map()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_user_workloads_config_map(
         &self,
     ) -> super::builder::environments::DeleteUserWorkloadsConfigMap {
@@ -367,6 +561,22 @@ impl Environments {
     }
 
     /// Fetches database properties.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_database_properties()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_database_properties(
         &self,
     ) -> super::builder::environments::FetchDatabaseProperties {
@@ -383,6 +593,22 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::environments::GetOperation {
         super::builder::environments::GetOperation::new(self.inner.clone())
     }
@@ -390,6 +616,21 @@ impl Environments {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+    /// async fn sample(
+    ///    client: &Environments
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::environments::DeleteOperation {
         super::builder::environments::DeleteOperation::new(self.inner.clone())
     }
@@ -512,6 +753,22 @@ impl ImageVersions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::ImageVersions;
+    /// async fn sample(
+    ///    client: &ImageVersions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::image_versions::GetOperation {
         super::builder::image_versions::GetOperation::new(self.inner.clone())
     }
@@ -519,6 +776,21 @@ impl ImageVersions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orchestration_airflow_service_v1::client::ImageVersions;
+    /// async fn sample(
+    ///    client: &ImageVersions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::image_versions::DeleteOperation {
         super::builder::image_versions::DeleteOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/orgpolicy/v2/src/client.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/client.rs
@@ -152,6 +152,23 @@ impl OrgPolicy {
     /// If no policy is set on the resource, `NOT_FOUND` is returned. The
     /// `etag` value can be used with `UpdatePolicy()` to update a
     /// policy during read-modify-write.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy(&self) -> super::builder::org_policy::GetPolicy {
         super::builder::org_policy::GetPolicy::new(self.inner.clone())
     }
@@ -162,6 +179,23 @@ impl OrgPolicy {
     /// an evaluated policy across multiple resources.
     /// Subtrees of Resource Manager resource hierarchy with 'under:' prefix will
     /// not be expanded.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_effective_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_effective_policy(&self) -> super::builder::org_policy::GetEffectivePolicy {
         super::builder::org_policy::GetEffectivePolicy::new(self.inner.clone())
     }
@@ -172,6 +206,22 @@ impl OrgPolicy {
     /// constraint does not exist.
     /// Returns a `google.rpc.Status` with `google.rpc.Code.ALREADY_EXISTS` if the
     /// policy already exists on the given Google Cloud resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_policy(&self) -> super::builder::org_policy::CreatePolicy {
         super::builder::org_policy::CreatePolicy::new(self.inner.clone())
     }
@@ -185,6 +235,22 @@ impl OrgPolicy {
     ///
     /// Note: the supplied policy will perform a full overwrite of all
     /// fields.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_policy(&self) -> super::builder::org_policy::UpdatePolicy {
         super::builder::org_policy::UpdatePolicy::new(self.inner.clone())
     }
@@ -193,6 +259,21 @@ impl OrgPolicy {
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// constraint or organization policy does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_policy(&self) -> super::builder::org_policy::DeletePolicy {
         super::builder::org_policy::DeletePolicy::new(self.inner.clone())
     }
@@ -203,6 +284,22 @@ impl OrgPolicy {
     /// organization does not exist.
     /// Returns a `google.rpc.Status` with `google.rpc.Code.ALREADY_EXISTS` if the
     /// constraint already exists on the given organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_custom_constraint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_custom_constraint(&self) -> super::builder::org_policy::CreateCustomConstraint {
         super::builder::org_policy::CreateCustomConstraint::new(self.inner.clone())
     }
@@ -214,6 +311,22 @@ impl OrgPolicy {
     ///
     /// Note: the supplied policy will perform a full overwrite of all
     /// fields.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_custom_constraint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_custom_constraint(&self) -> super::builder::org_policy::UpdateCustomConstraint {
         super::builder::org_policy::UpdateCustomConstraint::new(self.inner.clone())
     }
@@ -222,6 +335,23 @@ impl OrgPolicy {
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// custom or managed constraint does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_custom_constraint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_custom_constraint(&self) -> super::builder::org_policy::GetCustomConstraint {
         super::builder::org_policy::GetCustomConstraint::new(self.inner.clone())
     }
@@ -236,6 +366,21 @@ impl OrgPolicy {
     ///
     /// Returns a `google.rpc.Status` with `google.rpc.Code.NOT_FOUND` if the
     /// constraint does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+    /// async fn sample(
+    ///    client: &OrgPolicy
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_custom_constraint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_custom_constraint(&self) -> super::builder::org_policy::DeleteCustomConstraint {
         super::builder::org_policy::DeleteCustomConstraint::new(self.inner.clone())
     }

--- a/src/generated/cloud/osconfig/v1/src/client.rs
+++ b/src/generated/cloud/osconfig/v1/src/client.rs
@@ -127,18 +127,67 @@ impl OsConfigService {
     }
 
     /// Patch VM instances by creating and running a patch job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .execute_patch_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn execute_patch_job(&self) -> super::builder::os_config_service::ExecutePatchJob {
         super::builder::os_config_service::ExecutePatchJob::new(self.inner.clone())
     }
 
     /// Get the patch job. This can be used to track the progress of an
     /// ongoing patch job or review the details of completed jobs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_patch_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_patch_job(&self) -> super::builder::os_config_service::GetPatchJob {
         super::builder::os_config_service::GetPatchJob::new(self.inner.clone())
     }
 
     /// Cancel a patch job. The patch job must be active. Canceled patch jobs
     /// cannot be restarted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_patch_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_patch_job(&self) -> super::builder::os_config_service::CancelPatchJob {
         super::builder::os_config_service::CancelPatchJob::new(self.inner.clone())
     }
@@ -156,6 +205,22 @@ impl OsConfigService {
     }
 
     /// Create an OS Config patch deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_patch_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_patch_deployment(
         &self,
     ) -> super::builder::os_config_service::CreatePatchDeployment {
@@ -163,6 +228,23 @@ impl OsConfigService {
     }
 
     /// Get an OS Config patch deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_patch_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_patch_deployment(&self) -> super::builder::os_config_service::GetPatchDeployment {
         super::builder::os_config_service::GetPatchDeployment::new(self.inner.clone())
     }
@@ -175,6 +257,21 @@ impl OsConfigService {
     }
 
     /// Delete an OS Config patch deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_patch_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_patch_deployment(
         &self,
     ) -> super::builder::os_config_service::DeletePatchDeployment {
@@ -182,6 +279,22 @@ impl OsConfigService {
     }
 
     /// Update an OS Config patch deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_patch_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_patch_deployment(
         &self,
     ) -> super::builder::os_config_service::UpdatePatchDeployment {
@@ -190,6 +303,22 @@ impl OsConfigService {
 
     /// Change state of patch deployment to "PAUSED".
     /// Patch deployment in paused state doesn't generate patch jobs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_patch_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_patch_deployment(
         &self,
     ) -> super::builder::os_config_service::PausePatchDeployment {
@@ -198,6 +327,22 @@ impl OsConfigService {
 
     /// Change state of patch deployment back to "ACTIVE".
     /// Patch deployment in active state continues to generate patch jobs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_patch_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_patch_deployment(
         &self,
     ) -> super::builder::os_config_service::ResumePatchDeployment {
@@ -207,6 +352,22 @@ impl OsConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::os_config_service::GetOperation {
         super::builder::os_config_service::GetOperation::new(self.inner.clone())
     }
@@ -214,6 +375,21 @@ impl OsConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigService;
+    /// async fn sample(
+    ///    client: &OsConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::os_config_service::CancelOperation {
         super::builder::os_config_service::CancelOperation::new(self.inner.clone())
     }
@@ -382,6 +558,23 @@ impl OsConfigZonalService {
     /// This method always returns the latest revision. In order to retrieve a
     /// previous revision of the assignment, also provide the revision ID in the
     /// `name` parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_os_policy_assignment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_os_policy_assignment(
         &self,
     ) -> super::builder::os_config_zonal_service::GetOSPolicyAssignment {
@@ -436,6 +629,23 @@ impl OsConfigZonalService {
 
     /// Get the OS policy asssignment report for the specified Compute Engine VM
     /// instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_os_policy_assignment_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_os_policy_assignment_report(
         &self,
     ) -> super::builder::os_config_zonal_service::GetOSPolicyAssignmentReport {
@@ -456,6 +666,23 @@ impl OsConfigZonalService {
 
     /// Get inventory data for the specified VM instance. If the VM has no
     /// associated inventory, the message `NOT_FOUND` is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_inventory()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_inventory(&self) -> super::builder::os_config_zonal_service::GetInventory {
         super::builder::os_config_zonal_service::GetInventory::new(self.inner.clone())
     }
@@ -467,6 +694,23 @@ impl OsConfigZonalService {
 
     /// Gets the vulnerability report for the specified VM instance. Only VMs with
     /// inventory data have vulnerability reports associated with them.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vulnerability_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vulnerability_report(
         &self,
     ) -> super::builder::os_config_zonal_service::GetVulnerabilityReport {
@@ -483,6 +727,22 @@ impl OsConfigZonalService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::os_config_zonal_service::GetOperation {
         super::builder::os_config_zonal_service::GetOperation::new(self.inner.clone())
     }
@@ -490,6 +750,21 @@ impl OsConfigZonalService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
+    /// async fn sample(
+    ///    client: &OsConfigZonalService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::os_config_zonal_service::CancelOperation {
         super::builder::os_config_zonal_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/oslogin/v1/src/client.rs
+++ b/src/generated/cloud/oslogin/v1/src/client.rs
@@ -124,27 +124,106 @@ impl OsLoginService {
     }
 
     /// Create an SSH public key
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_ssh_public_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_ssh_public_key(&self) -> super::builder::os_login_service::CreateSshPublicKey {
         super::builder::os_login_service::CreateSshPublicKey::new(self.inner.clone())
     }
 
     /// Deletes a POSIX account.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_posix_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_posix_account(&self) -> super::builder::os_login_service::DeletePosixAccount {
         super::builder::os_login_service::DeletePosixAccount::new(self.inner.clone())
     }
 
     /// Deletes an SSH public key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_ssh_public_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_ssh_public_key(&self) -> super::builder::os_login_service::DeleteSshPublicKey {
         super::builder::os_login_service::DeleteSshPublicKey::new(self.inner.clone())
     }
 
     /// Retrieves the profile information used for logging in to a virtual machine
     /// on Google Compute Engine.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_login_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_login_profile(&self) -> super::builder::os_login_service::GetLoginProfile {
         super::builder::os_login_service::GetLoginProfile::new(self.inner.clone())
     }
 
     /// Retrieves an SSH public key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ssh_public_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ssh_public_key(&self) -> super::builder::os_login_service::GetSshPublicKey {
         super::builder::os_login_service::GetSshPublicKey::new(self.inner.clone())
     }
@@ -152,12 +231,44 @@ impl OsLoginService {
     /// Adds an SSH public key and returns the profile information. Default POSIX
     /// account information is set when no username and UID exist as part of the
     /// login profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_ssh_public_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_ssh_public_key(&self) -> super::builder::os_login_service::ImportSshPublicKey {
         super::builder::os_login_service::ImportSshPublicKey::new(self.inner.clone())
     }
 
     /// Updates an SSH public key and returns the profile information. This method
     /// supports patch semantics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_oslogin_v1::client::OsLoginService;
+    /// async fn sample(
+    ///    client: &OsLoginService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_ssh_public_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_ssh_public_key(&self) -> super::builder::os_login_service::UpdateSshPublicKey {
         super::builder::os_login_service::UpdateSshPublicKey::new(self.inner.clone())
     }

--- a/src/generated/cloud/parallelstore/v1/src/client.rs
+++ b/src/generated/cloud/parallelstore/v1/src/client.rs
@@ -140,6 +140,23 @@ impl Parallelstore {
     }
 
     /// Gets details of a single instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// async fn sample(
+    ///    client: &Parallelstore,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::parallelstore::GetInstance {
         super::builder::parallelstore::GetInstance::new(self.inner.clone())
     }
@@ -225,6 +242,22 @@ impl Parallelstore {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// async fn sample(
+    ///    client: &Parallelstore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::parallelstore::GetLocation {
         super::builder::parallelstore::GetLocation::new(self.inner.clone())
     }
@@ -239,6 +272,22 @@ impl Parallelstore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// async fn sample(
+    ///    client: &Parallelstore
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::parallelstore::GetOperation {
         super::builder::parallelstore::GetOperation::new(self.inner.clone())
     }
@@ -246,6 +295,21 @@ impl Parallelstore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// async fn sample(
+    ///    client: &Parallelstore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::parallelstore::DeleteOperation {
         super::builder::parallelstore::DeleteOperation::new(self.inner.clone())
     }
@@ -253,6 +317,21 @@ impl Parallelstore {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parallelstore_v1::client::Parallelstore;
+    /// async fn sample(
+    ///    client: &Parallelstore
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::parallelstore::CancelOperation {
         super::builder::parallelstore::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/parametermanager/v1/src/client.rs
+++ b/src/generated/cloud/parametermanager/v1/src/client.rs
@@ -127,21 +127,86 @@ impl ParameterManager {
     }
 
     /// Gets details of a single Parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_parameter()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_parameter(&self) -> super::builder::parameter_manager::GetParameter {
         super::builder::parameter_manager::GetParameter::new(self.inner.clone())
     }
 
     /// Creates a new Parameter in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_parameter()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_parameter(&self) -> super::builder::parameter_manager::CreateParameter {
         super::builder::parameter_manager::CreateParameter::new(self.inner.clone())
     }
 
     /// Updates a single Parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_parameter()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_parameter(&self) -> super::builder::parameter_manager::UpdateParameter {
         super::builder::parameter_manager::UpdateParameter::new(self.inner.clone())
     }
 
     /// Deletes a single Parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_parameter()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_parameter(&self) -> super::builder::parameter_manager::DeleteParameter {
         super::builder::parameter_manager::DeleteParameter::new(self.inner.clone())
     }
@@ -154,11 +219,44 @@ impl ParameterManager {
     }
 
     /// Gets details of a single ParameterVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_parameter_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_parameter_version(&self) -> super::builder::parameter_manager::GetParameterVersion {
         super::builder::parameter_manager::GetParameterVersion::new(self.inner.clone())
     }
 
     /// Gets rendered version of a ParameterVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .render_parameter_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn render_parameter_version(
         &self,
     ) -> super::builder::parameter_manager::RenderParameterVersion {
@@ -166,6 +264,22 @@ impl ParameterManager {
     }
 
     /// Creates a new ParameterVersion in a given project, location, and parameter.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_parameter_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_parameter_version(
         &self,
     ) -> super::builder::parameter_manager::CreateParameterVersion {
@@ -173,6 +287,22 @@ impl ParameterManager {
     }
 
     /// Updates a single ParameterVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_parameter_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_parameter_version(
         &self,
     ) -> super::builder::parameter_manager::UpdateParameterVersion {
@@ -180,6 +310,22 @@ impl ParameterManager {
     }
 
     /// Deletes a single ParameterVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_parameter_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_parameter_version(
         &self,
     ) -> super::builder::parameter_manager::DeleteParameterVersion {
@@ -192,6 +338,22 @@ impl ParameterManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_parametermanager_v1::client::ParameterManager;
+    /// async fn sample(
+    ///    client: &ParameterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::parameter_manager::GetLocation {
         super::builder::parameter_manager::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/policysimulator/v1/src/client.rs
+++ b/src/generated/cloud/policysimulator/v1/src/client.rs
@@ -157,6 +157,23 @@ impl OrgPolicyViolationsPreviewService {
     /// is available for at least 7 days.
     ///
     /// [google.cloud.policysimulator.v1.OrgPolicyViolationsPreview]: crate::model::OrgPolicyViolationsPreview
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policysimulator_v1::client::OrgPolicyViolationsPreviewService;
+    /// async fn sample(
+    ///    client: &OrgPolicyViolationsPreviewService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_org_policy_violations_preview()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_org_policy_violations_preview(
         &self,
     ) -> super::builder::org_policy_violations_preview_service::GetOrgPolicyViolationsPreview {
@@ -219,6 +236,22 @@ impl OrgPolicyViolationsPreviewService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policysimulator_v1::client::OrgPolicyViolationsPreviewService;
+    /// async fn sample(
+    ///    client: &OrgPolicyViolationsPreviewService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::org_policy_violations_preview_service::GetOperation {
@@ -345,6 +378,23 @@ impl Simulator {
     /// `Replay` is available for at least 7 days.
     ///
     /// [google.cloud.policysimulator.v1.Replay]: crate::model::Replay
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policysimulator_v1::client::Simulator;
+    /// async fn sample(
+    ///    client: &Simulator,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_replay()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_replay(&self) -> super::builder::simulator::GetReplay {
         super::builder::simulator::GetReplay::new(self.inner.clone())
     }
@@ -386,6 +436,22 @@ impl Simulator {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policysimulator_v1::client::Simulator;
+    /// async fn sample(
+    ///    client: &Simulator
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::simulator::GetOperation {
         super::builder::simulator::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
@@ -126,6 +126,22 @@ impl PolicyTroubleshooter {
     /// Checks whether a principal has a specific permission for a specific
     /// resource, and explains why the principal does or doesn't have that
     /// permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policytroubleshooter_iam_v3::client::PolicyTroubleshooter;
+    /// async fn sample(
+    ///    client: &PolicyTroubleshooter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .troubleshoot_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn troubleshoot_iam_policy(
         &self,
     ) -> super::builder::policy_troubleshooter::TroubleshootIamPolicy {

--- a/src/generated/cloud/policytroubleshooter/v1/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/client.rs
@@ -123,6 +123,22 @@ impl IamChecker {
     /// Checks whether a principal has a specific permission for a specific
     /// resource, and explains why the principal does or does not have that
     /// permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_policytroubleshooter_v1::client::IamChecker;
+    /// async fn sample(
+    ///    client: &IamChecker
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .troubleshoot_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn troubleshoot_iam_policy(&self) -> super::builder::iam_checker::TroubleshootIamPolicy {
         super::builder::iam_checker::TroubleshootIamPolicy::new(self.inner.clone())
     }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
@@ -144,6 +144,22 @@ impl PrivilegedAccessManager {
     /// `CheckOnboardingStatus` reports the onboarding status for a
     /// project/folder/organization. Any findings reported by this API need to be
     /// fixed before PAM can be used on the resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_onboarding_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_onboarding_status(
         &self,
     ) -> super::builder::privileged_access_manager::CheckOnboardingStatus {
@@ -164,6 +180,23 @@ impl PrivilegedAccessManager {
     }
 
     /// Gets details of a single entitlement.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_entitlement()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_entitlement(&self) -> super::builder::privileged_access_manager::GetEntitlement {
         super::builder::privileged_access_manager::GetEntitlement::new(self.inner.clone())
     }
@@ -253,12 +286,45 @@ impl PrivilegedAccessManager {
     }
 
     /// Get details of a single grant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_grant()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_grant(&self) -> super::builder::privileged_access_manager::GetGrant {
         super::builder::privileged_access_manager::GetGrant::new(self.inner.clone())
     }
 
     /// Creates a new grant in a given project/folder/organization and
     /// location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_grant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_grant(&self) -> super::builder::privileged_access_manager::CreateGrant {
         super::builder::privileged_access_manager::CreateGrant::new(self.inner.clone())
     }
@@ -266,6 +332,22 @@ impl PrivilegedAccessManager {
     /// `ApproveGrant` is used to approve a grant. This method can only be called
     /// on a grant when it's in the `APPROVAL_AWAITED` state. This operation can't
     /// be undone.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .approve_grant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn approve_grant(&self) -> super::builder::privileged_access_manager::ApproveGrant {
         super::builder::privileged_access_manager::ApproveGrant::new(self.inner.clone())
     }
@@ -273,6 +355,22 @@ impl PrivilegedAccessManager {
     /// `DenyGrant` is used to deny a grant. This method can only be called on a
     /// grant when it's in the `APPROVAL_AWAITED` state. This operation can't be
     /// undone.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .deny_grant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn deny_grant(&self) -> super::builder::privileged_access_manager::DenyGrant {
         super::builder::privileged_access_manager::DenyGrant::new(self.inner.clone())
     }
@@ -299,6 +397,22 @@ impl PrivilegedAccessManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::privileged_access_manager::GetLocation {
         super::builder::privileged_access_manager::GetLocation::new(self.inner.clone())
     }
@@ -313,6 +427,22 @@ impl PrivilegedAccessManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::privileged_access_manager::GetOperation {
         super::builder::privileged_access_manager::GetOperation::new(self.inner.clone())
     }
@@ -320,6 +450,21 @@ impl PrivilegedAccessManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+    /// async fn sample(
+    ///    client: &PrivilegedAccessManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::privileged_access_manager::DeleteOperation {
         super::builder::privileged_access_manager::DeleteOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
@@ -156,6 +156,23 @@ impl RapidMigrationAssessment {
     }
 
     /// Gets details of a single Annotation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_annotation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_annotation(&self) -> super::builder::rapid_migration_assessment::GetAnnotation {
         super::builder::rapid_migration_assessment::GetAnnotation::new(self.inner.clone())
     }
@@ -166,6 +183,23 @@ impl RapidMigrationAssessment {
     }
 
     /// Gets details of a single Collector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_collector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_collector(&self) -> super::builder::rapid_migration_assessment::GetCollector {
         super::builder::rapid_migration_assessment::GetCollector::new(self.inner.clone())
     }
@@ -254,6 +288,22 @@ impl RapidMigrationAssessment {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::rapid_migration_assessment::GetLocation {
         super::builder::rapid_migration_assessment::GetLocation::new(self.inner.clone())
     }
@@ -268,6 +318,22 @@ impl RapidMigrationAssessment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::rapid_migration_assessment::GetOperation {
         super::builder::rapid_migration_assessment::GetOperation::new(self.inner.clone())
     }
@@ -275,6 +341,21 @@ impl RapidMigrationAssessment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::rapid_migration_assessment::DeleteOperation {
         super::builder::rapid_migration_assessment::DeleteOperation::new(self.inner.clone())
     }
@@ -282,6 +363,21 @@ impl RapidMigrationAssessment {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+    /// async fn sample(
+    ///    client: &RapidMigrationAssessment
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::rapid_migration_assessment::CancelOperation {
         super::builder::rapid_migration_assessment::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
@@ -123,6 +123,22 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Creates an Assessment of the likelihood an event is legitimate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_assessment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_assessment(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::CreateAssessment {
@@ -131,6 +147,22 @@ impl RecaptchaEnterpriseService {
 
     /// Annotates a previously created Assessment to provide additional information
     /// on whether the event turned out to be authentic or fraudulent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .annotate_assessment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn annotate_assessment(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::AnnotateAssessment {
@@ -138,6 +170,22 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Creates a new reCAPTCHA Enterprise key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_key(&self) -> super::builder::recaptcha_enterprise_service::CreateKey {
         super::builder::recaptcha_enterprise_service::CreateKey::new(self.inner.clone())
     }
@@ -150,6 +198,22 @@ impl RecaptchaEnterpriseService {
     /// Returns the secret key related to the specified public key.
     /// You must use the legacy secret key only in a 3rd party integration with
     /// legacy reCAPTCHA.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .retrieve_legacy_secret_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn retrieve_legacy_secret_key(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::RetrieveLegacySecretKey {
@@ -159,16 +223,65 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Returns the specified key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_key(&self) -> super::builder::recaptcha_enterprise_service::GetKey {
         super::builder::recaptcha_enterprise_service::GetKey::new(self.inner.clone())
     }
 
     /// Updates the specified key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_key(&self) -> super::builder::recaptcha_enterprise_service::UpdateKey {
         super::builder::recaptcha_enterprise_service::UpdateKey::new(self.inner.clone())
     }
 
     /// Deletes the specified key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_key(&self) -> super::builder::recaptcha_enterprise_service::DeleteKey {
         super::builder::recaptcha_enterprise_service::DeleteKey::new(self.inner.clone())
     }
@@ -179,6 +292,22 @@ impl RecaptchaEnterpriseService {
     /// authenticated as one of the current owners of the reCAPTCHA Key, and
     /// your user must have the reCAPTCHA Enterprise Admin IAM role in the
     /// destination project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .migrate_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn migrate_key(&self) -> super::builder::recaptcha_enterprise_service::MigrateKey {
         super::builder::recaptcha_enterprise_service::MigrateKey::new(self.inner.clone())
     }
@@ -188,6 +317,22 @@ impl RecaptchaEnterpriseService {
     /// * The maximum number of IP overrides per key is 1000.
     /// * For any conflict (such as IP already exists or IP part of an existing
     ///   IP range), an error is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_ip_override()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_ip_override(&self) -> super::builder::recaptcha_enterprise_service::AddIpOverride {
         super::builder::recaptcha_enterprise_service::AddIpOverride::new(self.inner.clone())
     }
@@ -198,6 +343,22 @@ impl RecaptchaEnterpriseService {
     ///   is returned.
     /// * If the IP is found in an existing IP override, but the
     ///   override type does not match, a `NOT_FOUND` error is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_ip_override()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_ip_override(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::RemoveIpOverride {
@@ -213,6 +374,23 @@ impl RecaptchaEnterpriseService {
 
     /// Get some aggregated metrics for a Key. This data can be used to build
     /// dashboards.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metrics()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metrics(&self) -> super::builder::recaptcha_enterprise_service::GetMetrics {
         super::builder::recaptcha_enterprise_service::GetMetrics::new(self.inner.clone())
     }
@@ -220,6 +398,22 @@ impl RecaptchaEnterpriseService {
     /// Creates a new FirewallPolicy, specifying conditions at which reCAPTCHA
     /// Enterprise actions can be executed.
     /// A project may have a maximum of 1000 policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_firewall_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_firewall_policy(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::CreateFirewallPolicy {
@@ -234,6 +428,23 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Returns the specified firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_firewall_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_firewall_policy(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::GetFirewallPolicy {
@@ -241,6 +452,22 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Updates the specified firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_firewall_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_firewall_policy(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::UpdateFirewallPolicy {
@@ -248,6 +475,22 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Deletes the specified firewall policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_firewall_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_firewall_policy(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::DeleteFirewallPolicy {
@@ -255,6 +498,22 @@ impl RecaptchaEnterpriseService {
     }
 
     /// Reorders all firewall policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+    /// async fn sample(
+    ///    client: &RecaptchaEnterpriseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reorder_firewall_policies()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reorder_firewall_policies(
         &self,
     ) -> super::builder::recaptcha_enterprise_service::ReorderFirewallPolicies {

--- a/src/generated/cloud/recommender/v1/src/client.rs
+++ b/src/generated/cloud/recommender/v1/src/client.rs
@@ -129,6 +129,23 @@ impl Recommender {
 
     /// Gets the requested insight. Requires the recommender.*.get IAM permission
     /// for the specified insight type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_insight()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_insight(&self) -> super::builder::recommender::GetInsight {
         super::builder::recommender::GetInsight::new(self.inner.clone())
     }
@@ -139,6 +156,22 @@ impl Recommender {
     ///
     /// MarkInsightAccepted can be applied to insights in ACTIVE state. Requires
     /// the recommender.*.update IAM permission for the specified insight.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mark_insight_accepted()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mark_insight_accepted(&self) -> super::builder::recommender::MarkInsightAccepted {
         super::builder::recommender::MarkInsightAccepted::new(self.inner.clone())
     }
@@ -151,6 +184,23 @@ impl Recommender {
 
     /// Gets the requested recommendation. Requires the recommender.*.get
     /// IAM permission for the specified recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_recommendation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_recommendation(&self) -> super::builder::recommender::GetRecommendation {
         super::builder::recommender::GetRecommendation::new(self.inner.clone())
     }
@@ -164,6 +214,22 @@ impl Recommender {
     ///
     /// Requires the recommender.*.update IAM permission for the specified
     /// recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mark_recommendation_dismissed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mark_recommendation_dismissed(
         &self,
     ) -> super::builder::recommender::MarkRecommendationDismissed {
@@ -180,6 +246,22 @@ impl Recommender {
     ///
     /// Requires the recommender.*.update IAM permission for the specified
     /// recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mark_recommendation_claimed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mark_recommendation_claimed(
         &self,
     ) -> super::builder::recommender::MarkRecommendationClaimed {
@@ -197,6 +279,22 @@ impl Recommender {
     ///
     /// Requires the recommender.*.update IAM permission for the specified
     /// recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mark_recommendation_succeeded()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mark_recommendation_succeeded(
         &self,
     ) -> super::builder::recommender::MarkRecommendationSucceeded {
@@ -214,6 +312,22 @@ impl Recommender {
     ///
     /// Requires the recommender.*.update IAM permission for the specified
     /// recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .mark_recommendation_failed()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn mark_recommendation_failed(
         &self,
     ) -> super::builder::recommender::MarkRecommendationFailed {
@@ -222,12 +336,45 @@ impl Recommender {
 
     /// Gets the requested Recommender Config. There is only one instance of the
     /// config for each Recommender.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_recommender_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_recommender_config(&self) -> super::builder::recommender::GetRecommenderConfig {
         super::builder::recommender::GetRecommenderConfig::new(self.inner.clone())
     }
 
     /// Updates a Recommender Config. This will create a new revision of the
     /// config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_recommender_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_recommender_config(
         &self,
     ) -> super::builder::recommender::UpdateRecommenderConfig {
@@ -236,12 +383,45 @@ impl Recommender {
 
     /// Gets the requested InsightTypeConfig. There is only one instance of the
     /// config for each InsightType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_insight_type_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_insight_type_config(&self) -> super::builder::recommender::GetInsightTypeConfig {
         super::builder::recommender::GetInsightTypeConfig::new(self.inner.clone())
     }
 
     /// Updates an InsightTypeConfig change. This will create a new revision of the
     /// config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_recommender_v1::client::Recommender;
+    /// async fn sample(
+    ///    client: &Recommender
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_insight_type_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_insight_type_config(
         &self,
     ) -> super::builder::recommender::UpdateInsightTypeConfig {

--- a/src/generated/cloud/redis/cluster/v1/src/client.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/client.rs
@@ -151,6 +151,23 @@ impl CloudRedisCluster {
     }
 
     /// Gets the details of a specific Redis cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::cloud_redis_cluster::GetCluster {
         super::builder::cloud_redis_cluster::GetCluster::new(self.inner.clone())
     }
@@ -213,6 +230,22 @@ impl CloudRedisCluster {
     }
 
     /// Gets the details of certificate authority information for Redis cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster_certificate_authority()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster_certificate_authority(
         &self,
     ) -> super::builder::cloud_redis_cluster::GetClusterCertificateAuthority {
@@ -248,6 +281,23 @@ impl CloudRedisCluster {
     }
 
     /// Get a backup collection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_collection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_collection(
         &self,
     ) -> super::builder::cloud_redis_cluster::GetBackupCollection {
@@ -260,6 +310,23 @@ impl CloudRedisCluster {
     }
 
     /// Gets the details of a specific backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::cloud_redis_cluster::GetBackup {
         super::builder::cloud_redis_cluster::GetBackup::new(self.inner.clone())
     }
@@ -326,6 +393,22 @@ impl CloudRedisCluster {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_redis_cluster::GetLocation {
         super::builder::cloud_redis_cluster::GetLocation::new(self.inner.clone())
     }
@@ -340,6 +423,22 @@ impl CloudRedisCluster {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_redis_cluster::GetOperation {
         super::builder::cloud_redis_cluster::GetOperation::new(self.inner.clone())
     }
@@ -347,6 +446,21 @@ impl CloudRedisCluster {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cloud_redis_cluster::DeleteOperation {
         super::builder::cloud_redis_cluster::DeleteOperation::new(self.inner.clone())
     }
@@ -354,6 +468,21 @@ impl CloudRedisCluster {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+    /// async fn sample(
+    ///    client: &CloudRedisCluster
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_redis_cluster::CancelOperation {
         super::builder::cloud_redis_cluster::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/redis/v1/src/client.rs
+++ b/src/generated/cloud/redis/v1/src/client.rs
@@ -148,6 +148,23 @@ impl CloudRedis {
     }
 
     /// Gets the details of a specific Redis instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::cloud_redis::GetInstance {
         super::builder::cloud_redis::GetInstance::new(self.inner.clone())
     }
@@ -155,6 +172,22 @@ impl CloudRedis {
     /// Gets the AUTH string for a Redis instance. If AUTH is not enabled for the
     /// instance the response will be empty. This information is not included in
     /// the details returned to GetInstance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance_auth_string()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance_auth_string(&self) -> super::builder::cloud_redis::GetInstanceAuthString {
         super::builder::cloud_redis::GetInstanceAuthString::new(self.inner.clone())
     }
@@ -316,6 +349,22 @@ impl CloudRedis {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_redis::GetLocation {
         super::builder::cloud_redis::GetLocation::new(self.inner.clone())
     }
@@ -330,6 +379,22 @@ impl CloudRedis {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_redis::GetOperation {
         super::builder::cloud_redis::GetOperation::new(self.inner.clone())
     }
@@ -337,6 +402,21 @@ impl CloudRedis {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::cloud_redis::DeleteOperation {
         super::builder::cloud_redis::DeleteOperation::new(self.inner.clone())
     }
@@ -344,6 +424,21 @@ impl CloudRedis {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_redis_v1::client::CloudRedis;
+    /// async fn sample(
+    ///    client: &CloudRedis
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_redis::CancelOperation {
         super::builder::cloud_redis::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -125,6 +125,23 @@ impl Folders {
     /// (for example, `folders/1234`).
     /// The caller must have `resourcemanager.folders.get` permission on the
     /// identified folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// async fn sample(
+    ///    client: &Folders,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_folder(&self) -> super::builder::folders::GetFolder {
         super::builder::folders::GetFolder::new(self.inner.clone())
     }
@@ -318,6 +335,22 @@ impl Folders {
     /// be the folder's resource name, for example: "folders/1234".
     /// The caller must have `resourcemanager.folders.getIamPolicy` permission
     /// on the identified folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// async fn sample(
+    ///    client: &Folders
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::folders::GetIamPolicy {
         super::builder::folders::GetIamPolicy::new(self.inner.clone())
     }
@@ -327,6 +360,22 @@ impl Folders {
     /// "folders/1234".
     /// The caller must have `resourcemanager.folders.setIamPolicy` permission
     /// on the identified folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// async fn sample(
+    ///    client: &Folders
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::folders::SetIamPolicy {
         super::builder::folders::SetIamPolicy::new(self.inner.clone())
     }
@@ -336,6 +385,22 @@ impl Folders {
     /// for example: "folders/1234".
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// async fn sample(
+    ///    client: &Folders
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::folders::TestIamPermissions {
         super::builder::folders::TestIamPermissions::new(self.inner.clone())
     }
@@ -343,6 +408,22 @@ impl Folders {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// async fn sample(
+    ///    client: &Folders
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::folders::GetOperation {
         super::builder::folders::GetOperation::new(self.inner.clone())
     }
@@ -451,6 +532,23 @@ impl Organizations {
     }
 
     /// Fetches an organization resource identified by the specified resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// async fn sample(
+    ///    client: &Organizations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_organization()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_organization(&self) -> super::builder::organizations::GetOrganization {
         super::builder::organizations::GetOrganization::new(self.inner.clone())
     }
@@ -472,6 +570,22 @@ impl Organizations {
     ///
     /// Authorization requires the IAM permission
     /// `resourcemanager.organizations.getIamPolicy` on the specified organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// async fn sample(
+    ///    client: &Organizations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::organizations::GetIamPolicy {
         super::builder::organizations::GetIamPolicy::new(self.inner.clone())
     }
@@ -482,6 +596,22 @@ impl Organizations {
     ///
     /// Authorization requires the IAM permission
     /// `resourcemanager.organizations.setIamPolicy` on the specified organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// async fn sample(
+    ///    client: &Organizations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::organizations::SetIamPolicy {
         super::builder::organizations::SetIamPolicy::new(self.inner.clone())
     }
@@ -491,6 +621,22 @@ impl Organizations {
     /// for example: "organizations/123".
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// async fn sample(
+    ///    client: &Organizations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::organizations::TestIamPermissions {
         super::builder::organizations::TestIamPermissions::new(self.inner.clone())
     }
@@ -498,6 +644,22 @@ impl Organizations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// async fn sample(
+    ///    client: &Organizations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::organizations::GetOperation {
         super::builder::organizations::GetOperation::new(self.inner.clone())
     }
@@ -610,6 +772,23 @@ impl Projects {
     ///
     /// The caller must have `resourcemanager.projects.get` permission
     /// for this project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project(&self) -> super::builder::projects::GetProject {
         super::builder::projects::GetProject::new(self.inner.clone())
     }
@@ -784,6 +963,22 @@ impl Projects {
     /// Returns the IAM access control policy for the specified project, in the
     /// format `projects/{ProjectIdOrNumber}` e.g. projects/123.
     /// Permission is denied if the policy or the resource do not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::projects::GetIamPolicy {
         super::builder::projects::GetIamPolicy::new(self.inner.clone())
     }
@@ -830,12 +1025,44 @@ impl Projects {
     ///   rectified. If the project is part of an organization, you can remove all
     ///   owners, potentially making the organization inaccessible.
     ///
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::projects::SetIamPolicy {
         super::builder::projects::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Returns permissions that a caller has on the specified project, in the
     /// format `projects/{ProjectIdOrNumber}` e.g. projects/123..
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::projects::TestIamPermissions {
         super::builder::projects::TestIamPermissions::new(self.inner.clone())
     }
@@ -843,6 +1070,22 @@ impl Projects {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::projects::GetOperation {
         super::builder::projects::GetOperation::new(self.inner.clone())
     }
@@ -999,6 +1242,22 @@ impl TagBindings {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagBindings;
+    /// async fn sample(
+    ///    client: &TagBindings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tag_bindings::GetOperation {
         super::builder::tag_bindings::GetOperation::new(self.inner.clone())
     }
@@ -1149,6 +1408,22 @@ impl TagHolds {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagHolds;
+    /// async fn sample(
+    ///    client: &TagHolds
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tag_holds::GetOperation {
         super::builder::tag_holds::GetOperation::new(self.inner.clone())
     }
@@ -1263,6 +1538,23 @@ impl TagKeys {
 
     /// Retrieves a TagKey. This method will return `PERMISSION_DENIED` if the
     /// key does not exist or the user does not have permission to view it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tag_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tag_key(&self) -> super::builder::tag_keys::GetTagKey {
         super::builder::tag_keys::GetTagKey::new(self.inner.clone())
     }
@@ -1270,6 +1562,23 @@ impl TagKeys {
     /// Retrieves a TagKey by its namespaced name.
     /// This method will return `PERMISSION_DENIED` if the key does not exist
     /// or the user does not have permission to view it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_namespaced_tag_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_namespaced_tag_key(&self) -> super::builder::tag_keys::GetNamespacedTagKey {
         super::builder::tag_keys::GetNamespacedTagKey::new(self.inner.clone())
     }
@@ -1329,6 +1638,22 @@ impl TagKeys {
     /// The caller must have
     /// `cloudresourcemanager.googleapis.com/tagKeys.getIamPolicy` permission on
     /// the specified TagKey.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::tag_keys::GetIamPolicy {
         super::builder::tag_keys::GetIamPolicy::new(self.inner.clone())
     }
@@ -1338,6 +1663,22 @@ impl TagKeys {
     /// For example, "tagKeys/1234".
     /// The caller must have `resourcemanager.tagKeys.setIamPolicy` permission
     /// on the identified tagValue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::tag_keys::SetIamPolicy {
         super::builder::tag_keys::SetIamPolicy::new(self.inner.clone())
     }
@@ -1347,6 +1688,22 @@ impl TagKeys {
     /// For example, "tagKeys/1234".
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::tag_keys::TestIamPermissions {
         super::builder::tag_keys::TestIamPermissions::new(self.inner.clone())
     }
@@ -1354,6 +1711,22 @@ impl TagKeys {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// async fn sample(
+    ///    client: &TagKeys
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tag_keys::GetOperation {
         super::builder::tag_keys::GetOperation::new(self.inner.clone())
     }
@@ -1468,6 +1841,23 @@ impl TagValues {
 
     /// Retrieves a TagValue. This method will return `PERMISSION_DENIED` if the
     /// value does not exist or the user does not have permission to view it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tag_value()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tag_value(&self) -> super::builder::tag_values::GetTagValue {
         super::builder::tag_values::GetTagValue::new(self.inner.clone())
     }
@@ -1475,6 +1865,23 @@ impl TagValues {
     /// Retrieves a TagValue by its namespaced name.
     /// This method will return `PERMISSION_DENIED` if the value does not exist
     /// or the user does not have permission to view it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_namespaced_tag_value()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_namespaced_tag_value(&self) -> super::builder::tag_values::GetNamespacedTagValue {
         super::builder::tag_values::GetNamespacedTagValue::new(self.inner.clone())
     }
@@ -1534,6 +1941,22 @@ impl TagValues {
     /// The caller must have the
     /// `cloudresourcemanager.googleapis.com/tagValues.getIamPolicy` permission on
     /// the identified TagValue to get the access control policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::tag_values::GetIamPolicy {
         super::builder::tag_values::GetIamPolicy::new(self.inner.clone())
     }
@@ -1543,6 +1966,22 @@ impl TagValues {
     /// For example: `tagValues/1234`.
     /// The caller must have `resourcemanager.tagValues.setIamPolicy` permission
     /// on the identified tagValue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::tag_values::SetIamPolicy {
         super::builder::tag_values::SetIamPolicy::new(self.inner.clone())
     }
@@ -1552,6 +1991,22 @@ impl TagValues {
     /// `tagValues/1234`.
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::tag_values::TestIamPermissions {
         super::builder::tag_values::TestIamPermissions::new(self.inner.clone())
     }
@@ -1559,6 +2014,22 @@ impl TagValues {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// async fn sample(
+    ///    client: &TagValues
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tag_values::GetOperation {
         super::builder::tag_values::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/retail/v2/src/client.rs
+++ b/src/generated/cloud/retail/v2/src/client.rs
@@ -152,6 +152,22 @@ impl AnalyticsService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::AnalyticsService;
+    /// async fn sample(
+    ///    client: &AnalyticsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::analytics_service::GetOperation {
         super::builder::analytics_service::GetOperation::new(self.inner.clone())
     }
@@ -270,6 +286,22 @@ impl CatalogService {
     /// Updates the [Catalog][google.cloud.retail.v2.Catalog]s.
     ///
     /// [google.cloud.retail.v2.Catalog]: crate::model::Catalog
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_catalog()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_catalog(&self) -> super::builder::catalog_service::UpdateCatalog {
         super::builder::catalog_service::UpdateCatalog::new(self.inner.clone())
     }
@@ -313,6 +345,21 @@ impl CatalogService {
     /// [google.cloud.retail.v2.ProductService.ListProducts]: crate::client::ProductService::list_products
     /// [google.cloud.retail.v2.SearchRequest.branch]: crate::model::SearchRequest::branch
     /// [google.cloud.retail.v2.SearchService.Search]: crate::client::SearchService::search
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .set_default_branch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_default_branch(&self) -> super::builder::catalog_service::SetDefaultBranch {
         super::builder::catalog_service::SetDefaultBranch::new(self.inner.clone())
     }
@@ -322,6 +369,22 @@ impl CatalogService {
     /// method under a specified parent catalog.
     ///
     /// [google.cloud.retail.v2.CatalogService.SetDefaultBranch]: crate::client::CatalogService::set_default_branch
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_default_branch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_default_branch(&self) -> super::builder::catalog_service::GetDefaultBranch {
         super::builder::catalog_service::GetDefaultBranch::new(self.inner.clone())
     }
@@ -329,6 +392,23 @@ impl CatalogService {
     /// Gets a [CompletionConfig][google.cloud.retail.v2.CompletionConfig].
     ///
     /// [google.cloud.retail.v2.CompletionConfig]: crate::model::CompletionConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_completion_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_completion_config(&self) -> super::builder::catalog_service::GetCompletionConfig {
         super::builder::catalog_service::GetCompletionConfig::new(self.inner.clone())
     }
@@ -336,6 +416,22 @@ impl CatalogService {
     /// Updates the [CompletionConfig][google.cloud.retail.v2.CompletionConfig]s.
     ///
     /// [google.cloud.retail.v2.CompletionConfig]: crate::model::CompletionConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_completion_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_completion_config(
         &self,
     ) -> super::builder::catalog_service::UpdateCompletionConfig {
@@ -345,6 +441,23 @@ impl CatalogService {
     /// Gets an [AttributesConfig][google.cloud.retail.v2.AttributesConfig].
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attributes_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attributes_config(&self) -> super::builder::catalog_service::GetAttributesConfig {
         super::builder::catalog_service::GetAttributesConfig::new(self.inner.clone())
     }
@@ -359,6 +472,22 @@ impl CatalogService {
     /// catalog attribute fields, e.g., searchable and dynamic facetable options.
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_attributes_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_attributes_config(
         &self,
     ) -> super::builder::catalog_service::UpdateAttributesConfig {
@@ -374,6 +503,22 @@ impl CatalogService {
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
     /// [google.cloud.retail.v2.CatalogAttribute]: crate::model::CatalogAttribute
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_catalog_attribute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_catalog_attribute(&self) -> super::builder::catalog_service::AddCatalogAttribute {
         super::builder::catalog_service::AddCatalogAttribute::new(self.inner.clone())
     }
@@ -387,6 +532,22 @@ impl CatalogService {
     ///
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
     /// [google.cloud.retail.v2.CatalogAttribute]: crate::model::CatalogAttribute
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_catalog_attribute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_catalog_attribute(
         &self,
     ) -> super::builder::catalog_service::RemoveCatalogAttribute {
@@ -405,6 +566,22 @@ impl CatalogService {
     /// [google.cloud.retail.v2.AttributesConfig]: crate::model::AttributesConfig
     /// [google.cloud.retail.v2.CatalogAttribute]: crate::model::CatalogAttribute
     /// [google.cloud.retail.v2.CatalogAttribute.key]: crate::model::CatalogAttribute::key
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .replace_catalog_attribute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn replace_catalog_attribute(
         &self,
     ) -> super::builder::catalog_service::ReplaceCatalogAttribute {
@@ -421,6 +598,22 @@ impl CatalogService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CatalogService;
+    /// async fn sample(
+    ///    client: &CatalogService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::catalog_service::GetOperation {
         super::builder::catalog_service::GetOperation::new(self.inner.clone())
     }
@@ -538,6 +731,22 @@ impl CompletionService {
     ///
     /// This feature is only available for users who have Retail Search enabled.
     /// Enable Retail Search on Cloud Console before using this feature.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CompletionService;
+    /// async fn sample(
+    ///    client: &CompletionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_query(&self) -> super::builder::completion_service::CompleteQuery {
         super::builder::completion_service::CompleteQuery::new(self.inner.clone())
     }
@@ -577,6 +786,22 @@ impl CompletionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::CompletionService;
+    /// async fn sample(
+    ///    client: &CompletionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::completion_service::GetOperation {
         super::builder::completion_service::GetOperation::new(self.inner.clone())
     }
@@ -690,6 +915,22 @@ impl ControlService {
     /// an ALREADY_EXISTS error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_control(&self) -> super::builder::control_service::CreateControl {
         super::builder::control_service::CreateControl::new(self.inner.clone())
     }
@@ -700,6 +941,21 @@ impl ControlService {
     /// a NOT_FOUND error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_control(&self) -> super::builder::control_service::DeleteControl {
         super::builder::control_service::DeleteControl::new(self.inner.clone())
     }
@@ -712,11 +968,44 @@ impl ControlService {
     /// NOT_FOUND error is returned.
     ///
     /// [google.cloud.retail.v2.Control]: crate::model::Control
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_control(&self) -> super::builder::control_service::UpdateControl {
         super::builder::control_service::UpdateControl::new(self.inner.clone())
     }
 
     /// Gets a Control.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_control()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_control(&self) -> super::builder::control_service::GetControl {
         super::builder::control_service::GetControl::new(self.inner.clone())
     }
@@ -739,6 +1028,22 @@ impl ControlService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ControlService;
+    /// async fn sample(
+    ///    client: &ControlService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::control_service::GetOperation {
         super::builder::control_service::GetOperation::new(self.inner.clone())
     }
@@ -864,6 +1169,22 @@ impl ConversationalSearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ConversationalSearchService;
+    /// async fn sample(
+    ///    client: &ConversationalSearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::conversational_search_service::GetOperation {
         super::builder::conversational_search_service::GetOperation::new(self.inner.clone())
     }
@@ -977,6 +1298,22 @@ impl GenerativeQuestionService {
 
     /// Manages overal generative question feature state -- enables toggling
     /// feature on and off.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_generative_questions_feature_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_generative_questions_feature_config(
         &self,
     ) -> super::builder::generative_question_service::UpdateGenerativeQuestionsFeatureConfig {
@@ -987,6 +1324,22 @@ impl GenerativeQuestionService {
 
     /// Manages overal generative question feature state -- enables toggling
     /// feature on and off.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_generative_questions_feature_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_generative_questions_feature_config(
         &self,
     ) -> super::builder::generative_question_service::GetGenerativeQuestionsFeatureConfig {
@@ -996,6 +1349,22 @@ impl GenerativeQuestionService {
     }
 
     /// Returns all questions for a given catalog.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_generative_question_configs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_generative_question_configs(
         &self,
     ) -> super::builder::generative_question_service::ListGenerativeQuestionConfigs {
@@ -1005,6 +1374,22 @@ impl GenerativeQuestionService {
     }
 
     /// Allows management of individual questions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_generative_question_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_generative_question_config(
         &self,
     ) -> super::builder::generative_question_service::UpdateGenerativeQuestionConfig {
@@ -1014,6 +1399,22 @@ impl GenerativeQuestionService {
     }
 
     /// Allows management of multiple questions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_update_generative_question_configs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_update_generative_question_configs(
         &self,
     ) -> super::builder::generative_question_service::BatchUpdateGenerativeQuestionConfigs {
@@ -1032,6 +1433,22 @@ impl GenerativeQuestionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
+    /// async fn sample(
+    ///    client: &GenerativeQuestionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::generative_question_service::GetOperation {
         super::builder::generative_question_service::GetOperation::new(self.inner.clone())
     }
@@ -1166,21 +1583,85 @@ impl ModelService {
     }
 
     /// Gets a model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model(&self) -> super::builder::model_service::GetModel {
         super::builder::model_service::GetModel::new(self.inner.clone())
     }
 
     /// Pauses the training of an existing model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_model(&self) -> super::builder::model_service::PauseModel {
         super::builder::model_service::PauseModel::new(self.inner.clone())
     }
 
     /// Resumes the training of an existing model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_model(&self) -> super::builder::model_service::ResumeModel {
         super::builder::model_service::ResumeModel::new(self.inner.clone())
     }
 
     /// Deletes an existing model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_model(&self) -> super::builder::model_service::DeleteModel {
         super::builder::model_service::DeleteModel::new(self.inner.clone())
     }
@@ -1194,6 +1675,22 @@ impl ModelService {
     /// currently can be updated are: `filtering_option` and
     /// `periodic_tuning_state`.
     /// If other values are provided, this API method ignores them.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_model()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_model(&self) -> super::builder::model_service::UpdateModel {
         super::builder::model_service::UpdateModel::new(self.inner.clone())
     }
@@ -1223,6 +1720,22 @@ impl ModelService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ModelService;
+    /// async fn sample(
+    ///    client: &ModelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::model_service::GetOperation {
         super::builder::model_service::GetOperation::new(self.inner.clone())
     }
@@ -1334,6 +1847,22 @@ impl PredictionService {
     }
 
     /// Makes a recommendation prediction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .predict()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn predict(&self) -> super::builder::prediction_service::Predict {
         super::builder::prediction_service::Predict::new(self.inner.clone())
     }
@@ -1348,6 +1877,22 @@ impl PredictionService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::PredictionService;
+    /// async fn sample(
+    ///    client: &PredictionService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::prediction_service::GetOperation {
         super::builder::prediction_service::GetOperation::new(self.inner.clone())
     }
@@ -1461,6 +2006,22 @@ impl ProductService {
     /// Creates a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// async fn sample(
+    ///    client: &ProductService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_product(&self) -> super::builder::product_service::CreateProduct {
         super::builder::product_service::CreateProduct::new(self.inner.clone())
     }
@@ -1468,6 +2029,23 @@ impl ProductService {
     /// Gets a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// async fn sample(
+    ///    client: &ProductService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_product()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_product(&self) -> super::builder::product_service::GetProduct {
         super::builder::product_service::GetProduct::new(self.inner.clone())
     }
@@ -1482,6 +2060,22 @@ impl ProductService {
     /// Updates a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// async fn sample(
+    ///    client: &ProductService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_product(&self) -> super::builder::product_service::UpdateProduct {
         super::builder::product_service::UpdateProduct::new(self.inner.clone())
     }
@@ -1489,6 +2083,21 @@ impl ProductService {
     /// Deletes a [Product][google.cloud.retail.v2.Product].
     ///
     /// [google.cloud.retail.v2.Product]: crate::model::Product
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// async fn sample(
+    ///    client: &ProductService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_product(&self) -> super::builder::product_service::DeleteProduct {
         super::builder::product_service::DeleteProduct::new(self.inner.clone())
     }
@@ -1846,6 +2455,22 @@ impl ProductService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ProductService;
+    /// async fn sample(
+    ///    client: &ProductService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::product_service::GetOperation {
         super::builder::product_service::GetOperation::new(self.inner.clone())
     }
@@ -1974,6 +2599,22 @@ impl SearchService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::SearchService;
+    /// async fn sample(
+    ///    client: &SearchService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::search_service::GetOperation {
         super::builder::search_service::GetOperation::new(self.inner.clone())
     }
@@ -2092,6 +2733,22 @@ impl ServingConfigService {
     ///
     /// [google.cloud.retail.v2.Catalog]: crate::model::Catalog
     /// [google.cloud.retail.v2.ServingConfig]: crate::model::ServingConfig
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_serving_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_serving_config(
         &self,
     ) -> super::builder::serving_config_service::CreateServingConfig {
@@ -2101,6 +2758,21 @@ impl ServingConfigService {
     /// Deletes a ServingConfig.
     ///
     /// Returns a NotFound error if the ServingConfig does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_serving_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_serving_config(
         &self,
     ) -> super::builder::serving_config_service::DeleteServingConfig {
@@ -2108,6 +2780,22 @@ impl ServingConfigService {
     }
 
     /// Updates a ServingConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_serving_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_serving_config(
         &self,
     ) -> super::builder::serving_config_service::UpdateServingConfig {
@@ -2117,6 +2805,23 @@ impl ServingConfigService {
     /// Gets a ServingConfig.
     ///
     /// Returns a NotFound error if the ServingConfig does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_serving_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_serving_config(&self) -> super::builder::serving_config_service::GetServingConfig {
         super::builder::serving_config_service::GetServingConfig::new(self.inner.clone())
     }
@@ -2135,6 +2840,22 @@ impl ServingConfigService {
     /// Returns a ALREADY_EXISTS error if the control has already been applied.
     /// Returns a FAILED_PRECONDITION error if the addition could exceed maximum
     /// number of control allowed for that type of control.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_control(&self) -> super::builder::serving_config_service::AddControl {
         super::builder::serving_config_service::AddControl::new(self.inner.clone())
     }
@@ -2143,6 +2864,22 @@ impl ServingConfigService {
     /// The control is removed from the ServingConfig.
     /// Returns a NOT_FOUND error if the Control is not enabled for the
     /// ServingConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .remove_control()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_control(&self) -> super::builder::serving_config_service::RemoveControl {
         super::builder::serving_config_service::RemoveControl::new(self.inner.clone())
     }
@@ -2157,6 +2894,22 @@ impl ServingConfigService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::ServingConfigService;
+    /// async fn sample(
+    ///    client: &ServingConfigService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::serving_config_service::GetOperation {
         super::builder::serving_config_service::GetOperation::new(self.inner.clone())
     }
@@ -2268,6 +3021,22 @@ impl UserEventService {
     }
 
     /// Writes a single user event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_user_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_user_event(&self) -> super::builder::user_event_service::WriteUserEvent {
         super::builder::user_event_service::WriteUserEvent::new(self.inner.clone())
     }
@@ -2279,6 +3048,22 @@ impl UserEventService {
     ///
     /// This method is used only by the Retail API JavaScript pixel and Google Tag
     /// Manager. Users should not call this method directly.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .collect_user_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn collect_user_event(&self) -> super::builder::user_event_service::CollectUserEvent {
         super::builder::user_event_service::CollectUserEvent::new(self.inner.clone())
     }
@@ -2354,6 +3139,22 @@ impl UserEventService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_retail_v2::client::UserEventService;
+    /// async fn sample(
+    ///    client: &UserEventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::user_event_service::GetOperation {
         super::builder::user_event_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/run/v2/src/client.rs
+++ b/src/generated/cloud/run/v2/src/client.rs
@@ -119,6 +119,22 @@ impl Builds {
     }
 
     /// Submits a build in a given project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Builds;
+    /// async fn sample(
+    ///    client: &Builds
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .submit_build()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn submit_build(&self) -> super::builder::builds::SubmitBuild {
         super::builder::builds::SubmitBuild::new(self.inner.clone())
     }
@@ -133,6 +149,22 @@ impl Builds {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Builds;
+    /// async fn sample(
+    ///    client: &Builds
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::builds::GetOperation {
         super::builder::builds::GetOperation::new(self.inner.clone())
     }
@@ -140,6 +172,21 @@ impl Builds {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Builds;
+    /// async fn sample(
+    ///    client: &Builds
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::builds::DeleteOperation {
         super::builder::builds::DeleteOperation::new(self.inner.clone())
     }
@@ -147,6 +194,22 @@ impl Builds {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Builds;
+    /// async fn sample(
+    ///    client: &Builds
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::builds::WaitOperation {
         super::builder::builds::WaitOperation::new(self.inner.clone())
     }
@@ -255,6 +318,23 @@ impl Executions {
     }
 
     /// Gets information about an Execution.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_execution()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_execution(&self) -> super::builder::executions::GetExecution {
         super::builder::executions::GetExecution::new(self.inner.clone())
     }
@@ -305,6 +385,22 @@ impl Executions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::executions::GetOperation {
         super::builder::executions::GetOperation::new(self.inner.clone())
     }
@@ -312,6 +408,21 @@ impl Executions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::executions::DeleteOperation {
         super::builder::executions::DeleteOperation::new(self.inner.clone())
     }
@@ -319,6 +430,22 @@ impl Executions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::executions::WaitOperation {
         super::builder::executions::WaitOperation::new(self.inner.clone())
     }
@@ -442,6 +569,23 @@ impl Jobs {
     }
 
     /// Gets information about a Job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::jobs::GetJob {
         super::builder::jobs::GetJob::new(self.inner.clone())
     }
@@ -498,12 +642,44 @@ impl Jobs {
 
     /// Gets the IAM Access Control policy currently in effect for the given Job.
     /// This result does not include any inherited policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::jobs::GetIamPolicy {
         super::builder::jobs::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM Access control policy for the specified Job. Overwrites
     /// any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::jobs::SetIamPolicy {
         super::builder::jobs::SetIamPolicy::new(self.inner.clone())
     }
@@ -511,6 +687,22 @@ impl Jobs {
     /// Returns permissions that a caller has on the specified Project.
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::jobs::TestIamPermissions {
         super::builder::jobs::TestIamPermissions::new(self.inner.clone())
     }
@@ -525,6 +717,22 @@ impl Jobs {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::jobs::GetOperation {
         super::builder::jobs::GetOperation::new(self.inner.clone())
     }
@@ -532,6 +740,21 @@ impl Jobs {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::jobs::DeleteOperation {
         super::builder::jobs::DeleteOperation::new(self.inner.clone())
     }
@@ -539,6 +762,22 @@ impl Jobs {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Jobs;
+    /// async fn sample(
+    ///    client: &Jobs
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::jobs::WaitOperation {
         super::builder::jobs::WaitOperation::new(self.inner.clone())
     }
@@ -647,6 +886,23 @@ impl Revisions {
     }
 
     /// Gets information about a Revision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Revisions;
+    /// async fn sample(
+    ///    client: &Revisions,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_revision()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_revision(&self) -> super::builder::revisions::GetRevision {
         super::builder::revisions::GetRevision::new(self.inner.clone())
     }
@@ -682,6 +938,22 @@ impl Revisions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Revisions;
+    /// async fn sample(
+    ///    client: &Revisions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::revisions::GetOperation {
         super::builder::revisions::GetOperation::new(self.inner.clone())
     }
@@ -689,6 +961,21 @@ impl Revisions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Revisions;
+    /// async fn sample(
+    ///    client: &Revisions
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::revisions::DeleteOperation {
         super::builder::revisions::DeleteOperation::new(self.inner.clone())
     }
@@ -696,6 +983,22 @@ impl Revisions {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Revisions;
+    /// async fn sample(
+    ///    client: &Revisions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::revisions::WaitOperation {
         super::builder::revisions::WaitOperation::new(self.inner.clone())
     }
@@ -819,6 +1122,23 @@ impl Services {
     }
 
     /// Gets information about a Service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::services::GetService {
         super::builder::services::GetService::new(self.inner.clone())
     }
@@ -862,12 +1182,44 @@ impl Services {
 
     /// Gets the IAM Access Control policy currently in effect for the given
     /// Cloud Run Service. This result does not include any inherited policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::services::GetIamPolicy {
         super::builder::services::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM Access control policy for the specified Service. Overwrites
     /// any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::services::SetIamPolicy {
         super::builder::services::SetIamPolicy::new(self.inner.clone())
     }
@@ -875,6 +1227,22 @@ impl Services {
     /// Returns permissions that a caller has on the specified Project.
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::services::TestIamPermissions {
         super::builder::services::TestIamPermissions::new(self.inner.clone())
     }
@@ -889,6 +1257,22 @@ impl Services {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::services::GetOperation {
         super::builder::services::GetOperation::new(self.inner.clone())
     }
@@ -896,6 +1280,21 @@ impl Services {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::services::DeleteOperation {
         super::builder::services::DeleteOperation::new(self.inner.clone())
     }
@@ -903,6 +1302,22 @@ impl Services {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Services;
+    /// async fn sample(
+    ///    client: &Services
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::services::WaitOperation {
         super::builder::services::WaitOperation::new(self.inner.clone())
     }
@@ -1011,6 +1426,23 @@ impl Tasks {
     }
 
     /// Gets information about a Task.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Tasks;
+    /// async fn sample(
+    ///    client: &Tasks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_task()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_task(&self) -> super::builder::tasks::GetTask {
         super::builder::tasks::GetTask::new(self.inner.clone())
     }
@@ -1030,6 +1462,22 @@ impl Tasks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Tasks;
+    /// async fn sample(
+    ///    client: &Tasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tasks::GetOperation {
         super::builder::tasks::GetOperation::new(self.inner.clone())
     }
@@ -1037,6 +1485,21 @@ impl Tasks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Tasks;
+    /// async fn sample(
+    ///    client: &Tasks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::tasks::DeleteOperation {
         super::builder::tasks::DeleteOperation::new(self.inner.clone())
     }
@@ -1044,6 +1507,22 @@ impl Tasks {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::Tasks;
+    /// async fn sample(
+    ///    client: &Tasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::tasks::WaitOperation {
         super::builder::tasks::WaitOperation::new(self.inner.clone())
     }
@@ -1167,6 +1646,23 @@ impl WorkerPools {
     }
 
     /// Gets information about a WorkerPool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_worker_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_worker_pool(&self) -> super::builder::worker_pools::GetWorkerPool {
         super::builder::worker_pools::GetWorkerPool::new(self.inner.clone())
     }
@@ -1208,12 +1704,44 @@ impl WorkerPools {
 
     /// Gets the IAM Access Control policy currently in effect for the given
     /// Cloud Run WorkerPool. This result does not include any inherited policies.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::worker_pools::GetIamPolicy {
         super::builder::worker_pools::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM Access control policy for the specified WorkerPool. Overwrites
     /// any existing policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::worker_pools::SetIamPolicy {
         super::builder::worker_pools::SetIamPolicy::new(self.inner.clone())
     }
@@ -1221,6 +1749,22 @@ impl WorkerPools {
     /// Returns permissions that a caller has on the specified Project.
     ///
     /// There are no permissions required for making this API call.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::worker_pools::TestIamPermissions {
         super::builder::worker_pools::TestIamPermissions::new(self.inner.clone())
     }
@@ -1235,6 +1779,22 @@ impl WorkerPools {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::worker_pools::GetOperation {
         super::builder::worker_pools::GetOperation::new(self.inner.clone())
     }
@@ -1242,6 +1802,21 @@ impl WorkerPools {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::worker_pools::DeleteOperation {
         super::builder::worker_pools::DeleteOperation::new(self.inner.clone())
     }
@@ -1249,6 +1824,22 @@ impl WorkerPools {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_run_v2::client::WorkerPools;
+    /// async fn sample(
+    ///    client: &WorkerPools
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::worker_pools::WaitOperation {
         super::builder::worker_pools::WaitOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/scheduler/v1/src/client.rs
+++ b/src/generated/cloud/scheduler/v1/src/client.rs
@@ -125,11 +125,44 @@ impl CloudScheduler {
     }
 
     /// Gets a job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::cloud_scheduler::GetJob {
         super::builder::cloud_scheduler::GetJob::new(self.inner.clone())
     }
 
     /// Creates a job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_job(&self) -> super::builder::cloud_scheduler::CreateJob {
         super::builder::cloud_scheduler::CreateJob::new(self.inner.clone())
     }
@@ -147,11 +180,43 @@ impl CloudScheduler {
     ///
     /// [google.cloud.scheduler.v1.Job]: crate::model::Job
     /// [google.cloud.scheduler.v1.Job.State.UPDATE_FAILED]: crate::model::job::State::UpdateFailed
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_job(&self) -> super::builder::cloud_scheduler::UpdateJob {
         super::builder::cloud_scheduler::UpdateJob::new(self.inner.clone())
     }
 
     /// Deletes a job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::cloud_scheduler::DeleteJob {
         super::builder::cloud_scheduler::DeleteJob::new(self.inner.clone())
     }
@@ -171,6 +236,22 @@ impl CloudScheduler {
     /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
     /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_job(&self) -> super::builder::cloud_scheduler::PauseJob {
         super::builder::cloud_scheduler::PauseJob::new(self.inner.clone())
     }
@@ -188,6 +269,22 @@ impl CloudScheduler {
     /// [google.cloud.scheduler.v1.Job.State.ENABLED]: crate::model::job::State::Enabled
     /// [google.cloud.scheduler.v1.Job.State.PAUSED]: crate::model::job::State::Paused
     /// [google.cloud.scheduler.v1.Job.state]: crate::model::Job::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_job(&self) -> super::builder::cloud_scheduler::ResumeJob {
         super::builder::cloud_scheduler::ResumeJob::new(self.inner.clone())
     }
@@ -196,6 +293,22 @@ impl CloudScheduler {
     ///
     /// When this method is called, Cloud Scheduler will dispatch the job, even
     /// if the job is already running.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .run_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn run_job(&self) -> super::builder::cloud_scheduler::RunJob {
         super::builder::cloud_scheduler::RunJob::new(self.inner.clone())
     }
@@ -206,6 +319,22 @@ impl CloudScheduler {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_scheduler_v1::client::CloudScheduler;
+    /// async fn sample(
+    ///    client: &CloudScheduler
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_scheduler::GetLocation {
         super::builder::cloud_scheduler::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -142,6 +142,22 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_secret(&self) -> super::builder::secret_manager_service::CreateSecret {
         super::builder::secret_manager_service::CreateSecret::new(self.inner.clone())
     }
@@ -152,6 +168,22 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_secret_version(&self) -> super::builder::secret_manager_service::AddSecretVersion {
         super::builder::secret_manager_service::AddSecretVersion::new(self.inner.clone())
     }
@@ -159,6 +191,23 @@ impl SecretManagerService {
     /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret(&self) -> super::builder::secret_manager_service::GetSecret {
         super::builder::secret_manager_service::GetSecret::new(self.inner.clone())
     }
@@ -167,6 +216,22 @@ impl SecretManagerService {
     /// [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_secret(&self) -> super::builder::secret_manager_service::UpdateSecret {
         super::builder::secret_manager_service::UpdateSecret::new(self.inner.clone())
     }
@@ -174,6 +239,22 @@ impl SecretManagerService {
     /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_secret()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_secret(&self) -> super::builder::secret_manager_service::DeleteSecret {
         super::builder::secret_manager_service::DeleteSecret::new(self.inner.clone())
     }
@@ -195,6 +276,23 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret_version(&self) -> super::builder::secret_manager_service::GetSecretVersion {
         super::builder::secret_manager_service::GetSecretVersion::new(self.inner.clone())
     }
@@ -206,6 +304,22 @@ impl SecretManagerService {
     /// created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .access_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn access_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::AccessSecretVersion {
@@ -221,6 +335,22 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DISABLED]: crate::model::secret_version::State::Disabled
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::DisableSecretVersion {
@@ -236,6 +366,22 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.ENABLED]: crate::model::secret_version::State::Enabled
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .enable_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::EnableSecretVersion {
@@ -252,6 +398,22 @@ impl SecretManagerService {
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
     /// [google.cloud.secretmanager.v1.SecretVersion.State.DESTROYED]: crate::model::secret_version::State::Destroyed
     /// [google.cloud.secretmanager.v1.SecretVersion.state]: crate::model::SecretVersion::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .destroy_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn destroy_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::DestroySecretVersion {
@@ -268,12 +430,44 @@ impl SecretManagerService {
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::secret_manager_service::SetIamPolicy {
         super::builder::secret_manager_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::secret_manager_service::GetIamPolicy {
         super::builder::secret_manager_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -285,6 +479,22 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::secret_manager_service::TestIamPermissions {
@@ -297,6 +507,22 @@ impl SecretManagerService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::secret_manager_service::GetLocation {
         super::builder::secret_manager_service::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/securesourcemanager/v1/src/client.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/client.rs
@@ -129,6 +129,23 @@ impl SecureSourceManager {
     }
 
     /// Gets details of a single instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::secure_source_manager::GetInstance {
         super::builder::secure_source_manager::GetInstance::new(self.inner.clone())
     }
@@ -172,6 +189,23 @@ impl SecureSourceManager {
     }
 
     /// Gets metadata of a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_repository()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_repository(&self) -> super::builder::secure_source_manager::GetRepository {
         super::builder::secure_source_manager::GetRepository::new(self.inner.clone())
     }
@@ -230,6 +264,23 @@ impl SecureSourceManager {
     }
 
     /// Gets metadata of a hook.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_hook()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_hook(&self) -> super::builder::secure_source_manager::GetHook {
         super::builder::secure_source_manager::GetHook::new(self.inner.clone())
     }
@@ -280,17 +331,65 @@ impl SecureSourceManager {
     }
 
     /// Get IAM policy for a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy_repo()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy_repo(&self) -> super::builder::secure_source_manager::GetIamPolicyRepo {
         super::builder::secure_source_manager::GetIamPolicyRepo::new(self.inner.clone())
     }
 
     /// Set IAM policy on a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy_repo()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy_repo(&self) -> super::builder::secure_source_manager::SetIamPolicyRepo {
         super::builder::secure_source_manager::SetIamPolicyRepo::new(self.inner.clone())
     }
 
     /// Test IAM permissions on a repository.
     /// IAM permission checks are not required on this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions_repo()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions_repo(
         &self,
     ) -> super::builder::secure_source_manager::TestIamPermissionsRepo {
@@ -318,6 +417,23 @@ impl SecureSourceManager {
     }
 
     /// GetBranchRule gets a branch rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_branch_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_branch_rule(&self) -> super::builder::secure_source_manager::GetBranchRule {
         super::builder::secure_source_manager::GetBranchRule::new(self.inner.clone())
     }
@@ -368,6 +484,23 @@ impl SecureSourceManager {
     }
 
     /// Gets a pull request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pull_request()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pull_request(&self) -> super::builder::secure_source_manager::GetPullRequest {
         super::builder::secure_source_manager::GetPullRequest::new(self.inner.clone())
     }
@@ -450,6 +583,22 @@ impl SecureSourceManager {
     }
 
     /// Fetches a blob from a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_blob()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_blob(&self) -> super::builder::secure_source_manager::FetchBlob {
         super::builder::secure_source_manager::FetchBlob::new(self.inner.clone())
     }
@@ -470,6 +619,23 @@ impl SecureSourceManager {
     }
 
     /// Gets an issue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_issue()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_issue(&self) -> super::builder::secure_source_manager::GetIssue {
         super::builder::secure_source_manager::GetIssue::new(self.inner.clone())
     }
@@ -540,6 +706,23 @@ impl SecureSourceManager {
     }
 
     /// Gets a pull request comment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pull_request_comment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pull_request_comment(
         &self,
     ) -> super::builder::secure_source_manager::GetPullRequestComment {
@@ -689,6 +872,23 @@ impl SecureSourceManager {
     }
 
     /// Gets an issue comment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_issue_comment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_issue_comment(&self) -> super::builder::secure_source_manager::GetIssueComment {
         super::builder::secure_source_manager::GetIssueComment::new(self.inner.clone())
     }
@@ -738,6 +938,22 @@ impl SecureSourceManager {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::secure_source_manager::GetLocation {
         super::builder::secure_source_manager::GetLocation::new(self.inner.clone())
     }
@@ -747,12 +963,44 @@ impl SecureSourceManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::secure_source_manager::SetIamPolicy {
         super::builder::secure_source_manager::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::secure_source_manager::GetIamPolicy {
         super::builder::secure_source_manager::GetIamPolicy::new(self.inner.clone())
     }
@@ -764,6 +1012,22 @@ impl SecureSourceManager {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::secure_source_manager::TestIamPermissions {
@@ -780,6 +1044,22 @@ impl SecureSourceManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::secure_source_manager::GetOperation {
         super::builder::secure_source_manager::GetOperation::new(self.inner.clone())
     }
@@ -787,6 +1067,21 @@ impl SecureSourceManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::secure_source_manager::DeleteOperation {
         super::builder::secure_source_manager::DeleteOperation::new(self.inner.clone())
     }
@@ -794,6 +1089,21 @@ impl SecureSourceManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+    /// async fn sample(
+    ///    client: &SecureSourceManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::secure_source_manager::CancelOperation {
         super::builder::secure_source_manager::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/security/privateca/v1/src/client.rs
+++ b/src/generated/cloud/security/privateca/v1/src/client.rs
@@ -132,6 +132,22 @@ impl CertificateAuthorityService {
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_certificate(
         &self,
     ) -> super::builder::certificate_authority_service::CreateCertificate {
@@ -141,6 +157,23 @@ impl CertificateAuthorityService {
     /// Returns a [Certificate][google.cloud.security.privateca.v1.Certificate].
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate(&self) -> super::builder::certificate_authority_service::GetCertificate {
         super::builder::certificate_authority_service::GetCertificate::new(self.inner.clone())
     }
@@ -157,6 +190,22 @@ impl CertificateAuthorityService {
     /// Revoke a [Certificate][google.cloud.security.privateca.v1.Certificate].
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .revoke_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn revoke_certificate(
         &self,
     ) -> super::builder::certificate_authority_service::RevokeCertificate {
@@ -169,6 +218,22 @@ impl CertificateAuthorityService {
     ///
     /// [google.cloud.security.privateca.v1.Certificate]: crate::model::Certificate
     /// [google.cloud.security.privateca.v1.Certificate.labels]: crate::model::Certificate::labels
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_certificate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_certificate(
         &self,
     ) -> super::builder::certificate_authority_service::UpdateCertificate {
@@ -291,6 +356,22 @@ impl CertificateAuthorityService {
     /// [google.cloud.security.privateca.v1.CertificateAuthority.State.AWAITING_USER_ACTIVATION]: crate::model::certificate_authority::State::AwaitingUserActivation
     /// [google.cloud.security.privateca.v1.CertificateAuthority.Type.SUBORDINATE]: crate::model::certificate_authority::Type::Subordinate
     /// [google.cloud.security.privateca.v1.CertificateAuthorityService.ActivateCertificateAuthority]: crate::client::CertificateAuthorityService::activate_certificate_authority
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_certificate_authority_csr()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_certificate_authority_csr(
         &self,
     ) -> super::builder::certificate_authority_service::FetchCertificateAuthorityCsr {
@@ -303,6 +384,23 @@ impl CertificateAuthorityService {
     /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority].
     ///
     /// [google.cloud.security.privateca.v1.CertificateAuthority]: crate::model::CertificateAuthority
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_authority()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_authority(
         &self,
     ) -> super::builder::certificate_authority_service::GetCertificateAuthority {
@@ -427,6 +525,23 @@ impl CertificateAuthorityService {
     /// Returns a [CaPool][google.cloud.security.privateca.v1.CaPool].
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_ca_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_ca_pool(&self) -> super::builder::certificate_authority_service::GetCaPool {
         super::builder::certificate_authority_service::GetCaPool::new(self.inner.clone())
     }
@@ -461,6 +576,22 @@ impl CertificateAuthorityService {
     /// DISABLED, or STAGED states.
     ///
     /// [google.cloud.security.privateca.v1.CaPool]: crate::model::CaPool
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_ca_certs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_ca_certs(&self) -> super::builder::certificate_authority_service::FetchCaCerts {
         super::builder::certificate_authority_service::FetchCaCerts::new(self.inner.clone())
     }
@@ -469,6 +600,23 @@ impl CertificateAuthorityService {
     /// [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList].
     ///
     /// [google.cloud.security.privateca.v1.CertificateRevocationList]: crate::model::CertificateRevocationList
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_revocation_list()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_revocation_list(
         &self,
     ) -> super::builder::certificate_authority_service::GetCertificateRevocationList {
@@ -560,6 +708,23 @@ impl CertificateAuthorityService {
     /// [CertificateTemplate][google.cloud.security.privateca.v1.CertificateTemplate].
     ///
     /// [google.cloud.security.privateca.v1.CertificateTemplate]: crate::model::CertificateTemplate
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_certificate_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_certificate_template(
         &self,
     ) -> super::builder::certificate_authority_service::GetCertificateTemplate {
@@ -608,6 +773,22 @@ impl CertificateAuthorityService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::certificate_authority_service::GetLocation {
         super::builder::certificate_authority_service::GetLocation::new(self.inner.clone())
     }
@@ -617,12 +798,44 @@ impl CertificateAuthorityService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::certificate_authority_service::SetIamPolicy {
         super::builder::certificate_authority_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::certificate_authority_service::GetIamPolicy {
         super::builder::certificate_authority_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -634,6 +847,22 @@ impl CertificateAuthorityService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::certificate_authority_service::TestIamPermissions {
@@ -650,6 +879,22 @@ impl CertificateAuthorityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::certificate_authority_service::GetOperation {
         super::builder::certificate_authority_service::GetOperation::new(self.inner.clone())
     }
@@ -657,6 +902,21 @@ impl CertificateAuthorityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(
         &self,
     ) -> super::builder::certificate_authority_service::DeleteOperation {
@@ -666,6 +926,21 @@ impl CertificateAuthorityService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &CertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(
         &self,
     ) -> super::builder::certificate_authority_service::CancelOperation {

--- a/src/generated/cloud/security/publicca/v1/src/client.rs
+++ b/src/generated/cloud/security/publicca/v1/src/client.rs
@@ -129,6 +129,22 @@ impl PublicCertificateAuthorityService {
     /// bound to the project.
     ///
     /// [google.cloud.security.publicca.v1.ExternalAccountKey]: crate::model::ExternalAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_security_publicca_v1::client::PublicCertificateAuthorityService;
+    /// async fn sample(
+    ///    client: &PublicCertificateAuthorityService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_external_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_external_account_key(
         &self,
     ) -> super::builder::public_certificate_authority_service::CreateExternalAccountKey {

--- a/src/generated/cloud/securitycenter/v2/src/client.rs
+++ b/src/generated/cloud/securitycenter/v2/src/client.rs
@@ -120,6 +120,22 @@ impl SecurityCenter {
 
     /// Creates a ResourceValueConfig for an organization. Maps user's tags to
     /// difference resource values for use by the attack path simulation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_create_resource_value_configs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_create_resource_value_configs(
         &self,
     ) -> super::builder::security_center::BatchCreateResourceValueConfigs {
@@ -145,22 +161,86 @@ impl SecurityCenter {
     }
 
     /// Creates a BigQuery export.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_big_query_export()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_big_query_export(&self) -> super::builder::security_center::CreateBigQueryExport {
         super::builder::security_center::CreateBigQueryExport::new(self.inner.clone())
     }
 
     /// Creates a finding in a location. The corresponding source must exist for
     /// finding creation to succeed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_finding()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_finding(&self) -> super::builder::security_center::CreateFinding {
         super::builder::security_center::CreateFinding::new(self.inner.clone())
     }
 
     /// Creates a mute config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_mute_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_mute_config(&self) -> super::builder::security_center::CreateMuteConfig {
         super::builder::security_center::CreateMuteConfig::new(self.inner.clone())
     }
 
     /// Creates a notification config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_notification_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_notification_config(
         &self,
     ) -> super::builder::security_center::CreateNotificationConfig {
@@ -168,22 +248,86 @@ impl SecurityCenter {
     }
 
     /// Creates a source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_source()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_source(&self) -> super::builder::security_center::CreateSource {
         super::builder::security_center::CreateSource::new(self.inner.clone())
     }
 
     /// Deletes an existing BigQuery export.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_big_query_export()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_big_query_export(&self) -> super::builder::security_center::DeleteBigQueryExport {
         super::builder::security_center::DeleteBigQueryExport::new(self.inner.clone())
     }
 
     /// Deletes an existing mute config. If no location is specified, default is
     /// global.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_mute_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_mute_config(&self) -> super::builder::security_center::DeleteMuteConfig {
         super::builder::security_center::DeleteMuteConfig::new(self.inner.clone())
     }
 
     /// Deletes a notification config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_notification_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_notification_config(
         &self,
     ) -> super::builder::security_center::DeleteNotificationConfig {
@@ -191,6 +335,22 @@ impl SecurityCenter {
     }
 
     /// Deletes a ResourceValueConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_resource_value_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_resource_value_config(
         &self,
     ) -> super::builder::security_center::DeleteResourceValueConfig {
@@ -198,33 +358,134 @@ impl SecurityCenter {
     }
 
     /// Gets a BigQuery export.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_big_query_export()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_big_query_export(&self) -> super::builder::security_center::GetBigQueryExport {
         super::builder::security_center::GetBigQueryExport::new(self.inner.clone())
     }
 
     /// Get the simulation by name or the latest simulation for the given
     /// organization.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_simulation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_simulation(&self) -> super::builder::security_center::GetSimulation {
         super::builder::security_center::GetSimulation::new(self.inner.clone())
     }
 
     /// Get the valued resource by name
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_valued_resource()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_valued_resource(&self) -> super::builder::security_center::GetValuedResource {
         super::builder::security_center::GetValuedResource::new(self.inner.clone())
     }
 
     /// Gets the access control policy on the specified Source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::security_center::GetIamPolicy {
         super::builder::security_center::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets a mute config. If no location is specified, default is
     /// global.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_mute_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_mute_config(&self) -> super::builder::security_center::GetMuteConfig {
         super::builder::security_center::GetMuteConfig::new(self.inner.clone())
     }
 
     /// Gets a notification config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notification_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notification_config(
         &self,
     ) -> super::builder::security_center::GetNotificationConfig {
@@ -232,6 +493,23 @@ impl SecurityCenter {
     }
 
     /// Gets a ResourceValueConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_resource_value_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_resource_value_config(
         &self,
     ) -> super::builder::security_center::GetResourceValueConfig {
@@ -239,6 +517,23 @@ impl SecurityCenter {
     }
 
     /// Gets a source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_source(&self) -> super::builder::security_center::GetSource {
         super::builder::security_center::GetSource::new(self.inner.clone())
     }
@@ -322,33 +617,129 @@ impl SecurityCenter {
 
     /// Updates the state of a finding. If no location is specified, finding is
     /// assumed to be in global
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_finding_state()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_finding_state(&self) -> super::builder::security_center::SetFindingState {
         super::builder::security_center::SetFindingState::new(self.inner.clone())
     }
 
     /// Sets the access control policy on the specified Source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::security_center::SetIamPolicy {
         super::builder::security_center::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Updates the mute state of a finding. If no location is specified, finding
     /// is assumed to be in global
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_mute()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_mute(&self) -> super::builder::security_center::SetMute {
         super::builder::security_center::SetMute::new(self.inner.clone())
     }
 
     /// Returns the permissions that a caller has on the specified source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::security_center::TestIamPermissions {
         super::builder::security_center::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Updates a BigQuery export.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_big_query_export()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_big_query_export(&self) -> super::builder::security_center::UpdateBigQueryExport {
         super::builder::security_center::UpdateBigQueryExport::new(self.inner.clone())
     }
 
     /// Updates external system. This is for a given finding. If no location is
     /// specified, finding is assumed to be in global
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_external_system()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_external_system(&self) -> super::builder::security_center::UpdateExternalSystem {
         super::builder::security_center::UpdateExternalSystem::new(self.inner.clone())
     }
@@ -356,18 +747,66 @@ impl SecurityCenter {
     /// Creates or updates a finding. If no location is specified, finding is
     /// assumed to be in global. The corresponding source must exist for a finding
     /// creation to succeed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_finding()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_finding(&self) -> super::builder::security_center::UpdateFinding {
         super::builder::security_center::UpdateFinding::new(self.inner.clone())
     }
 
     /// Updates a mute config. If no location is specified, default is
     /// global.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_mute_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_mute_config(&self) -> super::builder::security_center::UpdateMuteConfig {
         super::builder::security_center::UpdateMuteConfig::new(self.inner.clone())
     }
 
     /// Updates a notification config. The following update
     /// fields are allowed: description, pubsub_topic, streaming_config.filter
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_notification_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_notification_config(
         &self,
     ) -> super::builder::security_center::UpdateNotificationConfig {
@@ -375,6 +814,22 @@ impl SecurityCenter {
     }
 
     /// Updates an existing ResourceValueConfigs with new rules.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_resource_value_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_resource_value_config(
         &self,
     ) -> super::builder::security_center::UpdateResourceValueConfig {
@@ -384,11 +839,43 @@ impl SecurityCenter {
     /// Updates security marks. For Finding Security marks, if no location is
     /// specified, finding is assumed to be in global. Assets Security Marks can
     /// only be accessed through global endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_security_marks()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_security_marks(&self) -> super::builder::security_center::UpdateSecurityMarks {
         super::builder::security_center::UpdateSecurityMarks::new(self.inner.clone())
     }
 
     /// Updates a source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_source()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_source(&self) -> super::builder::security_center::UpdateSource {
         super::builder::security_center::UpdateSource::new(self.inner.clone())
     }
@@ -403,6 +890,22 @@ impl SecurityCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::security_center::GetOperation {
         super::builder::security_center::GetOperation::new(self.inner.clone())
     }
@@ -410,6 +913,21 @@ impl SecurityCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::security_center::DeleteOperation {
         super::builder::security_center::DeleteOperation::new(self.inner.clone())
     }
@@ -417,6 +935,21 @@ impl SecurityCenter {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+    /// async fn sample(
+    ///    client: &SecurityCenter
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::security_center::CancelOperation {
         super::builder::security_center::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/securityposture/v1/src/client.rs
+++ b/src/generated/cloud/securityposture/v1/src/client.rs
@@ -143,6 +143,23 @@ impl SecurityPosture {
     /// NOT_FOUND error is returned if the revision_id or the Posture name does not
     /// exist. In case revision_id is not provided then the latest Posture revision
     /// by UpdateTime is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_posture()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_posture(&self) -> super::builder::security_posture::GetPosture {
         super::builder::security_posture::GetPosture::new(self.inner.clone())
     }
@@ -234,6 +251,23 @@ impl SecurityPosture {
     }
 
     /// Gets details of a single PostureDeployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_posture_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_posture_deployment(&self) -> super::builder::security_posture::GetPostureDeployment {
         super::builder::security_posture::GetPostureDeployment::new(self.inner.clone())
     }
@@ -301,6 +335,23 @@ impl SecurityPosture {
     /// NOT_FOUND error is returned if the revision_id or the PostureTemplate name
     /// does not exist. In case revision_id is not provided then the
     /// PostureTemplate with latest revision_id is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_posture_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_posture_template(&self) -> super::builder::security_posture::GetPostureTemplate {
         super::builder::security_posture::GetPostureTemplate::new(self.inner.clone())
     }
@@ -311,6 +362,22 @@ impl SecurityPosture {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::security_posture::GetLocation {
         super::builder::security_posture::GetLocation::new(self.inner.clone())
     }
@@ -325,6 +392,22 @@ impl SecurityPosture {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::security_posture::GetOperation {
         super::builder::security_posture::GetOperation::new(self.inner.clone())
     }
@@ -332,6 +415,21 @@ impl SecurityPosture {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::security_posture::DeleteOperation {
         super::builder::security_posture::DeleteOperation::new(self.inner.clone())
     }
@@ -339,6 +437,21 @@ impl SecurityPosture {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_securityposture_v1::client::SecurityPosture;
+    /// async fn sample(
+    ///    client: &SecurityPosture
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::security_posture::CancelOperation {
         super::builder::security_posture::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/servicedirectory/v1/src/client.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/client.rs
@@ -123,6 +123,22 @@ impl LookupService {
     /// Resolving a service is not considered an active developer method.
     ///
     /// [google.cloud.servicedirectory.v1.Service]: crate::model::Service
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::LookupService;
+    /// async fn sample(
+    ///    client: &LookupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resolve_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resolve_service(&self) -> super::builder::lookup_service::ResolveService {
         super::builder::lookup_service::ResolveService::new(self.inner.clone())
     }
@@ -133,6 +149,22 @@ impl LookupService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::LookupService;
+    /// async fn sample(
+    ///    client: &LookupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::lookup_service::GetLocation {
         super::builder::lookup_service::GetLocation::new(self.inner.clone())
     }
@@ -263,6 +295,22 @@ impl RegistrationService {
     }
 
     /// Creates a namespace, and returns the new namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_namespace(&self) -> super::builder::registration_service::CreateNamespace {
         super::builder::registration_service::CreateNamespace::new(self.inner.clone())
     }
@@ -273,22 +321,86 @@ impl RegistrationService {
     }
 
     /// Gets a namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_namespace()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_namespace(&self) -> super::builder::registration_service::GetNamespace {
         super::builder::registration_service::GetNamespace::new(self.inner.clone())
     }
 
     /// Updates a namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_namespace(&self) -> super::builder::registration_service::UpdateNamespace {
         super::builder::registration_service::UpdateNamespace::new(self.inner.clone())
     }
 
     /// Deletes a namespace. This also deletes all services and endpoints in
     /// the namespace.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_namespace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_namespace(&self) -> super::builder::registration_service::DeleteNamespace {
         super::builder::registration_service::DeleteNamespace::new(self.inner.clone())
     }
 
     /// Creates a service, and returns the new service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service(&self) -> super::builder::registration_service::CreateService {
         super::builder::registration_service::CreateService::new(self.inner.clone())
     }
@@ -299,22 +411,86 @@ impl RegistrationService {
     }
 
     /// Gets a service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::registration_service::GetService {
         super::builder::registration_service::GetService::new(self.inner.clone())
     }
 
     /// Updates a service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_service(&self) -> super::builder::registration_service::UpdateService {
         super::builder::registration_service::UpdateService::new(self.inner.clone())
     }
 
     /// Deletes a service. This also deletes all endpoints associated with
     /// the service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_service(&self) -> super::builder::registration_service::DeleteService {
         super::builder::registration_service::DeleteService::new(self.inner.clone())
     }
 
     /// Creates an endpoint, and returns the new endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_endpoint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_endpoint(&self) -> super::builder::registration_service::CreateEndpoint {
         super::builder::registration_service::CreateEndpoint::new(self.inner.clone())
     }
@@ -325,31 +501,127 @@ impl RegistrationService {
     }
 
     /// Gets an endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_endpoint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_endpoint(&self) -> super::builder::registration_service::GetEndpoint {
         super::builder::registration_service::GetEndpoint::new(self.inner.clone())
     }
 
     /// Updates an endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_endpoint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_endpoint(&self) -> super::builder::registration_service::UpdateEndpoint {
         super::builder::registration_service::UpdateEndpoint::new(self.inner.clone())
     }
 
     /// Deletes an endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_endpoint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_endpoint(&self) -> super::builder::registration_service::DeleteEndpoint {
         super::builder::registration_service::DeleteEndpoint::new(self.inner.clone())
     }
 
     /// Gets the IAM Policy for a resource (namespace or service only).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::registration_service::GetIamPolicy {
         super::builder::registration_service::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Sets the IAM Policy for a resource (namespace or service only).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::registration_service::SetIamPolicy {
         super::builder::registration_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Tests IAM permissions for a resource (namespace or service only).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::registration_service::TestIamPermissions {
         super::builder::registration_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -360,6 +632,22 @@ impl RegistrationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+    /// async fn sample(
+    ///    client: &RegistrationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::registration_service::GetLocation {
         super::builder::registration_service::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/servicehealth/v1/src/client.rs
+++ b/src/generated/cloud/servicehealth/v1/src/client.rs
@@ -124,6 +124,23 @@ impl ServiceHealth {
     }
 
     /// Retrieves a resource containing information about an event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+    /// async fn sample(
+    ///    client: &ServiceHealth,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_event()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_event(&self) -> super::builder::service_health::GetEvent {
         super::builder::service_health::GetEvent::new(self.inner.clone())
     }
@@ -137,6 +154,23 @@ impl ServiceHealth {
 
     /// Retrieves a resource containing information about an event affecting an
     /// organization .
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+    /// async fn sample(
+    ///    client: &ServiceHealth,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_organization_event()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_organization_event(&self) -> super::builder::service_health::GetOrganizationEvent {
         super::builder::service_health::GetOrganizationEvent::new(self.inner.clone())
     }
@@ -151,6 +185,23 @@ impl ServiceHealth {
 
     /// Retrieves a resource containing information about impact to an asset under
     /// an organization affected by a service health event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+    /// async fn sample(
+    ///    client: &ServiceHealth,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_organization_impact()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_organization_impact(&self) -> super::builder::service_health::GetOrganizationImpact {
         super::builder::service_health::GetOrganizationImpact::new(self.inner.clone())
     }
@@ -161,6 +212,22 @@ impl ServiceHealth {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+    /// async fn sample(
+    ///    client: &ServiceHealth
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::service_health::GetLocation {
         super::builder::service_health::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/shell/v1/src/client.rs
+++ b/src/generated/cloud/shell/v1/src/client.rs
@@ -128,6 +128,23 @@ impl CloudShellService {
     }
 
     /// Gets an environment. Returns NOT_FOUND if the environment does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_shell_v1::client::CloudShellService;
+    /// async fn sample(
+    ///    client: &CloudShellService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_environment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_environment(&self) -> super::builder::cloud_shell_service::GetEnvironment {
         super::builder::cloud_shell_service::GetEnvironment::new(self.inner.clone())
     }
@@ -210,6 +227,22 @@ impl CloudShellService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_shell_v1::client::CloudShellService;
+    /// async fn sample(
+    ///    client: &CloudShellService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_shell_service::GetOperation {
         super::builder::cloud_shell_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -146,6 +146,23 @@ impl Speech {
     /// exist.
     ///
     /// [google.cloud.speech.v2.Recognizer]: crate::model::Recognizer
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_recognizer()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_recognizer(&self) -> super::builder::speech::GetRecognizer {
         super::builder::speech::GetRecognizer::new(self.inner.clone())
     }
@@ -203,6 +220,22 @@ impl Speech {
 
     /// Performs synchronous Speech recognition: receive results after all audio
     /// has been sent and processed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .recognize()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn recognize(&self) -> super::builder::speech::Recognize {
         super::builder::speech::Recognize::new(self.inner.clone())
     }
@@ -227,6 +260,23 @@ impl Speech {
     /// Returns the requested [Config][google.cloud.speech.v2.Config].
     ///
     /// [google.cloud.speech.v2.Config]: crate::model::Config
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_config(&self) -> super::builder::speech::GetConfig {
         super::builder::speech::GetConfig::new(self.inner.clone())
     }
@@ -234,6 +284,22 @@ impl Speech {
     /// Updates the [Config][google.cloud.speech.v2.Config].
     ///
     /// [google.cloud.speech.v2.Config]: crate::model::Config
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_config(&self) -> super::builder::speech::UpdateConfig {
         super::builder::speech::UpdateConfig::new(self.inner.clone())
     }
@@ -264,6 +330,23 @@ impl Speech {
     /// [CustomClass][google.cloud.speech.v2.CustomClass].
     ///
     /// [google.cloud.speech.v2.CustomClass]: crate::model::CustomClass
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_custom_class()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_custom_class(&self) -> super::builder::speech::GetCustomClass {
         super::builder::speech::GetCustomClass::new(self.inner.clone())
     }
@@ -345,6 +428,23 @@ impl Speech {
     /// [PhraseSet][google.cloud.speech.v2.PhraseSet].
     ///
     /// [google.cloud.speech.v2.PhraseSet]: crate::model::PhraseSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_phrase_set()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_phrase_set(&self) -> super::builder::speech::GetPhraseSet {
         super::builder::speech::GetPhraseSet::new(self.inner.clone())
     }
@@ -406,6 +506,22 @@ impl Speech {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::speech::GetLocation {
         super::builder::speech::GetLocation::new(self.inner.clone())
     }
@@ -420,6 +536,22 @@ impl Speech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::speech::GetOperation {
         super::builder::speech::GetOperation::new(self.inner.clone())
     }
@@ -427,6 +559,21 @@ impl Speech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::speech::DeleteOperation {
         super::builder::speech::DeleteOperation::new(self.inner.clone())
     }
@@ -434,6 +581,21 @@ impl Speech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::speech::CancelOperation {
         super::builder::speech::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/sql/v1/src/client.rs
+++ b/src/generated/cloud/sql/v1/src/client.rs
@@ -122,16 +122,64 @@ impl SqlBackupRunsService {
     }
 
     /// Deletes the backup taken by a backup run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlBackupRunsService;
+    /// async fn sample(
+    ///    client: &SqlBackupRunsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::sql_backup_runs_service::Delete {
         super::builder::sql_backup_runs_service::Delete::new(self.inner.clone())
     }
 
     /// Retrieves a resource containing information about a backup run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlBackupRunsService;
+    /// async fn sample(
+    ///    client: &SqlBackupRunsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_backup_runs_service::Get {
         super::builder::sql_backup_runs_service::Get::new(self.inner.clone())
     }
 
     /// Creates a new backup run on demand.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlBackupRunsService;
+    /// async fn sample(
+    ///    client: &SqlBackupRunsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert(&self) -> super::builder::sql_backup_runs_service::Insert {
         super::builder::sql_backup_runs_service::Insert::new(self.inner.clone())
     }
@@ -250,6 +298,22 @@ impl SqlConnectService {
     }
 
     /// Retrieves connect settings about a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlConnectService;
+    /// async fn sample(
+    ///    client: &SqlConnectService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connect_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connect_settings(&self) -> super::builder::sql_connect_service::GetConnectSettings {
         super::builder::sql_connect_service::GetConnectSettings::new(self.inner.clone())
     }
@@ -258,6 +322,22 @@ impl SqlConnectService {
     /// and signed by a private key specific to the target instance. Users may use
     /// the certificate to authenticate as themselves when connecting to the
     /// database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlConnectService;
+    /// async fn sample(
+    ///    client: &SqlConnectService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_ephemeral_cert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_ephemeral_cert(
         &self,
     ) -> super::builder::sql_connect_service::GenerateEphemeralCert {
@@ -371,12 +451,44 @@ impl SqlDatabasesService {
     }
 
     /// Deletes a database from a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::sql_databases_service::Delete {
         super::builder::sql_databases_service::Delete::new(self.inner.clone())
     }
 
     /// Retrieves a resource containing information about a database inside a Cloud
     /// SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_databases_service::Get {
         super::builder::sql_databases_service::Get::new(self.inner.clone())
     }
@@ -385,23 +497,87 @@ impl SqlDatabasesService {
     /// SQL instance.
     ///
     /// **Note:** You can't modify the default character set and collation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert(&self) -> super::builder::sql_databases_service::Insert {
         super::builder::sql_databases_service::Insert::new(self.inner.clone())
     }
 
     /// Lists databases in the specified Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list(&self) -> super::builder::sql_databases_service::List {
         super::builder::sql_databases_service::List::new(self.inner.clone())
     }
 
     /// Partially updates a resource containing information about a database inside
     /// a Cloud SQL instance. This method supports patch semantics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch(&self) -> super::builder::sql_databases_service::Patch {
         super::builder::sql_databases_service::Patch::new(self.inner.clone())
     }
 
     /// Updates a resource containing information about a database inside a Cloud
     /// SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlDatabasesService;
+    /// async fn sample(
+    ///    client: &SqlDatabasesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update(&self) -> super::builder::sql_databases_service::Update {
         super::builder::sql_databases_service::Update::new(self.inner.clone())
     }
@@ -513,6 +689,22 @@ impl SqlFlagsService {
     }
 
     /// Lists all available database flags for Cloud SQL instances.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlFlagsService;
+    /// async fn sample(
+    ///    client: &SqlFlagsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list(&self) -> super::builder::sql_flags_service::List {
         super::builder::sql_flags_service::List::new(self.inner.clone())
     }
@@ -630,36 +822,132 @@ impl SqlInstancesService {
     /// waiting to be rotated in. For instances that have enabled Certificate
     /// Authority Service (CAS) based server CA, please use AddServerCertificate to
     /// add a new server certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_server_ca()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_server_ca(&self) -> super::builder::sql_instances_service::AddServerCa {
         super::builder::sql_instances_service::AddServerCa::new(self.inner.clone())
     }
 
     /// Creates a Cloud SQL instance as a clone of the source instance. Using this
     /// operation might cause your instance to restart.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .clone()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[allow(clippy::should_implement_trait)]
     pub fn clone(&self) -> super::builder::sql_instances_service::Clone {
         super::builder::sql_instances_service::Clone::new(self.inner.clone())
     }
 
     /// Deletes a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::sql_instances_service::Delete {
         super::builder::sql_instances_service::Delete::new(self.inner.clone())
     }
 
     /// Demotes the stand-alone instance to be a Cloud SQL read replica for an
     /// external database server.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .demote_master()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn demote_master(&self) -> super::builder::sql_instances_service::DemoteMaster {
         super::builder::sql_instances_service::DemoteMaster::new(self.inner.clone())
     }
 
     /// Demotes an existing standalone instance to be a Cloud SQL read replica
     /// for an external database server.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .demote()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn demote(&self) -> super::builder::sql_instances_service::Demote {
         super::builder::sql_instances_service::Demote::new(self.inner.clone())
     }
 
     /// Exports data from a Cloud SQL instance to a Cloud Storage bucket as a SQL
     /// dump or CSV file.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export(&self) -> super::builder::sql_instances_service::Export {
         super::builder::sql_instances_service::Export::new(self.inner.clone())
     }
@@ -672,27 +960,107 @@ impl SqlInstancesService {
     /// page in the Cloud SQL documentation.
     /// If using Legacy HA (MySQL only), this causes the instance to failover to
     /// its failover replica instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .failover()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn failover(&self) -> super::builder::sql_instances_service::Failover {
         super::builder::sql_instances_service::Failover::new(self.inner.clone())
     }
 
     /// Reencrypt CMEK instance with latest key version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reencrypt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reencrypt(&self) -> super::builder::sql_instances_service::Reencrypt {
         super::builder::sql_instances_service::Reencrypt::new(self.inner.clone())
     }
 
     /// Retrieves a resource containing information about a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_instances_service::Get {
         super::builder::sql_instances_service::Get::new(self.inner.clone())
     }
 
     /// Imports data into a Cloud SQL instance from a SQL dump  or CSV file in
     /// Cloud Storage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import(&self) -> super::builder::sql_instances_service::Import {
         super::builder::sql_instances_service::Import::new(self.inner.clone())
     }
 
     /// Creates a new Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert(&self) -> super::builder::sql_instances_service::Insert {
         super::builder::sql_instances_service::Insert::new(self.inner.clone())
     }
@@ -707,12 +1075,44 @@ impl SqlInstancesService {
     /// the certificate that is currently in use, a CA that has been added but not
     /// yet used to sign a certificate, and a CA used to sign a certificate that
     /// has previously rotated out.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_server_cas()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_server_cas(&self) -> super::builder::sql_instances_service::ListServerCas {
         super::builder::sql_instances_service::ListServerCas::new(self.inner.clone())
     }
 
     /// Partially updates settings of a Cloud SQL instance by merging the request
     /// with the current configuration. This method supports patch semantics.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch(&self) -> super::builder::sql_instances_service::Patch {
         super::builder::sql_instances_service::Patch::new(self.inner.clone())
     }
@@ -720,29 +1120,109 @@ impl SqlInstancesService {
     /// Promotes the read replica instance to be an independent Cloud SQL
     /// primary instance.
     /// Using this operation might cause your instance to restart.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .promote_replica()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn promote_replica(&self) -> super::builder::sql_instances_service::PromoteReplica {
         super::builder::sql_instances_service::PromoteReplica::new(self.inner.clone())
     }
 
     /// Switches over from the primary instance to the designated DR replica
     /// instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .switchover()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn switchover(&self) -> super::builder::sql_instances_service::Switchover {
         super::builder::sql_instances_service::Switchover::new(self.inner.clone())
     }
 
     /// Deletes all client certificates and generates a new server SSL certificate
     /// for the instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_ssl_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_ssl_config(&self) -> super::builder::sql_instances_service::ResetSslConfig {
         super::builder::sql_instances_service::ResetSslConfig::new(self.inner.clone())
     }
 
     /// Restarts a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restart()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restart(&self) -> super::builder::sql_instances_service::Restart {
         super::builder::sql_instances_service::Restart::new(self.inner.clone())
     }
 
     /// Restores a backup of a Cloud SQL instance. Using this operation might cause
     /// your instance to restart.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restore_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restore_backup(&self) -> super::builder::sql_instances_service::RestoreBackup {
         super::builder::sql_instances_service::RestoreBackup::new(self.inner.clone())
     }
@@ -751,28 +1231,108 @@ impl SqlInstancesService {
     /// (CA) version previously added with the addServerCA method. For instances
     /// that have enabled Certificate Authority Service (CAS) based server CA,
     /// please use RotateServerCertificate to rotate the server certificate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rotate_server_ca()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rotate_server_ca(&self) -> super::builder::sql_instances_service::RotateServerCa {
         super::builder::sql_instances_service::RotateServerCa::new(self.inner.clone())
     }
 
     /// Starts the replication in the read replica instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_replica()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_replica(&self) -> super::builder::sql_instances_service::StartReplica {
         super::builder::sql_instances_service::StartReplica::new(self.inner.clone())
     }
 
     /// Stops the replication in the read replica instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_replica()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_replica(&self) -> super::builder::sql_instances_service::StopReplica {
         super::builder::sql_instances_service::StopReplica::new(self.inner.clone())
     }
 
     /// Truncate MySQL general and slow query log tables
     /// MySQL only.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .truncate_log()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn truncate_log(&self) -> super::builder::sql_instances_service::TruncateLog {
         super::builder::sql_instances_service::TruncateLog::new(self.inner.clone())
     }
 
     /// Updates settings of a Cloud SQL instance. Using this operation might cause
     /// your instance to restart.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update(&self) -> super::builder::sql_instances_service::Update {
         super::builder::sql_instances_service::Update::new(self.inner.clone())
     }
@@ -781,11 +1341,43 @@ impl SqlInstancesService {
     /// and signed by a private key specific to the target instance. Users may use
     /// the certificate to authenticate as themselves when connecting to the
     /// database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_ephemeral()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_ephemeral(&self) -> super::builder::sql_instances_service::CreateEphemeral {
         super::builder::sql_instances_service::CreateEphemeral::new(self.inner.clone())
     }
 
     /// Reschedules the maintenance on the given instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reschedule_maintenance()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reschedule_maintenance(
         &self,
     ) -> super::builder::sql_instances_service::RescheduleMaintenance {
@@ -793,6 +1385,22 @@ impl SqlInstancesService {
     }
 
     /// Verify External primary instance external sync settings.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_external_sync_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_external_sync_settings(
         &self,
     ) -> super::builder::sql_instances_service::VerifyExternalSyncSettings {
@@ -800,16 +1408,64 @@ impl SqlInstancesService {
     }
 
     /// Start External primary instance migration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_external_sync()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_external_sync(&self) -> super::builder::sql_instances_service::StartExternalSync {
         super::builder::sql_instances_service::StartExternalSync::new(self.inner.clone())
     }
 
     /// Perform Disk Shrink on primary instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .perform_disk_shrink()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn perform_disk_shrink(&self) -> super::builder::sql_instances_service::PerformDiskShrink {
         super::builder::sql_instances_service::PerformDiskShrink::new(self.inner.clone())
     }
 
     /// Get Disk Shrink Config for a given instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_disk_shrink_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_disk_shrink_config(
         &self,
     ) -> super::builder::sql_instances_service::GetDiskShrinkConfig {
@@ -817,11 +1473,43 @@ impl SqlInstancesService {
     }
 
     /// Reset Replica Size to primary instance disk size.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_replica_size()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_replica_size(&self) -> super::builder::sql_instances_service::ResetReplicaSize {
         super::builder::sql_instances_service::ResetReplicaSize::new(self.inner.clone())
     }
 
     /// Get Latest Recovery Time for a given instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_latest_recovery_time()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_latest_recovery_time(
         &self,
     ) -> super::builder::sql_instances_service::GetLatestRecoveryTime {
@@ -829,11 +1517,43 @@ impl SqlInstancesService {
     }
 
     /// Acquire a lease for the setup of SQL Server Reporting Services (SSRS).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .acquire_ssrs_lease()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn acquire_ssrs_lease(&self) -> super::builder::sql_instances_service::AcquireSsrsLease {
         super::builder::sql_instances_service::AcquireSsrsLease::new(self.inner.clone())
     }
 
     /// Release a lease for the setup of SQL Server Reporting Services (SSRS).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlInstancesService;
+    /// async fn sample(
+    ///    client: &SqlInstancesService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .release_ssrs_lease()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn release_ssrs_lease(&self) -> super::builder::sql_instances_service::ReleaseSsrsLease {
         super::builder::sql_instances_service::ReleaseSsrsLease::new(self.inner.clone())
     }
@@ -945,6 +1665,22 @@ impl SqlOperationsService {
     }
 
     /// Retrieves an instance operation that has been performed on an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlOperationsService;
+    /// async fn sample(
+    ///    client: &SqlOperationsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_operations_service::Get {
         super::builder::sql_operations_service::Get::new(self.inner.clone())
     }
@@ -956,6 +1692,21 @@ impl SqlOperationsService {
     }
 
     /// Cancels an instance operation that has been performed on an instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlOperationsService;
+    /// async fn sample(
+    ///    client: &SqlOperationsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel(&self) -> super::builder::sql_operations_service::Cancel {
         super::builder::sql_operations_service::Cancel::new(self.inner.clone())
     }
@@ -1068,6 +1819,22 @@ impl SqlSslCertsService {
 
     /// Deletes the SSL certificate. For First Generation instances, the
     /// certificate remains valid until the instance is restarted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlSslCertsService;
+    /// async fn sample(
+    ///    client: &SqlSslCertsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::sql_ssl_certs_service::Delete {
         super::builder::sql_ssl_certs_service::Delete::new(self.inner.clone())
     }
@@ -1075,6 +1842,22 @@ impl SqlSslCertsService {
     /// Retrieves a particular SSL certificate.  Does not include the private key
     /// (required for usage).  The private key must be saved from the response to
     /// initial creation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlSslCertsService;
+    /// async fn sample(
+    ///    client: &SqlSslCertsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_ssl_certs_service::Get {
         super::builder::sql_ssl_certs_service::Get::new(self.inner.clone())
     }
@@ -1082,11 +1865,43 @@ impl SqlSslCertsService {
     /// Creates an SSL certificate and returns it along with the private key and
     /// server certificate authority.  The new certificate will not be usable until
     /// the instance is restarted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlSslCertsService;
+    /// async fn sample(
+    ///    client: &SqlSslCertsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert(&self) -> super::builder::sql_ssl_certs_service::Insert {
         super::builder::sql_ssl_certs_service::Insert::new(self.inner.clone())
     }
 
     /// Lists all of the current SSL certificates for the instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlSslCertsService;
+    /// async fn sample(
+    ///    client: &SqlSslCertsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list(&self) -> super::builder::sql_ssl_certs_service::List {
         super::builder::sql_ssl_certs_service::List::new(self.inner.clone())
     }
@@ -1200,6 +2015,22 @@ impl SqlTiersService {
     /// Lists all available machine types (tiers) for Cloud SQL, for example,
     /// `db-custom-1-3840`. For more information, see
     /// <https://cloud.google.com/sql/pricing>.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlTiersService;
+    /// async fn sample(
+    ///    client: &SqlTiersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list(&self) -> super::builder::sql_tiers_service::List {
         super::builder::sql_tiers_service::List::new(self.inner.clone())
     }
@@ -1311,26 +2142,106 @@ impl SqlUsersService {
     }
 
     /// Deletes a user from a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// async fn sample(
+    ///    client: &SqlUsersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete(&self) -> super::builder::sql_users_service::Delete {
         super::builder::sql_users_service::Delete::new(self.inner.clone())
     }
 
     /// Retrieves a resource containing information about a user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// async fn sample(
+    ///    client: &SqlUsersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get(&self) -> super::builder::sql_users_service::Get {
         super::builder::sql_users_service::Get::new(self.inner.clone())
     }
 
     /// Creates a new user in a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// async fn sample(
+    ///    client: &SqlUsersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .insert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn insert(&self) -> super::builder::sql_users_service::Insert {
         super::builder::sql_users_service::Insert::new(self.inner.clone())
     }
 
     /// Lists users in the specified Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// async fn sample(
+    ///    client: &SqlUsersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list(&self) -> super::builder::sql_users_service::List {
         super::builder::sql_users_service::List::new(self.inner.clone())
     }
 
     /// Updates an existing user in a Cloud SQL instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_sql_v1::client::SqlUsersService;
+    /// async fn sample(
+    ///    client: &SqlUsersService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update(&self) -> super::builder::sql_users_service::Update {
         super::builder::sql_users_service::Update::new(self.inner.clone())
     }

--- a/src/generated/cloud/storagebatchoperations/v1/src/client.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/client.rs
@@ -130,6 +130,23 @@ impl StorageBatchOperations {
     }
 
     /// Gets a batch job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::storage_batch_operations::GetJob {
         super::builder::storage_batch_operations::GetJob::new(self.inner.clone())
     }
@@ -150,11 +167,43 @@ impl StorageBatchOperations {
     }
 
     /// Deletes a batch job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::storage_batch_operations::DeleteJob {
         super::builder::storage_batch_operations::DeleteJob::new(self.inner.clone())
     }
 
     /// Cancels a batch job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_job(&self) -> super::builder::storage_batch_operations::CancelJob {
         super::builder::storage_batch_operations::CancelJob::new(self.inner.clone())
     }
@@ -165,6 +214,22 @@ impl StorageBatchOperations {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::storage_batch_operations::GetLocation {
         super::builder::storage_batch_operations::GetLocation::new(self.inner.clone())
     }
@@ -179,6 +244,22 @@ impl StorageBatchOperations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::storage_batch_operations::GetOperation {
         super::builder::storage_batch_operations::GetOperation::new(self.inner.clone())
     }
@@ -186,6 +267,21 @@ impl StorageBatchOperations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::storage_batch_operations::DeleteOperation {
         super::builder::storage_batch_operations::DeleteOperation::new(self.inner.clone())
     }
@@ -193,6 +289,21 @@ impl StorageBatchOperations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+    /// async fn sample(
+    ///    client: &StorageBatchOperations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::storage_batch_operations::CancelOperation {
         super::builder::storage_batch_operations::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/storageinsights/v1/src/client.rs
+++ b/src/generated/cloud/storageinsights/v1/src/client.rs
@@ -127,21 +127,85 @@ impl StorageInsights {
     }
 
     /// Gets details of a single ReportConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_report_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_report_config(&self) -> super::builder::storage_insights::GetReportConfig {
         super::builder::storage_insights::GetReportConfig::new(self.inner.clone())
     }
 
     /// Creates a new ReportConfig in a given project and location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_report_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_report_config(&self) -> super::builder::storage_insights::CreateReportConfig {
         super::builder::storage_insights::CreateReportConfig::new(self.inner.clone())
     }
 
     /// Updates the parameters of a single ReportConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_report_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_report_config(&self) -> super::builder::storage_insights::UpdateReportConfig {
         super::builder::storage_insights::UpdateReportConfig::new(self.inner.clone())
     }
 
     /// Deletes a single ReportConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_report_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_report_config(&self) -> super::builder::storage_insights::DeleteReportConfig {
         super::builder::storage_insights::DeleteReportConfig::new(self.inner.clone())
     }
@@ -152,6 +216,23 @@ impl StorageInsights {
     }
 
     /// Gets details of a single ReportDetail.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_report_detail()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_report_detail(&self) -> super::builder::storage_insights::GetReportDetail {
         super::builder::storage_insights::GetReportDetail::new(self.inner.clone())
     }
@@ -162,6 +243,23 @@ impl StorageInsights {
     }
 
     /// Gets the dataset configuration in a given project for a given location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset_config(&self) -> super::builder::storage_insights::GetDatasetConfig {
         super::builder::storage_insights::GetDatasetConfig::new(self.inner.clone())
     }
@@ -248,6 +346,22 @@ impl StorageInsights {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::storage_insights::GetLocation {
         super::builder::storage_insights::GetLocation::new(self.inner.clone())
     }
@@ -262,6 +376,22 @@ impl StorageInsights {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::storage_insights::GetOperation {
         super::builder::storage_insights::GetOperation::new(self.inner.clone())
     }
@@ -269,6 +399,21 @@ impl StorageInsights {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::storage_insights::DeleteOperation {
         super::builder::storage_insights::DeleteOperation::new(self.inner.clone())
     }
@@ -276,6 +421,21 @@ impl StorageInsights {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storageinsights_v1::client::StorageInsights;
+    /// async fn sample(
+    ///    client: &StorageInsights
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::storage_insights::CancelOperation {
         super::builder::storage_insights::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/support/v2/src/client.rs
+++ b/src/generated/cloud/support/v2/src/client.rs
@@ -230,6 +230,23 @@ impl CaseService {
     }
 
     /// Retrieve a case.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// async fn sample(
+    ///    client: &CaseService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_case()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_case(&self) -> super::builder::case_service::GetCase {
         super::builder::case_service::GetCase::new(self.inner.clone())
     }
@@ -253,11 +270,43 @@ impl CaseService {
     /// It must have the following fields set: `display_name`, `description`,
     /// `classification`, and `priority`. If you're just testing the API and don't
     /// want to route your case to an agent, set `testCase=true`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// async fn sample(
+    ///    client: &CaseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_case(&self) -> super::builder::case_service::CreateCase {
         super::builder::case_service::CreateCase::new(self.inner.clone())
     }
 
     /// Update a case. Only some fields can be updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// async fn sample(
+    ///    client: &CaseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_case(&self) -> super::builder::case_service::UpdateCase {
         super::builder::case_service::UpdateCase::new(self.inner.clone())
     }
@@ -269,11 +318,43 @@ impl CaseService {
     /// <https://cloud.google.com/support> and look for 'Technical support
     /// escalations' in the feature list to find out which ones let you
     /// do that.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// async fn sample(
+    ///    client: &CaseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .escalate_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn escalate_case(&self) -> super::builder::case_service::EscalateCase {
         super::builder::case_service::EscalateCase::new(self.inner.clone())
     }
 
     /// Close a case.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CaseService;
+    /// async fn sample(
+    ///    client: &CaseService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .close_case()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn close_case(&self) -> super::builder::case_service::CloseCase {
         super::builder::case_service::CloseCase::new(self.inner.clone())
     }
@@ -405,6 +486,22 @@ impl CommentService {
     /// Add a new comment to a case.
     ///
     /// The comment must have the following fields set: `body`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_support_v2::client::CommentService;
+    /// async fn sample(
+    ///    client: &CommentService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_comment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_comment(&self) -> super::builder::comment_service::CreateComment {
         super::builder::comment_service::CreateComment::new(self.inner.clone())
     }

--- a/src/generated/cloud/talent/v4/src/client.rs
+++ b/src/generated/cloud/talent/v4/src/client.rs
@@ -119,22 +119,86 @@ impl CompanyService {
     }
 
     /// Creates a new company entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// async fn sample(
+    ///    client: &CompanyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_company()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_company(&self) -> super::builder::company_service::CreateCompany {
         super::builder::company_service::CreateCompany::new(self.inner.clone())
     }
 
     /// Retrieves specified company.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// async fn sample(
+    ///    client: &CompanyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_company()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_company(&self) -> super::builder::company_service::GetCompany {
         super::builder::company_service::GetCompany::new(self.inner.clone())
     }
 
     /// Updates specified company.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// async fn sample(
+    ///    client: &CompanyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_company()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_company(&self) -> super::builder::company_service::UpdateCompany {
         super::builder::company_service::UpdateCompany::new(self.inner.clone())
     }
 
     /// Deletes specified company.
     /// Prerequisite: The company has no jobs associated with it.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// async fn sample(
+    ///    client: &CompanyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_company()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_company(&self) -> super::builder::company_service::DeleteCompany {
         super::builder::company_service::DeleteCompany::new(self.inner.clone())
     }
@@ -147,6 +211,22 @@ impl CompanyService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::CompanyService;
+    /// async fn sample(
+    ///    client: &CompanyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::company_service::GetOperation {
         super::builder::company_service::GetOperation::new(self.inner.clone())
     }
@@ -256,6 +336,22 @@ impl Completion {
 
     /// Completes the specified prefix with keyword suggestions.
     /// Intended for use by a job search auto-complete search box.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::Completion;
+    /// async fn sample(
+    ///    client: &Completion
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_query(&self) -> super::builder::completion::CompleteQuery {
         super::builder::completion::CompleteQuery::new(self.inner.clone())
     }
@@ -263,6 +359,22 @@ impl Completion {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::Completion;
+    /// async fn sample(
+    ///    client: &Completion
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::completion::GetOperation {
         super::builder::completion::GetOperation::new(self.inner.clone())
     }
@@ -377,6 +489,22 @@ impl EventService {
     /// [Learn
     /// more](https://cloud.google.com/talent-solution/docs/management-tools)
     /// about self service tools.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::EventService;
+    /// async fn sample(
+    ///    client: &EventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_client_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_client_event(&self) -> super::builder::event_service::CreateClientEvent {
         super::builder::event_service::CreateClientEvent::new(self.inner.clone())
     }
@@ -384,6 +512,22 @@ impl EventService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::EventService;
+    /// async fn sample(
+    ///    client: &EventService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::event_service::GetOperation {
         super::builder::event_service::GetOperation::new(self.inner.clone())
     }
@@ -495,6 +639,22 @@ impl JobService {
     ///
     /// Typically, the job becomes searchable within 10 seconds, but it may take
     /// up to 5 minutes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_job(&self) -> super::builder::job_service::CreateJob {
         super::builder::job_service::CreateJob::new(self.inner.clone())
     }
@@ -516,6 +676,23 @@ impl JobService {
 
     /// Retrieves the specified job, whose status is OPEN or recently EXPIRED
     /// within the last 90 days.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::job_service::GetJob {
         super::builder::job_service::GetJob::new(self.inner.clone())
     }
@@ -524,6 +701,22 @@ impl JobService {
     ///
     /// Typically, updated contents become visible in search results within 10
     /// seconds, but it may take up to 5 minutes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_job(&self) -> super::builder::job_service::UpdateJob {
         super::builder::job_service::UpdateJob::new(self.inner.clone())
     }
@@ -547,6 +740,21 @@ impl JobService {
     ///
     /// Typically, the job becomes unsearchable within 10 seconds, but it may take
     /// up to 5 minutes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::job_service::DeleteJob {
         super::builder::job_service::DeleteJob::new(self.inner.clone())
     }
@@ -581,6 +789,22 @@ impl JobService {
     ///
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
     /// [google.cloud.talent.v4.SearchJobsRequest]: crate::model::SearchJobsRequest
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_jobs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_jobs(&self) -> super::builder::job_service::SearchJobs {
         super::builder::job_service::SearchJobs::new(self.inner.clone())
     }
@@ -600,6 +824,22 @@ impl JobService {
     ///
     /// [google.cloud.talent.v4.Job.visibility]: crate::model::Job::visibility
     /// [google.cloud.talent.v4.SearchJobsRequest]: crate::model::SearchJobsRequest
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_jobs_for_alert()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_jobs_for_alert(&self) -> super::builder::job_service::SearchJobsForAlert {
         super::builder::job_service::SearchJobsForAlert::new(self.inner.clone())
     }
@@ -607,6 +847,22 @@ impl JobService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::JobService;
+    /// async fn sample(
+    ///    client: &JobService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::job_service::GetOperation {
         super::builder::job_service::GetOperation::new(self.inner.clone())
     }
@@ -715,21 +971,85 @@ impl TenantService {
     }
 
     /// Creates a new tenant entity.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// async fn sample(
+    ///    client: &TenantService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tenant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tenant(&self) -> super::builder::tenant_service::CreateTenant {
         super::builder::tenant_service::CreateTenant::new(self.inner.clone())
     }
 
     /// Retrieves specified tenant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// async fn sample(
+    ///    client: &TenantService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tenant()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tenant(&self) -> super::builder::tenant_service::GetTenant {
         super::builder::tenant_service::GetTenant::new(self.inner.clone())
     }
 
     /// Updates specified tenant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// async fn sample(
+    ///    client: &TenantService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tenant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tenant(&self) -> super::builder::tenant_service::UpdateTenant {
         super::builder::tenant_service::UpdateTenant::new(self.inner.clone())
     }
 
     /// Deletes specified tenant.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// async fn sample(
+    ///    client: &TenantService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tenant()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_tenant(&self) -> super::builder::tenant_service::DeleteTenant {
         super::builder::tenant_service::DeleteTenant::new(self.inner.clone())
     }
@@ -742,6 +1062,22 @@ impl TenantService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_talent_v4::client::TenantService;
+    /// async fn sample(
+    ///    client: &TenantService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tenant_service::GetOperation {
         super::builder::tenant_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/tasks/v2/src/client.rs
+++ b/src/generated/cloud/tasks/v2/src/client.rs
@@ -127,6 +127,23 @@ impl CloudTasks {
     }
 
     /// Gets a queue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_queue()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_queue(&self) -> super::builder::cloud_tasks::GetQueue {
         super::builder::cloud_tasks::GetQueue::new(self.inner.clone())
     }
@@ -143,6 +160,22 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_queue(&self) -> super::builder::cloud_tasks::CreateQueue {
         super::builder::cloud_tasks::CreateQueue::new(self.inner.clone())
     }
@@ -162,6 +195,22 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_queue(&self) -> super::builder::cloud_tasks::UpdateQueue {
         super::builder::cloud_tasks::UpdateQueue::new(self.inner.clone())
     }
@@ -179,6 +228,21 @@ impl CloudTasks {
     /// [Overview of Queue Management and
     /// queue.yaml](https://cloud.google.com/tasks/docs/queue-yaml) before using
     /// this method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_queue(&self) -> super::builder::cloud_tasks::DeleteQueue {
         super::builder::cloud_tasks::DeleteQueue::new(self.inner.clone())
     }
@@ -189,6 +253,22 @@ impl CloudTasks {
     ///
     /// Purge operations can take up to one minute to take effect. Tasks
     /// might be dispatched before the purge takes effect. A purge is irreversible.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .purge_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn purge_queue(&self) -> super::builder::cloud_tasks::PurgeQueue {
         super::builder::cloud_tasks::PurgeQueue::new(self.inner.clone())
     }
@@ -205,6 +285,22 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.CloudTasks.ResumeQueue]: crate::client::CloudTasks::resume_queue
     /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_queue(&self) -> super::builder::cloud_tasks::PauseQueue {
         super::builder::cloud_tasks::PauseQueue::new(self.inner.clone())
     }
@@ -228,6 +324,22 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.Queue.State.PAUSED]: crate::model::queue::State::Paused
     /// [google.cloud.tasks.v2.Queue.State.RUNNING]: crate::model::queue::State::Running
     /// [google.cloud.tasks.v2.Queue.state]: crate::model::Queue::state
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_queue()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_queue(&self) -> super::builder::cloud_tasks::ResumeQueue {
         super::builder::cloud_tasks::ResumeQueue::new(self.inner.clone())
     }
@@ -243,6 +355,22 @@ impl CloudTasks {
     /// * `cloudtasks.queues.getIamPolicy`
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::cloud_tasks::GetIamPolicy {
         super::builder::cloud_tasks::GetIamPolicy::new(self.inner.clone())
     }
@@ -260,6 +388,22 @@ impl CloudTasks {
     /// * `cloudtasks.queues.setIamPolicy`
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::cloud_tasks::SetIamPolicy {
         super::builder::cloud_tasks::SetIamPolicy::new(self.inner.clone())
     }
@@ -274,6 +418,22 @@ impl CloudTasks {
     /// may "fail open" without warning.
     ///
     /// [google.cloud.tasks.v2.Queue]: crate::model::Queue
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::cloud_tasks::TestIamPermissions {
         super::builder::cloud_tasks::TestIamPermissions::new(self.inner.clone())
     }
@@ -295,6 +455,23 @@ impl CloudTasks {
     }
 
     /// Gets a task.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_task()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_task(&self) -> super::builder::cloud_tasks::GetTask {
         super::builder::cloud_tasks::GetTask::new(self.inner.clone())
     }
@@ -304,6 +481,22 @@ impl CloudTasks {
     /// Tasks cannot be updated after creation; there is no UpdateTask command.
     ///
     /// * The maximum task size is 100KB.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_task()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_task(&self) -> super::builder::cloud_tasks::CreateTask {
         super::builder::cloud_tasks::CreateTask::new(self.inner.clone())
     }
@@ -313,6 +506,21 @@ impl CloudTasks {
     /// A task can be deleted if it is scheduled or dispatched. A task
     /// cannot be deleted if it has executed successfully or permanently
     /// failed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_task()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_task(&self) -> super::builder::cloud_tasks::DeleteTask {
         super::builder::cloud_tasks::DeleteTask::new(self.inner.clone())
     }
@@ -349,6 +557,22 @@ impl CloudTasks {
     /// [google.cloud.tasks.v2.RateLimits]: crate::model::RateLimits
     /// [google.cloud.tasks.v2.RetryConfig]: crate::model::RetryConfig
     /// [google.cloud.tasks.v2.Task.schedule_time]: crate::model::Task::schedule_time
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .run_task()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn run_task(&self) -> super::builder::cloud_tasks::RunTask {
         super::builder::cloud_tasks::RunTask::new(self.inner.clone())
     }
@@ -359,6 +583,22 @@ impl CloudTasks {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tasks_v2::client::CloudTasks;
+    /// async fn sample(
+    ///    client: &CloudTasks
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::cloud_tasks::GetLocation {
         super::builder::cloud_tasks::GetLocation::new(self.inner.clone())
     }

--- a/src/generated/cloud/telcoautomation/v1/src/client.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/client.rs
@@ -133,6 +133,23 @@ impl TelcoAutomation {
     }
 
     /// Gets details of a single OrchestrationCluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_orchestration_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_orchestration_cluster(
         &self,
     ) -> super::builder::telco_automation::GetOrchestrationCluster {
@@ -179,6 +196,23 @@ impl TelcoAutomation {
     }
 
     /// Gets details of a single EdgeSlm.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_edge_slm()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_edge_slm(&self) -> super::builder::telco_automation::GetEdgeSlm {
         super::builder::telco_automation::GetEdgeSlm::new(self.inner.clone())
     }
@@ -214,21 +248,86 @@ impl TelcoAutomation {
     }
 
     /// Creates a blueprint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_blueprint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_blueprint(&self) -> super::builder::telco_automation::CreateBlueprint {
         super::builder::telco_automation::CreateBlueprint::new(self.inner.clone())
     }
 
     /// Updates a blueprint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_blueprint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_blueprint(&self) -> super::builder::telco_automation::UpdateBlueprint {
         super::builder::telco_automation::UpdateBlueprint::new(self.inner.clone())
     }
 
     /// Returns the requested blueprint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_blueprint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_blueprint(&self) -> super::builder::telco_automation::GetBlueprint {
         super::builder::telco_automation::GetBlueprint::new(self.inner.clone())
     }
 
     /// Deletes a blueprint and all its revisions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_blueprint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_blueprint(&self) -> super::builder::telco_automation::DeleteBlueprint {
         super::builder::telco_automation::DeleteBlueprint::new(self.inner.clone())
     }
@@ -239,16 +338,64 @@ impl TelcoAutomation {
     }
 
     /// Approves a blueprint and commits a new revision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .approve_blueprint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn approve_blueprint(&self) -> super::builder::telco_automation::ApproveBlueprint {
         super::builder::telco_automation::ApproveBlueprint::new(self.inner.clone())
     }
 
     /// Proposes a blueprint for approval of changes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .propose_blueprint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn propose_blueprint(&self) -> super::builder::telco_automation::ProposeBlueprint {
         super::builder::telco_automation::ProposeBlueprint::new(self.inner.clone())
     }
 
     /// Rejects a blueprint revision proposal and flips it back to Draft state.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reject_blueprint()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reject_blueprint(&self) -> super::builder::telco_automation::RejectBlueprint {
         super::builder::telco_automation::RejectBlueprint::new(self.inner.clone())
     }
@@ -277,6 +424,22 @@ impl TelcoAutomation {
     /// Discards the changes in a blueprint and reverts the blueprint to the last
     /// approved blueprint revision. No changes take place if a blueprint does not
     /// have revisions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .discard_blueprint_changes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn discard_blueprint_changes(
         &self,
     ) -> super::builder::telco_automation::DiscardBlueprintChanges {
@@ -290,27 +453,108 @@ impl TelcoAutomation {
     }
 
     /// Returns the requested public blueprint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_public_blueprint()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_public_blueprint(&self) -> super::builder::telco_automation::GetPublicBlueprint {
         super::builder::telco_automation::GetPublicBlueprint::new(self.inner.clone())
     }
 
     /// Creates a deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_deployment(&self) -> super::builder::telco_automation::CreateDeployment {
         super::builder::telco_automation::CreateDeployment::new(self.inner.clone())
     }
 
     /// Updates a deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_deployment(&self) -> super::builder::telco_automation::UpdateDeployment {
         super::builder::telco_automation::UpdateDeployment::new(self.inner.clone())
     }
 
     /// Returns the requested deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deployment(&self) -> super::builder::telco_automation::GetDeployment {
         super::builder::telco_automation::GetDeployment::new(self.inner.clone())
     }
 
     /// Removes the deployment by marking it as DELETING. Post which deployment and
     /// it's revisions gets deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .remove_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_deployment(&self) -> super::builder::telco_automation::RemoveDeployment {
         super::builder::telco_automation::RemoveDeployment::new(self.inner.clone())
     }
@@ -330,6 +574,22 @@ impl TelcoAutomation {
     /// Discards the changes in a deployment and reverts the deployment to the last
     /// approved deployment revision. No changes take place if a deployment does
     /// not have revisions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .discard_deployment_changes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn discard_deployment_changes(
         &self,
     ) -> super::builder::telco_automation::DiscardDeploymentChanges {
@@ -337,11 +597,43 @@ impl TelcoAutomation {
     }
 
     /// Applies the deployment's YAML files to the parent orchestration cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .apply_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn apply_deployment(&self) -> super::builder::telco_automation::ApplyDeployment {
         super::builder::telco_automation::ApplyDeployment::new(self.inner.clone())
     }
 
     /// Returns the requested deployment status.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compute_deployment_status()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compute_deployment_status(
         &self,
     ) -> super::builder::telco_automation::ComputeDeploymentStatus {
@@ -350,11 +642,44 @@ impl TelcoAutomation {
 
     /// Rollback the active deployment to the given past approved deployment
     /// revision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rollback_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rollback_deployment(&self) -> super::builder::telco_automation::RollbackDeployment {
         super::builder::telco_automation::RollbackDeployment::new(self.inner.clone())
     }
 
     /// Returns the requested hydrated deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_hydrated_deployment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_hydrated_deployment(
         &self,
     ) -> super::builder::telco_automation::GetHydratedDeployment {
@@ -369,6 +694,22 @@ impl TelcoAutomation {
     }
 
     /// Updates a hydrated deployment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_hydrated_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_hydrated_deployment(
         &self,
     ) -> super::builder::telco_automation::UpdateHydratedDeployment {
@@ -376,6 +717,22 @@ impl TelcoAutomation {
     }
 
     /// Applies a hydrated deployment to a workload cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .apply_hydrated_deployment()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn apply_hydrated_deployment(
         &self,
     ) -> super::builder::telco_automation::ApplyHydratedDeployment {
@@ -388,6 +745,22 @@ impl TelcoAutomation {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::telco_automation::GetLocation {
         super::builder::telco_automation::GetLocation::new(self.inner.clone())
     }
@@ -402,6 +775,22 @@ impl TelcoAutomation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::telco_automation::GetOperation {
         super::builder::telco_automation::GetOperation::new(self.inner.clone())
     }
@@ -409,6 +798,21 @@ impl TelcoAutomation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::telco_automation::DeleteOperation {
         super::builder::telco_automation::DeleteOperation::new(self.inner.clone())
     }
@@ -416,6 +820,21 @@ impl TelcoAutomation {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+    /// async fn sample(
+    ///    client: &TelcoAutomation
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::telco_automation::CancelOperation {
         super::builder::telco_automation::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/texttospeech/v1/src/client.rs
+++ b/src/generated/cloud/texttospeech/v1/src/client.rs
@@ -119,12 +119,44 @@ impl TextToSpeech {
     }
 
     /// Returns a list of Voice supported for synthesis.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+    /// async fn sample(
+    ///    client: &TextToSpeech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_voices()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_voices(&self) -> super::builder::text_to_speech::ListVoices {
         super::builder::text_to_speech::ListVoices::new(self.inner.clone())
     }
 
     /// Synthesizes speech synchronously: receive results after all text input
     /// has been processed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+    /// async fn sample(
+    ///    client: &TextToSpeech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .synthesize_speech()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn synthesize_speech(&self) -> super::builder::text_to_speech::SynthesizeSpeech {
         super::builder::text_to_speech::SynthesizeSpeech::new(self.inner.clone())
     }
@@ -139,6 +171,22 @@ impl TextToSpeech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+    /// async fn sample(
+    ///    client: &TextToSpeech
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::text_to_speech::GetOperation {
         super::builder::text_to_speech::GetOperation::new(self.inner.clone())
     }
@@ -283,6 +331,22 @@ impl TextToSpeechLongAudioSynthesize {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_texttospeech_v1::client::TextToSpeechLongAudioSynthesize;
+    /// async fn sample(
+    ///    client: &TextToSpeechLongAudioSynthesize
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::text_to_speech_long_audio_synthesize::GetOperation {

--- a/src/generated/cloud/timeseriesinsights/v1/src/client.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/client.rs
@@ -140,6 +140,22 @@ impl TimeseriesInsightsController {
     /// might result.  For more information, see [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_data_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_data_set(&self) -> super::builder::timeseries_insights_controller::CreateDataSet {
         super::builder::timeseries_insights_controller::CreateDataSet::new(self.inner.clone())
     }
@@ -150,6 +166,21 @@ impl TimeseriesInsightsController {
     /// processed, it will be aborted and deleted.
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_data_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_data_set(&self) -> super::builder::timeseries_insights_controller::DeleteDataSet {
         super::builder::timeseries_insights_controller::DeleteDataSet::new(self.inner.clone())
     }
@@ -157,6 +188,22 @@ impl TimeseriesInsightsController {
     /// Append events to a `LOADED` [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .append_events()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn append_events(&self) -> super::builder::timeseries_insights_controller::AppendEvents {
         super::builder::timeseries_insights_controller::AppendEvents::new(self.inner.clone())
     }
@@ -165,6 +212,22 @@ impl TimeseriesInsightsController {
     /// [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_data_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_data_set(&self) -> super::builder::timeseries_insights_controller::QueryDataSet {
         super::builder::timeseries_insights_controller::QueryDataSet::new(self.inner.clone())
     }
@@ -172,11 +235,43 @@ impl TimeseriesInsightsController {
     /// Evaluate an explicit slice from a loaded [DataSet][google.cloud.timeseriesinsights.v1.DataSet].
     ///
     /// [google.cloud.timeseriesinsights.v1.DataSet]: crate::model::DataSet
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .evaluate_slice()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn evaluate_slice(&self) -> super::builder::timeseries_insights_controller::EvaluateSlice {
         super::builder::timeseries_insights_controller::EvaluateSlice::new(self.inner.clone())
     }
 
     /// Evaluate an explicit timeseries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+    /// async fn sample(
+    ///    client: &TimeseriesInsightsController
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .evaluate_timeseries()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn evaluate_timeseries(
         &self,
     ) -> super::builder::timeseries_insights_controller::EvaluateTimeseries {

--- a/src/generated/cloud/tpu/v2/src/client.rs
+++ b/src/generated/cloud/tpu/v2/src/client.rs
@@ -126,6 +126,23 @@ impl Tpu {
     }
 
     /// Gets the details of a node.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node(&self) -> super::builder::tpu::GetNode {
         super::builder::tpu::GetNode::new(self.inner.clone())
     }
@@ -211,6 +228,23 @@ impl Tpu {
     }
 
     /// Gets details of a queued resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_queued_resource()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_queued_resource(&self) -> super::builder::tpu::GetQueuedResource {
         super::builder::tpu::GetQueuedResource::new(self.inner.clone())
     }
@@ -261,6 +295,22 @@ impl Tpu {
     }
 
     /// Generates the Cloud TPU service identity for the project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_service_identity()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_service_identity(&self) -> super::builder::tpu::GenerateServiceIdentity {
         super::builder::tpu::GenerateServiceIdentity::new(self.inner.clone())
     }
@@ -271,6 +321,23 @@ impl Tpu {
     }
 
     /// Gets AcceleratorType.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_accelerator_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_accelerator_type(&self) -> super::builder::tpu::GetAcceleratorType {
         super::builder::tpu::GetAcceleratorType::new(self.inner.clone())
     }
@@ -281,11 +348,44 @@ impl Tpu {
     }
 
     /// Gets a runtime version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_runtime_version()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_runtime_version(&self) -> super::builder::tpu::GetRuntimeVersion {
         super::builder::tpu::GetRuntimeVersion::new(self.inner.clone())
     }
 
     /// Retrieves the guest attributes for the node.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_guest_attributes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_guest_attributes(&self) -> super::builder::tpu::GetGuestAttributes {
         super::builder::tpu::GetGuestAttributes::new(self.inner.clone())
     }
@@ -296,6 +396,22 @@ impl Tpu {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::tpu::GetLocation {
         super::builder::tpu::GetLocation::new(self.inner.clone())
     }
@@ -310,6 +426,22 @@ impl Tpu {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::tpu::GetOperation {
         super::builder::tpu::GetOperation::new(self.inner.clone())
     }
@@ -317,6 +449,21 @@ impl Tpu {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::tpu::DeleteOperation {
         super::builder::tpu::DeleteOperation::new(self.inner.clone())
     }
@@ -324,6 +471,21 @@ impl Tpu {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_tpu_v2::client::Tpu;
+    /// async fn sample(
+    ///    client: &Tpu
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::tpu::CancelOperation {
         super::builder::tpu::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/translate/v3/src/client.rs
+++ b/src/generated/cloud/translate/v3/src/client.rs
@@ -122,21 +122,85 @@ impl TranslationService {
     }
 
     /// Translates input text and returns translated text.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .translate_text()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn translate_text(&self) -> super::builder::translation_service::TranslateText {
         super::builder::translation_service::TranslateText::new(self.inner.clone())
     }
 
     /// Romanize input text written in non-Latin scripts to Latin text.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .romanize_text()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn romanize_text(&self) -> super::builder::translation_service::RomanizeText {
         super::builder::translation_service::RomanizeText::new(self.inner.clone())
     }
 
     /// Detects the language of text within a request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .detect_language()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn detect_language(&self) -> super::builder::translation_service::DetectLanguage {
         super::builder::translation_service::DetectLanguage::new(self.inner.clone())
     }
 
     /// Returns a list of supported languages for translation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_supported_languages()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_supported_languages(
         &self,
     ) -> super::builder::translation_service::GetSupportedLanguages {
@@ -144,6 +208,22 @@ impl TranslationService {
     }
 
     /// Translates documents in synchronous mode.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .translate_document()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn translate_document(&self) -> super::builder::translation_service::TranslateDocument {
         super::builder::translation_service::TranslateDocument::new(self.inner.clone())
     }
@@ -232,6 +312,23 @@ impl TranslationService {
 
     /// Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
     /// exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_glossary()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_glossary(&self) -> super::builder::translation_service::GetGlossary {
         super::builder::translation_service::GetGlossary::new(self.inner.clone())
     }
@@ -254,6 +351,23 @@ impl TranslationService {
     }
 
     /// Gets a single glossary entry by the given id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_glossary_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_glossary_entry(&self) -> super::builder::translation_service::GetGlossaryEntry {
         super::builder::translation_service::GetGlossaryEntry::new(self.inner.clone())
     }
@@ -266,6 +380,22 @@ impl TranslationService {
     }
 
     /// Creates a glossary entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_glossary_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_glossary_entry(
         &self,
     ) -> super::builder::translation_service::CreateGlossaryEntry {
@@ -273,6 +403,22 @@ impl TranslationService {
     }
 
     /// Updates a glossary entry.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_glossary_entry()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_glossary_entry(
         &self,
     ) -> super::builder::translation_service::UpdateGlossaryEntry {
@@ -280,6 +426,22 @@ impl TranslationService {
     }
 
     /// Deletes a single entry from the glossary
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_glossary_entry()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_glossary_entry(
         &self,
     ) -> super::builder::translation_service::DeleteGlossaryEntry {
@@ -302,6 +464,23 @@ impl TranslationService {
     }
 
     /// Gets a Dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dataset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dataset(&self) -> super::builder::translation_service::GetDataset {
         super::builder::translation_service::GetDataset::new(self.inner.clone())
     }
@@ -327,6 +506,22 @@ impl TranslationService {
     }
 
     /// Creates an Adaptive MT dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_adaptive_mt_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_adaptive_mt_dataset(
         &self,
     ) -> super::builder::translation_service::CreateAdaptiveMtDataset {
@@ -335,6 +530,21 @@ impl TranslationService {
 
     /// Deletes an Adaptive MT dataset, including all its entries and associated
     /// metadata.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_adaptive_mt_dataset()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_adaptive_mt_dataset(
         &self,
     ) -> super::builder::translation_service::DeleteAdaptiveMtDataset {
@@ -342,6 +552,23 @@ impl TranslationService {
     }
 
     /// Gets the Adaptive MT dataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_adaptive_mt_dataset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_adaptive_mt_dataset(
         &self,
     ) -> super::builder::translation_service::GetAdaptiveMtDataset {
@@ -356,6 +583,22 @@ impl TranslationService {
     }
 
     /// Translate text using Adaptive MT.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .adaptive_mt_translate()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn adaptive_mt_translate(
         &self,
     ) -> super::builder::translation_service::AdaptiveMtTranslate {
@@ -363,11 +606,44 @@ impl TranslationService {
     }
 
     /// Gets and AdaptiveMtFile
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_adaptive_mt_file()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_adaptive_mt_file(&self) -> super::builder::translation_service::GetAdaptiveMtFile {
         super::builder::translation_service::GetAdaptiveMtFile::new(self.inner.clone())
     }
 
     /// Deletes an AdaptiveMtFile along with its sentences.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_adaptive_mt_file()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_adaptive_mt_file(
         &self,
     ) -> super::builder::translation_service::DeleteAdaptiveMtFile {
@@ -376,6 +652,22 @@ impl TranslationService {
 
     /// Imports an AdaptiveMtFile and adds all of its sentences into the
     /// AdaptiveMtDataset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .import_adaptive_mt_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn import_adaptive_mt_file(
         &self,
     ) -> super::builder::translation_service::ImportAdaptiveMtFile {
@@ -452,6 +744,23 @@ impl TranslationService {
     }
 
     /// Gets a model.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_model()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_model(&self) -> super::builder::translation_service::GetModel {
         super::builder::translation_service::GetModel::new(self.inner.clone())
     }
@@ -477,6 +786,22 @@ impl TranslationService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::translation_service::GetLocation {
         super::builder::translation_service::GetLocation::new(self.inner.clone())
     }
@@ -491,6 +816,22 @@ impl TranslationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::translation_service::GetOperation {
         super::builder::translation_service::GetOperation::new(self.inner.clone())
     }
@@ -498,6 +839,21 @@ impl TranslationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::translation_service::DeleteOperation {
         super::builder::translation_service::DeleteOperation::new(self.inner.clone())
     }
@@ -505,6 +861,21 @@ impl TranslationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::translation_service::CancelOperation {
         super::builder::translation_service::CancelOperation::new(self.inner.clone())
     }
@@ -512,6 +883,22 @@ impl TranslationService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_translation_v3::client::TranslationService;
+    /// async fn sample(
+    ///    client: &TranslationService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .wait_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn wait_operation(&self) -> super::builder::translation_service::WaitOperation {
         super::builder::translation_service::WaitOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/video/livestream/v1/src/client.rs
+++ b/src/generated/cloud/video/livestream/v1/src/client.rs
@@ -147,6 +147,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified channel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_channel()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_channel(&self) -> super::builder::livestream_service::GetChannel {
         super::builder::livestream_service::GetChannel::new(self.inner.clone())
     }
@@ -265,6 +282,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified input.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_input()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_input(&self) -> super::builder::livestream_service::GetInput {
         super::builder::livestream_service::GetInput::new(self.inner.clone())
     }
@@ -300,11 +334,43 @@ impl LivestreamService {
     }
 
     /// Preview the streaming content of the specified input.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .preview_input()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn preview_input(&self) -> super::builder::livestream_service::PreviewInput {
         super::builder::livestream_service::PreviewInput::new(self.inner.clone())
     }
 
     /// Creates an event with the provided unique ID in the specified channel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_event(&self) -> super::builder::livestream_service::CreateEvent {
         super::builder::livestream_service::CreateEvent::new(self.inner.clone())
     }
@@ -315,11 +381,43 @@ impl LivestreamService {
     }
 
     /// Returns the specified event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_event()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_event(&self) -> super::builder::livestream_service::GetEvent {
         super::builder::livestream_service::GetEvent::new(self.inner.clone())
     }
 
     /// Deletes the specified event.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_event()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_event(&self) -> super::builder::livestream_service::DeleteEvent {
         super::builder::livestream_service::DeleteEvent::new(self.inner.clone())
     }
@@ -330,6 +428,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified clip.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_clip()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_clip(&self) -> super::builder::livestream_service::GetClip {
         super::builder::livestream_service::GetClip::new(self.inner.clone())
     }
@@ -386,6 +501,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified DVR session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dvr_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dvr_session(&self) -> super::builder::livestream_service::GetDvrSession {
         super::builder::livestream_service::GetDvrSession::new(self.inner.clone())
     }
@@ -452,6 +584,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified asset.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_asset()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_asset(&self) -> super::builder::livestream_service::GetAsset {
         super::builder::livestream_service::GetAsset::new(self.inner.clone())
     }
@@ -462,6 +611,23 @@ impl LivestreamService {
     }
 
     /// Returns the specified pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_pool(&self) -> super::builder::livestream_service::GetPool {
         super::builder::livestream_service::GetPool::new(self.inner.clone())
     }
@@ -487,6 +653,22 @@ impl LivestreamService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::livestream_service::GetLocation {
         super::builder::livestream_service::GetLocation::new(self.inner.clone())
     }
@@ -501,6 +683,22 @@ impl LivestreamService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::livestream_service::GetOperation {
         super::builder::livestream_service::GetOperation::new(self.inner.clone())
     }
@@ -508,6 +706,21 @@ impl LivestreamService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::livestream_service::DeleteOperation {
         super::builder::livestream_service::DeleteOperation::new(self.inner.clone())
     }
@@ -515,6 +728,21 @@ impl LivestreamService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_livestream_v1::client::LivestreamService;
+    /// async fn sample(
+    ///    client: &LivestreamService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::livestream_service::CancelOperation {
         super::builder::livestream_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/video/stitcher/v1/src/client.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/client.rs
@@ -146,6 +146,23 @@ impl VideoStitcherService {
     }
 
     /// Returns the specified CDN key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cdn_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cdn_key(&self) -> super::builder::video_stitcher_service::GetCdnKey {
         super::builder::video_stitcher_service::GetCdnKey::new(self.inner.clone())
     }
@@ -183,12 +200,45 @@ impl VideoStitcherService {
 
     /// Creates a client side playback VOD session and returns the full
     /// tracking and playback metadata of the session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_vod_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_vod_session(&self) -> super::builder::video_stitcher_service::CreateVodSession {
         super::builder::video_stitcher_service::CreateVodSession::new(self.inner.clone())
     }
 
     /// Returns the full tracking, playback metadata, and relevant ad-ops
     /// logs for the specified VOD session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vod_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vod_session(&self) -> super::builder::video_stitcher_service::GetVodSession {
         super::builder::video_stitcher_service::GetVodSession::new(self.inner.clone())
     }
@@ -202,6 +252,23 @@ impl VideoStitcherService {
     }
 
     /// Returns the specified stitching information for the specified VOD session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vod_stitch_detail()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vod_stitch_detail(
         &self,
     ) -> super::builder::video_stitcher_service::GetVodStitchDetail {
@@ -216,6 +283,23 @@ impl VideoStitcherService {
     }
 
     /// Returns the specified ad tag detail for the specified VOD session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vod_ad_tag_detail()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vod_ad_tag_detail(
         &self,
     ) -> super::builder::video_stitcher_service::GetVodAdTagDetail {
@@ -230,6 +314,23 @@ impl VideoStitcherService {
     }
 
     /// Returns the specified ad tag detail for the specified live session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_live_ad_tag_detail()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_live_ad_tag_detail(
         &self,
     ) -> super::builder::video_stitcher_service::GetLiveAdTagDetail {
@@ -257,6 +358,23 @@ impl VideoStitcherService {
     }
 
     /// Returns the specified slate.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_slate()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_slate(&self) -> super::builder::video_stitcher_service::GetSlate {
         super::builder::video_stitcher_service::GetSlate::new(self.inner.clone())
     }
@@ -292,11 +410,44 @@ impl VideoStitcherService {
     }
 
     /// Creates a new live session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_live_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_live_session(&self) -> super::builder::video_stitcher_service::CreateLiveSession {
         super::builder::video_stitcher_service::CreateLiveSession::new(self.inner.clone())
     }
 
     /// Returns the details for the specified live session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_live_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_live_session(&self) -> super::builder::video_stitcher_service::GetLiveSession {
         super::builder::video_stitcher_service::GetLiveSession::new(self.inner.clone())
     }
@@ -325,6 +476,23 @@ impl VideoStitcherService {
 
     /// Returns the specified live config managed by the Video
     /// Stitcher service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_live_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_live_config(&self) -> super::builder::video_stitcher_service::GetLiveConfig {
         super::builder::video_stitcher_service::GetLiveConfig::new(self.inner.clone())
     }
@@ -384,6 +552,23 @@ impl VideoStitcherService {
 
     /// Returns the specified VOD config managed by the Video
     /// Stitcher API service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vod_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vod_config(&self) -> super::builder::video_stitcher_service::GetVodConfig {
         super::builder::video_stitcher_service::GetVodConfig::new(self.inner.clone())
     }
@@ -429,6 +614,22 @@ impl VideoStitcherService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::video_stitcher_service::GetOperation {
         super::builder::video_stitcher_service::GetOperation::new(self.inner.clone())
     }
@@ -436,6 +637,21 @@ impl VideoStitcherService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::video_stitcher_service::DeleteOperation {
         super::builder::video_stitcher_service::DeleteOperation::new(self.inner.clone())
     }
@@ -443,6 +659,21 @@ impl VideoStitcherService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+    /// async fn sample(
+    ///    client: &VideoStitcherService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::video_stitcher_service::CancelOperation {
         super::builder::video_stitcher_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/video/transcoder/v1/src/client.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/client.rs
@@ -127,6 +127,22 @@ impl TranscoderService {
     }
 
     /// Creates a job in the specified region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_job(&self) -> super::builder::transcoder_service::CreateJob {
         super::builder::transcoder_service::CreateJob::new(self.inner.clone())
     }
@@ -137,16 +153,64 @@ impl TranscoderService {
     }
 
     /// Returns the job data.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job(&self) -> super::builder::transcoder_service::GetJob {
         super::builder::transcoder_service::GetJob::new(self.inner.clone())
     }
 
     /// Deletes a job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job(&self) -> super::builder::transcoder_service::DeleteJob {
         super::builder::transcoder_service::DeleteJob::new(self.inner.clone())
     }
 
     /// Creates a job template in the specified region.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_job_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_job_template(&self) -> super::builder::transcoder_service::CreateJobTemplate {
         super::builder::transcoder_service::CreateJobTemplate::new(self.inner.clone())
     }
@@ -157,11 +221,43 @@ impl TranscoderService {
     }
 
     /// Returns the job template data.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job_template(&self) -> super::builder::transcoder_service::GetJobTemplate {
         super::builder::transcoder_service::GetJobTemplate::new(self.inner.clone())
     }
 
     /// Deletes a job template.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+    /// async fn sample(
+    ///    client: &TranscoderService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job_template(&self) -> super::builder::transcoder_service::DeleteJobTemplate {
         super::builder::transcoder_service::DeleteJobTemplate::new(self.inner.clone())
     }

--- a/src/generated/cloud/videointelligence/v1/src/client.rs
+++ b/src/generated/cloud/videointelligence/v1/src/client.rs
@@ -150,6 +150,22 @@ impl VideoIntelligenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+    /// async fn sample(
+    ///    client: &VideoIntelligenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::video_intelligence_service::GetOperation {
         super::builder::video_intelligence_service::GetOperation::new(self.inner.clone())
     }
@@ -157,6 +173,21 @@ impl VideoIntelligenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+    /// async fn sample(
+    ///    client: &VideoIntelligenceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::video_intelligence_service::DeleteOperation {
         super::builder::video_intelligence_service::DeleteOperation::new(self.inner.clone())
     }
@@ -164,6 +195,21 @@ impl VideoIntelligenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+    /// async fn sample(
+    ///    client: &VideoIntelligenceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::video_intelligence_service::CancelOperation {
         super::builder::video_intelligence_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/vision/v1/src/client.rs
+++ b/src/generated/cloud/vision/v1/src/client.rs
@@ -121,6 +121,22 @@ impl ImageAnnotator {
     }
 
     /// Run image detection and annotation for a batch of images.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ImageAnnotator;
+    /// async fn sample(
+    ///    client: &ImageAnnotator
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_annotate_images()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_annotate_images(&self) -> super::builder::image_annotator::BatchAnnotateImages {
         super::builder::image_annotator::BatchAnnotateImages::new(self.inner.clone())
     }
@@ -132,6 +148,22 @@ impl ImageAnnotator {
     /// AnnotateFileRequest.pages) frames (gif) or pages (pdf or tiff) from each
     /// file provided and perform detection and annotation for each image
     /// extracted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ImageAnnotator;
+    /// async fn sample(
+    ///    client: &ImageAnnotator
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_annotate_files()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_annotate_files(&self) -> super::builder::image_annotator::BatchAnnotateFiles {
         super::builder::image_annotator::BatchAnnotateFiles::new(self.inner.clone())
     }
@@ -186,6 +218,22 @@ impl ImageAnnotator {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ImageAnnotator;
+    /// async fn sample(
+    ///    client: &ImageAnnotator
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::image_annotator::GetOperation {
         super::builder::image_annotator::GetOperation::new(self.inner.clone())
     }
@@ -319,6 +367,22 @@ impl ProductSearch {
     ///
     /// * Returns INVALID_ARGUMENT if display_name is missing, or is longer than
     ///   4096 characters.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_product_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_product_set(&self) -> super::builder::product_search::CreateProductSet {
         super::builder::product_search::CreateProductSet::new(self.inner.clone())
     }
@@ -338,6 +402,23 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the ProductSet does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_product_set()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_product_set(&self) -> super::builder::product_search::GetProductSet {
         super::builder::product_search::GetProductSet::new(self.inner.clone())
     }
@@ -350,6 +431,22 @@ impl ProductSearch {
     /// * Returns NOT_FOUND if the ProductSet does not exist.
     /// * Returns INVALID_ARGUMENT if display_name is present in update_mask but
     ///   missing from the request or longer than 4096 characters.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_product_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_product_set(&self) -> super::builder::product_search::UpdateProductSet {
         super::builder::product_search::UpdateProductSet::new(self.inner.clone())
     }
@@ -358,6 +455,21 @@ impl ProductSearch {
     /// ProductSet are not deleted.
     ///
     /// The actual image files are not deleted from Google Cloud Storage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_product_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_product_set(&self) -> super::builder::product_search::DeleteProductSet {
         super::builder::product_search::DeleteProductSet::new(self.inner.clone())
     }
@@ -370,6 +482,22 @@ impl ProductSearch {
     ///   characters.
     /// * Returns INVALID_ARGUMENT if description is longer than 4096 characters.
     /// * Returns INVALID_ARGUMENT if product_category is missing or invalid.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_product(&self) -> super::builder::product_search::CreateProduct {
         super::builder::product_search::CreateProduct::new(self.inner.clone())
     }
@@ -388,6 +516,23 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the Product does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_product()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_product(&self) -> super::builder::product_search::GetProduct {
         super::builder::product_search::GetProduct::new(self.inner.clone())
     }
@@ -407,6 +552,22 @@ impl ProductSearch {
     /// * Returns INVALID_ARGUMENT if description is present in update_mask but is
     ///   longer than 4096 characters.
     /// * Returns INVALID_ARGUMENT if product_category is present in update_mask.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_product(&self) -> super::builder::product_search::UpdateProduct {
         super::builder::product_search::UpdateProduct::new(self.inner.clone())
     }
@@ -416,6 +577,21 @@ impl ProductSearch {
     /// Metadata of the product and all its images will be deleted right away, but
     /// search queries against ProductSets containing the product may still work
     /// until all related caches are refreshed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_product()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_product(&self) -> super::builder::product_search::DeleteProduct {
         super::builder::product_search::DeleteProduct::new(self.inner.clone())
     }
@@ -439,6 +615,22 @@ impl ProductSearch {
     /// * Returns INVALID_ARGUMENT if bounding_poly is not provided, and nothing
     ///   compatible with the parent product's product_category is detected.
     /// * Returns INVALID_ARGUMENT if bounding_poly contains more than 10 polygons.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_reference_image()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_reference_image(&self) -> super::builder::product_search::CreateReferenceImage {
         super::builder::product_search::CreateReferenceImage::new(self.inner.clone())
     }
@@ -450,6 +642,21 @@ impl ProductSearch {
     /// caches are refreshed.
     ///
     /// The actual image files are not deleted from Google Cloud Storage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_reference_image()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_reference_image(&self) -> super::builder::product_search::DeleteReferenceImage {
         super::builder::product_search::DeleteReferenceImage::new(self.inner.clone())
     }
@@ -470,6 +677,23 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the specified image does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_reference_image()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_reference_image(&self) -> super::builder::product_search::GetReferenceImage {
         super::builder::product_search::GetReferenceImage::new(self.inner.clone())
     }
@@ -482,6 +706,21 @@ impl ProductSearch {
     /// Possible errors:
     ///
     /// * Returns NOT_FOUND if the Product or the ProductSet doesn't exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .add_product_to_product_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_product_to_product_set(
         &self,
     ) -> super::builder::product_search::AddProductToProductSet {
@@ -489,6 +728,21 @@ impl ProductSearch {
     }
 
     /// Removes a Product from the specified ProductSet.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .remove_product_from_product_set()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn remove_product_from_product_set(
         &self,
     ) -> super::builder::product_search::RemoveProductFromProductSet {
@@ -579,6 +833,22 @@ impl ProductSearch {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vision_v1::client::ProductSearch;
+    /// async fn sample(
+    ///    client: &ProductSearch
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::product_search::GetOperation {
         super::builder::product_search::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/vmmigration/v1/src/client.rs
+++ b/src/generated/cloud/vmmigration/v1/src/client.rs
@@ -124,6 +124,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single Source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_source()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_source(&self) -> super::builder::vm_migration::GetSource {
         super::builder::vm_migration::GetSource::new(self.inner.clone())
     }
@@ -178,6 +195,22 @@ impl VmMigration {
     /// Compute Engine). The inventory describes the list of existing VMs in that
     /// source. Note that this operation lists the VMs on the remote source, as
     /// opposed to listing the MigratingVms resources in the vmmigration service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_inventory()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_inventory(&self) -> super::builder::vm_migration::FetchInventory {
         super::builder::vm_migration::FetchInventory::new(self.inner.clone())
     }
@@ -198,6 +231,23 @@ impl VmMigration {
     }
 
     /// Gets a single Utilization Report.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_utilization_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_utilization_report(&self) -> super::builder::vm_migration::GetUtilizationReport {
         super::builder::vm_migration::GetUtilizationReport::new(self.inner.clone())
     }
@@ -244,6 +294,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single DatacenterConnector.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_datacenter_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_datacenter_connector(&self) -> super::builder::vm_migration::GetDatacenterConnector {
         super::builder::vm_migration::GetDatacenterConnector::new(self.inner.clone())
     }
@@ -319,6 +386,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single MigratingVm.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_migrating_vm()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_migrating_vm(&self) -> super::builder::vm_migration::GetMigratingVm {
         super::builder::vm_migration::GetMigratingVm::new(self.inner.clone())
     }
@@ -472,6 +556,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single CloneJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_clone_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_clone_job(&self) -> super::builder::vm_migration::GetCloneJob {
         super::builder::vm_migration::GetCloneJob::new(self.inner.clone())
     }
@@ -515,6 +616,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single CutoverJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cutover_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cutover_job(&self) -> super::builder::vm_migration::GetCutoverJob {
         super::builder::vm_migration::GetCutoverJob::new(self.inner.clone())
     }
@@ -525,6 +643,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single Group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_group(&self) -> super::builder::vm_migration::GetGroup {
         super::builder::vm_migration::GetGroup::new(self.inner.clone())
     }
@@ -616,6 +751,23 @@ impl VmMigration {
     ///
     /// NOTE: TargetProject is a global resource; hence the only supported value
     /// for location is `global`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_target_project()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_target_project(&self) -> super::builder::vm_migration::GetTargetProject {
         super::builder::vm_migration::GetTargetProject::new(self.inner.clone())
     }
@@ -680,6 +832,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single ReplicationCycle.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_replication_cycle()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_replication_cycle(&self) -> super::builder::vm_migration::GetReplicationCycle {
         super::builder::vm_migration::GetReplicationCycle::new(self.inner.clone())
     }
@@ -690,6 +859,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single ImageImport.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_image_import()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_image_import(&self) -> super::builder::vm_migration::GetImageImport {
         super::builder::vm_migration::GetImageImport::new(self.inner.clone())
     }
@@ -730,6 +916,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single ImageImportJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_image_import_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_image_import_job(&self) -> super::builder::vm_migration::GetImageImportJob {
         super::builder::vm_migration::GetImageImportJob::new(self.inner.clone())
     }
@@ -772,6 +975,23 @@ impl VmMigration {
     }
 
     /// Gets details of a single DiskMigrationJob.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_disk_migration_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_disk_migration_job(&self) -> super::builder::vm_migration::GetDiskMigrationJob {
         super::builder::vm_migration::GetDiskMigrationJob::new(self.inner.clone())
     }
@@ -848,6 +1068,22 @@ impl VmMigration {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vm_migration::GetLocation {
         super::builder::vm_migration::GetLocation::new(self.inner.clone())
     }
@@ -862,6 +1098,22 @@ impl VmMigration {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vm_migration::GetOperation {
         super::builder::vm_migration::GetOperation::new(self.inner.clone())
     }
@@ -869,6 +1121,21 @@ impl VmMigration {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vm_migration::DeleteOperation {
         super::builder::vm_migration::DeleteOperation::new(self.inner.clone())
     }
@@ -876,6 +1143,21 @@ impl VmMigration {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmmigration_v1::client::VmMigration;
+    /// async fn sample(
+    ///    client: &VmMigration
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::vm_migration::CancelOperation {
         super::builder::vm_migration::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/vmwareengine/v1/src/client.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/client.rs
@@ -124,6 +124,23 @@ impl VmwareEngine {
     }
 
     /// Retrieves a `PrivateCloud` resource by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_private_cloud()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_private_cloud(&self) -> super::builder::vmware_engine::GetPrivateCloud {
         super::builder::vmware_engine::GetPrivateCloud::new(self.inner.clone())
     }
@@ -224,6 +241,23 @@ impl VmwareEngine {
     }
 
     /// Retrieves a `Cluster` resource by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::vmware_engine::GetCluster {
         super::builder::vmware_engine::GetCluster::new(self.inner.clone())
     }
@@ -291,6 +325,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of a single node.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node(&self) -> super::builder::vmware_engine::GetNode {
         super::builder::vmware_engine::GetNode::new(self.inner.clone())
     }
@@ -310,6 +361,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of a single external IP address.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_external_address()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_external_address(&self) -> super::builder::vmware_engine::GetExternalAddress {
         super::builder::vmware_engine::GetExternalAddress::new(self.inner.clone())
     }
@@ -375,6 +443,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of a single subnet.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_subnet()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_subnet(&self) -> super::builder::vmware_engine::GetSubnet {
         super::builder::vmware_engine::GetSubnet::new(self.inner.clone())
     }
@@ -407,6 +492,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of a single external access rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_external_access_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_external_access_rule(&self) -> super::builder::vmware_engine::GetExternalAccessRule {
         super::builder::vmware_engine::GetExternalAccessRule::new(self.inner.clone())
     }
@@ -470,6 +572,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of a logging server.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_logging_server()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_logging_server(&self) -> super::builder::vmware_engine::GetLoggingServer {
         super::builder::vmware_engine::GetLoggingServer::new(self.inner.clone())
     }
@@ -526,16 +645,65 @@ impl VmwareEngine {
     }
 
     /// Gets details of a single `NodeType`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node_type(&self) -> super::builder::vmware_engine::GetNodeType {
         super::builder::vmware_engine::GetNodeType::new(self.inner.clone())
     }
 
     /// Gets details of credentials for NSX appliance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .show_nsx_credentials()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn show_nsx_credentials(&self) -> super::builder::vmware_engine::ShowNsxCredentials {
         super::builder::vmware_engine::ShowNsxCredentials::new(self.inner.clone())
     }
 
     /// Gets details of credentials for Vcenter appliance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .show_vcenter_credentials()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn show_vcenter_credentials(
         &self,
     ) -> super::builder::vmware_engine::ShowVcenterCredentials {
@@ -575,6 +743,23 @@ impl VmwareEngine {
     }
 
     /// Gets details of the `DnsForwarding` config.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dns_forwarding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dns_forwarding(&self) -> super::builder::vmware_engine::GetDnsForwarding {
         super::builder::vmware_engine::GetDnsForwarding::new(self.inner.clone())
     }
@@ -599,6 +784,23 @@ impl VmwareEngine {
     /// contains details of the network peering, such as peered
     /// networks, import and export custom route configurations, and peering state.
     /// NetworkPeering is a global resource and location can only be global.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_network_peering()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_network_peering(&self) -> super::builder::vmware_engine::GetNetworkPeering {
         super::builder::vmware_engine::GetNetworkPeering::new(self.inner.clone())
     }
@@ -690,11 +892,45 @@ impl VmwareEngine {
     }
 
     /// Retrieves a `HcxActivationKey` resource by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_hcx_activation_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_hcx_activation_key(&self) -> super::builder::vmware_engine::GetHcxActivationKey {
         super::builder::vmware_engine::GetHcxActivationKey::new(self.inner.clone())
     }
 
     /// Retrieves a `NetworkPolicy` resource by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_network_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_network_policy(&self) -> super::builder::vmware_engine::GetNetworkPolicy {
         super::builder::vmware_engine::GetNetworkPolicy::new(self.inner.clone())
     }
@@ -772,6 +1008,23 @@ impl VmwareEngine {
     }
 
     /// Retrieves a 'ManagementDnsZoneBinding' resource by its resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_management_dns_zone_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_management_dns_zone_binding(
         &self,
     ) -> super::builder::vmware_engine::GetManagementDnsZoneBinding {
@@ -916,6 +1169,23 @@ impl VmwareEngine {
     /// resource contains details of the VMware Engine network, such as its VMware
     /// Engine network type, peered networks in a service project, and state
     /// (for example, `CREATING`, `ACTIVE`, `DELETING`).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vmware_engine_network()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vmware_engine_network(
         &self,
     ) -> super::builder::vmware_engine::GetVmwareEngineNetwork {
@@ -950,6 +1220,23 @@ impl VmwareEngine {
     /// Retrieves a `PrivateConnection` resource by its resource name. The resource
     /// contains details of the private connection, such as connected
     /// network, routing mode and state.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_private_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_private_connection(&self) -> super::builder::vmware_engine::GetPrivateConnection {
         super::builder::vmware_engine::GetPrivateConnection::new(self.inner.clone())
     }
@@ -1029,6 +1316,23 @@ impl VmwareEngine {
     /// Gets all the principals having bind permission on the intranet VPC
     /// associated with the consumer project granted by the Grant API.
     /// DnsBindPermission is a global resource and location can only be global.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dns_bind_permission()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dns_bind_permission(&self) -> super::builder::vmware_engine::GetDnsBindPermission {
         super::builder::vmware_engine::GetDnsBindPermission::new(self.inner.clone())
     }
@@ -1058,6 +1362,22 @@ impl VmwareEngine {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::vmware_engine::GetLocation {
         super::builder::vmware_engine::GetLocation::new(self.inner.clone())
     }
@@ -1067,12 +1387,44 @@ impl VmwareEngine {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::vmware_engine::SetIamPolicy {
         super::builder::vmware_engine::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::vmware_engine::GetIamPolicy {
         super::builder::vmware_engine::GetIamPolicy::new(self.inner.clone())
     }
@@ -1084,6 +1436,22 @@ impl VmwareEngine {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::vmware_engine::TestIamPermissions {
         super::builder::vmware_engine::TestIamPermissions::new(self.inner.clone())
     }
@@ -1098,6 +1466,22 @@ impl VmwareEngine {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vmware_engine::GetOperation {
         super::builder::vmware_engine::GetOperation::new(self.inner.clone())
     }
@@ -1105,6 +1489,21 @@ impl VmwareEngine {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+    /// async fn sample(
+    ///    client: &VmwareEngine
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::vmware_engine::DeleteOperation {
         super::builder::vmware_engine::DeleteOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/vpcaccess/v1/src/client.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/client.rs
@@ -140,6 +140,23 @@ impl VpcAccessService {
 
     /// Gets a Serverless VPC Access connector. Returns NOT_FOUND if the resource
     /// does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
+    /// async fn sample(
+    ///    client: &VpcAccessService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connector()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connector(&self) -> super::builder::vpc_access_service::GetConnector {
         super::builder::vpc_access_service::GetConnector::new(self.inner.clone())
     }
@@ -180,6 +197,22 @@ impl VpcAccessService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
+    /// async fn sample(
+    ///    client: &VpcAccessService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::vpc_access_service::GetOperation {
         super::builder::vpc_access_service::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/webrisk/v1/src/client.rs
+++ b/src/generated/cloud/webrisk/v1/src/client.rs
@@ -127,6 +127,22 @@ impl WebRiskService {
     /// be returned. This Method only updates a single ThreatList at a time. To
     /// update multiple ThreatList databases, this method needs to be called once
     /// for each list.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compute_threat_list_diff()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compute_threat_list_diff(
         &self,
     ) -> super::builder::web_risk_service::ComputeThreatListDiff {
@@ -138,6 +154,22 @@ impl WebRiskService {
     /// The response will list all requested threatLists the URI was found to
     /// match. If the URI is not found on any of the requested ThreatList an
     /// empty response will be returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_uris()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_uris(&self) -> super::builder::web_risk_service::SearchUris {
         super::builder::web_risk_service::SearchUris::new(self.inner.clone())
     }
@@ -147,6 +179,22 @@ impl WebRiskService {
     /// and there is a match. The client side threatList only holds partial hashes
     /// so the client must query this method to determine if there is a full
     /// hash match of a threat.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .search_hashes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_hashes(&self) -> super::builder::web_risk_service::SearchHashes {
         super::builder::web_risk_service::SearchHashes::new(self.inner.clone())
     }
@@ -158,6 +206,22 @@ impl WebRiskService {
     /// protect users that could get exposed to this threat in the future. Only
     /// allowlisted projects can use this method during Early Access. Please reach
     /// out to Sales or your customer engineer to obtain access.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_submission()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_submission(&self) -> super::builder::web_risk_service::CreateSubmission {
         super::builder::web_risk_service::CreateSubmission::new(self.inner.clone())
     }
@@ -196,6 +260,22 @@ impl WebRiskService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::web_risk_service::GetOperation {
         super::builder::web_risk_service::GetOperation::new(self.inner.clone())
     }
@@ -203,6 +283,21 @@ impl WebRiskService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::web_risk_service::DeleteOperation {
         super::builder::web_risk_service::DeleteOperation::new(self.inner.clone())
     }
@@ -210,6 +305,21 @@ impl WebRiskService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_webrisk_v1::client::WebRiskService;
+    /// async fn sample(
+    ///    client: &WebRiskService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::web_risk_service::CancelOperation {
         super::builder::web_risk_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/websecurityscanner/v1/src/client.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/client.rs
@@ -124,16 +124,63 @@ impl WebSecurityScanner {
     }
 
     /// Creates a new ScanConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_scan_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_scan_config(&self) -> super::builder::web_security_scanner::CreateScanConfig {
         super::builder::web_security_scanner::CreateScanConfig::new(self.inner.clone())
     }
 
     /// Deletes an existing ScanConfig and its child resources.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_scan_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_scan_config(&self) -> super::builder::web_security_scanner::DeleteScanConfig {
         super::builder::web_security_scanner::DeleteScanConfig::new(self.inner.clone())
     }
 
     /// Gets a ScanConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_scan_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_scan_config(&self) -> super::builder::web_security_scanner::GetScanConfig {
         super::builder::web_security_scanner::GetScanConfig::new(self.inner.clone())
     }
@@ -144,16 +191,64 @@ impl WebSecurityScanner {
     }
 
     /// Updates a ScanConfig. This method support partial update of a ScanConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_scan_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_scan_config(&self) -> super::builder::web_security_scanner::UpdateScanConfig {
         super::builder::web_security_scanner::UpdateScanConfig::new(self.inner.clone())
     }
 
     /// Start a ScanRun according to the given ScanConfig.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_scan_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_scan_run(&self) -> super::builder::web_security_scanner::StartScanRun {
         super::builder::web_security_scanner::StartScanRun::new(self.inner.clone())
     }
 
     /// Gets a ScanRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_scan_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_scan_run(&self) -> super::builder::web_security_scanner::GetScanRun {
         super::builder::web_security_scanner::GetScanRun::new(self.inner.clone())
     }
@@ -165,6 +260,22 @@ impl WebSecurityScanner {
     }
 
     /// Stops a ScanRun. The stopped ScanRun is returned.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .stop_scan_run()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn stop_scan_run(&self) -> super::builder::web_security_scanner::StopScanRun {
         super::builder::web_security_scanner::StopScanRun::new(self.inner.clone())
     }
@@ -175,6 +286,22 @@ impl WebSecurityScanner {
     }
 
     /// Gets a Finding.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_finding()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_finding(&self) -> super::builder::web_security_scanner::GetFinding {
         super::builder::web_security_scanner::GetFinding::new(self.inner.clone())
     }
@@ -185,6 +312,22 @@ impl WebSecurityScanner {
     }
 
     /// List all FindingTypeStats under a given ScanRun.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+    /// async fn sample(
+    ///    client: &WebSecurityScanner
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_finding_type_stats()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_finding_type_stats(
         &self,
     ) -> super::builder::web_security_scanner::ListFindingTypeStats {

--- a/src/generated/cloud/workflows/executions/v1/src/client.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/client.rs
@@ -128,16 +128,65 @@ impl Executions {
     }
 
     /// Creates a new execution using the latest revision of the given workflow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_executions_v1::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_execution()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_execution(&self) -> super::builder::executions::CreateExecution {
         super::builder::executions::CreateExecution::new(self.inner.clone())
     }
 
     /// Returns an execution of the given name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_executions_v1::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_execution()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_execution(&self) -> super::builder::executions::GetExecution {
         super::builder::executions::GetExecution::new(self.inner.clone())
     }
 
     /// Cancels an execution of the given name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_executions_v1::client::Executions;
+    /// async fn sample(
+    ///    client: &Executions
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_execution()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_execution(&self) -> super::builder::executions::CancelExecution {
         super::builder::executions::CancelExecution::new(self.inner.clone())
     }

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -129,6 +129,23 @@ impl Workflows {
     }
 
     /// Gets details of a single workflow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_v1::client::Workflows;
+    /// async fn sample(
+    ///    client: &Workflows,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workflow()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workflow(&self) -> super::builder::workflows::GetWorkflow {
         super::builder::workflows::GetWorkflow::new(self.inner.clone())
     }
@@ -197,6 +214,22 @@ impl Workflows {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_v1::client::Workflows;
+    /// async fn sample(
+    ///    client: &Workflows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::workflows::GetLocation {
         super::builder::workflows::GetLocation::new(self.inner.clone())
     }
@@ -211,6 +244,22 @@ impl Workflows {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_v1::client::Workflows;
+    /// async fn sample(
+    ///    client: &Workflows
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::workflows::GetOperation {
         super::builder::workflows::GetOperation::new(self.inner.clone())
     }
@@ -218,6 +267,21 @@ impl Workflows {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workflows_v1::client::Workflows;
+    /// async fn sample(
+    ///    client: &Workflows
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::workflows::DeleteOperation {
         super::builder::workflows::DeleteOperation::new(self.inner.clone())
     }

--- a/src/generated/cloud/workstations/v1/src/client.rs
+++ b/src/generated/cloud/workstations/v1/src/client.rs
@@ -119,6 +119,23 @@ impl Workstations {
     }
 
     /// Returns the requested workstation cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workstation_cluster()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workstation_cluster(&self) -> super::builder::workstations::GetWorkstationCluster {
         super::builder::workstations::GetWorkstationCluster::new(self.inner.clone())
     }
@@ -182,6 +199,23 @@ impl Workstations {
     }
 
     /// Returns the requested workstation configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workstation_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workstation_config(&self) -> super::builder::workstations::GetWorkstationConfig {
         super::builder::workstations::GetWorkstationConfig::new(self.inner.clone())
     }
@@ -251,6 +285,23 @@ impl Workstations {
     }
 
     /// Returns the requested workstation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_workstation()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_workstation(&self) -> super::builder::workstations::GetWorkstation {
         super::builder::workstations::GetWorkstation::new(self.inner.clone())
     }
@@ -343,6 +394,22 @@ impl Workstations {
 
     /// Returns a short-lived credential that can be used to send authenticated and
     /// authorized traffic to a workstation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_access_token(&self) -> super::builder::workstations::GenerateAccessToken {
         super::builder::workstations::GenerateAccessToken::new(self.inner.clone())
     }
@@ -352,12 +419,44 @@ impl Workstations {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::workstations::SetIamPolicy {
         super::builder::workstations::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::workstations::GetIamPolicy {
         super::builder::workstations::GetIamPolicy::new(self.inner.clone())
     }
@@ -369,6 +468,22 @@ impl Workstations {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::workstations::TestIamPermissions {
         super::builder::workstations::TestIamPermissions::new(self.inner.clone())
     }
@@ -383,6 +498,22 @@ impl Workstations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::workstations::GetOperation {
         super::builder::workstations::GetOperation::new(self.inner.clone())
     }
@@ -390,6 +521,21 @@ impl Workstations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::workstations::DeleteOperation {
         super::builder::workstations::DeleteOperation::new(self.inner.clone())
     }
@@ -397,6 +543,21 @@ impl Workstations {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_workstations_v1::client::Workstations;
+    /// async fn sample(
+    ///    client: &Workstations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::workstations::CancelOperation {
         super::builder::workstations::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/container/v1/src/client.rs
+++ b/src/generated/container/v1/src/client.rs
@@ -120,11 +120,43 @@ impl ClusterManager {
 
     /// Lists all clusters owned by a project in either the specified zone or all
     /// zones.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_clusters()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_clusters(&self) -> super::builder::cluster_manager::ListClusters {
         super::builder::cluster_manager::ListClusters::new(self.inner.clone())
     }
 
     /// Gets the details of a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cluster()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cluster(&self) -> super::builder::cluster_manager::GetCluster {
         super::builder::cluster_manager::GetCluster::new(self.inner.clone())
     }
@@ -143,21 +175,85 @@ impl ClusterManager {
     ///
     /// Finally, an entry is added to the project's global metadata indicating
     /// which CIDR range the cluster is using.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_cluster()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_cluster(&self) -> super::builder::cluster_manager::CreateCluster {
         super::builder::cluster_manager::CreateCluster::new(self.inner.clone())
     }
 
     /// Updates the settings of a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_cluster()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_cluster(&self) -> super::builder::cluster_manager::UpdateCluster {
         super::builder::cluster_manager::UpdateCluster::new(self.inner.clone())
     }
 
     /// Updates the version and/or image type for the specified node pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_node_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_node_pool(&self) -> super::builder::cluster_manager::UpdateNodePool {
         super::builder::cluster_manager::UpdateNodePool::new(self.inner.clone())
     }
 
     /// Sets the autoscaling settings for the specified node pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_node_pool_autoscaling()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_node_pool_autoscaling(
         &self,
     ) -> super::builder::cluster_manager::SetNodePoolAutoscaling {
@@ -165,16 +261,64 @@ impl ClusterManager {
     }
 
     /// Sets the logging service for a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_logging_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_logging_service(&self) -> super::builder::cluster_manager::SetLoggingService {
         super::builder::cluster_manager::SetLoggingService::new(self.inner.clone())
     }
 
     /// Sets the monitoring service for a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_monitoring_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_monitoring_service(&self) -> super::builder::cluster_manager::SetMonitoringService {
         super::builder::cluster_manager::SetMonitoringService::new(self.inner.clone())
     }
 
     /// Sets the addons for a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_addons_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_addons_config(&self) -> super::builder::cluster_manager::SetAddonsConfig {
         super::builder::cluster_manager::SetAddonsConfig::new(self.inner.clone())
     }
@@ -183,12 +327,44 @@ impl ClusterManager {
     /// Deprecated. Use
     /// [projects.locations.clusters.update](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters/update)
     /// instead.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_locations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn set_locations(&self) -> super::builder::cluster_manager::SetLocations {
         super::builder::cluster_manager::SetLocations::new(self.inner.clone())
     }
 
     /// Updates the master for a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_master()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_master(&self) -> super::builder::cluster_manager::UpdateMaster {
         super::builder::cluster_manager::UpdateMaster::new(self.inner.clone())
     }
@@ -196,6 +372,22 @@ impl ClusterManager {
     /// Sets master auth materials. Currently supports changing the admin password
     /// or a specific cluster, either via password generation or explicitly setting
     /// the password.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_master_auth()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_master_auth(&self) -> super::builder::cluster_manager::SetMasterAuth {
         super::builder::cluster_manager::SetMasterAuth::new(self.inner.clone())
     }
@@ -209,58 +401,232 @@ impl ClusterManager {
     /// Other Google Compute Engine resources that might be in use by the cluster,
     /// such as load balancer resources, are not deleted if they weren't present
     /// when the cluster was initially created.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_cluster()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_cluster(&self) -> super::builder::cluster_manager::DeleteCluster {
         super::builder::cluster_manager::DeleteCluster::new(self.inner.clone())
     }
 
     /// Lists all operations in a project in a specific zone or all zones.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_operations()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_operations(&self) -> super::builder::cluster_manager::ListOperations {
         super::builder::cluster_manager::ListOperations::new(self.inner.clone())
     }
 
     /// Gets the specified operation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cluster_manager::GetOperation {
         super::builder::cluster_manager::GetOperation::new(self.inner.clone())
     }
 
     /// Cancels the specified operation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cluster_manager::CancelOperation {
         super::builder::cluster_manager::CancelOperation::new(self.inner.clone())
     }
 
     /// Returns configuration info about the Google Kubernetes Engine service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_server_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_server_config(&self) -> super::builder::cluster_manager::GetServerConfig {
         super::builder::cluster_manager::GetServerConfig::new(self.inner.clone())
     }
 
     /// Gets the public component of the cluster signing keys in
     /// JSON Web Key format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_json_web_keys()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_json_web_keys(&self) -> super::builder::cluster_manager::GetJSONWebKeys {
         super::builder::cluster_manager::GetJSONWebKeys::new(self.inner.clone())
     }
 
     /// Lists the node pools for a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_node_pools()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_node_pools(&self) -> super::builder::cluster_manager::ListNodePools {
         super::builder::cluster_manager::ListNodePools::new(self.inner.clone())
     }
 
     /// Retrieves the requested node pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_node_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_node_pool(&self) -> super::builder::cluster_manager::GetNodePool {
         super::builder::cluster_manager::GetNodePool::new(self.inner.clone())
     }
 
     /// Creates a node pool for a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_node_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_node_pool(&self) -> super::builder::cluster_manager::CreateNodePool {
         super::builder::cluster_manager::CreateNodePool::new(self.inner.clone())
     }
 
     /// Deletes a node pool from a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_node_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_node_pool(&self) -> super::builder::cluster_manager::DeleteNodePool {
         super::builder::cluster_manager::DeleteNodePool::new(self.inner.clone())
     }
 
     /// CompleteNodePoolUpgrade will signal an on-going node pool upgrade to
     /// complete.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .complete_node_pool_upgrade()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_node_pool_upgrade(
         &self,
     ) -> super::builder::cluster_manager::CompleteNodePoolUpgrade {
@@ -269,6 +635,22 @@ impl ClusterManager {
 
     /// Rolls back a previously Aborted or Failed NodePool upgrade.
     /// This makes no changes if the last upgrade successfully completed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rollback_node_pool_upgrade()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rollback_node_pool_upgrade(
         &self,
     ) -> super::builder::cluster_manager::RollbackNodePoolUpgrade {
@@ -276,6 +658,22 @@ impl ClusterManager {
     }
 
     /// Sets the NodeManagement options for a node pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_node_pool_management()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_node_pool_management(
         &self,
     ) -> super::builder::cluster_manager::SetNodePoolManagement {
@@ -283,21 +681,85 @@ impl ClusterManager {
     }
 
     /// Sets labels on a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_labels()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_labels(&self) -> super::builder::cluster_manager::SetLabels {
         super::builder::cluster_manager::SetLabels::new(self.inner.clone())
     }
 
     /// Enables or disables the ABAC authorization mechanism on a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_legacy_abac()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_legacy_abac(&self) -> super::builder::cluster_manager::SetLegacyAbac {
         super::builder::cluster_manager::SetLegacyAbac::new(self.inner.clone())
     }
 
     /// Starts master IP rotation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .start_ip_rotation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn start_ip_rotation(&self) -> super::builder::cluster_manager::StartIPRotation {
         super::builder::cluster_manager::StartIPRotation::new(self.inner.clone())
     }
 
     /// Completes master IP rotation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .complete_ip_rotation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn complete_ip_rotation(&self) -> super::builder::cluster_manager::CompleteIPRotation {
         super::builder::cluster_manager::CompleteIPRotation::new(self.inner.clone())
     }
@@ -307,16 +769,64 @@ impl ClusterManager {
     /// [NodePool.locations][google.container.v1.NodePool.locations].
     ///
     /// [google.container.v1.NodePool.locations]: crate::model::NodePool::locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_node_pool_size()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_node_pool_size(&self) -> super::builder::cluster_manager::SetNodePoolSize {
         super::builder::cluster_manager::SetNodePoolSize::new(self.inner.clone())
     }
 
     /// Enables or disables Network Policy for a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_network_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_network_policy(&self) -> super::builder::cluster_manager::SetNetworkPolicy {
         super::builder::cluster_manager::SetNetworkPolicy::new(self.inner.clone())
     }
 
     /// Sets the maintenance policy for a cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_maintenance_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_maintenance_policy(&self) -> super::builder::cluster_manager::SetMaintenancePolicy {
         super::builder::cluster_manager::SetMaintenancePolicy::new(self.inner.clone())
     }
@@ -330,6 +840,22 @@ impl ClusterManager {
 
     /// Checks the cluster compatibility with Autopilot mode, and returns a list of
     /// compatibility issues.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .check_autopilot_compatibility()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn check_autopilot_compatibility(
         &self,
     ) -> super::builder::cluster_manager::CheckAutopilotCompatibility {
@@ -337,6 +863,22 @@ impl ClusterManager {
     }
 
     /// Fetch upgrade information of a specific cluster.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_cluster_upgrade_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_cluster_upgrade_info(
         &self,
     ) -> super::builder::cluster_manager::FetchClusterUpgradeInfo {
@@ -344,6 +886,22 @@ impl ClusterManager {
     }
 
     /// Fetch upgrade information of a specific nodepool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_container_v1::client::ClusterManager;
+    /// async fn sample(
+    ///    client: &ClusterManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_node_pool_upgrade_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_node_pool_upgrade_info(
         &self,
     ) -> super::builder::cluster_manager::FetchNodePoolUpgradeInfo {

--- a/src/generated/datastore/admin/v1/src/client.rs
+++ b/src/generated/datastore/admin/v1/src/client.rs
@@ -266,6 +266,22 @@ impl DatastoreAdmin {
     }
 
     /// Gets an index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+    /// async fn sample(
+    ///    client: &DatastoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_index()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_index(&self) -> super::builder::datastore_admin::GetIndex {
         super::builder::datastore_admin::GetIndex::new(self.inner.clone())
     }
@@ -287,6 +303,22 @@ impl DatastoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+    /// async fn sample(
+    ///    client: &DatastoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::datastore_admin::GetOperation {
         super::builder::datastore_admin::GetOperation::new(self.inner.clone())
     }
@@ -294,6 +326,21 @@ impl DatastoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+    /// async fn sample(
+    ///    client: &DatastoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::datastore_admin::DeleteOperation {
         super::builder::datastore_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -301,6 +348,21 @@ impl DatastoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+    /// async fn sample(
+    ///    client: &DatastoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::datastore_admin::CancelOperation {
         super::builder::datastore_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/devtools/artifactregistry/v1/src/client.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/client.rs
@@ -139,6 +139,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a docker image.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_docker_image()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_docker_image(&self) -> super::builder::artifact_registry::GetDockerImage {
         super::builder::artifact_registry::GetDockerImage::new(self.inner.clone())
     }
@@ -149,6 +166,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a maven artifact.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_maven_artifact()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_maven_artifact(&self) -> super::builder::artifact_registry::GetMavenArtifact {
         super::builder::artifact_registry::GetMavenArtifact::new(self.inner.clone())
     }
@@ -159,6 +193,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a npm package.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_npm_package()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_npm_package(&self) -> super::builder::artifact_registry::GetNpmPackage {
         super::builder::artifact_registry::GetNpmPackage::new(self.inner.clone())
     }
@@ -169,6 +220,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a python package.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_python_package()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_python_package(&self) -> super::builder::artifact_registry::GetPythonPackage {
         super::builder::artifact_registry::GetPythonPackage::new(self.inner.clone())
     }
@@ -215,6 +283,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_repository()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_repository(&self) -> super::builder::artifact_registry::GetRepository {
         super::builder::artifact_registry::GetRepository::new(self.inner.clone())
     }
@@ -236,6 +321,22 @@ impl ArtifactRegistry {
     }
 
     /// Updates a repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_repository()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_repository(&self) -> super::builder::artifact_registry::UpdateRepository {
         super::builder::artifact_registry::UpdateRepository::new(self.inner.clone())
     }
@@ -263,6 +364,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a package.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_package()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_package(&self) -> super::builder::artifact_registry::GetPackage {
         super::builder::artifact_registry::GetPackage::new(self.inner.clone())
     }
@@ -289,6 +407,22 @@ impl ArtifactRegistry {
     }
 
     /// Gets a version
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_version(&self) -> super::builder::artifact_registry::GetVersion {
         super::builder::artifact_registry::GetVersion::new(self.inner.clone())
     }
@@ -326,6 +460,22 @@ impl ArtifactRegistry {
     }
 
     /// Updates a version.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_version(&self) -> super::builder::artifact_registry::UpdateVersion {
         super::builder::artifact_registry::UpdateVersion::new(self.inner.clone())
     }
@@ -336,6 +486,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets a file.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_file()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_file(&self) -> super::builder::artifact_registry::GetFile {
         super::builder::artifact_registry::GetFile::new(self.inner.clone())
     }
@@ -358,6 +525,22 @@ impl ArtifactRegistry {
     }
 
     /// Updates a file.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_file()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_file(&self) -> super::builder::artifact_registry::UpdateFile {
         super::builder::artifact_registry::UpdateFile::new(self.inner.clone())
     }
@@ -368,26 +551,105 @@ impl ArtifactRegistry {
     }
 
     /// Gets a tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_tag(&self) -> super::builder::artifact_registry::GetTag {
         super::builder::artifact_registry::GetTag::new(self.inner.clone())
     }
 
     /// Creates a tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_tag(&self) -> super::builder::artifact_registry::CreateTag {
         super::builder::artifact_registry::CreateTag::new(self.inner.clone())
     }
 
     /// Updates a tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_tag(&self) -> super::builder::artifact_registry::UpdateTag {
         super::builder::artifact_registry::UpdateTag::new(self.inner.clone())
     }
 
     /// Deletes a tag.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_tag()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_tag(&self) -> super::builder::artifact_registry::DeleteTag {
         super::builder::artifact_registry::DeleteTag::new(self.inner.clone())
     }
 
     /// Creates a rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_rule(&self) -> super::builder::artifact_registry::CreateRule {
         super::builder::artifact_registry::CreateRule::new(self.inner.clone())
     }
@@ -398,41 +660,170 @@ impl ArtifactRegistry {
     }
 
     /// Gets a rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_rule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_rule(&self) -> super::builder::artifact_registry::GetRule {
         super::builder::artifact_registry::GetRule::new(self.inner.clone())
     }
 
     /// Updates a rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_rule(&self) -> super::builder::artifact_registry::UpdateRule {
         super::builder::artifact_registry::UpdateRule::new(self.inner.clone())
     }
 
     /// Deletes a rule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_rule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_rule(&self) -> super::builder::artifact_registry::DeleteRule {
         super::builder::artifact_registry::DeleteRule::new(self.inner.clone())
     }
 
     /// Updates the IAM policy for a given resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::artifact_registry::SetIamPolicy {
         super::builder::artifact_registry::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the IAM policy for a given resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::artifact_registry::GetIamPolicy {
         super::builder::artifact_registry::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Tests if the caller has a list of permissions on a resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::artifact_registry::TestIamPermissions {
         super::builder::artifact_registry::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Retrieves the Settings for the Project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project_settings(&self) -> super::builder::artifact_registry::GetProjectSettings {
         super::builder::artifact_registry::GetProjectSettings::new(self.inner.clone())
     }
 
     /// Updates the Settings for the Project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_project_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_project_settings(
         &self,
     ) -> super::builder::artifact_registry::UpdateProjectSettings {
@@ -440,16 +831,65 @@ impl ArtifactRegistry {
     }
 
     /// Retrieves the VPCSC Config for the Project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vpcsc_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vpcsc_config(&self) -> super::builder::artifact_registry::GetVPCSCConfig {
         super::builder::artifact_registry::GetVPCSCConfig::new(self.inner.clone())
     }
 
     /// Updates the VPCSC Config for the Project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_vpcsc_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_vpcsc_config(&self) -> super::builder::artifact_registry::UpdateVPCSCConfig {
         super::builder::artifact_registry::UpdateVPCSCConfig::new(self.inner.clone())
     }
 
     /// Updates a package.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_package()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_package(&self) -> super::builder::artifact_registry::UpdatePackage {
         super::builder::artifact_registry::UpdatePackage::new(self.inner.clone())
     }
@@ -460,6 +900,23 @@ impl ArtifactRegistry {
     }
 
     /// Gets an attachment.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_attachment()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_attachment(&self) -> super::builder::artifact_registry::GetAttachment {
         super::builder::artifact_registry::GetAttachment::new(self.inner.clone())
     }
@@ -518,6 +975,22 @@ impl ArtifactRegistry {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::artifact_registry::GetLocation {
         super::builder::artifact_registry::GetLocation::new(self.inner.clone())
     }
@@ -525,6 +998,22 @@ impl ArtifactRegistry {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+    /// async fn sample(
+    ///    client: &ArtifactRegistry
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::artifact_registry::GetOperation {
         super::builder::artifact_registry::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/devtools/cloudbuild/v1/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/client.rs
@@ -148,6 +148,23 @@ impl CloudBuild {
     ///
     /// The `Build` that is returned includes its status (such as `SUCCESS`,
     /// `FAILURE`, or `WORKING`), and timing information.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_build()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_build(&self) -> super::builder::cloud_build::GetBuild {
         super::builder::cloud_build::GetBuild::new(self.inner.clone())
     }
@@ -161,6 +178,22 @@ impl CloudBuild {
     }
 
     /// Cancels a build in progress.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .cancel_build()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_build(&self) -> super::builder::cloud_build::CancelBuild {
         super::builder::cloud_build::CancelBuild::new(self.inner.clone())
     }
@@ -227,11 +260,43 @@ impl CloudBuild {
     }
 
     /// Creates a new `BuildTrigger`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_build_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_build_trigger(&self) -> super::builder::cloud_build::CreateBuildTrigger {
         super::builder::cloud_build::CreateBuildTrigger::new(self.inner.clone())
     }
 
     /// Returns information about a `BuildTrigger`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_build_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_build_trigger(&self) -> super::builder::cloud_build::GetBuildTrigger {
         super::builder::cloud_build::GetBuildTrigger::new(self.inner.clone())
     }
@@ -242,11 +307,42 @@ impl CloudBuild {
     }
 
     /// Deletes a `BuildTrigger` by its project ID and trigger ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_build_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_build_trigger(&self) -> super::builder::cloud_build::DeleteBuildTrigger {
         super::builder::cloud_build::DeleteBuildTrigger::new(self.inner.clone())
     }
 
     /// Updates a `BuildTrigger` by its project ID and trigger ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_build_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_build_trigger(&self) -> super::builder::cloud_build::UpdateBuildTrigger {
         super::builder::cloud_build::UpdateBuildTrigger::new(self.inner.clone())
     }
@@ -274,6 +370,22 @@ impl CloudBuild {
 
     /// ReceiveTriggerWebhook [Experimental] is called when the API receives a
     /// webhook request targeted at a specific trigger.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .receive_trigger_webhook()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn receive_trigger_webhook(&self) -> super::builder::cloud_build::ReceiveTriggerWebhook {
         super::builder::cloud_build::ReceiveTriggerWebhook::new(self.inner.clone())
     }
@@ -294,6 +406,23 @@ impl CloudBuild {
     }
 
     /// Returns details of a `WorkerPool`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_worker_pool()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_worker_pool(&self) -> super::builder::cloud_build::GetWorkerPool {
         super::builder::cloud_build::GetWorkerPool::new(self.inner.clone())
     }
@@ -334,6 +463,23 @@ impl CloudBuild {
     }
 
     /// Returns the `DefaultServiceAccount` used by the project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_default_service_account()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_default_service_account(
         &self,
     ) -> super::builder::cloud_build::GetDefaultServiceAccount {
@@ -343,6 +489,22 @@ impl CloudBuild {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::cloud_build::GetOperation {
         super::builder::cloud_build::GetOperation::new(self.inner.clone())
     }
@@ -350,6 +512,21 @@ impl CloudBuild {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v1::client::CloudBuild;
+    /// async fn sample(
+    ///    client: &CloudBuild
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::cloud_build::CancelOperation {
         super::builder::cloud_build::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/devtools/cloudbuild/v2/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/client.rs
@@ -137,6 +137,23 @@ impl RepositoryManager {
     }
 
     /// Gets details of a single connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection(&self) -> super::builder::repository_manager::GetConnection {
         super::builder::repository_manager::GetConnection::new(self.inner.clone())
     }
@@ -209,6 +226,23 @@ impl RepositoryManager {
     }
 
     /// Gets details of a single repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_repository()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_repository(&self) -> super::builder::repository_manager::GetRepository {
         super::builder::repository_manager::GetRepository::new(self.inner.clone())
     }
@@ -234,6 +268,22 @@ impl RepositoryManager {
     }
 
     /// Fetches read/write token of a given repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_read_write_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_read_write_token(
         &self,
     ) -> super::builder::repository_manager::FetchReadWriteToken {
@@ -241,6 +291,22 @@ impl RepositoryManager {
     }
 
     /// Fetches read token of a given repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_read_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_read_token(&self) -> super::builder::repository_manager::FetchReadToken {
         super::builder::repository_manager::FetchReadToken::new(self.inner.clone())
     }
@@ -254,6 +320,22 @@ impl RepositoryManager {
     }
 
     /// Fetch the list of branches or tags for a given repository.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fetch_git_refs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fetch_git_refs(&self) -> super::builder::repository_manager::FetchGitRefs {
         super::builder::repository_manager::FetchGitRefs::new(self.inner.clone())
     }
@@ -263,12 +345,44 @@ impl RepositoryManager {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::repository_manager::SetIamPolicy {
         super::builder::repository_manager::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::repository_manager::GetIamPolicy {
         super::builder::repository_manager::GetIamPolicy::new(self.inner.clone())
     }
@@ -280,6 +394,22 @@ impl RepositoryManager {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::repository_manager::TestIamPermissions {
         super::builder::repository_manager::TestIamPermissions::new(self.inner.clone())
     }
@@ -287,6 +417,22 @@ impl RepositoryManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::repository_manager::GetOperation {
         super::builder::repository_manager::GetOperation::new(self.inner.clone())
     }
@@ -294,6 +440,21 @@ impl RepositoryManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_build_v2::client::RepositoryManager;
+    /// async fn sample(
+    ///    client: &RepositoryManager
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::repository_manager::CancelOperation {
         super::builder::repository_manager::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/devtools/cloudprofiler/v2/src/client.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/client.rs
@@ -143,6 +143,22 @@ impl ProfilerService {
     /// status. To a gRPC client, the extension will be return as a
     /// binary-serialized proto in the trailing metadata item named
     /// "google.rpc.retryinfo-bin".
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_profiler_v2::client::ProfilerService;
+    /// async fn sample(
+    ///    client: &ProfilerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_profile(&self) -> super::builder::profiler_service::CreateProfile {
         super::builder::profiler_service::CreateProfile::new(self.inner.clone())
     }
@@ -155,6 +171,22 @@ impl ProfilerService {
     /// profiler
     /// agent](https://cloud.google.com/profiler/docs/about-profiler#profiling_agent)
     /// instead for profile collection._
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_profiler_v2::client::ProfilerService;
+    /// async fn sample(
+    ///    client: &ProfilerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_offline_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_offline_profile(&self) -> super::builder::profiler_service::CreateOfflineProfile {
         super::builder::profiler_service::CreateOfflineProfile::new(self.inner.clone())
     }
@@ -168,6 +200,22 @@ impl ProfilerService {
     /// profiler
     /// agent](https://cloud.google.com/profiler/docs/about-profiler#profiling_agent)
     /// instead for profile collection._
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_profiler_v2::client::ProfilerService;
+    /// async fn sample(
+    ///    client: &ProfilerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_profile(&self) -> super::builder::profiler_service::UpdateProfile {
         super::builder::profiler_service::UpdateProfile::new(self.inner.clone())
     }

--- a/src/generated/devtools/cloudtrace/v1/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v1/src/client.rs
@@ -128,6 +128,22 @@ impl TraceService {
     }
 
     /// Gets a single trace by its ID.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_trace_v1::client::TraceService;
+    /// async fn sample(
+    ///    client: &TraceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_trace()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_trace(&self) -> super::builder::trace_service::GetTrace {
         super::builder::trace_service::GetTrace::new(self.inner.clone())
     }
@@ -137,6 +153,21 @@ impl TraceService {
     /// in the existing trace and its spans are overwritten by the provided values,
     /// and any new fields provided are merged with the existing trace data. If the
     /// ID does not match, a new trace is created.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_trace_v1::client::TraceService;
+    /// async fn sample(
+    ///    client: &TraceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .patch_traces()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch_traces(&self) -> super::builder::trace_service::PatchTraces {
         super::builder::trace_service::PatchTraces::new(self.inner.clone())
     }

--- a/src/generated/devtools/cloudtrace/v2/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/client.rs
@@ -126,11 +126,42 @@ impl TraceService {
 
     /// Batch writes new spans to new or existing traces. You cannot update
     /// existing spans.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_trace_v2::client::TraceService;
+    /// async fn sample(
+    ///    client: &TraceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .batch_write_spans()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_write_spans(&self) -> super::builder::trace_service::BatchWriteSpans {
         super::builder::trace_service::BatchWriteSpans::new(self.inner.clone())
     }
 
     /// Creates a new span.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_trace_v2::client::TraceService;
+    /// async fn sample(
+    ///    client: &TraceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_span()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_span(&self) -> super::builder::trace_service::CreateSpan {
         super::builder::trace_service::CreateSpan::new(self.inner.clone())
     }

--- a/src/generated/devtools/containeranalysis/v1/src/client.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/client.rs
@@ -141,6 +141,22 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// async fn sample(
+    ///    client: &ContainerAnalysis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::container_analysis::SetIamPolicy {
         super::builder::container_analysis::SetIamPolicy::new(self.inner.clone())
     }
@@ -153,6 +169,22 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// async fn sample(
+    ///    client: &ContainerAnalysis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::container_analysis::GetIamPolicy {
         super::builder::container_analysis::GetIamPolicy::new(self.inner.clone())
     }
@@ -164,11 +196,43 @@ impl ContainerAnalysis {
     /// The resource takes the format `projects/[PROJECT_ID]/notes/[NOTE_ID]` for
     /// notes and `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]` for
     /// occurrences.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// async fn sample(
+    ///    client: &ContainerAnalysis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::container_analysis::TestIamPermissions {
         super::builder::container_analysis::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Gets a summary of the number and severity of occurrences.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// async fn sample(
+    ///    client: &ContainerAnalysis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_vulnerability_occurrences_summary()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_vulnerability_occurrences_summary(
         &self,
     ) -> super::builder::container_analysis::GetVulnerabilityOccurrencesSummary {
@@ -178,6 +242,22 @@ impl ContainerAnalysis {
     }
 
     /// Generates an SBOM for the given resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+    /// async fn sample(
+    ///    client: &ContainerAnalysis
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .export_sbom()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn export_sbom(&self) -> super::builder::container_analysis::ExportSBOM {
         super::builder::container_analysis::ExportSBOM::new(self.inner.clone())
     }

--- a/src/generated/firestore/admin/v1/src/client.rs
+++ b/src/generated/firestore/admin/v1/src/client.rs
@@ -173,16 +173,65 @@ impl FirestoreAdmin {
     }
 
     /// Gets a composite index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_index()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_index(&self) -> super::builder::firestore_admin::GetIndex {
         super::builder::firestore_admin::GetIndex::new(self.inner.clone())
     }
 
     /// Deletes a composite index.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_index()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_index(&self) -> super::builder::firestore_admin::DeleteIndex {
         super::builder::firestore_admin::DeleteIndex::new(self.inner.clone())
     }
 
     /// Gets the metadata and configuration for a Field.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_field()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_field(&self) -> super::builder::firestore_admin::GetField {
         super::builder::firestore_admin::GetField::new(self.inner.clone())
     }
@@ -318,11 +367,44 @@ impl FirestoreAdmin {
     }
 
     /// Gets information about a database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_database()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_database(&self) -> super::builder::firestore_admin::GetDatabase {
         super::builder::firestore_admin::GetDatabase::new(self.inner.clone())
     }
 
     /// List all the databases in the project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_databases()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_databases(&self) -> super::builder::firestore_admin::ListDatabases {
         super::builder::firestore_admin::ListDatabases::new(self.inner.clone())
     }
@@ -358,53 +440,214 @@ impl FirestoreAdmin {
     }
 
     /// Create a user creds.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_user_creds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_user_creds(&self) -> super::builder::firestore_admin::CreateUserCreds {
         super::builder::firestore_admin::CreateUserCreds::new(self.inner.clone())
     }
 
     /// Gets a user creds resource. Note that the returned resource does not
     /// contain the secret value itself.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_user_creds()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_user_creds(&self) -> super::builder::firestore_admin::GetUserCreds {
         super::builder::firestore_admin::GetUserCreds::new(self.inner.clone())
     }
 
     /// List all user creds in the database. Note that the returned resource
     /// does not contain the secret value itself.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_user_creds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_user_creds(&self) -> super::builder::firestore_admin::ListUserCreds {
         super::builder::firestore_admin::ListUserCreds::new(self.inner.clone())
     }
 
     /// Enables a user creds. No-op if the user creds are already enabled.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .enable_user_creds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_user_creds(&self) -> super::builder::firestore_admin::EnableUserCreds {
         super::builder::firestore_admin::EnableUserCreds::new(self.inner.clone())
     }
 
     /// Disables a user creds. No-op if the user creds are already disabled.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_user_creds()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_user_creds(&self) -> super::builder::firestore_admin::DisableUserCreds {
         super::builder::firestore_admin::DisableUserCreds::new(self.inner.clone())
     }
 
     /// Resets the password of a user creds.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reset_user_password()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reset_user_password(&self) -> super::builder::firestore_admin::ResetUserPassword {
         super::builder::firestore_admin::ResetUserPassword::new(self.inner.clone())
     }
 
     /// Deletes a user creds.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_user_creds()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_user_creds(&self) -> super::builder::firestore_admin::DeleteUserCreds {
         super::builder::firestore_admin::DeleteUserCreds::new(self.inner.clone())
     }
 
     /// Gets information about a backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::firestore_admin::GetBackup {
         super::builder::firestore_admin::GetBackup::new(self.inner.clone())
     }
 
     /// Lists all the backups.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_backups()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_backups(&self) -> super::builder::firestore_admin::ListBackups {
         super::builder::firestore_admin::ListBackups::new(self.inner.clone())
     }
 
     /// Deletes a backup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_backup(&self) -> super::builder::firestore_admin::DeleteBackup {
         super::builder::firestore_admin::DeleteBackup::new(self.inner.clone())
     }
@@ -450,26 +693,106 @@ impl FirestoreAdmin {
     /// Creates a backup schedule on a database.
     /// At most two backup schedules can be configured on a database, one daily
     /// backup schedule and one weekly backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_backup_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_backup_schedule(&self) -> super::builder::firestore_admin::CreateBackupSchedule {
         super::builder::firestore_admin::CreateBackupSchedule::new(self.inner.clone())
     }
 
     /// Gets information about a backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_schedule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_schedule(&self) -> super::builder::firestore_admin::GetBackupSchedule {
         super::builder::firestore_admin::GetBackupSchedule::new(self.inner.clone())
     }
 
     /// List backup schedules.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_backup_schedules()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_backup_schedules(&self) -> super::builder::firestore_admin::ListBackupSchedules {
         super::builder::firestore_admin::ListBackupSchedules::new(self.inner.clone())
     }
 
     /// Updates a backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_backup_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_backup_schedule(&self) -> super::builder::firestore_admin::UpdateBackupSchedule {
         super::builder::firestore_admin::UpdateBackupSchedule::new(self.inner.clone())
     }
 
     /// Deletes a backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_backup_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_backup_schedule(&self) -> super::builder::firestore_admin::DeleteBackupSchedule {
         super::builder::firestore_admin::DeleteBackupSchedule::new(self.inner.clone())
     }
@@ -522,6 +845,22 @@ impl FirestoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::firestore_admin::GetOperation {
         super::builder::firestore_admin::GetOperation::new(self.inner.clone())
     }
@@ -529,6 +868,21 @@ impl FirestoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::firestore_admin::DeleteOperation {
         super::builder::firestore_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -536,6 +890,21 @@ impl FirestoreAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+    /// async fn sample(
+    ///    client: &FirestoreAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::firestore_admin::CancelOperation {
         super::builder::firestore_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/grafeas/v1/src/client.rs
+++ b/src/generated/grafeas/v1/src/client.rs
@@ -132,6 +132,23 @@ impl Grafeas {
     }
 
     /// Gets the specified occurrence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_occurrence()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_occurrence(&self) -> super::builder::grafeas::GetOccurrence {
         super::builder::grafeas::GetOccurrence::new(self.inner.clone())
     }
@@ -144,32 +161,128 @@ impl Grafeas {
     /// Deletes the specified occurrence. For example, use this method to delete an
     /// occurrence when the occurrence is no longer applicable for the given
     /// resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_occurrence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_occurrence(&self) -> super::builder::grafeas::DeleteOccurrence {
         super::builder::grafeas::DeleteOccurrence::new(self.inner.clone())
     }
 
     /// Creates a new occurrence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_occurrence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_occurrence(&self) -> super::builder::grafeas::CreateOccurrence {
         super::builder::grafeas::CreateOccurrence::new(self.inner.clone())
     }
 
     /// Creates new occurrences in batch.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_create_occurrences()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_create_occurrences(&self) -> super::builder::grafeas::BatchCreateOccurrences {
         super::builder::grafeas::BatchCreateOccurrences::new(self.inner.clone())
     }
 
     /// Updates the specified occurrence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_occurrence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_occurrence(&self) -> super::builder::grafeas::UpdateOccurrence {
         super::builder::grafeas::UpdateOccurrence::new(self.inner.clone())
     }
 
     /// Gets the note attached to the specified occurrence. Consumer projects can
     /// use this method to get a note that belongs to a provider project.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_occurrence_note()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_occurrence_note(&self) -> super::builder::grafeas::GetOccurrenceNote {
         super::builder::grafeas::GetOccurrenceNote::new(self.inner.clone())
     }
 
     /// Gets the specified note.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_note()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_note(&self) -> super::builder::grafeas::GetNote {
         super::builder::grafeas::GetNote::new(self.inner.clone())
     }
@@ -180,21 +293,84 @@ impl Grafeas {
     }
 
     /// Deletes the specified note.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_note()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_note(&self) -> super::builder::grafeas::DeleteNote {
         super::builder::grafeas::DeleteNote::new(self.inner.clone())
     }
 
     /// Creates a new note.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_note()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_note(&self) -> super::builder::grafeas::CreateNote {
         super::builder::grafeas::CreateNote::new(self.inner.clone())
     }
 
     /// Creates new notes in batch.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .batch_create_notes()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn batch_create_notes(&self) -> super::builder::grafeas::BatchCreateNotes {
         super::builder::grafeas::BatchCreateNotes::new(self.inner.clone())
     }
 
     /// Updates the specified note.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_grafeas_v1::client::Grafeas;
+    /// async fn sample(
+    ///    client: &Grafeas
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_note()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_note(&self) -> super::builder::grafeas::UpdateNote {
         super::builder::grafeas::UpdateNote::new(self.inner.clone())
     }

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -156,6 +156,23 @@ impl Iam {
     /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_account()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_account(&self) -> super::builder::iam::GetServiceAccount {
         super::builder::iam::GetServiceAccount::new(self.inner.clone())
     }
@@ -163,6 +180,22 @@ impl Iam {
     /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service_account(&self) -> super::builder::iam::CreateServiceAccount {
         super::builder::iam::CreateServiceAccount::new(self.inner.clone())
     }
@@ -176,6 +209,22 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.PatchServiceAccount]: crate::client::Iam::patch_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_service_account(&self) -> super::builder::iam::UpdateServiceAccount {
         super::builder::iam::UpdateServiceAccount::new(self.inner.clone())
     }
@@ -183,6 +232,22 @@ impl Iam {
     /// Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .patch_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn patch_service_account(&self) -> super::builder::iam::PatchServiceAccount {
         super::builder::iam::PatchServiceAccount::new(self.inner.clone())
     }
@@ -205,6 +270,21 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.DisableServiceAccount]: crate::client::Iam::disable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_service_account(&self) -> super::builder::iam::DeleteServiceAccount {
         super::builder::iam::DeleteServiceAccount::new(self.inner.clone())
     }
@@ -219,6 +299,22 @@ impl Iam {
     /// that has been permanently removed.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .undelete_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn undelete_service_account(&self) -> super::builder::iam::UndeleteServiceAccount {
         super::builder::iam::UndeleteServiceAccount::new(self.inner.clone())
     }
@@ -234,6 +330,21 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.DisableServiceAccount]: crate::client::Iam::disable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .enable_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_service_account(&self) -> super::builder::iam::EnableServiceAccount {
         super::builder::iam::EnableServiceAccount::new(self.inner.clone())
     }
@@ -258,6 +369,21 @@ impl Iam {
     /// [google.iam.admin.v1.IAM.DeleteServiceAccount]: crate::client::Iam::delete_service_account
     /// [google.iam.admin.v1.IAM.EnableServiceAccount]: crate::client::Iam::enable_service_account
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .disable_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_service_account(&self) -> super::builder::iam::DisableServiceAccount {
         super::builder::iam::DisableServiceAccount::new(self.inner.clone())
     }
@@ -265,6 +391,22 @@ impl Iam {
     /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_service_account_keys()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_service_account_keys(&self) -> super::builder::iam::ListServiceAccountKeys {
         super::builder::iam::ListServiceAccountKeys::new(self.inner.clone())
     }
@@ -272,6 +414,23 @@ impl Iam {
     /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_account_key()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_account_key(&self) -> super::builder::iam::GetServiceAccountKey {
         super::builder::iam::GetServiceAccountKey::new(self.inner.clone())
     }
@@ -279,6 +438,22 @@ impl Iam {
     /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service_account_key(&self) -> super::builder::iam::CreateServiceAccountKey {
         super::builder::iam::CreateServiceAccountKey::new(self.inner.clone())
     }
@@ -290,6 +465,22 @@ impl Iam {
     /// pair as a service account key.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .upload_service_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn upload_service_account_key(&self) -> super::builder::iam::UploadServiceAccountKey {
         super::builder::iam::UploadServiceAccountKey::new(self.inner.clone())
     }
@@ -299,6 +490,21 @@ impl Iam {
     /// account key.
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_service_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_service_account_key(&self) -> super::builder::iam::DeleteServiceAccountKey {
         super::builder::iam::DeleteServiceAccountKey::new(self.inner.clone())
     }
@@ -308,6 +514,21 @@ impl Iam {
     ///
     /// [google.iam.admin.v1.IAM.EnableServiceAccountKey]: crate::client::Iam::enable_service_account_key
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .disable_service_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_service_account_key(&self) -> super::builder::iam::DisableServiceAccountKey {
         super::builder::iam::DisableServiceAccountKey::new(self.inner.clone())
     }
@@ -315,6 +536,21 @@ impl Iam {
     /// Enable a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
     ///
     /// [google.iam.admin.v1.ServiceAccountKey]: crate::model::ServiceAccountKey
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .enable_service_account_key()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_service_account_key(&self) -> super::builder::iam::EnableServiceAccountKey {
         super::builder::iam::EnableServiceAccountKey::new(self.inner.clone())
     }
@@ -329,6 +565,22 @@ impl Iam {
     /// Signs a blob using the system-managed private key for a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sign_blob()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn sign_blob(&self) -> super::builder::iam::SignBlob {
         super::builder::iam::SignBlob::new(self.inner.clone())
@@ -345,6 +597,22 @@ impl Iam {
     /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sign_jwt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     #[deprecated]
     pub fn sign_jwt(&self) -> super::builder::iam::SignJwt {
         super::builder::iam::SignJwt::new(self.inner.clone())
@@ -362,6 +630,22 @@ impl Iam {
     /// method.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::iam::GetIamPolicy {
         super::builder::iam::GetIamPolicy::new(self.inner.clone())
     }
@@ -387,6 +671,22 @@ impl Iam {
     /// resources](https://cloud.google.com/iam/help/access/manage-other-resources).
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::iam::SetIamPolicy {
         super::builder::iam::SetIamPolicy::new(self.inner.clone())
     }
@@ -395,6 +695,22 @@ impl Iam {
     /// [ServiceAccount][google.iam.admin.v1.ServiceAccount].
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::iam::TestIamPermissions {
         super::builder::iam::TestIamPermissions::new(self.inner.clone())
     }
@@ -417,6 +733,22 @@ impl Iam {
     /// Gets the definition of a [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_role()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_role(&self) -> super::builder::iam::GetRole {
         super::builder::iam::GetRole::new(self.inner.clone())
     }
@@ -424,6 +756,22 @@ impl Iam {
     /// Creates a new custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_role()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_role(&self) -> super::builder::iam::CreateRole {
         super::builder::iam::CreateRole::new(self.inner.clone())
     }
@@ -431,6 +779,22 @@ impl Iam {
     /// Updates the definition of a custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_role()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_role(&self) -> super::builder::iam::UpdateRole {
         super::builder::iam::UpdateRole::new(self.inner.clone())
     }
@@ -456,6 +820,22 @@ impl Iam {
     /// [google.iam.admin.v1.IAM.ListRoles]: crate::client::Iam::list_roles
     /// [google.iam.admin.v1.Role]: crate::model::Role
     /// [google.iam.v1.Policy]: iam_v1::model::Policy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_role()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_role(&self) -> super::builder::iam::DeleteRole {
         super::builder::iam::DeleteRole::new(self.inner.clone())
     }
@@ -463,6 +843,22 @@ impl Iam {
     /// Undeletes a custom [Role][google.iam.admin.v1.Role].
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .undelete_role()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn undelete_role(&self) -> super::builder::iam::UndeleteRole {
         super::builder::iam::UndeleteRole::new(self.inner.clone())
     }
@@ -479,6 +875,22 @@ impl Iam {
     ///
     /// To learn more about audit logs, see the [Logging
     /// documentation](https://cloud.google.com/logging/docs/audit).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .query_auditable_services()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_auditable_services(&self) -> super::builder::iam::QueryAuditableServices {
         super::builder::iam::QueryAuditableServices::new(self.inner.clone())
     }
@@ -491,6 +903,22 @@ impl Iam {
     /// even if the linter detects an issue in the IAM policy.
     ///
     /// [google.iam.v1.Binding.condition]: iam_v1::model::Binding::condition
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lint_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lint_policy(&self) -> super::builder::iam::LintPolicy {
         super::builder::iam::LintPolicy::new(self.inner.clone())
     }

--- a/src/generated/iam/credentials/v1/src/client.rs
+++ b/src/generated/iam/credentials/v1/src/client.rs
@@ -127,21 +127,85 @@ impl IAMCredentials {
     }
 
     /// Generates an OAuth 2.0 access token for a service account.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+    /// async fn sample(
+    ///    client: &IAMCredentials
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_access_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_access_token(&self) -> super::builder::iam_credentials::GenerateAccessToken {
         super::builder::iam_credentials::GenerateAccessToken::new(self.inner.clone())
     }
 
     /// Generates an OpenID Connect ID token for a service account.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+    /// async fn sample(
+    ///    client: &IAMCredentials
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .generate_id_token()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn generate_id_token(&self) -> super::builder::iam_credentials::GenerateIdToken {
         super::builder::iam_credentials::GenerateIdToken::new(self.inner.clone())
     }
 
     /// Signs a blob using a service account's system-managed private key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+    /// async fn sample(
+    ///    client: &IAMCredentials
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sign_blob()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn sign_blob(&self) -> super::builder::iam_credentials::SignBlob {
         super::builder::iam_credentials::SignBlob::new(self.inner.clone())
     }
 
     /// Signs a JWT using a service account's system-managed private key.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+    /// async fn sample(
+    ///    client: &IAMCredentials
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .sign_jwt()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn sign_jwt(&self) -> super::builder::iam_credentials::SignJwt {
         super::builder::iam_credentials::SignJwt::new(self.inner.clone())
     }

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -146,6 +146,22 @@ impl IAMPolicy {
     /// existing policy.
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED` errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v1::client::IAMPolicy;
+    /// async fn sample(
+    ///    client: &IAMPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::iam_policy::SetIamPolicy {
         super::builder::iam_policy::SetIamPolicy::new(self.inner.clone())
     }
@@ -153,6 +169,22 @@ impl IAMPolicy {
     /// Gets the access control policy for a resource.
     /// Returns an empty policy if the resource exists and does not have a policy
     /// set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v1::client::IAMPolicy;
+    /// async fn sample(
+    ///    client: &IAMPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::iam_policy::GetIamPolicy {
         super::builder::iam_policy::GetIamPolicy::new(self.inner.clone())
     }
@@ -164,6 +196,22 @@ impl IAMPolicy {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v1::client::IAMPolicy;
+    /// async fn sample(
+    ///    client: &IAMPolicy
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::iam_policy::TestIamPermissions {
         super::builder::iam_policy::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -128,6 +128,22 @@ impl Policies {
     }
 
     /// Gets a policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v2::client::Policies;
+    /// async fn sample(
+    ///    client: &Policies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy(&self) -> super::builder::policies::GetPolicy {
         super::builder::policies::GetPolicy::new(self.inner.clone())
     }
@@ -192,6 +208,22 @@ impl Policies {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v2::client::Policies;
+    /// async fn sample(
+    ///    client: &Policies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::policies::GetOperation {
         super::builder::policies::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/iam/v3/src/client.rs
+++ b/src/generated/iam/v3/src/client.rs
@@ -137,6 +137,23 @@ impl PolicyBindings {
     }
 
     /// Gets a policy binding.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v3::client::PolicyBindings;
+    /// async fn sample(
+    ///    client: &PolicyBindings,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_policy_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_policy_binding(&self) -> super::builder::policy_bindings::GetPolicyBinding {
         super::builder::policy_bindings::GetPolicyBinding::new(self.inner.clone())
     }
@@ -193,6 +210,22 @@ impl PolicyBindings {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v3::client::PolicyBindings;
+    /// async fn sample(
+    ///    client: &PolicyBindings
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::policy_bindings::GetOperation {
         super::builder::policy_bindings::GetOperation::new(self.inner.clone())
     }
@@ -327,6 +360,23 @@ impl PrincipalAccessBoundaryPolicies {
     }
 
     /// Gets a principal access boundary policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v3::client::PrincipalAccessBoundaryPolicies;
+    /// async fn sample(
+    ///    client: &PrincipalAccessBoundaryPolicies,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_principal_access_boundary_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_principal_access_boundary_policy(
         &self,
     ) -> super::builder::principal_access_boundary_policies::GetPrincipalAccessBoundaryPolicy {
@@ -395,6 +445,22 @@ impl PrincipalAccessBoundaryPolicies {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_v3::client::PrincipalAccessBoundaryPolicies;
+    /// async fn sample(
+    ///    client: &PrincipalAccessBoundaryPolicies
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(
         &self,
     ) -> super::builder::principal_access_boundary_policies::GetOperation {

--- a/src/generated/identity/accesscontextmanager/v1/src/client.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/client.rs
@@ -142,6 +142,23 @@ impl AccessContextManager {
 
     /// Returns an [access policy]
     /// [google.identity.accesscontextmanager.v1.AccessPolicy] based on the name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_access_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_access_policy(&self) -> super::builder::access_context_manager::GetAccessPolicy {
         super::builder::access_context_manager::GetAccessPolicy::new(self.inner.clone())
     }
@@ -220,6 +237,23 @@ impl AccessContextManager {
     /// Gets an [access level]
     /// [google.identity.accesscontextmanager.v1.AccessLevel] based on the resource
     /// name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_access_level()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_access_level(&self) -> super::builder::access_context_manager::GetAccessLevel {
         super::builder::access_context_manager::GetAccessLevel::new(self.inner.clone())
     }
@@ -332,6 +366,23 @@ impl AccessContextManager {
     /// Gets a [service perimeter]
     /// [google.identity.accesscontextmanager.v1.ServicePerimeter] based on the
     /// resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_perimeter()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_perimeter(
         &self,
     ) -> super::builder::access_context_manager::GetServicePerimeter {
@@ -482,6 +533,23 @@ impl AccessContextManager {
     /// Gets the [GcpUserAccessBinding]
     /// [google.identity.accesscontextmanager.v1.GcpUserAccessBinding] with
     /// the given name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_gcp_user_access_binding()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_gcp_user_access_binding(
         &self,
     ) -> super::builder::access_context_manager::GetGcpUserAccessBinding {
@@ -564,6 +632,22 @@ impl AccessContextManager {
     /// policy][google.identity.accesscontextmanager.v1.AccessPolicy].
     ///
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::access_context_manager::SetIamPolicy {
         super::builder::access_context_manager::SetIamPolicy::new(self.inner.clone())
     }
@@ -572,6 +656,22 @@ impl AccessContextManager {
     /// [access policy][google.identity.accesscontextmanager.v1.AccessPolicy].
     ///
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::access_context_manager::GetIamPolicy {
         super::builder::access_context_manager::GetIamPolicy::new(self.inner.clone())
     }
@@ -585,6 +685,22 @@ impl AccessContextManager {
     ///
     /// [google.identity.accesscontextmanager.v1.AccessLevel]: crate::model::AccessLevel
     /// [google.identity.accesscontextmanager.v1.AccessPolicy]: crate::model::AccessPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::access_context_manager::TestIamPermissions {
@@ -594,6 +710,22 @@ impl AccessContextManager {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+    /// async fn sample(
+    ///    client: &AccessContextManager
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::access_context_manager::GetOperation {
         super::builder::access_context_manager::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/logging/v2/src/client.rs
+++ b/src/generated/logging/v2/src/client.rs
@@ -125,6 +125,21 @@ impl LoggingServiceV2 {
     /// reappears if it receives new entries. Log entries written shortly before
     /// the delete operation might not be deleted. Entries received after the
     /// delete operation with a timestamp before the operation will be deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// async fn sample(
+    ///    client: &LoggingServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_log()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_log(&self) -> super::builder::logging_service_v_2::DeleteLog {
         super::builder::logging_service_v_2::DeleteLog::new(self.inner.clone())
     }
@@ -136,6 +151,22 @@ impl LoggingServiceV2 {
     /// A single request may contain log entries for a maximum of 1000
     /// different resources (projects, organizations, billing accounts or
     /// folders)
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// async fn sample(
+    ///    client: &LoggingServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .write_log_entries()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn write_log_entries(&self) -> super::builder::logging_service_v_2::WriteLogEntries {
         super::builder::logging_service_v_2::WriteLogEntries::new(self.inner.clone())
     }
@@ -159,6 +190,22 @@ impl LoggingServiceV2 {
 
     /// Lists the logs in projects, organizations, folders, or billing accounts.
     /// Only logs that have entries are listed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// async fn sample(
+    ///    client: &LoggingServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_logs()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_logs(&self) -> super::builder::logging_service_v_2::ListLogs {
         super::builder::logging_service_v_2::ListLogs::new(self.inner.clone())
     }
@@ -173,6 +220,22 @@ impl LoggingServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// async fn sample(
+    ///    client: &LoggingServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::logging_service_v_2::GetOperation {
         super::builder::logging_service_v_2::GetOperation::new(self.inner.clone())
     }
@@ -180,6 +243,21 @@ impl LoggingServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::LoggingServiceV2;
+    /// async fn sample(
+    ///    client: &LoggingServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::logging_service_v_2::CancelOperation {
         super::builder::logging_service_v_2::CancelOperation::new(self.inner.clone())
     }
@@ -296,6 +374,23 @@ impl ConfigServiceV2 {
     }
 
     /// Gets a log bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_bucket()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_bucket(&self) -> super::builder::config_service_v_2::GetBucket {
         super::builder::config_service_v_2::GetBucket::new(self.inner.clone())
     }
@@ -339,6 +434,22 @@ impl ConfigServiceV2 {
 
     /// Creates a log bucket that can be used to store log entries. After a bucket
     /// has been created, the bucket's location cannot be changed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_bucket(&self) -> super::builder::config_service_v_2::CreateBucket {
         super::builder::config_service_v_2::CreateBucket::new(self.inner.clone())
     }
@@ -349,6 +460,22 @@ impl ConfigServiceV2 {
     /// `FAILED_PRECONDITION` will be returned.
     ///
     /// After a bucket has been created, the bucket's location cannot be changed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_bucket(&self) -> super::builder::config_service_v_2::UpdateBucket {
         super::builder::config_service_v_2::UpdateBucket::new(self.inner.clone())
     }
@@ -358,12 +485,42 @@ impl ConfigServiceV2 {
     /// Changes the bucket's `lifecycle_state` to the `DELETE_REQUESTED` state.
     /// After 7 days, the bucket will be purged and all log entries in the bucket
     /// will be permanently deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_bucket(&self) -> super::builder::config_service_v_2::DeleteBucket {
         super::builder::config_service_v_2::DeleteBucket::new(self.inner.clone())
     }
 
     /// Undeletes a log bucket. A bucket that has been deleted can be undeleted
     /// within the grace period of 7 days.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .undelete_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn undelete_bucket(&self) -> super::builder::config_service_v_2::UndeleteBucket {
         super::builder::config_service_v_2::UndeleteBucket::new(self.inner.clone())
     }
@@ -374,12 +531,45 @@ impl ConfigServiceV2 {
     }
 
     /// Gets a view on a log bucket..
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_view()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_view(&self) -> super::builder::config_service_v_2::GetView {
         super::builder::config_service_v_2::GetView::new(self.inner.clone())
     }
 
     /// Creates a view over log entries in a log bucket. A bucket may contain a
     /// maximum of 30 views.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_view(&self) -> super::builder::config_service_v_2::CreateView {
         super::builder::config_service_v_2::CreateView::new(self.inner.clone())
     }
@@ -389,6 +579,22 @@ impl ConfigServiceV2 {
     /// If an `UNAVAILABLE` error is returned, this indicates that system is not in
     /// a state where it can update the view. If this occurs, please try again in a
     /// few minutes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_view(&self) -> super::builder::config_service_v_2::UpdateView {
         super::builder::config_service_v_2::UpdateView::new(self.inner.clone())
     }
@@ -397,6 +603,21 @@ impl ConfigServiceV2 {
     /// If an `UNAVAILABLE` error is returned, this indicates that system is not in
     /// a state where it can delete the view. If this occurs, please try again in a
     /// few minutes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_view()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_view(&self) -> super::builder::config_service_v_2::DeleteView {
         super::builder::config_service_v_2::DeleteView::new(self.inner.clone())
     }
@@ -407,6 +628,23 @@ impl ConfigServiceV2 {
     }
 
     /// Gets a sink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_sink()
+    ///         .set_sink_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_sink(&self) -> super::builder::config_service_v_2::GetSink {
         super::builder::config_service_v_2::GetSink::new(self.inner.clone())
     }
@@ -415,6 +653,22 @@ impl ConfigServiceV2 {
     /// export of newly-ingested log entries begins immediately, unless the sink's
     /// `writer_identity` is not permitted to write to the destination. A sink can
     /// export log entries only from the resource owning the sink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_sink()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_sink(&self) -> super::builder::config_service_v_2::CreateSink {
         super::builder::config_service_v_2::CreateSink::new(self.inner.clone())
     }
@@ -424,12 +678,43 @@ impl ConfigServiceV2 {
     ///
     /// The updated sink might also have a new `writer_identity`; see the
     /// `unique_writer_identity` field.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_sink()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_sink(&self) -> super::builder::config_service_v_2::UpdateSink {
         super::builder::config_service_v_2::UpdateSink::new(self.inner.clone())
     }
 
     /// Deletes a sink. If the sink has a unique `writer_identity`, then that
     /// service account is also deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_sink()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_sink(&self) -> super::builder::config_service_v_2::DeleteSink {
         super::builder::config_service_v_2::DeleteSink::new(self.inner.clone())
     }
@@ -473,6 +758,23 @@ impl ConfigServiceV2 {
     }
 
     /// Gets a link.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_link()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_link(&self) -> super::builder::config_service_v_2::GetLink {
         super::builder::config_service_v_2::GetLink::new(self.inner.clone())
     }
@@ -483,6 +785,23 @@ impl ConfigServiceV2 {
     }
 
     /// Gets the description of an exclusion in the _Default sink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_exclusion()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_exclusion(&self) -> super::builder::config_service_v_2::GetExclusion {
         super::builder::config_service_v_2::GetExclusion::new(self.inner.clone())
     }
@@ -490,17 +809,64 @@ impl ConfigServiceV2 {
     /// Creates a new exclusion in the _Default sink in a specified parent
     /// resource. Only log entries belonging to that resource can be excluded. You
     /// can have up to 10 exclusions in a resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_exclusion()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_exclusion(&self) -> super::builder::config_service_v_2::CreateExclusion {
         super::builder::config_service_v_2::CreateExclusion::new(self.inner.clone())
     }
 
     /// Changes one or more properties of an existing exclusion in the _Default
     /// sink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_exclusion()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_exclusion(&self) -> super::builder::config_service_v_2::UpdateExclusion {
         super::builder::config_service_v_2::UpdateExclusion::new(self.inner.clone())
     }
 
     /// Deletes an exclusion in the _Default sink.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_exclusion()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_exclusion(&self) -> super::builder::config_service_v_2::DeleteExclusion {
         super::builder::config_service_v_2::DeleteExclusion::new(self.inner.clone())
     }
@@ -515,6 +881,23 @@ impl ConfigServiceV2 {
     /// See [Enabling CMEK for Log
     /// Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
     /// for more information.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_cmek_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_cmek_settings(&self) -> super::builder::config_service_v_2::GetCmekSettings {
         super::builder::config_service_v_2::GetCmekSettings::new(self.inner.clone())
     }
@@ -536,6 +919,22 @@ impl ConfigServiceV2 {
     /// for more information.
     ///
     /// [google.logging.v2.ConfigServiceV2.UpdateCmekSettings]: crate::client::ConfigServiceV2::update_cmek_settings
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_cmek_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_cmek_settings(&self) -> super::builder::config_service_v_2::UpdateCmekSettings {
         super::builder::config_service_v_2::UpdateCmekSettings::new(self.inner.clone())
     }
@@ -550,6 +949,23 @@ impl ConfigServiceV2 {
     /// See [Enabling CMEK for Log
     /// Router](https://cloud.google.com/logging/docs/routing/managed-encryption)
     /// for more information.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_settings()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_settings(&self) -> super::builder::config_service_v_2::GetSettings {
         super::builder::config_service_v_2::GetSettings::new(self.inner.clone())
     }
@@ -572,6 +988,22 @@ impl ConfigServiceV2 {
     /// for more information.
     ///
     /// [google.logging.v2.ConfigServiceV2.UpdateSettings]: crate::client::ConfigServiceV2::update_settings
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_settings()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_settings(&self) -> super::builder::config_service_v_2::UpdateSettings {
         super::builder::config_service_v_2::UpdateSettings::new(self.inner.clone())
     }
@@ -601,6 +1033,22 @@ impl ConfigServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::config_service_v_2::GetOperation {
         super::builder::config_service_v_2::GetOperation::new(self.inner.clone())
     }
@@ -608,6 +1056,21 @@ impl ConfigServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::ConfigServiceV2;
+    /// async fn sample(
+    ///    client: &ConfigServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::config_service_v_2::CancelOperation {
         super::builder::config_service_v_2::CancelOperation::new(self.inner.clone())
     }
@@ -724,21 +1187,85 @@ impl MetricsServiceV2 {
     }
 
     /// Gets a logs-based metric.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_log_metric()
+    ///         .set_metric_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_log_metric(&self) -> super::builder::metrics_service_v_2::GetLogMetric {
         super::builder::metrics_service_v_2::GetLogMetric::new(self.inner.clone())
     }
 
     /// Creates a logs-based metric.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_log_metric()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_log_metric(&self) -> super::builder::metrics_service_v_2::CreateLogMetric {
         super::builder::metrics_service_v_2::CreateLogMetric::new(self.inner.clone())
     }
 
     /// Creates or updates a logs-based metric.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_log_metric()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_log_metric(&self) -> super::builder::metrics_service_v_2::UpdateLogMetric {
         super::builder::metrics_service_v_2::UpdateLogMetric::new(self.inner.clone())
     }
 
     /// Deletes a logs-based metric.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_log_metric()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_log_metric(&self) -> super::builder::metrics_service_v_2::DeleteLogMetric {
         super::builder::metrics_service_v_2::DeleteLogMetric::new(self.inner.clone())
     }
@@ -753,6 +1280,22 @@ impl MetricsServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::metrics_service_v_2::GetOperation {
         super::builder::metrics_service_v_2::GetOperation::new(self.inner.clone())
     }
@@ -760,6 +1303,21 @@ impl MetricsServiceV2 {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_logging_v2::client::MetricsServiceV2;
+    /// async fn sample(
+    ///    client: &MetricsServiceV2
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::metrics_service_v_2::CancelOperation {
         super::builder::metrics_service_v_2::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -137,6 +137,22 @@ impl Operations {
     /// Gets the latest state of a long-running operation.  Clients can use this
     /// method to poll the operation result at intervals as recommended by the API
     /// service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_longrunning::client::Operations;
+    /// async fn sample(
+    ///    client: &Operations
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::operations::GetOperation {
         super::builder::operations::GetOperation::new(self.inner.clone())
     }
@@ -145,6 +161,21 @@ impl Operations {
     /// no longer interested in the operation result. It does not cancel the
     /// operation. If the server doesn't support this method, it returns
     /// `google.rpc.Code.UNIMPLEMENTED`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_longrunning::client::Operations;
+    /// async fn sample(
+    ///    client: &Operations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::operations::DeleteOperation {
         super::builder::operations::DeleteOperation::new(self.inner.clone())
     }
@@ -164,6 +195,21 @@ impl Operations {
     /// [google.longrunning.Operation.error]: crate::model::Operation::result
     /// [google.longrunning.Operations.GetOperation]: crate::client::Operations::get_operation
     /// [google.rpc.Status.code]: rpc::model::Status::code
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_longrunning::client::Operations;
+    /// async fn sample(
+    ///    client: &Operations
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::operations::CancelOperation {
         super::builder::operations::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/monitoring/dashboard/v1/src/client.rs
+++ b/src/generated/monitoring/dashboard/v1/src/client.rs
@@ -128,6 +128,22 @@ impl DashboardsService {
     /// method requires the `monitoring.dashboards.create` permission on the
     /// specified project. For more information about permissions, see [Cloud
     /// Identity and Access Management](https://cloud.google.com/iam).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+    /// async fn sample(
+    ///    client: &DashboardsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_dashboard()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_dashboard(&self) -> super::builder::dashboards_service::CreateDashboard {
         super::builder::dashboards_service::CreateDashboard::new(self.inner.clone())
     }
@@ -146,6 +162,23 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.get` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+    /// async fn sample(
+    ///    client: &DashboardsService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dashboard()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dashboard(&self) -> super::builder::dashboards_service::GetDashboard {
         super::builder::dashboards_service::GetDashboard::new(self.inner.clone())
     }
@@ -155,6 +188,21 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.delete` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+    /// async fn sample(
+    ///    client: &DashboardsService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_dashboard()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_dashboard(&self) -> super::builder::dashboards_service::DeleteDashboard {
         super::builder::dashboards_service::DeleteDashboard::new(self.inner.clone())
     }
@@ -164,6 +212,22 @@ impl DashboardsService {
     /// This method requires the `monitoring.dashboards.update` permission
     /// on the specified dashboard. For more information, see
     /// [Cloud Identity and Access Management](https://cloud.google.com/iam).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+    /// async fn sample(
+    ///    client: &DashboardsService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_dashboard()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_dashboard(&self) -> super::builder::dashboards_service::UpdateDashboard {
         super::builder::dashboards_service::UpdateDashboard::new(self.inner.clone())
     }

--- a/src/generated/monitoring/metricsscope/v1/src/client.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/client.rs
@@ -120,6 +120,23 @@ impl MetricsScopes {
     }
 
     /// Returns a specific `Metrics Scope`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+    /// async fn sample(
+    ///    client: &MetricsScopes,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metrics_scope()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metrics_scope(&self) -> super::builder::metrics_scopes::GetMetricsScope {
         super::builder::metrics_scopes::GetMetricsScope::new(self.inner.clone())
     }
@@ -127,6 +144,22 @@ impl MetricsScopes {
     /// Returns a list of every `Metrics Scope` that a specific `MonitoredProject`
     /// has been added to. The metrics scope representing the specified monitored
     /// project will always be the first entry in the response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+    /// async fn sample(
+    ///    client: &MetricsScopes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_metrics_scopes_by_monitored_project()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_metrics_scopes_by_monitored_project(
         &self,
     ) -> super::builder::metrics_scopes::ListMetricsScopesByMonitoredProject {
@@ -171,6 +204,22 @@ impl MetricsScopes {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+    /// async fn sample(
+    ///    client: &MetricsScopes
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::metrics_scopes::GetOperation {
         super::builder::metrics_scopes::GetOperation::new(self.inner.clone())
     }

--- a/src/generated/monitoring/v3/src/client.rs
+++ b/src/generated/monitoring/v3/src/client.rs
@@ -135,6 +135,23 @@ impl AlertPolicyService {
     }
 
     /// Gets a single alerting policy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+    /// async fn sample(
+    ///    client: &AlertPolicyService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_alert_policy()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_alert_policy(&self) -> super::builder::alert_policy_service::GetAlertPolicy {
         super::builder::alert_policy_service::GetAlertPolicy::new(self.inner.clone())
     }
@@ -144,6 +161,22 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+    /// async fn sample(
+    ///    client: &AlertPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_alert_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_alert_policy(&self) -> super::builder::alert_policy_service::CreateAlertPolicy {
         super::builder::alert_policy_service::CreateAlertPolicy::new(self.inner.clone())
     }
@@ -153,6 +186,21 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+    /// async fn sample(
+    ///    client: &AlertPolicyService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_alert_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_alert_policy(&self) -> super::builder::alert_policy_service::DeleteAlertPolicy {
         super::builder::alert_policy_service::DeleteAlertPolicy::new(self.inner.clone())
     }
@@ -165,6 +213,22 @@ impl AlertPolicyService {
     /// Design your application to single-thread API calls that modify the state of
     /// alerting policies in a single project. This includes calls to
     /// CreateAlertPolicy, DeleteAlertPolicy and UpdateAlertPolicy.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
+    /// async fn sample(
+    ///    client: &AlertPolicyService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_alert_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_alert_policy(&self) -> super::builder::alert_policy_service::UpdateAlertPolicy {
         super::builder::alert_policy_service::UpdateAlertPolicy::new(self.inner.clone())
     }
@@ -289,22 +353,86 @@ impl GroupService {
     }
 
     /// Gets a single group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::GroupService;
+    /// async fn sample(
+    ///    client: &GroupService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_group()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_group(&self) -> super::builder::group_service::GetGroup {
         super::builder::group_service::GetGroup::new(self.inner.clone())
     }
 
     /// Creates a new group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::GroupService;
+    /// async fn sample(
+    ///    client: &GroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_group(&self) -> super::builder::group_service::CreateGroup {
         super::builder::group_service::CreateGroup::new(self.inner.clone())
     }
 
     /// Updates an existing group.
     /// You can change any group attributes except `name`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::GroupService;
+    /// async fn sample(
+    ///    client: &GroupService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_group(&self) -> super::builder::group_service::UpdateGroup {
         super::builder::group_service::UpdateGroup::new(self.inner.clone())
     }
 
     /// Deletes an existing group.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::GroupService;
+    /// async fn sample(
+    ///    client: &GroupService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_group()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_group(&self) -> super::builder::group_service::DeleteGroup {
         super::builder::group_service::DeleteGroup::new(self.inner.clone())
     }
@@ -426,6 +554,22 @@ impl MetricService {
     }
 
     /// Gets a single monitored resource descriptor.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_monitored_resource_descriptor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_monitored_resource_descriptor(
         &self,
     ) -> super::builder::metric_service::GetMonitoredResourceDescriptor {
@@ -438,6 +582,22 @@ impl MetricService {
     }
 
     /// Gets a single metric descriptor.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_metric_descriptor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_metric_descriptor(&self) -> super::builder::metric_service::GetMetricDescriptor {
         super::builder::metric_service::GetMetricDescriptor::new(self.inner.clone())
     }
@@ -448,6 +608,22 @@ impl MetricService {
     /// [custom metrics](https://cloud.google.com/monitoring/custom-metrics).
     /// The metric descriptor is updated if it already exists,
     /// except that metric labels are never removed.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_metric_descriptor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_metric_descriptor(
         &self,
     ) -> super::builder::metric_service::CreateMetricDescriptor {
@@ -457,6 +633,21 @@ impl MetricService {
     /// Deletes a metric descriptor. Only user-created
     /// [custom metrics](https://cloud.google.com/monitoring/custom-metrics) can be
     /// deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_metric_descriptor()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_metric_descriptor(
         &self,
     ) -> super::builder::metric_service::DeleteMetricDescriptor {
@@ -475,6 +666,21 @@ impl MetricService {
     /// This method does not support
     /// [resource locations constraint of an organization
     /// policy](https://cloud.google.com/resource-manager/docs/organization-policy/defining-locations#setting_the_organization_policy).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .create_time_series()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_time_series(&self) -> super::builder::metric_service::CreateTimeSeries {
         super::builder::metric_service::CreateTimeSeries::new(self.inner.clone())
     }
@@ -490,6 +696,21 @@ impl MetricService {
     /// instead.
     ///
     /// [google.monitoring.v3.MetricService.CreateTimeSeries]: crate::client::MetricService::create_time_series
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::MetricService;
+    /// async fn sample(
+    ///    client: &MetricService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .create_service_time_series()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service_time_series(
         &self,
     ) -> super::builder::metric_service::CreateServiceTimeSeries {
@@ -616,6 +837,23 @@ impl NotificationChannelService {
 
     /// Gets a single channel descriptor. The descriptor indicates which fields
     /// are expected / permitted for a notification channel of the given type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notification_channel_descriptor()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notification_channel_descriptor(
         &self,
     ) -> super::builder::notification_channel_service::GetNotificationChannelDescriptor {
@@ -640,6 +878,23 @@ impl NotificationChannelService {
     /// response may truncate or omit passwords, API keys, or other private key
     /// matter and thus the response may not be 100% identical to the information
     /// that was supplied in the call to the create method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notification_channel()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notification_channel(
         &self,
     ) -> super::builder::notification_channel_service::GetNotificationChannel {
@@ -655,6 +910,22 @@ impl NotificationChannelService {
     /// notification channels in a single project. This includes calls to
     /// CreateNotificationChannel, DeleteNotificationChannel and
     /// UpdateNotificationChannel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_notification_channel()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_notification_channel(
         &self,
     ) -> super::builder::notification_channel_service::CreateNotificationChannel {
@@ -670,6 +941,22 @@ impl NotificationChannelService {
     /// notification channels in a single project. This includes calls to
     /// CreateNotificationChannel, DeleteNotificationChannel and
     /// UpdateNotificationChannel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_notification_channel()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_notification_channel(
         &self,
     ) -> super::builder::notification_channel_service::UpdateNotificationChannel {
@@ -684,6 +971,21 @@ impl NotificationChannelService {
     /// notification channels in a single project. This includes calls to
     /// CreateNotificationChannel, DeleteNotificationChannel and
     /// UpdateNotificationChannel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_notification_channel()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_notification_channel(
         &self,
     ) -> super::builder::notification_channel_service::DeleteNotificationChannel {
@@ -694,6 +996,21 @@ impl NotificationChannelService {
 
     /// Causes a verification code to be delivered to the channel. The code
     /// can then be supplied in `VerifyNotificationChannel` to verify the channel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .send_notification_channel_verification_code()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn send_notification_channel_verification_code(
         &self,
     ) -> super::builder::notification_channel_service::SendNotificationChannelVerificationCode {
@@ -723,6 +1040,22 @@ impl NotificationChannelService {
     /// have a shorter expiration (e.g. codes such as "G-123456") whereas
     /// GetVerificationCode() will typically return a much longer, websafe base
     /// 64 encoded string that has a longer expiration time.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_notification_channel_verification_code()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_notification_channel_verification_code(
         &self,
     ) -> super::builder::notification_channel_service::GetNotificationChannelVerificationCode {
@@ -734,6 +1067,22 @@ impl NotificationChannelService {
     /// Verifies a `NotificationChannel` by proving receipt of the code
     /// delivered to the channel as a result of calling
     /// `SendNotificationChannelVerificationCode`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
+    /// async fn sample(
+    ///    client: &NotificationChannelService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_notification_channel()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_notification_channel(
         &self,
     ) -> super::builder::notification_channel_service::VerifyNotificationChannel {
@@ -967,11 +1316,44 @@ impl ServiceMonitoringService {
     }
 
     /// Create a `Service`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service(&self) -> super::builder::service_monitoring_service::CreateService {
         super::builder::service_monitoring_service::CreateService::new(self.inner.clone())
     }
 
     /// Get the named `Service`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service(&self) -> super::builder::service_monitoring_service::GetService {
         super::builder::service_monitoring_service::GetService::new(self.inner.clone())
     }
@@ -982,16 +1364,63 @@ impl ServiceMonitoringService {
     }
 
     /// Update this `Service`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_service(&self) -> super::builder::service_monitoring_service::UpdateService {
         super::builder::service_monitoring_service::UpdateService::new(self.inner.clone())
     }
 
     /// Soft delete this `Service`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_service()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_service(&self) -> super::builder::service_monitoring_service::DeleteService {
         super::builder::service_monitoring_service::DeleteService::new(self.inner.clone())
     }
 
     /// Create a `ServiceLevelObjective` for the given `Service`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_service_level_objective()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_service_level_objective(
         &self,
     ) -> super::builder::service_monitoring_service::CreateServiceLevelObjective {
@@ -1001,6 +1430,23 @@ impl ServiceMonitoringService {
     }
 
     /// Get a `ServiceLevelObjective` by name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_service_level_objective()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_service_level_objective(
         &self,
     ) -> super::builder::service_monitoring_service::GetServiceLevelObjective {
@@ -1019,6 +1465,22 @@ impl ServiceMonitoringService {
     }
 
     /// Update the given `ServiceLevelObjective`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_service_level_objective()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_service_level_objective(
         &self,
     ) -> super::builder::service_monitoring_service::UpdateServiceLevelObjective {
@@ -1028,6 +1490,21 @@ impl ServiceMonitoringService {
     }
 
     /// Delete the given `ServiceLevelObjective`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+    /// async fn sample(
+    ///    client: &ServiceMonitoringService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_service_level_objective()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_service_level_objective(
         &self,
     ) -> super::builder::service_monitoring_service::DeleteServiceLevelObjective {
@@ -1144,6 +1621,22 @@ impl SnoozeService {
     /// Creates a `Snooze` that will prevent alerts, which match the provided
     /// criteria, from being opened. The `Snooze` applies for a specific time
     /// interval.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::SnoozeService;
+    /// async fn sample(
+    ///    client: &SnoozeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_snooze()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_snooze(&self) -> super::builder::snooze_service::CreateSnooze {
         super::builder::snooze_service::CreateSnooze::new(self.inner.clone())
     }
@@ -1155,12 +1648,45 @@ impl SnoozeService {
     }
 
     /// Retrieves a `Snooze` by `name`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::SnoozeService;
+    /// async fn sample(
+    ///    client: &SnoozeService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_snooze()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_snooze(&self) -> super::builder::snooze_service::GetSnooze {
         super::builder::snooze_service::GetSnooze::new(self.inner.clone())
     }
 
     /// Updates a `Snooze`, identified by its `name`, with the parameters in the
     /// given `Snooze` object.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::SnoozeService;
+    /// async fn sample(
+    ///    client: &SnoozeService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_snooze()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_snooze(&self) -> super::builder::snooze_service::UpdateSnooze {
         super::builder::snooze_service::UpdateSnooze::new(self.inner.clone())
     }
@@ -1287,6 +1813,23 @@ impl UptimeCheckService {
     }
 
     /// Gets a single Uptime check configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+    /// async fn sample(
+    ///    client: &UptimeCheckService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_uptime_check_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_uptime_check_config(
         &self,
     ) -> super::builder::uptime_check_service::GetUptimeCheckConfig {
@@ -1294,6 +1837,22 @@ impl UptimeCheckService {
     }
 
     /// Creates a new Uptime check configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+    /// async fn sample(
+    ///    client: &UptimeCheckService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_uptime_check_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_uptime_check_config(
         &self,
     ) -> super::builder::uptime_check_service::CreateUptimeCheckConfig {
@@ -1304,6 +1863,22 @@ impl UptimeCheckService {
     /// configuration with a new one or replace only certain fields in the current
     /// configuration by specifying the fields to be updated via `updateMask`.
     /// Returns the updated configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+    /// async fn sample(
+    ///    client: &UptimeCheckService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_uptime_check_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_uptime_check_config(
         &self,
     ) -> super::builder::uptime_check_service::UpdateUptimeCheckConfig {
@@ -1313,6 +1888,21 @@ impl UptimeCheckService {
     /// Deletes an Uptime check configuration. Note that this method will fail
     /// if the Uptime check configuration is referenced by an alert policy or
     /// other dependent configs that would be rendered invalid by the deletion.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
+    /// async fn sample(
+    ///    client: &UptimeCheckService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_uptime_check_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_uptime_check_config(
         &self,
     ) -> super::builder::uptime_check_service::DeleteUptimeCheckConfig {

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -128,6 +128,22 @@ impl SecretManagerService {
     }
 
     /// Gets information about a location.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::secret_manager_service::GetLocation {
         super::builder::secret_manager_service::GetLocation::new(self.inner.clone())
     }
@@ -138,6 +154,22 @@ impl SecretManagerService {
     }
 
     /// Creates a new Secret containing no SecretVersions.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_secret(&self) -> super::builder::secret_manager_service::CreateSecret {
         super::builder::secret_manager_service::CreateSecret::new(self.inner.clone())
     }
@@ -152,6 +184,22 @@ impl SecretManagerService {
     }
 
     /// Creates a new Secret containing no SecretVersions.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_secret_by_project_and_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_secret_by_project_and_location(
         &self,
     ) -> super::builder::secret_manager_service::CreateSecretByProjectAndLocation {
@@ -162,12 +210,44 @@ impl SecretManagerService {
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_secret_version(&self) -> super::builder::secret_manager_service::AddSecretVersion {
         super::builder::secret_manager_service::AddSecretVersion::new(self.inner.clone())
     }
 
     /// Creates a new SecretVersion containing secret data and attaches
     /// it to an existing Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_secret_version_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_secret_version_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::AddSecretVersionByProjectAndLocationAndSecret {
@@ -177,21 +257,85 @@ impl SecretManagerService {
     }
 
     /// Gets metadata for a given Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret(&self) -> super::builder::secret_manager_service::GetSecret {
         super::builder::secret_manager_service::GetSecret::new(self.inner.clone())
     }
 
     /// Deletes a Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_secret(&self) -> super::builder::secret_manager_service::DeleteSecret {
         super::builder::secret_manager_service::DeleteSecret::new(self.inner.clone())
     }
 
     /// Updates metadata of an existing Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_secret(&self) -> super::builder::secret_manager_service::UpdateSecret {
         super::builder::secret_manager_service::UpdateSecret::new(self.inner.clone())
     }
 
     /// Gets metadata for a given Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::GetSecretByProjectAndLocationAndSecret {
@@ -201,6 +345,22 @@ impl SecretManagerService {
     }
 
     /// Deletes a Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_secret_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_secret_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::DeleteSecretByProjectAndLocationAndSecret {
@@ -210,6 +370,22 @@ impl SecretManagerService {
     }
 
     /// Updates metadata of an existing Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_secret_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_secret_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::UpdateSecretByProjectAndLocationAndSecret {
@@ -241,6 +417,22 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret_version(&self) -> super::builder::secret_manager_service::GetSecretVersion {
         super::builder::secret_manager_service::GetSecretVersion::new(self.inner.clone())
     }
@@ -249,6 +441,22 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_secret_version_by_project_and_location_and_secret_and_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
@@ -258,6 +466,22 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .access_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn access_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::AccessSecretVersion {
@@ -268,6 +492,22 @@ impl SecretManagerService {
     ///
     /// `projects/_*_/secrets/_*_/versions/latest` is an alias to the most recently
     /// created SecretVersion.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .access_secret_version_by_project_and_location_and_secret_and_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn access_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
@@ -277,6 +517,22 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::DisableSecretVersion {
@@ -287,6 +543,22 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// DISABLED.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_secret_version_by_project_and_location_and_secret_and_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
@@ -296,6 +568,22 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .enable_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::EnableSecretVersion {
@@ -306,6 +594,22 @@ impl SecretManagerService {
     ///
     /// Sets the state of the SecretVersion to
     /// ENABLED.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .enable_secret_version_by_project_and_location_and_secret_and_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn enable_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
@@ -316,6 +620,22 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .destroy_secret_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn destroy_secret_version(
         &self,
     ) -> super::builder::secret_manager_service::DestroySecretVersion {
@@ -327,6 +647,22 @@ impl SecretManagerService {
     /// Sets the state of the SecretVersion to
     /// DESTROYED and irrevocably destroys the
     /// secret data.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .destroy_secret_version_by_project_and_location_and_secret_and_version()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn destroy_secret_version_by_project_and_location_and_secret_and_version(&self) -> super::builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion
     {
         super::builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion::new(self.inner.clone())
@@ -337,6 +673,22 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::secret_manager_service::SetIamPolicy {
         super::builder::secret_manager_service::SetIamPolicy::new(self.inner.clone())
     }
@@ -346,6 +698,22 @@ impl SecretManagerService {
     ///
     /// Permissions on SecretVersions are enforced according
     /// to the policy set on the associated Secret.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::SetIamPolicyByProjectAndLocationAndSecret {
@@ -356,12 +724,44 @@ impl SecretManagerService {
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::secret_manager_service::GetIamPolicy {
         super::builder::secret_manager_service::GetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a secret.
     /// Returns empty policy if the secret exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::GetIamPolicyByProjectAndLocationAndSecret {
@@ -377,6 +777,22 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(
         &self,
     ) -> super::builder::secret_manager_service::TestIamPermissions {
@@ -390,6 +806,22 @@ impl SecretManagerService {
     /// Note: This operation is designed to be used for building permission-aware
     /// UIs and command-line tools, not for authorization checking. This operation
     /// may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use secretmanager_openapi_v1::client::SecretManagerService;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions_by_project_and_location_and_secret()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions_by_project_and_location_and_secret(
         &self,
     ) -> super::builder::secret_manager_service::TestIamPermissionsByProjectAndLocationAndSecret

--- a/src/generated/privacy/dlp/v2/src/client.rs
+++ b/src/generated/privacy/dlp/v2/src/client.rs
@@ -133,6 +133,22 @@ impl DlpService {
     /// <https://cloud.google.com/sensitive-data-protection/docs/inspecting-images>
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/inspecting-text>,
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .inspect_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn inspect_content(&self) -> super::builder::dlp_service::InspectContent {
         super::builder::dlp_service::InspectContent::new(self.inner.clone())
     }
@@ -149,6 +165,22 @@ impl DlpService {
     ///
     /// Only the first frame of each multiframe image is redacted. Metadata and
     /// other frames are omitted in the response.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .redact_image()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn redact_image(&self) -> super::builder::dlp_service::RedactImage {
         super::builder::dlp_service::RedactImage::new(self.inner.clone())
     }
@@ -162,6 +194,22 @@ impl DlpService {
     /// When no InfoTypes or CustomInfoTypes are specified in this request, the
     /// system will automatically choose what detectors to run. By default this may
     /// be all types, but may change over time as detectors are updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .deidentify_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn deidentify_content(&self) -> super::builder::dlp_service::DeidentifyContent {
         super::builder::dlp_service::DeidentifyContent::new(self.inner.clone())
     }
@@ -170,6 +218,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/pseudonymization#re-identification_in_free_text_code_example>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .reidentify_content()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn reidentify_content(&self) -> super::builder::dlp_service::ReidentifyContent {
         super::builder::dlp_service::ReidentifyContent::new(self.inner.clone())
     }
@@ -178,6 +242,22 @@ impl DlpService {
     /// supports. See
     /// <https://cloud.google.com/sensitive-data-protection/docs/infotypes-reference>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_info_types()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_info_types(&self) -> super::builder::dlp_service::ListInfoTypes {
         super::builder::dlp_service::ListInfoTypes::new(self.inner.clone())
     }
@@ -187,6 +267,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_inspect_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_inspect_template(&self) -> super::builder::dlp_service::CreateInspectTemplate {
         super::builder::dlp_service::CreateInspectTemplate::new(self.inner.clone())
     }
@@ -195,6 +291,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_inspect_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_inspect_template(&self) -> super::builder::dlp_service::UpdateInspectTemplate {
         super::builder::dlp_service::UpdateInspectTemplate::new(self.inner.clone())
     }
@@ -203,6 +315,23 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_inspect_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_inspect_template(&self) -> super::builder::dlp_service::GetInspectTemplate {
         super::builder::dlp_service::GetInspectTemplate::new(self.inner.clone())
     }
@@ -219,6 +348,21 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_inspect_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_inspect_template(&self) -> super::builder::dlp_service::DeleteInspectTemplate {
         super::builder::dlp_service::DeleteInspectTemplate::new(self.inner.clone())
     }
@@ -228,6 +372,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates-deid>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_deidentify_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_deidentify_template(
         &self,
     ) -> super::builder::dlp_service::CreateDeidentifyTemplate {
@@ -238,6 +398,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates-deid>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_deidentify_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_deidentify_template(
         &self,
     ) -> super::builder::dlp_service::UpdateDeidentifyTemplate {
@@ -248,6 +424,23 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates-deid>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_deidentify_template()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_deidentify_template(&self) -> super::builder::dlp_service::GetDeidentifyTemplate {
         super::builder::dlp_service::GetDeidentifyTemplate::new(self.inner.clone())
     }
@@ -266,6 +459,21 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-templates-deid>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_deidentify_template()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_deidentify_template(
         &self,
     ) -> super::builder::dlp_service::DeleteDeidentifyTemplate {
@@ -277,6 +485,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_job_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_job_trigger(&self) -> super::builder::dlp_service::CreateJobTrigger {
         super::builder::dlp_service::CreateJobTrigger::new(self.inner.clone())
     }
@@ -285,6 +509,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_job_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_job_trigger(&self) -> super::builder::dlp_service::UpdateJobTrigger {
         super::builder::dlp_service::UpdateJobTrigger::new(self.inner.clone())
     }
@@ -292,6 +532,22 @@ impl DlpService {
     /// Inspect hybrid content and store findings to a trigger. The inspection
     /// will be processed asynchronously. To review the findings monitor the
     /// jobs within the trigger.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .hybrid_inspect_job_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn hybrid_inspect_job_trigger(
         &self,
     ) -> super::builder::dlp_service::HybridInspectJobTrigger {
@@ -302,6 +558,23 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_job_trigger()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_job_trigger(&self) -> super::builder::dlp_service::GetJobTrigger {
         super::builder::dlp_service::GetJobTrigger::new(self.inner.clone())
     }
@@ -318,27 +591,107 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-job-triggers>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_job_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_job_trigger(&self) -> super::builder::dlp_service::DeleteJobTrigger {
         super::builder::dlp_service::DeleteJobTrigger::new(self.inner.clone())
     }
 
     /// Activate a job trigger. Causes the immediate execute of a trigger
     /// instead of waiting on the trigger event to occur.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .activate_job_trigger()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn activate_job_trigger(&self) -> super::builder::dlp_service::ActivateJobTrigger {
         super::builder::dlp_service::ActivateJobTrigger::new(self.inner.clone())
     }
 
     /// Creates a config for discovery to scan and profile storage.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_discovery_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_discovery_config(&self) -> super::builder::dlp_service::CreateDiscoveryConfig {
         super::builder::dlp_service::CreateDiscoveryConfig::new(self.inner.clone())
     }
 
     /// Updates a discovery configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_discovery_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_discovery_config(&self) -> super::builder::dlp_service::UpdateDiscoveryConfig {
         super::builder::dlp_service::UpdateDiscoveryConfig::new(self.inner.clone())
     }
 
     /// Gets a discovery configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_discovery_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_discovery_config(&self) -> super::builder::dlp_service::GetDiscoveryConfig {
         super::builder::dlp_service::GetDiscoveryConfig::new(self.inner.clone())
     }
@@ -349,6 +702,21 @@ impl DlpService {
     }
 
     /// Deletes a discovery configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_discovery_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_discovery_config(&self) -> super::builder::dlp_service::DeleteDiscoveryConfig {
         super::builder::dlp_service::DeleteDiscoveryConfig::new(self.inner.clone())
     }
@@ -363,6 +731,22 @@ impl DlpService {
     /// When no InfoTypes or CustomInfoTypes are specified in inspect jobs, the
     /// system will automatically choose what detectors to run. By default this may
     /// be all types, but may change over time as detectors are updated.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_dlp_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_dlp_job(&self) -> super::builder::dlp_service::CreateDlpJob {
         super::builder::dlp_service::CreateDlpJob::new(self.inner.clone())
     }
@@ -383,6 +767,23 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_dlp_job()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_dlp_job(&self) -> super::builder::dlp_service::GetDlpJob {
         super::builder::dlp_service::GetDlpJob::new(self.inner.clone())
     }
@@ -395,6 +796,21 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_dlp_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_dlp_job(&self) -> super::builder::dlp_service::DeleteDlpJob {
         super::builder::dlp_service::DeleteDlpJob::new(self.inner.clone())
     }
@@ -407,6 +823,21 @@ impl DlpService {
     /// and
     /// <https://cloud.google.com/sensitive-data-protection/docs/compute-risk-analysis>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_dlp_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_dlp_job(&self) -> super::builder::dlp_service::CancelDlpJob {
         super::builder::dlp_service::CancelDlpJob::new(self.inner.clone())
     }
@@ -415,6 +846,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_stored_info_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_stored_info_type(&self) -> super::builder::dlp_service::CreateStoredInfoType {
         super::builder::dlp_service::CreateStoredInfoType::new(self.inner.clone())
     }
@@ -424,6 +871,22 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_stored_info_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_stored_info_type(&self) -> super::builder::dlp_service::UpdateStoredInfoType {
         super::builder::dlp_service::UpdateStoredInfoType::new(self.inner.clone())
     }
@@ -432,6 +895,23 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_stored_info_type()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_stored_info_type(&self) -> super::builder::dlp_service::GetStoredInfoType {
         super::builder::dlp_service::GetStoredInfoType::new(self.inner.clone())
     }
@@ -448,6 +928,21 @@ impl DlpService {
     /// See
     /// <https://cloud.google.com/sensitive-data-protection/docs/creating-stored-infotypes>
     /// to learn more.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_stored_info_type()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_stored_info_type(&self) -> super::builder::dlp_service::DeleteStoredInfoType {
         super::builder::dlp_service::DeleteStoredInfoType::new(self.inner.clone())
     }
@@ -470,6 +965,23 @@ impl DlpService {
     }
 
     /// Gets a project data profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project_data_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project_data_profile(&self) -> super::builder::dlp_service::GetProjectDataProfile {
         super::builder::dlp_service::GetProjectDataProfile::new(self.inner.clone())
     }
@@ -482,6 +994,22 @@ impl DlpService {
     }
 
     /// Gets a file store data profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_file_store_data_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_file_store_data_profile(
         &self,
     ) -> super::builder::dlp_service::GetFileStoreDataProfile {
@@ -490,6 +1018,21 @@ impl DlpService {
 
     /// Delete a FileStoreDataProfile. Will not prevent the profile from being
     /// regenerated if the resource is still included in a discovery configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_file_store_data_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_file_store_data_profile(
         &self,
     ) -> super::builder::dlp_service::DeleteFileStoreDataProfile {
@@ -497,17 +1040,66 @@ impl DlpService {
     }
 
     /// Gets a table data profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_table_data_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_table_data_profile(&self) -> super::builder::dlp_service::GetTableDataProfile {
         super::builder::dlp_service::GetTableDataProfile::new(self.inner.clone())
     }
 
     /// Gets a column data profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_column_data_profile()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_column_data_profile(&self) -> super::builder::dlp_service::GetColumnDataProfile {
         super::builder::dlp_service::GetColumnDataProfile::new(self.inner.clone())
     }
 
     /// Delete a TableDataProfile. Will not prevent the profile from being
     /// regenerated if the table is still included in a discovery configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_table_data_profile()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_table_data_profile(&self) -> super::builder::dlp_service::DeleteTableDataProfile {
         super::builder::dlp_service::DeleteTableDataProfile::new(self.inner.clone())
     }
@@ -515,22 +1107,86 @@ impl DlpService {
     /// Inspect hybrid content and store findings to a job.
     /// To review the findings, inspect the job. Inspection will occur
     /// asynchronously.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .hybrid_inspect_dlp_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn hybrid_inspect_dlp_job(&self) -> super::builder::dlp_service::HybridInspectDlpJob {
         super::builder::dlp_service::HybridInspectDlpJob::new(self.inner.clone())
     }
 
     /// Finish a running hybrid DlpJob. Triggers the finalization steps and running
     /// of any enabled actions that have not yet run.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .finish_dlp_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn finish_dlp_job(&self) -> super::builder::dlp_service::FinishDlpJob {
         super::builder::dlp_service::FinishDlpJob::new(self.inner.clone())
     }
 
     /// Create a Connection to an external data source.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_connection(&self) -> super::builder::dlp_service::CreateConnection {
         super::builder::dlp_service::CreateConnection::new(self.inner.clone())
     }
 
     /// Get a Connection by name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_connection()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_connection(&self) -> super::builder::dlp_service::GetConnection {
         super::builder::dlp_service::GetConnection::new(self.inner.clone())
     }
@@ -547,11 +1203,42 @@ impl DlpService {
     }
 
     /// Delete a Connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_connection(&self) -> super::builder::dlp_service::DeleteConnection {
         super::builder::dlp_service::DeleteConnection::new(self.inner.clone())
     }
 
     /// Update a Connection.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_privacy_dlp_v2::client::DlpService;
+    /// async fn sample(
+    ///    client: &DlpService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_connection()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_connection(&self) -> super::builder::dlp_service::UpdateConnection {
         super::builder::dlp_service::UpdateConnection::new(self.inner.clone())
     }

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -122,6 +122,22 @@ impl Compliance {
 
     /// This method echoes the ComplianceData request. This method exercises
     /// sending the entire request object in the REST body.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_body()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_body(&self) -> super::builder::compliance::RepeatDataBody {
         super::builder::compliance::RepeatDataBody::new(self.inner.clone())
     }
@@ -129,12 +145,44 @@ impl Compliance {
     /// This method echoes the ComplianceData request. This method exercises
     /// sending the a message-type field in the REST body. Per AIP-127, only
     /// top-level, non-repeated fields can be sent this way.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_body_info()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_body_info(&self) -> super::builder::compliance::RepeatDataBodyInfo {
         super::builder::compliance::RepeatDataBodyInfo::new(self.inner.clone())
     }
 
     /// This method echoes the ComplianceData request. This method exercises
     /// sending all request fields as query parameters.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_query()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_query(&self) -> super::builder::compliance::RepeatDataQuery {
         super::builder::compliance::RepeatDataQuery::new(self.inner.clone())
     }
@@ -142,16 +190,64 @@ impl Compliance {
     /// This method echoes the ComplianceData request. This method exercises
     /// sending some parameters as "simple" path variables (i.e., of the form
     /// "/bar/{foo}" rather than "/{foo=bar/*}"), and the rest as query parameters.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_simple_path()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_simple_path(&self) -> super::builder::compliance::RepeatDataSimplePath {
         super::builder::compliance::RepeatDataSimplePath::new(self.inner.clone())
     }
 
     /// Same as RepeatDataSimplePath, but with a path resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_path_resource()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_path_resource(&self) -> super::builder::compliance::RepeatDataPathResource {
         super::builder::compliance::RepeatDataPathResource::new(self.inner.clone())
     }
 
     /// Same as RepeatDataSimplePath, but with a trailing resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_path_trailing_resource()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_path_trailing_resource(
         &self,
     ) -> super::builder::compliance::RepeatDataPathTrailingResource {
@@ -159,11 +255,43 @@ impl Compliance {
     }
 
     /// This method echoes the ComplianceData request, using the HTTP PUT method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_body_put()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_body_put(&self) -> super::builder::compliance::RepeatDataBodyPut {
         super::builder::compliance::RepeatDataBodyPut::new(self.inner.clone())
     }
 
     /// This method echoes the ComplianceData request, using the HTTP PATCH method.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .repeat_data_body_patch()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn repeat_data_body_patch(&self) -> super::builder::compliance::RepeatDataBodyPatch {
         super::builder::compliance::RepeatDataBodyPatch::new(self.inner.clone())
     }
@@ -174,6 +302,22 @@ impl Compliance {
     ///
     /// The values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run (this is needed for
     /// VerifyEnum() to work) but are not guaranteed to be the same across separate Showcase server runs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_enum()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_enum(&self) -> super::builder::compliance::GetEnum {
         super::builder::compliance::GetEnum::new(self.inner.clone())
     }
@@ -184,6 +328,22 @@ impl Compliance {
     ///
     /// This works because the values of enums sent by the server when a known or unknown value is requested will be the same within a single Showcase server run,
     /// although they are not guaranteed to be the same across separate Showcase server runs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_enum()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_enum(&self) -> super::builder::compliance::VerifyEnum {
         super::builder::compliance::VerifyEnum::new(self.inner.clone())
     }
@@ -198,6 +358,22 @@ impl Compliance {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::compliance::GetLocation {
         super::builder::compliance::GetLocation::new(self.inner.clone())
     }
@@ -205,6 +381,22 @@ impl Compliance {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::compliance::SetIamPolicy {
         super::builder::compliance::SetIamPolicy::new(self.inner.clone())
     }
@@ -212,6 +404,22 @@ impl Compliance {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::compliance::GetIamPolicy {
         super::builder::compliance::GetIamPolicy::new(self.inner.clone())
     }
@@ -219,6 +427,22 @@ impl Compliance {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::compliance::TestIamPermissions {
         super::builder::compliance::TestIamPermissions::new(self.inner.clone())
     }
@@ -233,6 +457,22 @@ impl Compliance {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::compliance::GetOperation {
         super::builder::compliance::GetOperation::new(self.inner.clone())
     }
@@ -240,6 +480,21 @@ impl Compliance {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::compliance::DeleteOperation {
         super::builder::compliance::DeleteOperation::new(self.inner.clone())
     }
@@ -247,6 +502,21 @@ impl Compliance {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Compliance;
+    /// async fn sample(
+    ///    client: &Compliance
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::compliance::CancelOperation {
         super::builder::compliance::CancelOperation::new(self.inner.clone())
     }
@@ -361,6 +631,22 @@ impl Echo {
     }
 
     /// This method simply echoes the request. This method showcases unary RPCs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .echo()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn echo(&self) -> super::builder::echo::Echo {
         super::builder::echo::Echo::new(self.inner.clone())
     }
@@ -371,6 +657,22 @@ impl Echo {
     /// "google.protobuf.Any" for field paths ending in "error.details", and, at
     /// run-time, the actual types for these fields must be one of the types in
     /// google/rpc/error_details.proto.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .echo_error_details()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn echo_error_details(&self) -> super::builder::echo::EchoErrorDetails {
         super::builder::echo::EchoErrorDetails::new(self.inner.clone())
     }
@@ -382,6 +684,22 @@ impl Echo {
     /// plus a custom, Showcase-defined PoetryError. The intent of this RPC is to
     /// verify that GAPICs can process these various error details and surface them
     /// to the user in an idiomatic form.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .fail_echo_with_details()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn fail_echo_with_details(&self) -> super::builder::echo::FailEchoWithDetails {
         super::builder::echo::FailEchoWithDetails::new(self.inner.clone())
     }
@@ -427,6 +745,22 @@ impl Echo {
     /// This method will block (wait) for the requested amount of time
     /// and then return the response or error.
     /// This method showcases how a client handles delays or retries.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .block()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn block(&self) -> super::builder::echo::Block {
         super::builder::echo::Block::new(self.inner.clone())
     }
@@ -441,6 +775,22 @@ impl Echo {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::echo::GetLocation {
         super::builder::echo::GetLocation::new(self.inner.clone())
     }
@@ -448,6 +798,22 @@ impl Echo {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::echo::SetIamPolicy {
         super::builder::echo::SetIamPolicy::new(self.inner.clone())
     }
@@ -455,6 +821,22 @@ impl Echo {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::echo::GetIamPolicy {
         super::builder::echo::GetIamPolicy::new(self.inner.clone())
     }
@@ -462,6 +844,22 @@ impl Echo {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::echo::TestIamPermissions {
         super::builder::echo::TestIamPermissions::new(self.inner.clone())
     }
@@ -476,6 +874,22 @@ impl Echo {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::echo::GetOperation {
         super::builder::echo::GetOperation::new(self.inner.clone())
     }
@@ -483,6 +897,21 @@ impl Echo {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::echo::DeleteOperation {
         super::builder::echo::DeleteOperation::new(self.inner.clone())
     }
@@ -490,6 +919,21 @@ impl Echo {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Echo;
+    /// async fn sample(
+    ///    client: &Echo
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::echo::CancelOperation {
         super::builder::echo::CancelOperation::new(self.inner.clone())
     }
@@ -598,21 +1042,85 @@ impl Identity {
     }
 
     /// Creates a user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_user()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_user(&self) -> super::builder::identity::CreateUser {
         super::builder::identity::CreateUser::new(self.inner.clone())
     }
 
     /// Retrieves the User with the given uri.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_user()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_user(&self) -> super::builder::identity::GetUser {
         super::builder::identity::GetUser::new(self.inner.clone())
     }
 
     /// Updates a user.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_user()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_user(&self) -> super::builder::identity::UpdateUser {
         super::builder::identity::UpdateUser::new(self.inner.clone())
     }
 
     /// Deletes a user, their profile, and all of their authored messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_user()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_user(&self) -> super::builder::identity::DeleteUser {
         super::builder::identity::DeleteUser::new(self.inner.clone())
     }
@@ -632,6 +1140,22 @@ impl Identity {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::identity::GetLocation {
         super::builder::identity::GetLocation::new(self.inner.clone())
     }
@@ -639,6 +1163,22 @@ impl Identity {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::identity::SetIamPolicy {
         super::builder::identity::SetIamPolicy::new(self.inner.clone())
     }
@@ -646,6 +1186,22 @@ impl Identity {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::identity::GetIamPolicy {
         super::builder::identity::GetIamPolicy::new(self.inner.clone())
     }
@@ -653,6 +1209,22 @@ impl Identity {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::identity::TestIamPermissions {
         super::builder::identity::TestIamPermissions::new(self.inner.clone())
     }
@@ -667,6 +1239,22 @@ impl Identity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::identity::GetOperation {
         super::builder::identity::GetOperation::new(self.inner.clone())
     }
@@ -674,6 +1262,21 @@ impl Identity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::identity::DeleteOperation {
         super::builder::identity::DeleteOperation::new(self.inner.clone())
     }
@@ -681,6 +1284,21 @@ impl Identity {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Identity;
+    /// async fn sample(
+    ///    client: &Identity
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::identity::CancelOperation {
         super::builder::identity::CancelOperation::new(self.inner.clone())
     }
@@ -792,21 +1410,85 @@ impl Messaging {
     }
 
     /// Creates a room.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_room()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_room(&self) -> super::builder::messaging::CreateRoom {
         super::builder::messaging::CreateRoom::new(self.inner.clone())
     }
 
     /// Retrieves the Room with the given resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_room()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_room(&self) -> super::builder::messaging::GetRoom {
         super::builder::messaging::GetRoom::new(self.inner.clone())
     }
 
     /// Updates a room.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_room()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_room(&self) -> super::builder::messaging::UpdateRoom {
         super::builder::messaging::UpdateRoom::new(self.inner.clone())
     }
 
     /// Deletes a room and all of its blurbs.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_room()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_room(&self) -> super::builder::messaging::DeleteRoom {
         super::builder::messaging::DeleteRoom::new(self.inner.clone())
     }
@@ -819,21 +1501,85 @@ impl Messaging {
     /// Creates a blurb. If the parent is a room, the blurb is understood to be a
     /// message in that room. If the parent is a profile, the blurb is understood
     /// to be a post on the profile.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_blurb()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_blurb(&self) -> super::builder::messaging::CreateBlurb {
         super::builder::messaging::CreateBlurb::new(self.inner.clone())
     }
 
     /// Retrieves the Blurb with the given resource name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_blurb()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_blurb(&self) -> super::builder::messaging::GetBlurb {
         super::builder::messaging::GetBlurb::new(self.inner.clone())
     }
 
     /// Updates a blurb.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_blurb()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_blurb(&self) -> super::builder::messaging::UpdateBlurb {
         super::builder::messaging::UpdateBlurb::new(self.inner.clone())
     }
 
     /// Deletes a blurb.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_blurb()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_blurb(&self) -> super::builder::messaging::DeleteBlurb {
         super::builder::messaging::DeleteBlurb::new(self.inner.clone())
     }
@@ -871,6 +1617,22 @@ impl Messaging {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::messaging::GetLocation {
         super::builder::messaging::GetLocation::new(self.inner.clone())
     }
@@ -878,6 +1640,22 @@ impl Messaging {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::messaging::SetIamPolicy {
         super::builder::messaging::SetIamPolicy::new(self.inner.clone())
     }
@@ -885,6 +1663,22 @@ impl Messaging {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::messaging::GetIamPolicy {
         super::builder::messaging::GetIamPolicy::new(self.inner.clone())
     }
@@ -892,6 +1686,22 @@ impl Messaging {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::messaging::TestIamPermissions {
         super::builder::messaging::TestIamPermissions::new(self.inner.clone())
     }
@@ -906,6 +1716,22 @@ impl Messaging {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::messaging::GetOperation {
         super::builder::messaging::GetOperation::new(self.inner.clone())
     }
@@ -913,6 +1739,21 @@ impl Messaging {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::messaging::DeleteOperation {
         super::builder::messaging::DeleteOperation::new(self.inner.clone())
     }
@@ -920,6 +1761,21 @@ impl Messaging {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Messaging;
+    /// async fn sample(
+    ///    client: &Messaging
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::messaging::CancelOperation {
         super::builder::messaging::CancelOperation::new(self.inner.clone())
     }
@@ -1030,11 +1886,43 @@ impl SequenceService {
     }
 
     /// Creates a sequence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_sequence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_sequence(&self) -> super::builder::sequence_service::CreateSequence {
         super::builder::sequence_service::CreateSequence::new(self.inner.clone())
     }
 
     /// Creates a sequence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_streaming_sequence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_streaming_sequence(
         &self,
     ) -> super::builder::sequence_service::CreateStreamingSequence {
@@ -1042,11 +1930,45 @@ impl SequenceService {
     }
 
     /// Retrieves a sequence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_sequence_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_sequence_report(&self) -> super::builder::sequence_service::GetSequenceReport {
         super::builder::sequence_service::GetSequenceReport::new(self.inner.clone())
     }
 
     /// Retrieves a sequence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_streaming_sequence_report()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_streaming_sequence_report(
         &self,
     ) -> super::builder::sequence_service::GetStreamingSequenceReport {
@@ -1054,6 +1976,21 @@ impl SequenceService {
     }
 
     /// Attempts a sequence.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .attempt_sequence()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn attempt_sequence(&self) -> super::builder::sequence_service::AttemptSequence {
         super::builder::sequence_service::AttemptSequence::new(self.inner.clone())
     }
@@ -1068,6 +2005,22 @@ impl SequenceService {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::sequence_service::GetLocation {
         super::builder::sequence_service::GetLocation::new(self.inner.clone())
     }
@@ -1075,6 +2028,22 @@ impl SequenceService {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::sequence_service::SetIamPolicy {
         super::builder::sequence_service::SetIamPolicy::new(self.inner.clone())
     }
@@ -1082,6 +2051,22 @@ impl SequenceService {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::sequence_service::GetIamPolicy {
         super::builder::sequence_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -1089,6 +2074,22 @@ impl SequenceService {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::sequence_service::TestIamPermissions {
         super::builder::sequence_service::TestIamPermissions::new(self.inner.clone())
     }
@@ -1103,6 +2104,22 @@ impl SequenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::sequence_service::GetOperation {
         super::builder::sequence_service::GetOperation::new(self.inner.clone())
     }
@@ -1110,6 +2127,21 @@ impl SequenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::sequence_service::DeleteOperation {
         super::builder::sequence_service::DeleteOperation::new(self.inner.clone())
     }
@@ -1117,6 +2149,21 @@ impl SequenceService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::SequenceService;
+    /// async fn sample(
+    ///    client: &SequenceService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::sequence_service::CancelOperation {
         super::builder::sequence_service::CancelOperation::new(self.inner.clone())
     }
@@ -1236,11 +2283,44 @@ impl Testing {
     /// 1. (abra->kadabra->alakazam)
     ///
     /// 1. [Nonsense][]: `pokemon/*/psychic/*`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_session(&self) -> super::builder::testing::CreateSession {
         super::builder::testing::CreateSession::new(self.inner.clone())
     }
 
     /// Gets a testing session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_session()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_session(&self) -> super::builder::testing::GetSession {
         super::builder::testing::GetSession::new(self.inner.clone())
     }
@@ -1251,6 +2331,21 @@ impl Testing {
     }
 
     /// Delete a test session.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_session(&self) -> super::builder::testing::DeleteSession {
         super::builder::testing::DeleteSession::new(self.inner.clone())
     }
@@ -1258,6 +2353,22 @@ impl Testing {
     /// Report on the status of a session.
     /// This generates a report detailing which tests have been completed,
     /// and an overall rollup.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .report_session()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn report_session(&self) -> super::builder::testing::ReportSession {
         super::builder::testing::ReportSession::new(self.inner.clone())
     }
@@ -1273,6 +2384,21 @@ impl Testing {
     /// attempting to do the test will error.
     ///
     /// This method will error if attempting to delete a required test.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_test()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_test(&self) -> super::builder::testing::DeleteTest {
         super::builder::testing::DeleteTest::new(self.inner.clone())
     }
@@ -1281,6 +2407,22 @@ impl Testing {
     ///
     /// In cases where a test involves registering a final answer at the
     /// end of the test, this method provides the means to do so.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .verify_test()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn verify_test(&self) -> super::builder::testing::VerifyTest {
         super::builder::testing::VerifyTest::new(self.inner.clone())
     }
@@ -1295,6 +2437,22 @@ impl Testing {
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.
     ///
     /// [google.cloud.location.Locations]: location::client::Locations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_location()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_location(&self) -> super::builder::testing::GetLocation {
         super::builder::testing::GetLocation::new(self.inner.clone())
     }
@@ -1302,6 +2460,22 @@ impl Testing {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::testing::SetIamPolicy {
         super::builder::testing::SetIamPolicy::new(self.inner.clone())
     }
@@ -1309,6 +2483,22 @@ impl Testing {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::testing::GetIamPolicy {
         super::builder::testing::GetIamPolicy::new(self.inner.clone())
     }
@@ -1316,6 +2506,22 @@ impl Testing {
     /// Provides the [IAMPolicy][google.iam.v1.IAMPolicy] service functionality in this service.
     ///
     /// [google.iam.v1.IAMPolicy]: iam_v1::client::IAMPolicy
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::testing::TestIamPermissions {
         super::builder::testing::TestIamPermissions::new(self.inner.clone())
     }
@@ -1330,6 +2536,22 @@ impl Testing {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::testing::GetOperation {
         super::builder::testing::GetOperation::new(self.inner.clone())
     }
@@ -1337,6 +2559,21 @@ impl Testing {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::testing::DeleteOperation {
         super::builder::testing::DeleteOperation::new(self.inner.clone())
     }
@@ -1344,6 +2581,21 @@ impl Testing {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::client::Testing;
+    /// async fn sample(
+    ///    client: &Testing
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::testing::CancelOperation {
         super::builder::testing::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/spanner/admin/database/v1/src/client.rs
+++ b/src/generated/spanner/admin/database/v1/src/client.rs
@@ -159,6 +159,23 @@ impl DatabaseAdmin {
     }
 
     /// Gets the state of a Cloud Spanner database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_database()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_database(&self) -> super::builder::database_admin::GetDatabase {
         super::builder::database_admin::GetDatabase::new(self.inner.clone())
     }
@@ -252,6 +269,21 @@ impl DatabaseAdmin {
     /// `expire_time`.
     /// Note: Cloud Spanner might continue to accept requests for a few seconds
     /// after the database has been deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .drop_database()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn drop_database(&self) -> super::builder::database_admin::DropDatabase {
         super::builder::database_admin::DropDatabase::new(self.inner.clone())
     }
@@ -261,6 +293,22 @@ impl DatabaseAdmin {
     /// be queried using the [Operations][google.longrunning.Operations] API.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_database_ddl()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_database_ddl(&self) -> super::builder::database_admin::GetDatabaseDdl {
         super::builder::database_admin::GetDatabaseDdl::new(self.inner.clone())
     }
@@ -274,6 +322,22 @@ impl DatabaseAdmin {
     /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.SetIamPolicyRequest.resource]: iam_v1::model::SetIamPolicyRequest::resource
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::database_admin::SetIamPolicy {
         super::builder::database_admin::SetIamPolicy::new(self.inner.clone())
     }
@@ -288,6 +352,22 @@ impl DatabaseAdmin {
     /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.GetIamPolicyRequest.resource]: iam_v1::model::GetIamPolicyRequest::resource
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::database_admin::GetIamPolicy {
         super::builder::database_admin::GetIamPolicy::new(self.inner.clone())
     }
@@ -302,6 +382,22 @@ impl DatabaseAdmin {
     /// Calling this method on a backup that does not exist will
     /// result in a NOT_FOUND error if the user has
     /// `spanner.backups.list` permission on the containing instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::database_admin::TestIamPermissions {
         super::builder::database_admin::TestIamPermissions::new(self.inner.clone())
     }
@@ -375,6 +471,23 @@ impl DatabaseAdmin {
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup(&self) -> super::builder::database_admin::GetBackup {
         super::builder::database_admin::GetBackup::new(self.inner.clone())
     }
@@ -383,6 +496,22 @@ impl DatabaseAdmin {
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_backup(&self) -> super::builder::database_admin::UpdateBackup {
         super::builder::database_admin::UpdateBackup::new(self.inner.clone())
     }
@@ -391,6 +520,21 @@ impl DatabaseAdmin {
     /// [Backup][google.spanner.admin.database.v1.Backup].
     ///
     /// [google.spanner.admin.database.v1.Backup]: crate::model::Backup
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_backup()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_backup(&self) -> super::builder::database_admin::DeleteBackup {
         super::builder::database_admin::DeleteBackup::new(self.inner.clone())
     }
@@ -479,26 +623,107 @@ impl DatabaseAdmin {
     }
 
     /// Adds split points to specified tables, indexes of a database.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .add_split_points()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn add_split_points(&self) -> super::builder::database_admin::AddSplitPoints {
         super::builder::database_admin::AddSplitPoints::new(self.inner.clone())
     }
 
     /// Creates a new backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_backup_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_backup_schedule(&self) -> super::builder::database_admin::CreateBackupSchedule {
         super::builder::database_admin::CreateBackupSchedule::new(self.inner.clone())
     }
 
     /// Gets backup schedule for the input schedule name.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_backup_schedule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_backup_schedule(&self) -> super::builder::database_admin::GetBackupSchedule {
         super::builder::database_admin::GetBackupSchedule::new(self.inner.clone())
     }
 
     /// Updates a backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_backup_schedule()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_backup_schedule(&self) -> super::builder::database_admin::UpdateBackupSchedule {
         super::builder::database_admin::UpdateBackupSchedule::new(self.inner.clone())
     }
 
     /// Deletes a backup schedule.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_backup_schedule()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_backup_schedule(&self) -> super::builder::database_admin::DeleteBackupSchedule {
         super::builder::database_admin::DeleteBackupSchedule::new(self.inner.clone())
     }
@@ -518,6 +743,22 @@ impl DatabaseAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::database_admin::GetOperation {
         super::builder::database_admin::GetOperation::new(self.inner.clone())
     }
@@ -525,6 +766,21 @@ impl DatabaseAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::database_admin::DeleteOperation {
         super::builder::database_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -532,6 +788,21 @@ impl DatabaseAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+    /// async fn sample(
+    ///    client: &DatabaseAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::database_admin::CancelOperation {
         super::builder::database_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/spanner/admin/instance/v1/src/client.rs
+++ b/src/generated/spanner/admin/instance/v1/src/client.rs
@@ -147,6 +147,23 @@ impl InstanceAdmin {
     }
 
     /// Gets information about a particular instance configuration.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance_config(&self) -> super::builder::instance_admin::GetInstanceConfig {
         super::builder::instance_admin::GetInstanceConfig::new(self.inner.clone())
     }
@@ -285,6 +302,22 @@ impl InstanceAdmin {
     /// the resource [name][google.spanner.admin.instance.v1.InstanceConfig.name].
     ///
     /// [google.spanner.admin.instance.v1.InstanceConfig.name]: crate::model::InstanceConfig::name
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_instance_config()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_instance_config(&self) -> super::builder::instance_admin::DeleteInstanceConfig {
         super::builder::instance_admin::DeleteInstanceConfig::new(self.inner.clone())
     }
@@ -319,6 +352,23 @@ impl InstanceAdmin {
     }
 
     /// Gets information about a particular instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance(&self) -> super::builder::instance_admin::GetInstance {
         super::builder::instance_admin::GetInstance::new(self.inner.clone())
     }
@@ -443,6 +493,22 @@ impl InstanceAdmin {
     /// * The instance and *all of its databases* immediately and
     ///   irrevocably disappear from the API. All data in the databases
     ///   is permanently deleted.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_instance()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_instance(&self) -> super::builder::instance_admin::DeleteInstance {
         super::builder::instance_admin::DeleteInstance::new(self.inner.clone())
     }
@@ -454,6 +520,22 @@ impl InstanceAdmin {
     /// [resource][google.iam.v1.SetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.SetIamPolicyRequest.resource]: iam_v1::model::SetIamPolicyRequest::resource
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::instance_admin::SetIamPolicy {
         super::builder::instance_admin::SetIamPolicy::new(self.inner.clone())
     }
@@ -465,6 +547,22 @@ impl InstanceAdmin {
     /// [resource][google.iam.v1.GetIamPolicyRequest.resource].
     ///
     /// [google.iam.v1.GetIamPolicyRequest.resource]: iam_v1::model::GetIamPolicyRequest::resource
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::instance_admin::GetIamPolicy {
         super::builder::instance_admin::GetIamPolicy::new(self.inner.clone())
     }
@@ -475,11 +573,44 @@ impl InstanceAdmin {
     /// result in a NOT_FOUND error if the user has `spanner.instances.list`
     /// permission on the containing Google Cloud Project. Otherwise returns an
     /// empty set of permissions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::instance_admin::TestIamPermissions {
         super::builder::instance_admin::TestIamPermissions::new(self.inner.clone())
     }
 
     /// Gets information about a particular instance partition.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_instance_partition()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_instance_partition(&self) -> super::builder::instance_admin::GetInstancePartition {
         super::builder::instance_admin::GetInstancePartition::new(self.inner.clone())
     }
@@ -549,6 +680,22 @@ impl InstanceAdmin {
     /// [name][google.spanner.admin.instance.v1.InstancePartition.name].
     ///
     /// [google.spanner.admin.instance.v1.InstancePartition.name]: crate::model::InstancePartition::name
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_instance_partition()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_instance_partition(
         &self,
     ) -> super::builder::instance_admin::DeleteInstancePartition {
@@ -732,6 +879,22 @@ impl InstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::instance_admin::GetOperation {
         super::builder::instance_admin::GetOperation::new(self.inner.clone())
     }
@@ -739,6 +902,21 @@ impl InstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_operation(&self) -> super::builder::instance_admin::DeleteOperation {
         super::builder::instance_admin::DeleteOperation::new(self.inner.clone())
     }
@@ -746,6 +924,21 @@ impl InstanceAdmin {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+    /// async fn sample(
+    ///    client: &InstanceAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::instance_admin::CancelOperation {
         super::builder::instance_admin::CancelOperation::new(self.inner.clone())
     }

--- a/src/generated/storagetransfer/v1/src/client.rs
+++ b/src/generated/storagetransfer/v1/src/client.rs
@@ -131,6 +131,22 @@ impl StorageTransferService {
     /// ACLs to grant access to Storage Transfer Service. This service
     /// account is created and owned by Storage Transfer Service and can
     /// only be used by Storage Transfer Service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_google_service_account()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_google_service_account(
         &self,
     ) -> super::builder::storage_transfer_service::GetGoogleServiceAccount {
@@ -138,6 +154,22 @@ impl StorageTransferService {
     }
 
     /// Creates a transfer job that runs periodically.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_transfer_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_transfer_job(
         &self,
     ) -> super::builder::storage_transfer_service::CreateTransferJob {
@@ -157,6 +189,22 @@ impl StorageTransferService {
     /// [google.storagetransfer.v1.TransferJob.Status.DISABLED]: crate::model::transfer_job::Status::Disabled
     /// [google.storagetransfer.v1.TransferJob.Status.ENABLED]: crate::model::transfer_job::Status::Enabled
     /// [google.storagetransfer.v1.TransferJob.status]: crate::model::TransferJob::status
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_transfer_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_transfer_job(
         &self,
     ) -> super::builder::storage_transfer_service::UpdateTransferJob {
@@ -164,6 +212,22 @@ impl StorageTransferService {
     }
 
     /// Gets a transfer job.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_transfer_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_transfer_job(&self) -> super::builder::storage_transfer_service::GetTransferJob {
         super::builder::storage_transfer_service::GetTransferJob::new(self.inner.clone())
     }
@@ -174,6 +238,21 @@ impl StorageTransferService {
     }
 
     /// Pauses a transfer operation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .pause_transfer_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_transfer_operation(
         &self,
     ) -> super::builder::storage_transfer_service::PauseTransferOperation {
@@ -181,6 +260,21 @@ impl StorageTransferService {
     }
 
     /// Resumes a transfer operation that is paused.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .resume_transfer_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_transfer_operation(
         &self,
     ) -> super::builder::storage_transfer_service::ResumeTransferOperation {
@@ -209,6 +303,21 @@ impl StorageTransferService {
     /// [DELETED][google.storagetransfer.v1.TransferJob.Status.DELETED].
     ///
     /// [google.storagetransfer.v1.TransferJob.Status.DELETED]: crate::model::transfer_job::Status::Deleted
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_transfer_job()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_transfer_job(
         &self,
     ) -> super::builder::storage_transfer_service::DeleteTransferJob {
@@ -216,16 +325,64 @@ impl StorageTransferService {
     }
 
     /// Creates an agent pool resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_agent_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_agent_pool(&self) -> super::builder::storage_transfer_service::CreateAgentPool {
         super::builder::storage_transfer_service::CreateAgentPool::new(self.inner.clone())
     }
 
     /// Updates an existing agent pool resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_agent_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_agent_pool(&self) -> super::builder::storage_transfer_service::UpdateAgentPool {
         super::builder::storage_transfer_service::UpdateAgentPool::new(self.inner.clone())
     }
 
     /// Gets an agent pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_agent_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_agent_pool(&self) -> super::builder::storage_transfer_service::GetAgentPool {
         super::builder::storage_transfer_service::GetAgentPool::new(self.inner.clone())
     }
@@ -236,6 +393,21 @@ impl StorageTransferService {
     }
 
     /// Deletes an agent pool.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_agent_pool()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_agent_pool(&self) -> super::builder::storage_transfer_service::DeleteAgentPool {
         super::builder::storage_transfer_service::DeleteAgentPool::new(self.inner.clone())
     }
@@ -249,6 +421,22 @@ impl StorageTransferService {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::storage_transfer_service::GetOperation {
         super::builder::storage_transfer_service::GetOperation::new(self.inner.clone())
     }
@@ -274,6 +462,21 @@ impl StorageTransferService {
     /// before you canceled the job, tomorrow's transfer operation will
     /// compute a new delta with the five files that were not copied today
     /// plus any new files discovered tomorrow.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+    /// async fn sample(
+    ///    client: &StorageTransferService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .cancel_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn cancel_operation(&self) -> super::builder::storage_transfer_service::CancelOperation {
         super::builder::storage_transfer_service::CancelOperation::new(self.inner.clone())
     }

--- a/src/pubsub/src/generated/gapic/client.rs
+++ b/src/pubsub/src/generated/gapic/client.rs
@@ -120,17 +120,66 @@ impl TopicAdmin {
 
     /// Creates the given topic with the given name. See the [resource name rules]
     /// (<https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names>).
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_topic()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_topic(&self) -> super::builder::topic_admin::CreateTopic {
         super::builder::topic_admin::CreateTopic::new(self.inner.clone())
     }
 
     /// Updates an existing topic by updating the fields specified in the update
     /// mask. Note that certain properties of a topic are not modifiable.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_topic()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_topic(&self) -> super::builder::topic_admin::UpdateTopic {
         super::builder::topic_admin::UpdateTopic::new(self.inner.clone())
     }
 
     /// Gets the configuration of a topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_topic()
+    ///         .set_topic(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_topic(&self) -> super::builder::topic_admin::GetTopic {
         super::builder::topic_admin::GetTopic::new(self.inner.clone())
     }
@@ -141,6 +190,22 @@ impl TopicAdmin {
     }
 
     /// Lists the names of the attached subscriptions on this topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_topic_subscriptions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_topic_subscriptions(&self) -> super::builder::topic_admin::ListTopicSubscriptions {
         super::builder::topic_admin::ListTopicSubscriptions::new(self.inner.clone())
     }
@@ -150,6 +215,22 @@ impl TopicAdmin {
     /// which allow you to manage message acknowledgments in bulk. That is, you can
     /// set the acknowledgment state of messages in an existing subscription to the
     /// state captured by a snapshot.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .list_topic_snapshots()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_topic_snapshots(&self) -> super::builder::topic_admin::ListTopicSnapshots {
         super::builder::topic_admin::ListTopicSnapshots::new(self.inner.clone())
     }
@@ -159,6 +240,22 @@ impl TopicAdmin {
     /// the same name; this is an entirely new topic with none of the old
     /// configuration or subscriptions. Existing subscriptions to this topic are
     /// not deleted, but their `topic` field is set to `_deleted-topic_`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_topic()
+    ///         .set_topic(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_topic(&self) -> super::builder::topic_admin::DeleteTopic {
         super::builder::topic_admin::DeleteTopic::new(self.inner.clone())
     }
@@ -167,6 +264,22 @@ impl TopicAdmin {
     /// subscription are dropped. Subsequent `Pull` and `StreamingPull` requests
     /// will return FAILED_PRECONDITION. If the subscription is a push
     /// subscription, pushes to the endpoint will stop.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::TopicAdmin;
+    /// async fn sample(
+    ///    client: &TopicAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .detach_subscription()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn detach_subscription(&self) -> super::builder::topic_admin::DetachSubscription {
         super::builder::topic_admin::DetachSubscription::new(self.inner.clone())
     }
@@ -288,11 +401,44 @@ impl SubscriptionAdmin {
     /// (<https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names>). The
     /// generated name is populated in the returned Subscription object. Note that
     /// for REST API requests, you must specify a name in the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_subscription()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_subscription(&self) -> super::builder::subscription_admin::CreateSubscription {
         super::builder::subscription_admin::CreateSubscription::new(self.inner.clone())
     }
 
     /// Gets the configuration details of a subscription.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_subscription()
+    ///         .set_subscription(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_subscription(&self) -> super::builder::subscription_admin::GetSubscription {
         super::builder::subscription_admin::GetSubscription::new(self.inner.clone())
     }
@@ -300,6 +446,22 @@ impl SubscriptionAdmin {
     /// Updates an existing subscription by updating the fields specified in the
     /// update mask. Note that certain properties of a subscription, such as its
     /// topic, are not modifiable.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_subscription()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_subscription(&self) -> super::builder::subscription_admin::UpdateSubscription {
         super::builder::subscription_admin::UpdateSubscription::new(self.inner.clone())
     }
@@ -314,6 +476,22 @@ impl SubscriptionAdmin {
     /// `NOT_FOUND`. After a subscription is deleted, a new one may be created with
     /// the same name, but the new one has no association with the old
     /// subscription or its topic unless the same topic is specified.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_subscription()
+    ///         .set_subscription(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_subscription(&self) -> super::builder::subscription_admin::DeleteSubscription {
         super::builder::subscription_admin::DeleteSubscription::new(self.inner.clone())
     }
@@ -324,6 +502,21 @@ impl SubscriptionAdmin {
     /// an empty `PushConfig`) or vice versa, or change the endpoint URL and other
     /// attributes of a push subscription. Messages will accumulate for delivery
     /// continuously through the call regardless of changes to the `PushConfig`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .modify_push_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn modify_push_config(&self) -> super::builder::subscription_admin::ModifyPushConfig {
         super::builder::subscription_admin::ModifyPushConfig::new(self.inner.clone())
     }
@@ -333,6 +526,23 @@ impl SubscriptionAdmin {
     /// which allow you to manage message acknowledgments in bulk. That is, you can
     /// set the acknowledgment state of messages in an existing subscription to the
     /// state captured by a snapshot.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_snapshot()
+    ///         .set_snapshot(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_snapshot(&self) -> super::builder::subscription_admin::GetSnapshot {
         super::builder::subscription_admin::GetSnapshot::new(self.inner.clone())
     }
@@ -362,6 +572,22 @@ impl SubscriptionAdmin {
     /// (<https://cloud.google.com/pubsub/docs/pubsub-basics#resource_names>). The
     /// generated name is populated in the returned Snapshot object. Note that for
     /// REST API requests, you must specify a name in the request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_snapshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_snapshot(&self) -> super::builder::subscription_admin::CreateSnapshot {
         super::builder::subscription_admin::CreateSnapshot::new(self.inner.clone())
     }
@@ -372,6 +598,22 @@ impl SubscriptionAdmin {
     /// which allow you to manage message acknowledgments in bulk. That is, you can
     /// set the acknowledgment state of messages in an existing subscription to the
     /// state captured by a snapshot.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_snapshot()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_snapshot(&self) -> super::builder::subscription_admin::UpdateSnapshot {
         super::builder::subscription_admin::UpdateSnapshot::new(self.inner.clone())
     }
@@ -385,6 +627,22 @@ impl SubscriptionAdmin {
     /// are immediately dropped. After a snapshot is deleted, a new one may be
     /// created with the same name, but the new one has no association with the old
     /// snapshot or its subscription, unless the same subscription is specified.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_snapshot()
+    ///         .set_snapshot(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_snapshot(&self) -> super::builder::subscription_admin::DeleteSnapshot {
         super::builder::subscription_admin::DeleteSnapshot::new(self.inner.clone())
     }
@@ -396,6 +654,22 @@ impl SubscriptionAdmin {
     /// the acknowledgment state of messages in an existing subscription to the
     /// state captured by a snapshot. Note that both the subscription and the
     /// snapshot must be on the same topic.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SubscriptionAdmin;
+    /// async fn sample(
+    ///    client: &SubscriptionAdmin
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .seek()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn seek(&self) -> super::builder::subscription_admin::Seek {
         super::builder::subscription_admin::Seek::new(self.inner.clone())
     }
@@ -504,11 +778,44 @@ impl SchemaService {
     }
 
     /// Creates a schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_schema(&self) -> super::builder::schema_service::CreateSchema {
         super::builder::schema_service::CreateSchema::new(self.inner.clone())
     }
 
     /// Gets a schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_schema()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_schema(&self) -> super::builder::schema_service::GetSchema {
         super::builder::schema_service::GetSchema::new(self.inner.clone())
     }
@@ -524,31 +831,126 @@ impl SchemaService {
     }
 
     /// Commits a new schema revision to an existing schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .commit_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn commit_schema(&self) -> super::builder::schema_service::CommitSchema {
         super::builder::schema_service::CommitSchema::new(self.inner.clone())
     }
 
     /// Creates a new schema revision that is a copy of the provided revision_id.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rollback_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rollback_schema(&self) -> super::builder::schema_service::RollbackSchema {
         super::builder::schema_service::RollbackSchema::new(self.inner.clone())
     }
 
     /// Deletes a specific schema revision.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .delete_schema_revision()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema_revision(&self) -> super::builder::schema_service::DeleteSchemaRevision {
         super::builder::schema_service::DeleteSchemaRevision::new(self.inner.clone())
     }
 
     /// Deletes a schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_schema(&self) -> super::builder::schema_service::DeleteSchema {
         super::builder::schema_service::DeleteSchema::new(self.inner.clone())
     }
 
     /// Validates a schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_schema()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_schema(&self) -> super::builder::schema_service::ValidateSchema {
         super::builder::schema_service::ValidateSchema::new(self.inner.clone())
     }
 
     /// Validates a message against a schema.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .validate_message()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn validate_message(&self) -> super::builder::schema_service::ValidateMessage {
         super::builder::schema_service::ValidateMessage::new(self.inner.clone())
     }
@@ -558,12 +960,44 @@ impl SchemaService {
     ///
     /// Can return `NOT_FOUND`, `INVALID_ARGUMENT`, and `PERMISSION_DENIED`
     /// errors.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::schema_service::SetIamPolicy {
         super::builder::schema_service::SetIamPolicy::new(self.inner.clone())
     }
 
     /// Gets the access control policy for a resource. Returns an empty policy
     /// if the resource exists and does not have a policy set.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::schema_service::GetIamPolicy {
         super::builder::schema_service::GetIamPolicy::new(self.inner.clone())
     }
@@ -575,6 +1009,22 @@ impl SchemaService {
     /// Note: This operation is designed to be used for building
     /// permission-aware UIs and command-line tools, not for authorization
     /// checking. This operation may "fail open" without warning.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::SchemaService;
+    /// async fn sample(
+    ///    client: &SchemaService
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::schema_service::TestIamPermissions {
         super::builder::schema_service::TestIamPermissions::new(self.inner.clone())
     }

--- a/src/pubsub/src/generated/gapic_dataplane/client.rs
+++ b/src/pubsub/src/generated/gapic_dataplane/client.rs
@@ -68,6 +68,22 @@ impl Publisher {
 
     /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
     /// does not exist.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::Publisher;
+    /// async fn sample(
+    ///    client: &Publisher
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .publish()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn publish(&self) -> super::builder::publisher::Publish {
         super::builder::publisher::Publish::new(self.inner.clone())
     }
@@ -128,6 +144,21 @@ impl Subscriber {
     /// subscriber, or to make the message available for redelivery if the
     /// processing was interrupted. Note that this does not modify the
     /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::Subscriber;
+    /// async fn sample(
+    ///    client: &Subscriber
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .modify_ack_deadline()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn modify_ack_deadline(&self) -> super::builder::subscriber::ModifyAckDeadline {
         super::builder::subscriber::ModifyAckDeadline::new(self.inner.clone())
     }
@@ -139,6 +170,21 @@ impl Subscriber {
     /// Acknowledging a message whose ack deadline has expired may succeed,
     /// but such a message may be redelivered later. Acknowledging a message more
     /// than once will not result in an error.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::Subscriber;
+    /// async fn sample(
+    ///    client: &Subscriber
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .acknowledge()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn acknowledge(&self) -> super::builder::subscriber::Acknowledge {
         super::builder::subscriber::Acknowledge::new(self.inner.clone())
     }

--- a/src/storage/src/control/generated/client.rs
+++ b/src/storage/src/control/generated/client.rs
@@ -53,6 +53,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.buckets.delete` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_bucket()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_bucket(&self) -> crate::builder::storage_control::DeleteBucket {
         self.storage.delete_bucket()
     }
@@ -68,6 +84,23 @@ impl StorageControl {
     ///
     /// - To return the IAM policies: `storage.buckets.getIamPolicy`
     /// - To return the bucket IP filtering rules: `storage.buckets.getIpFilter`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_bucket()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_bucket(&self) -> crate::builder::storage_control::GetBucket {
         self.storage.get_bucket()
     }
@@ -83,6 +116,22 @@ impl StorageControl {
     /// - To enable object retention using the `enableObjectRetention` query
     ///   parameter: `storage.buckets.enableObjectRetention`
     /// - To set the bucket IP filtering rules: `storage.buckets.setIpFilter`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_bucket(&self) -> crate::builder::storage_control::CreateBucket {
         self.storage.create_bucket()
     }
@@ -121,6 +170,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.buckets.update` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lock_bucket_retention_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lock_bucket_retention_policy(
         &self,
     ) -> crate::builder::storage_control::LockBucketRetentionPolicy {
@@ -140,6 +205,22 @@ impl StorageControl {
     /// - To set bucket IP filtering rules: `storage.buckets.setIpFilter`
     /// - To update public access prevention policies or access control lists
     ///   (ACLs): `storage.buckets.setIamPolicy`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_bucket(&self) -> crate::builder::storage_control::UpdateBucket {
         self.storage.update_bucket()
     }
@@ -155,6 +236,22 @@ impl StorageControl {
     /// the `storage.objects.delete` permission. If the request body includes
     /// the retention property, the authenticated user must also have the
     /// `storage.objects.setRetention` IAM permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compose_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compose_object(&self) -> crate::builder::storage_control::ComposeObject {
         self.storage.compose_object()
     }
@@ -179,6 +276,21 @@ impl StorageControl {
     /// Requires `storage.objects.delete` IAM permission on the bucket.
     ///
     /// [google.storage.v2.Storage.RestoreObject]: crate::client::StorageControl::restore_object
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_object(&self) -> crate::builder::storage_control::DeleteObject {
         self.storage.delete_object()
     }
@@ -220,6 +332,22 @@ impl StorageControl {
     /// - `storage.objects.setIamPolicy` (only required if `copySourceAcl` is
     ///   `true` and the relevant
     ///   bucket has uniform bucket-level access disabled)
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restore_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restore_object(&self) -> crate::builder::storage_control::RestoreObject {
         self.storage.restore_object()
     }
@@ -231,6 +359,22 @@ impl StorageControl {
     /// Requires `storage.objects.get` IAM permission on the bucket.
     /// To return object ACLs, the authenticated user must also have
     /// the `storage.objects.getIamPolicy` permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_object(&self) -> crate::builder::storage_control::GetObject {
         self.storage.get_object()
     }
@@ -241,6 +385,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.objects.update` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_object(&self) -> crate::builder::storage_control::UpdateObject {
         self.storage.update_object()
     }
@@ -259,6 +419,22 @@ impl StorageControl {
 
     /// Rewrites a source object to a destination object. Optionally overrides
     /// metadata.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rewrite_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rewrite_object(&self) -> crate::builder::storage_control::RewriteObject {
         self.storage.rewrite_object()
     }
@@ -277,24 +453,89 @@ impl StorageControl {
     /// - `storage.objects.create`
     /// - `storage.objects.delete` (only required if overwriting an existing
     ///   object)
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_object(&self) -> crate::builder::storage_control::MoveObject {
         self.storage.move_object()
     }
 
     /// Creates a new folder. This operation is only applicable to a hierarchical
     /// namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_folder()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_folder(&self) -> crate::builder::storage_control::CreateFolder {
         self.control.create_folder()
     }
 
     /// Permanently deletes an empty folder. This operation is only applicable to a
     /// hierarchical namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_folder(&self) -> crate::builder::storage_control::DeleteFolder {
         self.control.delete_folder()
     }
 
     /// Returns metadata for the specified folder. This operation is only
     /// applicable to a hierarchical namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_folder(&self) -> crate::builder::storage_control::GetFolder {
         self.control.get_folder()
     }
@@ -324,21 +565,87 @@ impl StorageControl {
     }
 
     /// Returns the storage layout configuration for a given bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_storage_layout()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_storage_layout(&self) -> crate::builder::storage_control::GetStorageLayout {
         self.control.get_storage_layout()
     }
 
     /// Creates a new managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_managed_folder()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_managed_folder(&self) -> crate::builder::storage_control::CreateManagedFolder {
         self.control.create_managed_folder()
     }
 
     /// Permanently deletes an empty managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_managed_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_managed_folder(&self) -> crate::builder::storage_control::DeleteManagedFolder {
         self.control.delete_managed_folder()
     }
 
     /// Returns metadata for the specified managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_managed_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_managed_folder(&self) -> crate::builder::storage_control::GetManagedFolder {
         self.control.get_managed_folder()
     }
@@ -383,21 +690,86 @@ impl StorageControl {
     /// disablement could be revoked by calling ResumeAnywhereCache. The cache
     /// instance will be deleted automatically if it remains in the disabled state
     /// for at least one hour.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_anywhere_cache(&self) -> crate::builder::storage_control::DisableAnywhereCache {
         self.control.disable_anywhere_cache()
     }
 
     /// Pauses an Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_anywhere_cache(&self) -> crate::builder::storage_control::PauseAnywhereCache {
         self.control.pause_anywhere_cache()
     }
 
     /// Resumes a disabled or paused Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_anywhere_cache(&self) -> crate::builder::storage_control::ResumeAnywhereCache {
         self.control.resume_anywhere_cache()
     }
 
     /// Gets an Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_anywhere_cache()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_anywhere_cache(&self) -> crate::builder::storage_control::GetAnywhereCache {
         self.control.get_anywhere_cache()
     }
@@ -408,6 +780,22 @@ impl StorageControl {
     }
 
     /// Returns the Project scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::GetProjectIntelligenceConfig {
@@ -415,6 +803,22 @@ impl StorageControl {
     }
 
     /// Updates the Project scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_project_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_project_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::UpdateProjectIntelligenceConfig {
@@ -422,6 +826,22 @@ impl StorageControl {
     }
 
     /// Returns the Folder scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_folder_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_folder_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::GetFolderIntelligenceConfig {
@@ -429,6 +849,22 @@ impl StorageControl {
     }
 
     /// Updates the Folder scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_folder_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_folder_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::UpdateFolderIntelligenceConfig {
@@ -436,6 +872,22 @@ impl StorageControl {
     }
 
     /// Returns the Organization scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_organization_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_organization_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::GetOrganizationIntelligenceConfig {
@@ -443,6 +895,22 @@ impl StorageControl {
     }
 
     /// Updates the Organization scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_organization_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_organization_intelligence_config(
         &self,
     ) -> crate::builder::storage_control::UpdateOrganizationIntelligenceConfig {
@@ -454,6 +922,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}` for a bucket, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> crate::builder::storage_control::GetIamPolicy {
         self.control.get_iam_policy()
     }
@@ -463,6 +947,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}` for a bucket, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> crate::builder::storage_control::SetIamPolicy {
         self.control.set_iam_policy()
     }
@@ -474,6 +974,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}/objects/{object}` for an object, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> crate::builder::storage_control::TestIamPermissions {
         self.control.test_iam_permissions()
     }
@@ -481,6 +997,22 @@ impl StorageControl {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> crate::builder::storage_control::GetOperation {
         self.control.get_operation()
     }

--- a/src/storage/src/generated/gapic/client.rs
+++ b/src/storage/src/generated/gapic/client.rs
@@ -90,6 +90,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.buckets.delete` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_bucket()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_bucket(&self) -> super::builder::storage_control::DeleteBucket {
         super::builder::storage_control::DeleteBucket::new(self.inner.clone())
     }
@@ -105,6 +121,23 @@ impl StorageControl {
     ///
     /// - To return the IAM policies: `storage.buckets.getIamPolicy`
     /// - To return the bucket IP filtering rules: `storage.buckets.getIpFilter`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_bucket()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_bucket(&self) -> super::builder::storage_control::GetBucket {
         super::builder::storage_control::GetBucket::new(self.inner.clone())
     }
@@ -120,6 +153,22 @@ impl StorageControl {
     /// - To enable object retention using the `enableObjectRetention` query
     ///   parameter: `storage.buckets.enableObjectRetention`
     /// - To set the bucket IP filtering rules: `storage.buckets.setIpFilter`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_bucket(&self) -> super::builder::storage_control::CreateBucket {
         super::builder::storage_control::CreateBucket::new(self.inner.clone())
     }
@@ -158,6 +207,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.buckets.update` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .lock_bucket_retention_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn lock_bucket_retention_policy(
         &self,
     ) -> super::builder::storage_control::LockBucketRetentionPolicy {
@@ -177,6 +242,22 @@ impl StorageControl {
     /// - To set bucket IP filtering rules: `storage.buckets.setIpFilter`
     /// - To update public access prevention policies or access control lists
     ///   (ACLs): `storage.buckets.setIamPolicy`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_bucket()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_bucket(&self) -> super::builder::storage_control::UpdateBucket {
         super::builder::storage_control::UpdateBucket::new(self.inner.clone())
     }
@@ -192,6 +273,22 @@ impl StorageControl {
     /// the `storage.objects.delete` permission. If the request body includes
     /// the retention property, the authenticated user must also have the
     /// `storage.objects.setRetention` IAM permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .compose_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn compose_object(&self) -> super::builder::storage_control::ComposeObject {
         super::builder::storage_control::ComposeObject::new(self.inner.clone())
     }
@@ -216,6 +313,21 @@ impl StorageControl {
     /// Requires `storage.objects.delete` IAM permission on the bucket.
     ///
     /// [google.storage.v2.Storage.RestoreObject]: crate::client::StorageControl::restore_object
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_object(&self) -> super::builder::storage_control::DeleteObject {
         super::builder::storage_control::DeleteObject::new(self.inner.clone())
     }
@@ -257,6 +369,22 @@ impl StorageControl {
     /// - `storage.objects.setIamPolicy` (only required if `copySourceAcl` is
     ///   `true` and the relevant
     ///   bucket has uniform bucket-level access disabled)
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .restore_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn restore_object(&self) -> super::builder::storage_control::RestoreObject {
         super::builder::storage_control::RestoreObject::new(self.inner.clone())
     }
@@ -268,6 +396,22 @@ impl StorageControl {
     /// Requires `storage.objects.get` IAM permission on the bucket.
     /// To return object ACLs, the authenticated user must also have
     /// the `storage.objects.getIamPolicy` permission.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_object(&self) -> super::builder::storage_control::GetObject {
         super::builder::storage_control::GetObject::new(self.inner.clone())
     }
@@ -278,6 +422,22 @@ impl StorageControl {
     /// **IAM Permissions**:
     ///
     /// Requires `storage.objects.update` IAM permission on the bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_object(&self) -> super::builder::storage_control::UpdateObject {
         super::builder::storage_control::UpdateObject::new(self.inner.clone())
     }
@@ -296,6 +456,22 @@ impl StorageControl {
 
     /// Rewrites a source object to a destination object. Optionally overrides
     /// metadata.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .rewrite_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn rewrite_object(&self) -> super::builder::storage_control::RewriteObject {
         super::builder::storage_control::RewriteObject::new(self.inner.clone())
     }
@@ -314,6 +490,22 @@ impl StorageControl {
     /// - `storage.objects.create`
     /// - `storage.objects.delete` (only required if overwriting an existing
     ///   object)
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .move_object()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn move_object(&self) -> super::builder::storage_control::MoveObject {
         super::builder::storage_control::MoveObject::new(self.inner.clone())
     }

--- a/src/storage/src/generated/gapic_control/client.rs
+++ b/src/storage/src/generated/gapic_control/client.rs
@@ -68,18 +68,67 @@ impl StorageControl {
 
     /// Creates a new folder. This operation is only applicable to a hierarchical
     /// namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_folder()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_folder(&self) -> super::builder::storage_control::CreateFolder {
         super::builder::storage_control::CreateFolder::new(self.inner.clone())
     }
 
     /// Permanently deletes an empty folder. This operation is only applicable to a
     /// hierarchical namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_folder(&self) -> super::builder::storage_control::DeleteFolder {
         super::builder::storage_control::DeleteFolder::new(self.inner.clone())
     }
 
     /// Returns metadata for the specified folder. This operation is only
     /// applicable to a hierarchical namespace enabled bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_folder(&self) -> super::builder::storage_control::GetFolder {
         super::builder::storage_control::GetFolder::new(self.inner.clone())
     }
@@ -109,21 +158,87 @@ impl StorageControl {
     }
 
     /// Returns the storage layout configuration for a given bucket.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_storage_layout()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_storage_layout(&self) -> super::builder::storage_control::GetStorageLayout {
         super::builder::storage_control::GetStorageLayout::new(self.inner.clone())
     }
 
     /// Creates a new managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .create_managed_folder()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn create_managed_folder(&self) -> super::builder::storage_control::CreateManagedFolder {
         super::builder::storage_control::CreateManagedFolder::new(self.inner.clone())
     }
 
     /// Permanently deletes an empty managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     client
+    ///         .delete_managed_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn delete_managed_folder(&self) -> super::builder::storage_control::DeleteManagedFolder {
         super::builder::storage_control::DeleteManagedFolder::new(self.inner.clone())
     }
 
     /// Returns metadata for the specified managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_managed_folder()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_managed_folder(&self) -> super::builder::storage_control::GetManagedFolder {
         super::builder::storage_control::GetManagedFolder::new(self.inner.clone())
     }
@@ -168,21 +283,86 @@ impl StorageControl {
     /// disablement could be revoked by calling ResumeAnywhereCache. The cache
     /// instance will be deleted automatically if it remains in the disabled state
     /// for at least one hour.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .disable_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn disable_anywhere_cache(&self) -> super::builder::storage_control::DisableAnywhereCache {
         super::builder::storage_control::DisableAnywhereCache::new(self.inner.clone())
     }
 
     /// Pauses an Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .pause_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn pause_anywhere_cache(&self) -> super::builder::storage_control::PauseAnywhereCache {
         super::builder::storage_control::PauseAnywhereCache::new(self.inner.clone())
     }
 
     /// Resumes a disabled or paused Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .resume_anywhere_cache()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn resume_anywhere_cache(&self) -> super::builder::storage_control::ResumeAnywhereCache {
         super::builder::storage_control::ResumeAnywhereCache::new(self.inner.clone())
     }
 
     /// Gets an Anywhere Cache instance.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl,
+    ///    resource_name: &str
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_anywhere_cache()
+    ///         .set_name(resource_name)
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_anywhere_cache(&self) -> super::builder::storage_control::GetAnywhereCache {
         super::builder::storage_control::GetAnywhereCache::new(self.inner.clone())
     }
@@ -193,6 +373,22 @@ impl StorageControl {
     }
 
     /// Returns the Project scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_project_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_project_intelligence_config(
         &self,
     ) -> super::builder::storage_control::GetProjectIntelligenceConfig {
@@ -200,6 +396,22 @@ impl StorageControl {
     }
 
     /// Updates the Project scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_project_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_project_intelligence_config(
         &self,
     ) -> super::builder::storage_control::UpdateProjectIntelligenceConfig {
@@ -207,6 +419,22 @@ impl StorageControl {
     }
 
     /// Returns the Folder scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_folder_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_folder_intelligence_config(
         &self,
     ) -> super::builder::storage_control::GetFolderIntelligenceConfig {
@@ -214,6 +442,22 @@ impl StorageControl {
     }
 
     /// Updates the Folder scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_folder_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_folder_intelligence_config(
         &self,
     ) -> super::builder::storage_control::UpdateFolderIntelligenceConfig {
@@ -221,6 +465,22 @@ impl StorageControl {
     }
 
     /// Returns the Organization scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_organization_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_organization_intelligence_config(
         &self,
     ) -> super::builder::storage_control::GetOrganizationIntelligenceConfig {
@@ -228,6 +488,22 @@ impl StorageControl {
     }
 
     /// Updates the Organization scoped singleton IntelligenceConfig resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .update_organization_intelligence_config()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn update_organization_intelligence_config(
         &self,
     ) -> super::builder::storage_control::UpdateOrganizationIntelligenceConfig {
@@ -241,6 +517,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}` for a bucket, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_iam_policy(&self) -> super::builder::storage_control::GetIamPolicy {
         super::builder::storage_control::GetIamPolicy::new(self.inner.clone())
     }
@@ -250,6 +542,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}` for a bucket, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .set_iam_policy()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn set_iam_policy(&self) -> super::builder::storage_control::SetIamPolicy {
         super::builder::storage_control::SetIamPolicy::new(self.inner.clone())
     }
@@ -261,6 +569,22 @@ impl StorageControl {
     /// `projects/_/buckets/{bucket}/objects/{object}` for an object, or
     /// `projects/_/buckets/{bucket}/managedFolders/{managedFolder}`
     /// for a managed folder.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .test_iam_permissions()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn test_iam_permissions(&self) -> super::builder::storage_control::TestIamPermissions {
         super::builder::storage_control::TestIamPermissions::new(self.inner.clone())
     }
@@ -268,6 +592,22 @@ impl StorageControl {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::StorageControl;
+    /// async fn sample(
+    ///    client: &StorageControl
+    /// ) -> gax::Result<()> {
+    ///     let response = client
+    ///         .get_operation()
+    ///         /* set fields */
+    ///         .send()
+    ///         .await?;
+    ///     println!("response {:?}", response);
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn get_operation(&self) -> super::builder::storage_control::GetOperation {
         super::builder::storage_control::GetOperation::new(self.inner.clone())
     }


### PR DESCRIPTION
In order to prep for migration to Librarian we need to run sidekick refresh-all to get the latest changes made to sidekick [example](https://github.com/googleapis/librarian/pull/33120).

For https://github.com/googleapis/librarian/issues/3405