### PR TITLE
doc: update librarian commands used

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -40,12 +40,16 @@ run the necessary tests:
 
 ```bash
 V=$(cat .librarian-version.txt)
-go run github.com/googleapis/librarian/cmd/librarian@${V} create ${library}
+# add library to librarian.yaml
+go run github.com/googleapis/librarian/cmd/librarian@${V} add ${library}
+# generate library
+go run github.com/googleapis/librarian/cmd/librarian@${V} generate ${library}
 ```
 
 Commit all these changes and send a PR to merge them:
 
 ```bash
+git add .
 git commit -m "feat(${library}): generate library"
 ```
 
@@ -81,7 +85,7 @@ Run:
 git fetch upstream
 git checkout -b chore-bump-version-numbers-circa-$(date +%Y-%m-%d)
 V=$(cat .librarian-version.txt)
-go run github.com/googleapis/librarian/cmd/librarian@${V} release --all
+go run github.com/googleapis/librarian/cmd/librarian@${V} bump --all
 git add Cargo.lock '*Cargo.toml' '*README.md'
 git restore . # Effectively a `cargo fmt`, but much faster.
 git commit -m"chore: bump version numbers circa $(date +%Y-%m-%d)"


### PR DESCRIPTION
Update how-to guide commands after recent renames in Librarian CLI. 

Context:
https://github.com/googleapis/librarian/pull/3498
https://github.com/googleapis/librarian/pull/3644