### PR TITLE
chore: update guide on bump versions

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -86,7 +86,8 @@ git fetch upstream
 git checkout -b chore-bump-version-numbers-circa-$(date +%Y-%m-%d)
 V=$(cat .librarian-version.txt)
 go run github.com/googleapis/librarian/cmd/librarian@${V} bump --all
-git add Cargo.lock '*Cargo.toml' '*README.md'
+go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
+git add Cargo.lock librarian.yaml '*Cargo.toml' '*README.md'
 git restore . # Effectively a `cargo fmt`, but much faster.
 git commit -m"chore: bump version numbers circa $(date +%Y-%m-%d)"
 ```


### PR DESCRIPTION
We recently removed generate step from bump command (https://github.com/googleapis/librarian/issues/3511), update guide to call `generate` separately. Also added librarian.yaml to list of files to stage.