### PR TITLE
fix(librarian.yaml): fix path for secretmanager-openapi-v1

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1593,7 +1593,7 @@ libraries:
   - name: secretmanager-openapi-v1
     version: 1.0.0
     channels:
-      - path: google/cloud/secretmanager/v1
+      - path: testdata/secretmanager_openapi_v1.json
     copyright_year: "2024"
     output: src/generated/openapi-validation
     skip_publish: true


### PR DESCRIPTION
The channel path should be testdata/secretmanager_openapi_v1.json not google/cloud/secretmanager/v1.