### PR TITLE
impl(pubsub): introduce streaming_pull RPC

### DIFF
--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::session::Session;
 use super::transport::Transport;
+use crate::Result;
 use std::sync::Arc;
 
 const MIB: i64 = 1024 * 1024;
@@ -37,6 +39,26 @@ impl StreamingPull {
         }
     }
 
+    /// Creates a new session to receive messages from the subscription.
+    ///
+    /// # Example
+    /// ```no_rust
+    /// # use google_cloud_pubsub::client::Subscriber;
+    /// # async fn sample(client: Subscriber) -> anyhow::Result<()> {
+    /// let mut session = client
+    ///     .streaming_pull("projects/my-project/subscriptions/my-subscription")
+    ///     .start()
+    ///     .await?;
+    /// while let Some((m, h)) = session.next().await.transpose()? {
+    ///     println!("Received message m={m:?}");
+    ///     h.ack();
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub async fn start(self) -> Result<Session> {
+        Session::new(self).await
+    }
+
     /// Sets the ack deadline to use for the stream.
     ///
     /// This value represents how long the application has to ack or nack an
@@ -53,7 +75,6 @@ impl StreamingPull {
     /// The default value is 10 seconds.
     ///
     /// # Example
-    ///
     /// ```no_rust
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
@@ -81,7 +102,6 @@ impl StreamingPull {
     /// The default value is 1000 messages.
     ///
     /// # Example
-    ///
     /// ```no_rust
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
@@ -109,7 +129,6 @@ impl StreamingPull {
     /// The default value is 100 MiB.
     ///
     /// # Example
-    ///
     /// ```no_rust
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {

--- a/src/pubsub/src/subscriber/client_builder.rs
+++ b/src/pubsub/src/subscriber/client_builder.rs
@@ -18,6 +18,7 @@ use gaxi::options::ClientConfig;
 
 /// A builder for [Subscriber].
 ///
+/// # Example
 /// ```no_rust
 /// # use google_cloud_pubsub::client::Subscriber;
 /// # async fn sample() -> anyhow::Result<()> {

--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -40,9 +40,10 @@ use tokio_util::sync::{CancellationToken, DropGuard};
 /// # async fn sample(client: Subscriber) -> anyhow::Result<()> {
 /// let mut session = client
 ///     .streaming_pull("projects/my-project/subscriptions/my-subscription")
-///     .start()?;
+///     .start()
+///     .await?;
 /// while let Some((m, h)) = session.next().await.transpose()? {
-///     println!("Received message m={m}");
+///     println!("Received message m={m:?}");
 ///     h.ack();
 /// }
 /// # Ok(()) }
@@ -132,7 +133,7 @@ impl Session {
     /// # use google_cloud_pubsub::subscriber::session::Session;
     /// # async fn sample(mut session: Session) -> anyhow::Result<()> {
     /// while let Some((m, h)) = session.next().await.transpose()? {
-    ///     println!("Received message m={m}");
+    ///     println!("Received message m={m:?}");
     ///     h.ack();
     /// }
     /// # Ok(()) }


### PR DESCRIPTION
Part of the work for #3941 

Add the `streaming_pull` RPC to the subscriber surface. Aside: maybe it should be called `subscribe`... but let's review that later. I am OK with renaming things from a preview release of this client.

While we are here, normalize and fix some of the examples. The examples are repetitive, but I think that is close to what we want.

Note that this is not the final pass on documentation. But I want to get this in to unblock making the structs public and adding an integration test against production.