### PR TITLE
fix(librarian): add back release.tools.cargo to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -36,6 +36,12 @@ release:
     - .repo-metadata.json
     - .sidekick.toml
   remote: upstream
+  tools:
+    cargo:
+      - name: cargo-semver-checks
+        version: 0.44.0
+      - name: cargo-workspaces
+        version: 0.4.0
 default:
   output: src/generated/
   release_level: stable


### PR DESCRIPTION
This was in [.sidekick.toml](https://github.com/ldetmer/google-cloud-rust/blob/c77f39656962ea96e0ee505adcf9f59a7702d72d/.sidekick.toml#L97-L103) but missed in librarian.yaml during migration.

verified locally, now install cargo tool steps are done. 
```
╰─$ librarian publish --dry-run                                             
Running: /usr/bin/git --version
Running: /usr/bin/git remote get-url upstream
Running: /usr/local/google/home/zhumin/.cargo/bin/cargo --version
2026/01/14 11:35:49 INFO installing cargo tool name=cargo-semver-checks version=0.44.0
Running: /usr/local/google/home/zhumin/.cargo/bin/cargo install --locked cargo-semver-checks@0.44.0
2026/01/14 11:35:49 INFO installing cargo tool name=cargo-workspaces version=0.4.0
Running: /usr/local/google/home/zhumin/.cargo/bin/cargo install --locked cargo-workspaces@0.4.0
```

Fix https://github.com/googleapis/librarian/issues/3534