### PR TITLE
chore(pubsub): add metadata file

### DIFF
--- a/src/pubsub/.repo-metadata.json
+++ b/src/pubsub/.repo-metadata.json
@@ -1,0 +1,13 @@
+{
+  "api_id": "pubsub.googleapis.com",
+  "api_shortname": "pubsub",
+  "client_documentation": "https://docs.rs/google-cloud-pubsub/latest",
+  "distribution_name": "google-cloud-rust",
+  "language": "rust",
+  "library_type": "GAPIC_COMBO",
+  "name_pretty": "Cloud Pub/Sub API",
+  "release_level": "preview",
+  "repo": "googleapis/google-cloud-rust",
+  "product_documentation": "https://cloud.google.com/pubsub/docs",
+  "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:187173%20status:open"
+}


### PR DESCRIPTION
This is used to track what services have client libraries.