### PR TITLE
impl(pubsub): add Handler

### DIFF
--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -22,7 +22,36 @@ pub(crate) enum AckResult {
     // TODO(#3964) - support exactly once acking
 }
 
-/// A handler for at-least-once delivery
+/// A handler for acknowledging or rejecting messages.
+#[non_exhaustive]
+pub enum Handler {
+    AtLeastOnce(AtLeastOnce),
+    // TODO(#3964) - support exactly once acking
+}
+
+impl Handler {
+    /// Acknowledge the message associated with this handler.
+    ///
+    /// Note that the acknowledgement is best effort. The message may still be
+    /// redelivered to this client, or another client.
+    pub fn ack(self) {
+        match self {
+            Handler::AtLeastOnce(h) => h.ack(),
+        }
+    }
+
+    /// Rejects the message associated with this handler.
+    ///
+    /// The message will be removed from this `Subscriber`'s lease management.
+    /// The service will redeliver this message, possibly to another client.
+    pub fn nack(self) {
+        match self {
+            Handler::AtLeastOnce(h) => h.nack(),
+        }
+    }
+}
+
+/// A handler for at-least-once delivery.
 pub struct AtLeastOnce {
     pub(crate) ack_id: String,
     pub(crate) ack_tx: UnboundedSender<AckResult>,
@@ -54,7 +83,39 @@ mod tests {
     use tokio::sync::mpsc::unbounded_channel;
 
     #[test]
-    fn ack() -> anyhow::Result<()> {
+    fn handler_ack() -> anyhow::Result<()> {
+        let (ack_tx, mut ack_rx) = unbounded_channel();
+        let h = Handler::AtLeastOnce(AtLeastOnce {
+            ack_id: test_id(1),
+            ack_tx,
+        });
+        assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
+
+        h.ack();
+        let ack = ack_rx.try_recv()?;
+        assert_eq!(ack, AckResult::Ack(test_id(1)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn handler_nack() -> anyhow::Result<()> {
+        let (ack_tx, mut ack_rx) = unbounded_channel();
+        let h = Handler::AtLeastOnce(AtLeastOnce {
+            ack_id: test_id(1),
+            ack_tx,
+        });
+        assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
+
+        h.nack();
+        let ack = ack_rx.try_recv()?;
+        assert_eq!(ack, AckResult::Nack(test_id(1)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn at_least_once_ack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let h = AtLeastOnce {
             ack_id: test_id(1),
@@ -70,7 +131,7 @@ mod tests {
     }
 
     #[test]
-    fn nack() -> anyhow::Result<()> {
+    fn at_least_once_nack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let h = AtLeastOnce {
             ack_id: test_id(1),


### PR DESCRIPTION
Part of the work for #3941 

Googlers can see go/cloud-rust:subscriber-ack-api

Add a Handler that can support both at-least-once and exactly-once delivery in the future.

Future work will:
- make this thing mock-able
- support exactly once delivery