### PR TITLE
docs(auth): how-to migrate from 1.4.0 features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +255,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -304,6 +328,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "common"
@@ -548,6 +581,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +796,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -5832,6 +5877,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6894,6 +6949,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -6931,6 +6987,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -56,6 +56,7 @@ httptest.workspace    = true
 mockall.workspace     = true
 regex.workspace       = true
 rsa                   = { workspace = true, features = ["pem"] }
+rustls                = { workspace = true, features = ["aws_lc_rs", "ring"] }
 scoped-env.workspace  = true
 serial_test.workspace = true
 tempfile.workspace    = true

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -43,6 +43,12 @@
 //!     `features = ["idtoken"]`
 //!   - Select the desired backend for `jsonwebtoken`.
 //!
+//! # Manual
+//!
+//! The [google-cloud-auth manual][manual] contains documentation about crate
+//! limitations, caveats, migration guides between versions, and in general any
+//! documentation that is too large to include here.
+//!
 //! [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 //! [ring]: https://crates.io/crates/ring
 //! [jsonwebtoken]: https://crates.io/crates/jsonwebtoken
@@ -57,6 +63,7 @@ pub(crate) mod constants;
 pub mod credentials;
 pub mod errors;
 pub(crate) mod headers_util;
+pub mod manual;
 pub(crate) mod mds;
 pub(crate) mod retry;
 pub mod signer;

--- a/src/auth/src/manual.rs
+++ b/src/auth/src/manual.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Additional documentation for `google-cloud-auth`.
+//!
+//! This module contains documentation about crate limitations, caveats,
+//! migration guides between versions, and in general any documentation that is
+//! too large to include in the top-level module documentation.
+
+pub mod _migrate_from_1_4_x_features;

--- a/src/auth/src/manual/_migrate_from_1_4_x_features.rs
+++ b/src/auth/src/manual/_migrate_from_1_4_x_features.rs
@@ -1,0 +1,91 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Introduction
+//!
+//! The 1.5.0 release introduces different features to control the default
+//! [rustls] crypto provider, applications using `google-cloud-auth` with the
+//! default features disabled[^1] may need to enable some features to select
+//! the right crypto provider. This guide discusses how to change your
+//! application to use the new features.
+//!
+//! # Using default crypto provider
+//!
+//! If you have no preference about what crypto provider, just add the
+//! `default-rustls-provider` feature. Edit your `Cargo.toml` file, for example,
+//! change the `google-cloud-auth` dependency from:
+//!
+//! ```toml
+//! [dependencies.google-cloud-auth]
+//! version = "1"
+//! default-features = false
+//! ```
+//!
+//! to:
+//!
+//! ```toml
+//! [dependencies.google-cloud-auth]
+//! version = "1"
+//! default-features = false
+//! features = ["default-rustls-provider"]
+//! ```
+//!
+//! # Selecting your own crypto provider
+//!
+//! The current default crypto provider is [ring]. This default may change in
+//! the future. If you need to use a different crypto provider or want to
+//! isolate your application from future changes on the default provider, then
+//! you need to change your `main()` function to install a different provider.
+//!
+//! Furthermore, you may want to disable the default provider to prune the
+//! `ring` dependency from your dependency graph.
+//!
+//! In this guide we will use [aws-lc-rs]. The changes to use other providers
+//! are similar. Consult the `rustls` documentation to find out about available
+//! providers.
+//!
+//! First, modify your `Cargo.toml` to disable the default provider and to
+//! depend on `rustls` with the desired provider enabled:
+//!
+//! ```toml
+//! [dependencies]
+//! google-cloud-auth = { version = "1", default-features = false }
+//! rustls            = { version = "0.23", features = ["aws_lc_rs"] }
+//! ```
+//!
+//! <div class="warning">
+//! You must use the same version of `rustls` as `google-cloud-auth`.
+//! </div>
+//!
+//! Then change your `main()` function to install this provider:
+//!
+//! ```
+//! use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // Install a default crypto provider.
+//!     CryptoProvider::install_default(default_provider())
+//!         .map_err(|_| anyhow::anyhow!("default crypto provider already installed"))?;
+//!     // ... ... ...
+//!     Ok(())
+//! }
+//! ```
+//!
+//! [^1]: Either via `cargo add --no-default-features` or via
+//!       `default-features = false` in your `Cargo.toml` file.
+//!
+//! [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
+//! [ring]: https://crates.io/crates/ring
+//! [rustls]: https://crates.io/crates/rustls


### PR DESCRIPTION
In 1.5.0 we are introducing new default features, which may require some applications to change how they depend on and initialize their client.

Part of the work for #4170 , probably should wait until #4220 is merged.

[google_cloud_auth__manual___migrate_from_1_4_x_features - Rust.pdf](https://github.com/user-attachments/files/24824688/google_cloud_auth__manual___migrate_from_1_4_x_features.-.Rust.pdf)
