### PR TITLE
cleanup(pubsub): determine no-ops earlier

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -135,12 +135,6 @@ mod tests {
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(0..10))
                 .returning(move |_| ());
-            mock.lock()
-                .await
-                .expect_nack()
-                .times(1)
-                .withf(|v| v.is_empty())
-                .returning(|_| ());
             tokio::time::advance(FLUSH_START).await;
 
             // Yield the current task, so tokio can execute the flush().
@@ -155,12 +149,6 @@ mod tests {
 
         // Advance to and validate the second flush
         {
-            mock.lock()
-                .await
-                .expect_ack()
-                .times(1)
-                .withf(|v| v.is_empty())
-                .returning(move |_| ());
             mock.lock()
                 .await
                 .expect_nack()
@@ -378,12 +366,6 @@ mod tests {
                     .expect_ack()
                     .times(1)
                     .withf(|v| *v == vec![test_id(1)])
-                    .returning(|_| ());
-                mock.lock()
-                    .await
-                    .expect_nack()
-                    .times(1)
-                    .withf(|v| v.is_empty())
                     .returning(|_| ());
                 tokio::time::advance(Duration::from_millis(100)).await;
 

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -65,18 +65,12 @@ where
     T: Stub,
 {
     async fn ack(&self, ack_ids: Vec<String>) {
-        if ack_ids.is_empty() {
-            return;
-        }
         let req = AcknowledgeRequest::new()
             .set_subscription(self.subscription.clone())
             .set_ack_ids(ack_ids);
         let _ = self.inner.acknowledge(req, no_retry()).await;
     }
     async fn nack(&self, ack_ids: Vec<String>) {
-        if ack_ids.is_empty() {
-            return;
-        }
         let req = ModifyAckDeadlineRequest::new()
             .set_subscription(self.subscription.clone())
             .set_ack_ids(ack_ids)
@@ -84,9 +78,6 @@ where
         let _ = self.inner.modify_ack_deadline(req, no_retry()).await;
     }
     async fn extend(&self, ack_ids: Vec<String>) {
-        if ack_ids.is_empty() {
-            return;
-        }
         let req = ModifyAckDeadlineRequest::new()
             .set_subscription(self.subscription.clone())
             .set_ack_ids(ack_ids)
@@ -204,21 +195,5 @@ pub(super) mod tests {
             10,
         );
         leaser.extend(test_ids(0..10)).await;
-    }
-
-    #[tokio::test]
-    async fn empty_is_noop() {
-        let mock = MockStub::new();
-        // We expect no calls on the mock stub, as there is no reason to send an
-        // RPC with an empty list of ack IDs.
-
-        let leaser = DefaultLeaser::new(
-            Arc::new(mock),
-            "projects/my-project/subscriptions/my-subscription".to_string(),
-            10,
-        );
-        leaser.ack(Vec::new()).await;
-        leaser.nack(Vec::new()).await;
-        leaser.extend(Vec::new()).await;
     }
 }


### PR DESCRIPTION
Motivated by #3975 

Bail on no-ops from the `LeaseState` instead of the `Leaser`.

This will help us optimize the lease loop performance. It already simplifies test expectations.

---

More context on the motivation:

I need to clone the `Leaser` and move it into a background task. I don't want the `Leaser` to hold a subscription and then clone the subscription again for every call. So we should make the `Leaser` functional. (i.e. it will accept a `subscription: String`).

I do not want to be cloning that subscription string when the `DefaultLeaser` will just bail. I also don't want to be passing references around.