### PR TITLE
cleanup(gax-internal): remove duplicate deps

### DIFF
--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -37,10 +37,8 @@ workspace = true
 [features]
 _internal-http-client = [
   "_internal-common",
-  "dep:auth",
   "dep:bytes",
   "dep:futures",
-  "dep:gax",
   "dep:http",
   "dep:http-body-util",
   "dep:hyper",
@@ -54,10 +52,8 @@ _internal-http-client = [
 ]
 _internal-grpc-client = [
   "_internal-common",
-  "dep:auth",
   "dep:bytes",
   "dep:futures",
-  "dep:gax",
   "dep:http",
   "dep:http-body",
   "dep:http-body-util",


### PR DESCRIPTION
This will make it easier to use these dependencies with or without the default features.

Par of the work for #4170 