### PR TITLE
chore: create librarian.yaml as first step to migrating google-cloud-rust to librarian

### DIFF
--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -82,10 +82,7 @@ steps:
       #!/usr/bin/env bash
       set -euv
       go install github.com/google/yamlfmt/cmd/yamlfmt@v0.13.0
-      git ls-files -z -- '*.yaml' '*.yml' \
-        ':!:testdata/**' \
-        ':!:**/generated/**' \
-        ':!:**/librarian.yaml' | \
+      git ls-files -z -- '*.yaml' '*.yml' ':!:testdata/**' ':!:**/generated/**' | \
         xargs -0 yamlfmt
     waitFor: ['-']
   - name: 'ubuntu:24.04'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -266,10 +266,7 @@ libraries:
           match: |2
                 - `folders/<folder-number>`
                 - `organizations/<organization-number>`
-          replace: |+
-            - `folders/<folder-number>`
-            - `organizations/<organization-number>`
-
+          replace: "- `folders/<folder-number>`\n- `organizations/<organization-number>`\n\n"
   - name: google-cloud-api-servicemanagement-v1
     version: 1.3.0
     channels:


### PR DESCRIPTION
This maps the list of libraries into a librarian.yaml file that librarian tool uses as source of configuration values.