### PR TITLE
cleanup(pubsub): simplify lease loop shutdown

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -17,7 +17,6 @@ use super::lease_state::{LeaseEvent, LeaseOptions, LeaseState};
 use super::leaser::Leaser;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
-use tokio_util::sync::CancellationToken;
 
 /// A convenience struct that groups the components of the lease loop.
 pub(crate) struct LeaseLoop {
@@ -30,7 +29,7 @@ pub(crate) struct LeaseLoop {
 }
 
 impl LeaseLoop {
-    pub(crate) fn new<L>(leaser: L, shutdown: CancellationToken, options: LeaseOptions) -> Self
+    pub(crate) fn new<L>(leaser: L, options: LeaseOptions) -> Self
     where
         L: Leaser + Send + 'static,
     {
@@ -42,10 +41,6 @@ impl LeaseLoop {
             loop {
                 tokio::select! {
                     biased;
-                    _ = shutdown.cancelled() => {
-                        state.shutdown().await;
-                        break;
-                    },
                     event = state.next_event() => {
                         match event {
                             LeaseEvent::Flush => state.flush().await,
@@ -54,7 +49,7 @@ impl LeaseLoop {
                     },
                     message = message_rx.recv() => {
                         match message {
-                            None => break,
+                            None => break state.shutdown().await,
                             Some(ack_id) => state.add(ack_id),
                         }
                     },
@@ -99,8 +94,7 @@ mod tests {
             extend_start: Duration::from_secs(900),
             ..Default::default()
         };
-        let shutdown = CancellationToken::new();
-        let lease_loop = LeaseLoop::new(mock.clone(), shutdown.clone(), options);
+        let lease_loop = LeaseLoop::new(mock.clone(), options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -211,8 +205,7 @@ mod tests {
             extend_start: EXTEND_START,
             ..Default::default()
         };
-        let shutdown = CancellationToken::new();
-        let lease_loop = LeaseLoop::new(mock.clone(), shutdown.clone(), options);
+        let lease_loop = LeaseLoop::new(mock.clone(), options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -266,8 +259,7 @@ mod tests {
     async fn drop_does_not_wait_for_pending_operations() -> anyhow::Result<()> {
         let start = Instant::now();
         let mock = MockLeaser::new();
-        let shutdown = CancellationToken::new();
-        let lease_loop = LeaseLoop::new(mock, shutdown, LeaseOptions::default());
+        let lease_loop = LeaseLoop::new(mock, LeaseOptions::default());
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -304,8 +296,7 @@ mod tests {
             async fn nack(&self, _ack_ids: Vec<String>) {}
             async fn extend(&self, _ack_ids: Vec<String>) {}
         }
-        let shutdown = CancellationToken::new();
-        let lease_loop = LeaseLoop::new(FakeLeaser, shutdown.clone(), LeaseOptions::default());
+        let lease_loop = LeaseLoop::new(FakeLeaser, LeaseOptions::default());
 
         // Seed the lease loop with some messages
         for i in 0..30 {
@@ -318,7 +309,7 @@ mod tests {
         }
 
         // Shutdown the lease_loop.
-        shutdown.cancel();
+        drop(lease_loop.message_tx);
         lease_loop.handle.await?;
 
         // Verify that we flushed the acks immediately, and waited for them to
@@ -343,13 +334,12 @@ mod tests {
             // Run this test enough times to trigger a race, if one existed.
 
             let mock = Arc::new(Mutex::new(MockLeaser::new()));
-            let shutdown = CancellationToken::new();
             let options = LeaseOptions {
                 flush_start: Duration::from_millis(100),
                 extend_start: Duration::from_millis(200),
                 ..Default::default()
             };
-            let lease_loop = LeaseLoop::new(mock.clone(), shutdown, options);
+            let lease_loop = LeaseLoop::new(mock.clone(), options);
             // Yield execution, so tokio can actually start the lease loop.
             tokio::task::yield_now().await;
 


### PR DESCRIPTION
Part of the work for #3957 

The `CancellationToken` was unnecessary. We can signal a shutdown by dropping the new message sender.

Moreover, the `CancellationToken` for the lease loop would have been different than the `CancellationToken` for the stream. I didn't realize this until I tried to implement `Session::close()`.