### PR TITLE
refactor(auth): simplify `lib.rs` structure

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Types and functions to work with Google Cloud authentication [Credentials].
+//!
+//! [Credentials]: https://cloud.google.com/docs/authentication#credentials
+
 use crate::build_errors::Error as BuilderError;
 use crate::constants::GOOGLE_CLOUD_QUOTA_PROJECT_VAR;
 use crate::errors::{self, CredentialsError};

--- a/src/auth/src/headers_util.rs
+++ b/src/auth/src/headers_util.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Headers utility functions to work with Google Cloud authentication [Credentials].
+//!
+//! [Credentials]: https://cloud.google.com/docs/authentication#credentials
+
 use crate::Result;
 use crate::credentials::{CacheableResource, QUOTA_PROJECT_KEY};
 use crate::errors;

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -46,34 +46,18 @@
 //! [Credentials]: https://cloud.google.com/docs/authentication#credentials
 
 pub mod build_errors;
+pub(crate) mod constants;
+pub mod credentials;
 pub mod errors;
+pub(crate) mod headers_util;
+pub(crate) mod mds;
+pub(crate) mod retry;
+pub mod signer;
+pub(crate) mod token;
+pub(crate) mod token_cache;
 
 /// A `Result` alias where the `Err` case is [BuildCredentialsError].
 pub(crate) type BuildResult<T> = std::result::Result<T, build_errors::Error>;
 
-/// Types and functions to work with Google Cloud authentication [Credentials].
-///
-/// [Credentials]: https://cloud.google.com/docs/authentication#credentials
-pub mod credentials;
-
-pub(crate) mod constants;
-
-pub(crate) mod mds;
-
-pub(crate) mod token;
-
-/// The token cache
-pub(crate) mod token_cache;
-
 /// A `Result` alias where the `Err` case is [CredentialsError][errors::CredentialsError].
 pub(crate) type Result<T> = std::result::Result<T, errors::CredentialsError>;
-
-/// The retry module
-pub(crate) mod retry;
-
-/// Headers utility functions to work with Google Cloud authentication [Credentials].
-///
-/// [Credentials]: https://cloud.google.com/docs/authentication#credentials
-pub(crate) mod headers_util;
-
-pub mod signer;

--- a/src/auth/src/retry.rs
+++ b/src/auth/src/retry.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! The retry module
+
 use crate::errors::CredentialsError;
 use crate::token::{Token, TokenProvider};
 use crate::{Result, constants};

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! The token cache
+
 use crate::Result;
 use crate::credentials::{CacheableResource, EntityTag};
 use crate::token::{CachedTokenProvider, Token, TokenProvider};


### PR DESCRIPTION
Make it easier to add modules and to find what modules do exist.