### PR TITLE
chore: update cargo.toml file to have matching copyright year

### DIFF
--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We changed logic in librarian to pull the correct copyright year from the [cargo.toml file header](https://github.com/googleapis/librarian/pull/33670).  For all libraries except for wkt this works correctly, but wkt seems to have a mismatch where cargo.toml's copyright year is 2024 but the generated files are all copyrighted 2025.  This PR updates cargo.toml to match the generated files.  

Alternatively the files could be updated to have 2024, if that is preferred.

Fixes https://github.com/googleapis/librarian/issues/3405