### PR TITLE
feat(pubsub): add `Subscriber`

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -31,6 +31,9 @@
 //! For publishing messages:
 //! * [Client][client::Client] and [Publisher][client::Publisher]
 //!
+//! For receiving messages:
+//! * [Subscriber][client::Subscriber]
+//!
 //! Receiving messages is not yet supported by this crate.
 //!
 //! **NOTE:** This crate used to contain a different implementation, with a
@@ -45,8 +48,9 @@
 pub(crate) mod generated;
 
 pub(crate) mod publisher;
-#[allow(dead_code)]
-pub(crate) mod subscriber;
+/// Types related to receiving messages with a [Subscriber][client::Subscriber]
+/// client.
+pub mod subscriber;
 
 pub use gax::Result;
 pub use gax::error::Error;
@@ -63,13 +67,18 @@ pub mod builder {
     }
     /// Request and client builders for the [SchemaService][crate::client::SchemaService] client.
     pub use crate::generated::gapic::builder::schema_service;
+    /// Request and client builders for the [Subscriber][crate::client::Subscriber] client.
+    pub mod subscriber {
+        // TODO(#3959) - remove internal types from the public API.
+        #[doc(hidden)]
+        pub use crate::generated::gapic_dataplane::builder::subscriber::*;
+        pub use crate::subscriber::builder::StreamingPull;
+        pub use crate::subscriber::client_builder::ClientBuilder;
+    }
     /// Request and client builders for the [SubscriptionAdmin][crate::client::SubscriptionAdmin] client.
     pub use crate::generated::gapic::builder::subscription_admin;
     /// Request and client builders for the [TopicAdmin][crate::client::TopicAdmin] client.
     pub use crate::generated::gapic::builder::topic_admin;
-    // TODO(#3959) - remove internal types from the public API.
-    #[doc(hidden)]
-    pub use crate::generated::gapic_dataplane::builder::subscriber;
 }
 
 /// The messages and enums that are part of this client library.
@@ -124,6 +133,7 @@ pub mod client {
     pub use crate::generated::gapic::client::*;
     pub use crate::publisher::client::Client;
     pub use crate::publisher::publisher::Publisher;
+    pub use crate::subscriber::client::Subscriber;
 }
 
 /// Traits to mock the clients in this library.

--- a/src/pubsub/src/subscriber.rs
+++ b/src/pubsub/src/subscriber.rs
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod builder;
-mod client;
-mod client_builder;
-mod handler;
+/// Handlers for acknowledging or rejecting messages.
+pub mod handler;
+
+/// Defines the return interface for
+/// [Subscriber::streaming_pull][crate::client::Subscriber::streaming_pull].
+pub mod session;
+
+pub(super) mod builder;
+pub(super) mod client;
+pub(super) mod client_builder;
 mod keepalive;
 mod lease_loop;
 mod lease_state;
 mod leaser;
-mod session;
 mod stream;
 mod stub;
 mod transport;

--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -42,7 +42,7 @@ impl StreamingPull {
     /// Creates a new session to receive messages from the subscription.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample(client: Subscriber) -> anyhow::Result<()> {
     /// let mut session = client
@@ -75,7 +75,7 @@ impl StreamingPull {
     /// The default value is 10 seconds.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// # let client = Subscriber::builder().build().await?;
@@ -102,7 +102,7 @@ impl StreamingPull {
     /// The default value is 1000 messages.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// # let client = Subscriber::builder().build().await?;

--- a/src/pubsub/src/subscriber/client.rs
+++ b/src/pubsub/src/subscriber/client.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 /// Use this client to receive messages from a [pull subscription] on a topic.
 ///
 /// # Example
-/// ```no_rust
+/// ```
 /// # use google_cloud_pubsub::client::Subscriber;
 /// # async fn sample() -> anyhow::Result<()> {
 /// let client = Subscriber::builder().build().await?;
@@ -41,7 +41,7 @@ use std::sync::Arc;
 /// # Configuration
 ///
 /// To configure a `Subscriber` use the `with_*` methods in the type returned by
-/// [builder()][Storage::builder]. The default configuration should work for
+/// [builder()][Subscriber::builder]. The default configuration should work for
 /// most applications. Common configuration changes include:
 ///
 /// * [with_endpoint()]: by default this client uses the global default endpoint
@@ -75,7 +75,7 @@ impl Subscriber {
     /// Returns a builder for [Subscriber].
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = Subscriber::builder().build().await?;
@@ -91,7 +91,7 @@ impl Subscriber {
     /// `projects/*/subscriptions/*`.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample(client: Subscriber) -> anyhow::Result<()> {
     /// let mut session = client
@@ -103,6 +103,7 @@ impl Subscriber {
     ///     h.ack();
     /// }
     /// # Ok(()) }
+    /// ```
     ///
     /// [subscription]: https://docs.cloud.google.com/pubsub/docs/subscription-overview
     pub fn streaming_pull<T>(&self, subscription: T) -> StreamingPull

--- a/src/pubsub/src/subscriber/client_builder.rs
+++ b/src/pubsub/src/subscriber/client_builder.rs
@@ -19,7 +19,7 @@ use gaxi::options::ClientConfig;
 /// A builder for [Subscriber].
 ///
 /// # Example
-/// ```no_rust
+/// ```
 /// # use google_cloud_pubsub::client::Subscriber;
 /// # async fn sample() -> anyhow::Result<()> {
 /// let builder = Subscriber::builder();
@@ -43,7 +43,7 @@ impl ClientBuilder {
     /// Creates a new client.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = Subscriber::builder().build().await?;
@@ -56,7 +56,7 @@ impl ClientBuilder {
     /// Sets the endpoint.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = Subscriber::builder()
@@ -76,7 +76,7 @@ impl ClientBuilder {
     /// [google-cloud-auth] crate documentation.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::client::Subscriber;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use auth::credentials::mds;

--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -35,7 +35,7 @@ use tokio_util::sync::{CancellationToken, DropGuard};
 /// This is a stream-like struct for serving messages to an application.
 ///
 /// # Example
-/// ```no_rust
+/// ```
 /// # use google_cloud_pubsub::client::Subscriber;
 /// # async fn sample(client: Subscriber) -> anyhow::Result<()> {
 /// let mut session = client
@@ -129,7 +129,7 @@ impl Session {
     /// open until it is cancelled or encounters a permanent error.
     ///
     /// # Example
-    /// ```no_rust
+    /// ```
     /// # use google_cloud_pubsub::subscriber::session::Session;
     /// # async fn sample(mut session: Session) -> anyhow::Result<()> {
     /// while let Some((m, h)) = session.next().await.transpose()? {


### PR DESCRIPTION
Part of the work for #3941 

Add the `Subscriber` client, which can receive messages from Cloud Pub/Sub.

An integration test against production is coming in the next PR.

Add a little coverage to the docs. They are still scant. This is not the final pass on them. Docs look like this: [docs.zip](https://github.com/user-attachments/files/24535978/docs.zip). (download, unzip, and open `doc/google_cloud_pubsub/index.html`)