### PR TITLE
refactor(pubsub): prepare for lease expirations

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -14,6 +14,7 @@
 
 use super::leaser::Leaser;
 use std::collections::HashMap;
+// Use a `tokio::time::Instant` to facilitate time-based unit testing.
 use tokio::time::{Duration, Instant, Interval, interval_at};
 
 // An ack ID is less than 200 bytes. The limit for a request is 512kB. It should


### PR DESCRIPTION
Part of the work for #4211

Keep track of when a message was accepted under lease management.

The next PR will use this information to decide if a message should be dropped from lease management, because it has been held for too long.