### PR TITLE
impl(storage): remove with_universe_domain in SignedUrlBuilder

### DIFF
--- a/src/storage/src/storage/signed_url.rs
+++ b/src/storage/src/storage/signed_url.rs
@@ -119,7 +119,6 @@ pub struct SignedUrlBuilder {
     headers: BTreeMap<String, String>,
     query_parameters: BTreeMap<String, String>,
     endpoint: Option<String>,
-    universe_domain: String,
     client_email: Option<String>,
     timestamp: DateTime<Utc>,
     url_style: UrlStyle,
@@ -207,7 +206,6 @@ impl SignedUrlBuilder {
             headers: BTreeMap::new(),
             query_parameters: BTreeMap::new(),
             endpoint: None,
-            universe_domain: "googleapis.com".to_string(),
             client_email: None,
             timestamp: Utc::now(),
             url_style: UrlStyle::PathStyle,
@@ -381,8 +379,6 @@ impl SignedUrlBuilder {
     ///
     /// This is useful when using a custom domain, or when testing with some Cloud Storage emulators.
     ///
-    /// Setting an endpoint takes precedence over using `with_universe_domain`.
-    ///
     /// # Example
     ///
     /// ```
@@ -399,27 +395,6 @@ impl SignedUrlBuilder {
     /// ```
     pub fn with_endpoint<S: Into<String>>(mut self, endpoint: S) -> Self {
         self.endpoint = Some(endpoint.into());
-        self
-    }
-
-    /// Sets the universe domain for the signed URL. The default is "googleapis.com".
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use google_cloud_storage::builder::storage::SignedUrlBuilder;
-    /// # use auth::signer::Signer;
-    ///
-    /// # async fn run(signer: &Signer) -> anyhow::Result<()> {
-    /// let url = SignedUrlBuilder::for_object("my-bucket", "my-object.txt")
-    ///     .with_universe_domain("my-universe.com")
-    ///     .sign_with(signer)
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn with_universe_domain<S: Into<String>>(mut self, universe_domain: S) -> Self {
-        self.universe_domain = universe_domain.into();
         self
     }
 
@@ -473,7 +448,7 @@ impl SignedUrlBuilder {
             Some(e) if e.starts_with("http://") => e.clone(),
             Some(e) if e.starts_with("https://") => e.clone(),
             Some(e) => format!("https://{}", e),
-            None => format!("https://storage.{}", self.universe_domain),
+            None => "https://storage.googleapis.com".to_string(),
         }
     }
 
@@ -653,7 +628,6 @@ mod tests {
             .with_header("x-goog-meta-test", "value")
             .with_query_param("test", "value")
             .with_endpoint("https://storage.googleapis.com")
-            .with_universe_domain("googleapis.com")
             .with_client_email("test@example.com")
             .with_url_style(UrlStyle::PathStyle)
             .sign_with(&signer)
@@ -833,7 +807,7 @@ mod tests {
                 .universe_domain
                 .iter()
                 .fold(builder, |builder, universe_domain| {
-                    builder.with_universe_domain(universe_domain)
+                    builder.with_endpoint(format!("https://storage.{}", universe_domain))
                 });
             let builder = test
                 .client_endpoint


### PR DESCRIPTION
Add support for that when universe domain is supported in the rest of the SDK.

Towards #3645 