### PR TITLE
fix: force http1 only

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -58,6 +58,7 @@ impl ReqwestClient {
         let cred = Self::make_credentials(&config).await?;
         let mut builder = reqwest::Client::builder();
         // Force http1 as http2 with not currently supported.
+        // TODO(#4298): Remove after adding HTTP2 support.
         builder = builder.http1_only();
         if config.disable_automatic_decompression {
             builder = builder.no_gzip().no_brotli().no_deflate();


### PR DESCRIPTION
Force reqwest to use http1 only as we currently do not support HTTP2 in our clients.