### PR TITLE
impl(pubsub): identify subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -46,6 +46,7 @@ tokio                  = { workspace = true, features = ["sync"] }
 tokio-stream.workspace = true
 tokio-util.workspace   = true
 tracing.workspace      = true
+uuid.workspace         = true
 wkt.workspace          = true
 
 [dev-dependencies]

--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -23,16 +23,18 @@ const MIB: i64 = 1024 * 1024;
 pub struct StreamingPull {
     pub(super) inner: Arc<Transport>,
     pub(super) subscription: String,
+    pub(super) client_id: String,
     pub(super) ack_deadline_seconds: i32,
     pub(super) max_outstanding_messages: i64,
     pub(super) max_outstanding_bytes: i64,
 }
 
 impl StreamingPull {
-    pub(super) fn new(inner: Arc<Transport>, subscription: String) -> Self {
+    pub(super) fn new(inner: Arc<Transport>, subscription: String, client_id: String) -> Self {
         Self {
             inner,
             subscription,
+            client_id,
             ack_deadline_seconds: 10,
             max_outstanding_messages: 1000,
             max_outstanding_bytes: 100 * MIB,
@@ -165,6 +167,7 @@ mod tests {
         let builder = StreamingPull::new(
             test_inner().await?,
             "projects/my-project/subscriptions/my-subscription".to_string(),
+            "client-id".to_string(),
         );
         assert_eq!(
             builder.subscription,
@@ -190,6 +193,7 @@ mod tests {
         let builder = StreamingPull::new(
             test_inner().await?,
             "projects/my-project/subscriptions/my-subscription".to_string(),
+            "client-id".to_string(),
         )
         .set_ack_deadline_seconds(20)
         .set_max_outstanding_messages(12345)

--- a/src/pubsub/src/subscriber/client.rs
+++ b/src/pubsub/src/subscriber/client.rs
@@ -69,6 +69,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct Subscriber {
     inner: Arc<Transport>,
+    client_id: String,
 }
 
 impl Subscriber {
@@ -110,13 +111,18 @@ impl Subscriber {
     where
         T: Into<String>,
     {
-        StreamingPull::new(self.inner.clone(), subscription.into())
+        StreamingPull::new(
+            self.inner.clone(),
+            subscription.into(),
+            self.client_id.clone(),
+        )
     }
 
     pub(super) async fn new(builder: ClientBuilder) -> BuilderResult<Self> {
         let transport = Transport::new(builder.config).await?;
         Ok(Self {
             inner: Arc::new(transport),
+            client_id: uuid::Uuid::new_v4().to_string(),
         })
     }
 }


### PR DESCRIPTION
Fixes #4222 

This identifier helps the server recover state on retries and make routing decisions.