### PR TITLE
cleanup(pubsub): restrict subscriber internals visibility

### DIFF
--- a/src/pubsub/src/subscriber.rs
+++ b/src/pubsub/src/subscriber.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod builder;
-pub(crate) mod client;
-pub(crate) mod client_builder;
-pub(crate) mod handler;
-pub(crate) mod keepalive;
-pub(crate) mod lease_loop;
-pub(crate) mod lease_state;
-pub(crate) mod leaser;
-pub(crate) mod session;
-pub(crate) mod stream;
-pub(crate) mod stub;
-pub(crate) mod transport;
+mod builder;
+mod client;
+mod client_builder;
+mod handler;
+mod keepalive;
+mod lease_loop;
+mod lease_state;
+mod leaser;
+mod session;
+mod stream;
+mod stub;
+mod transport;

--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -19,15 +19,15 @@ const MIB: i64 = 1024 * 1024;
 
 /// Builder for the `client::Subscriber::streaming_pull` method.
 pub struct StreamingPull {
-    pub(crate) inner: Arc<Transport>,
-    pub(crate) subscription: String,
-    pub(crate) ack_deadline_seconds: i32,
-    pub(crate) max_outstanding_messages: i64,
-    pub(crate) max_outstanding_bytes: i64,
+    pub(super) inner: Arc<Transport>,
+    pub(super) subscription: String,
+    pub(super) ack_deadline_seconds: i32,
+    pub(super) max_outstanding_messages: i64,
+    pub(super) max_outstanding_bytes: i64,
 }
 
 impl StreamingPull {
-    pub(crate) fn new(inner: Arc<Transport>, subscription: String) -> Self {
+    pub(super) fn new(inner: Arc<Transport>, subscription: String) -> Self {
         Self {
             inner,
             subscription,

--- a/src/pubsub/src/subscriber/client.rs
+++ b/src/pubsub/src/subscriber/client.rs
@@ -70,7 +70,7 @@ impl Subscriber {
         ClientBuilder::new()
     }
 
-    pub(crate) async fn new(builder: ClientBuilder) -> BuilderResult<Self> {
+    pub(super) async fn new(builder: ClientBuilder) -> BuilderResult<Self> {
         let transport = Transport::new(builder.config).await?;
         Ok(Self {
             inner: Arc::new(transport),

--- a/src/pubsub/src/subscriber/client_builder.rs
+++ b/src/pubsub/src/subscriber/client_builder.rs
@@ -29,11 +29,11 @@ use gaxi::options::ClientConfig;
 /// # Ok(()) }
 /// ```
 pub struct ClientBuilder {
-    pub(crate) config: ClientConfig,
+    pub(super) config: ClientConfig,
 }
 
 impl ClientBuilder {
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             config: ClientConfig::default(),
         }

--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -16,7 +16,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 /// The action an application does with a message.
 #[derive(Debug, PartialEq)]
-pub(crate) enum AckResult {
+pub(super) enum AckResult {
     Ack(String),
     Nack(String),
     // TODO(#3964) - support exactly once acking
@@ -55,8 +55,8 @@ impl Handler {
 /// A handler for at-least-once delivery.
 #[derive(Debug)]
 pub struct AtLeastOnce {
-    pub(crate) ack_id: String,
-    pub(crate) ack_tx: UnboundedSender<AckResult>,
+    pub(super) ack_id: String,
+    pub(super) ack_tx: UnboundedSender<AckResult>,
 }
 
 impl AtLeastOnce {

--- a/src/pubsub/src/subscriber/keepalive.rs
+++ b/src/pubsub/src/subscriber/keepalive.rs
@@ -18,7 +18,7 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant, interval_at};
 use tokio_util::sync::CancellationToken;
 
-pub(crate) const KEEPALIVE_PERIOD: Duration = Duration::from_secs(30);
+pub(super) const KEEPALIVE_PERIOD: Duration = Duration::from_secs(30);
 
 /// Spawns a task to keepalive a stream
 ///
@@ -29,7 +29,7 @@ pub(crate) const KEEPALIVE_PERIOD: Duration = Duration::from_secs(30);
 /// `CancellationToken` and `await`ing the returned handle.
 ///
 /// Callers can also just drop the returned handle to shutdown.
-pub(crate) fn spawn(
+pub(super) fn spawn(
     request_tx: Sender<StreamingPullRequest>,
     shutdown: CancellationToken,
 ) -> JoinHandle<()> {

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -19,17 +19,17 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 
 /// A convenience struct that groups the components of the lease loop.
-pub(crate) struct LeaseLoop {
+pub(super) struct LeaseLoop {
     /// A handle to the task running the lease loop.
-    pub(crate) handle: JoinHandle<()>,
+    pub(super) handle: JoinHandle<()>,
     /// For sending messages from the stream to the lease loop.
-    pub(crate) message_tx: UnboundedSender<String>,
+    pub(super) message_tx: UnboundedSender<String>,
     /// For sending acks/nacks from the application to the lease loop.
-    pub(crate) ack_tx: UnboundedSender<AckResult>,
+    pub(super) ack_tx: UnboundedSender<AckResult>,
 }
 
 impl LeaseLoop {
-    pub(crate) fn new<L>(leaser: L, options: LeaseOptions) -> Self
+    pub(super) fn new<L>(leaser: L, options: LeaseOptions) -> Self
     where
         L: Leaser + Send + 'static,
     {

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 ///
 /// We stub out the interface, in order to test the lease management.
 #[async_trait::async_trait]
-pub(crate) trait Leaser {
+pub(super) trait Leaser {
     /// Acknowledge a batch of messages.
     async fn ack(&self, ack_ids: Vec<String>);
     /// Negatively acknowledge a batch of messages.
@@ -31,7 +31,7 @@ pub(crate) trait Leaser {
     async fn extend(&self, ack_ids: Vec<String>);
 }
 
-pub(crate) struct DefaultLeaser<T>
+pub(super) struct DefaultLeaser<T>
 where
     T: Stub,
 {
@@ -44,7 +44,7 @@ impl<T> DefaultLeaser<T>
 where
     T: Stub,
 {
-    pub(crate) fn new(inner: Arc<T>, subscription: String, ack_deadline_seconds: i32) -> Self {
+    pub(super) fn new(inner: Arc<T>, subscription: String, ack_deadline_seconds: i32) -> Self {
         DefaultLeaser {
             inner,
             subscription,
@@ -96,7 +96,7 @@ where
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub(super) mod tests {
     use super::super::lease_state::tests::test_ids;
     use super::super::stub::tests::MockStub;
     use super::*;
@@ -106,7 +106,7 @@ pub(crate) mod tests {
 
     mockall::mock! {
         #[derive(Debug)]
-        pub(crate) Leaser {}
+        pub(in super::super) Leaser {}
         #[async_trait::async_trait]
         impl Leaser for Leaser {
             async fn ack(&self, ack_ids: Vec<String>);

--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -80,7 +80,7 @@ pub struct Session {
 }
 
 impl Session {
-    pub(crate) async fn new(builder: StreamingPull) -> Result<Self> {
+    pub(super) async fn new(builder: StreamingPull) -> Result<Self> {
         let shutdown = CancellationToken::new();
         let inner = builder.inner;
         let subscription = builder.subscription;
@@ -150,7 +150,7 @@ impl Session {
         }
     }
 
-    pub(crate) async fn stream_next(&mut self) -> Option<Result<()>> {
+    async fn stream_next(&mut self) -> Option<Result<()>> {
         let resp = match self.stream.next_message().await.transpose()? {
             Ok(resp) => resp,
             Err(e) => return Some(Err(to_gax_error(e))),

--- a/src/pubsub/src/subscriber/stream.rs
+++ b/src/pubsub/src/subscriber/stream.rs
@@ -22,7 +22,7 @@ use tokio::sync::mpsc;
 /// Open a stream for the `StreamingPull` RPC.
 ///
 /// This returns the stream and a Sender for feeding the stream writes.
-pub(crate) async fn open_stream<T>(
+pub(super) async fn open_stream<T>(
     inner: Arc<T>,
     initial_req: StreamingPullRequest,
 ) -> Result<(<T as Stub>::Stream, mpsc::Sender<StreamingPullRequest>)>

--- a/src/pubsub/src/subscriber/stub.rs
+++ b/src/pubsub/src/subscriber/stub.rs
@@ -16,7 +16,7 @@ use crate::Result;
 use crate::google::pubsub::v1::{StreamingPullRequest, StreamingPullResponse};
 use tokio::sync::mpsc::Receiver;
 
-pub(crate) trait TonicStreaming: std::fmt::Debug + Send + 'static {
+pub(super) trait TonicStreaming: std::fmt::Debug + Send + 'static {
     fn next_message(
         &mut self,
     ) -> impl Future<Output = tonic::Result<Option<StreamingPullResponse>>> + Send;
@@ -24,7 +24,7 @@ pub(crate) trait TonicStreaming: std::fmt::Debug + Send + 'static {
 
 /// An internal trait for mocking the transport layer.
 #[async_trait::async_trait]
-pub(crate) trait Stub: std::fmt::Debug + Send + Sync {
+pub(super) trait Stub: std::fmt::Debug + Send + Sync {
     type Stream: Sized;
     async fn streaming_pull(
         &self,
@@ -46,7 +46,7 @@ pub(crate) trait Stub: std::fmt::Debug + Send + Sync {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub(super) mod tests {
     use super::*;
     use tokio::sync::mpsc::Receiver;
 
@@ -61,7 +61,7 @@ pub(crate) mod tests {
 
     mockall::mock! {
         #[derive(Debug)]
-        pub(crate) Stub {}
+        pub(in super::super) Stub {}
         #[async_trait::async_trait]
         impl Stub for Stub {
             type Stream = MockStream;

--- a/src/pubsub/src/subscriber/transport.rs
+++ b/src/pubsub/src/subscriber/transport.rs
@@ -15,7 +15,7 @@
 use super::stub::{Stub, TonicStreaming};
 use crate::Result;
 use crate::generated::gapic_dataplane::stub::dynamic::Subscriber as GapicStub;
-pub(crate) use crate::generated::gapic_dataplane::transport::Subscriber as Transport;
+pub(super) use crate::generated::gapic_dataplane::transport::Subscriber as Transport;
 use crate::google::pubsub::v1::{StreamingPullRequest, StreamingPullResponse};
 use tokio::sync::mpsc::Receiver;
 use tokio_stream::wrappers::ReceiverStream;
@@ -24,7 +24,7 @@ mod info {
     const NAME: &str = env!("CARGO_PKG_NAME");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
     lazy_static::lazy_static! {
-        pub(crate) static ref X_GOOG_API_CLIENT_HEADER: String = {
+        pub(super) static ref X_GOOG_API_CLIENT_HEADER: String = {
             let ac = gaxi::api_header::XGoogApiClient{
                 name:          NAME,
                 version:       VERSION,
@@ -90,14 +90,14 @@ impl Stub for Transport {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+pub(super) mod tests {
     use super::*;
     use crate::google::pubsub::v1::ReceivedMessage;
     use auth::credentials::anonymous::Builder as Anonymous;
     use pubsub_grpc_mock::google::pubsub::v1;
     use pubsub_grpc_mock::{MockSubscriber, start};
 
-    pub(crate) async fn test_transport(endpoint: String) -> anyhow::Result<Transport> {
+    pub(in super::super) async fn test_transport(endpoint: String) -> anyhow::Result<Transport> {
         let mut config = gaxi::options::ClientConfig::default();
         config.cred = Some(Anonymous::new().build());
         config.endpoint = Some(endpoint);


### PR DESCRIPTION
Basically, you can only use subscriber internals from within `mod crate::subscriber`.

Noticed in: https://github.com/googleapis/google-cloud-rust/pull/4214#discussion_r2677172656