### PR TITLE
refactor(pubsub): use client in unit tests

### DIFF
--- a/src/pubsub/src/subscriber/transport.rs
+++ b/src/pubsub/src/subscriber/transport.rs
@@ -97,7 +97,7 @@ pub(super) mod tests {
     use pubsub_grpc_mock::google::pubsub::v1;
     use pubsub_grpc_mock::{MockSubscriber, start};
 
-    pub(in super::super) async fn test_transport(endpoint: String) -> anyhow::Result<Transport> {
+    async fn test_transport(endpoint: String) -> anyhow::Result<Transport> {
         let mut config = gaxi::options::ClientConfig::default();
         config.cred = Some(Anonymous::new().build());
         config.endpoint = Some(endpoint);


### PR DESCRIPTION
Motivated by #4222 

A pure unit test refactor. Use a client directly instead of going through the builder. (We didn't have a `streaming_pull` method on the client when these tests were written).

I need to change the `StreamingPull::new()` to accept a client ID. All of this code would change.