### PR TITLE
feat(gax-internal): prune crypto provider dependencies

### DIFF
--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -35,6 +35,7 @@ features = []
 workspace = true
 
 [features]
+default = ["_default-rustls-provider"]
 _internal-http-client = [
   "_internal-common",
   "dep:bytes",
@@ -72,6 +73,7 @@ _internal-grpc-client = [
   "dep:wkt",
 ]
 _internal-common = ["dep:gax", "dep:google-cloud-auth", "dep:percent-encoding", "dep:thiserror"]
+_default-rustls-provider = ["google-cloud-auth?/default-rustls-provider"]
 
 [dependencies]
 bytes                              = { workspace = true, optional = true, features = ["serde"] }
@@ -96,7 +98,7 @@ tonic-prost                        = { workspace = true, optional = true }
 tower                              = { workspace = true, optional = true }
 tracing                            = { workspace = true, optional = true }
 # Local crates
-google-cloud-auth = { workspace = true, optional = true, features = ["default-rustls-provider"] }
+google-cloud-auth = { workspace = true, optional = true }
 gax               = { workspace = true, optional = true }
 rpc               = { workspace = true, optional = true }
 wkt               = { workspace = true, optional = true }

--- a/tests/crypto-providers/auth-without-default/Cargo.toml
+++ b/tests/crypto-providers/auth-without-default/Cargo.toml
@@ -31,7 +31,7 @@ rust-version = "1.92.0"
 
 [dependencies]
 anyhow        = { default-features = false, version = "1", features = ["std"] }
-rustls        = { default-features = false, version = "0.23", features = ["ring"] }
+rustls        = { default-features = false, version = "0.23" }
 tokio         = { default-features = false, version = "1", features = ["test-util"] }
 test-metadata = { default-features = false, path = "../test-metadata" }
 test-auth     = { default-features = false, path = "../test-auth" }

--- a/tests/crypto-providers/auth-without-default/src/main.rs
+++ b/tests/crypto-providers/auth-without-default/src/main.rs
@@ -16,7 +16,7 @@ use rustls::crypto::{ring::default_provider, CryptoProvider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), true)?;
 
     // Install a default crypto provider.
     CryptoProvider::install_default(default_provider())

--- a/tests/crypto-providers/gaxi-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/gaxi-with-aws-lc-rs/src/main.rs
@@ -16,7 +16,8 @@ use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    // TODO(#4170) - use `pruned == true` when we switch the default provider.
+    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), false)?;
 
     // Install a default crypto provider and verify gax-internal works.
     CryptoProvider::install_default(default_provider())

--- a/tests/crypto-providers/gaxi-with-ring/src/main.rs
+++ b/tests/crypto-providers/gaxi-with-ring/src/main.rs
@@ -16,7 +16,7 @@ use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), true)?;
 
     // Install a default crypto provider and verify gax-internal works.
     CryptoProvider::install_default(default_provider())

--- a/tests/crypto-providers/secret-manager-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/secret-manager-with-aws-lc-rs/src/main.rs
@@ -16,7 +16,8 @@ use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    // TODO(#4170) - use `pruned == true`.
+    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), false)?;
 
     // Install a default crypto provider and verify the secret manager client
     // library works.

--- a/tests/crypto-providers/secret-manager-with-ring/src/main.rs
+++ b/tests/crypto-providers/secret-manager-with-ring/src/main.rs
@@ -16,7 +16,8 @@ use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    // TODO(#4170) - use `pruned == true`.
+    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), false)?;
 
     // Install a default crypto provider and verify the secret manager client
     // library works.

--- a/tests/crypto-providers/storage-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/storage-with-aws-lc-rs/src/main.rs
@@ -16,7 +16,8 @@ use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    // TODO(#4170) - use `pruned == true`.
+    test_metadata::only_aws_lc_rs(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), false)?;
 
     // Install a default crypto provider and verify storage works.
     CryptoProvider::install_default(default_provider())

--- a/tests/crypto-providers/storage-with-ring/src/main.rs
+++ b/tests/crypto-providers/storage-with-ring/src/main.rs
@@ -16,7 +16,8 @@ use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;
+    // TODO(#4170) - use `pruned == true`.
+    test_metadata::only_ring(env!("CARGO"), env!("CARGO_MANIFEST_DIR"), false)?;
 
     // Install a default crypto provider and verify storage works.
     CryptoProvider::install_default(default_provider())

--- a/tests/crypto-providers/test-gaxi/Cargo.toml
+++ b/tests/crypto-providers/test-gaxi/Cargo.toml
@@ -52,7 +52,4 @@ path             = "../../../src/gax-internal"
 features = ["_internal-http-client"]
 
 [features]
-with-default = [
-  # TODO(#4170) - enable when gax-internal is ready
-  # "google-cloud-gax-internal/_default-rustls-provider"
-]
+with-default = ["google-cloud-gax-internal/_default-rustls-provider"]

--- a/tests/crypto-providers/test-metadata/src/lib.rs
+++ b/tests/crypto-providers/test-metadata/src/lib.rs
@@ -39,10 +39,11 @@ pub fn has_default_crypto_provider(cargo: &str, dir: &str) -> anyhow::Result<()>
     if !features.contains(&FeatureName::new(RUSTLS_DEFAULT_FEATURE.to_string())) {
         bail!("rustls should have {RUSTLS_DEFAULT_FEATURE} enabled")
     }
-    only_ring(cargo, dir)
+    // TODO(#4170) - use `true` for the pruned parameter.
+    only_ring(cargo, dir, false)
 }
 
-pub fn only_aws_lc_rs(cargo: &str, dir: &str) -> anyhow::Result<()> {
+pub fn only_aws_lc_rs(cargo: &str, dir: &str, pruned: bool) -> anyhow::Result<()> {
     use std::process::Stdio;
     let output = std::process::Command::new(cargo)
         .args(["tree"])
@@ -53,11 +54,9 @@ pub fn only_aws_lc_rs(cargo: &str, dir: &str) -> anyhow::Result<()> {
         bail!("cargo tree failed: {output:?}")
     }
     let stdout = String::try_from(output.stdout)?;
-    // TODO(#4170) - enable this code
-    // if stdout.contains(format!(" {RING_CRATE_NAME} ").as_str())
-    // {
-    //     bail!("{RING_CRATE_NAME} should **not** be a dependency")
-    // }
+    if pruned && stdout.contains(format!(" {RING_CRATE_NAME} ").as_str()) {
+        bail!("{RING_CRATE_NAME} should **not** be a dependency")
+    }
     if !stdout.contains(format!(" {AWS_LC_RS_CRATE_NAME} ").as_str()) {
         bail!(
             "{AWS_LC_RS_CRATE_NAME} should be a dependency: {}",
@@ -67,7 +66,7 @@ pub fn only_aws_lc_rs(cargo: &str, dir: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn only_ring(cargo: &str, dir: &str) -> anyhow::Result<()> {
+pub fn only_ring(cargo: &str, dir: &str, pruned: bool) -> anyhow::Result<()> {
     use std::process::Stdio;
     let output = std::process::Command::new(cargo)
         .args(["tree"])
@@ -81,11 +80,9 @@ pub fn only_ring(cargo: &str, dir: &str) -> anyhow::Result<()> {
     if !stdout.contains(format!(" {RING_CRATE_NAME} ").as_str()) {
         bail!("{RING_CRATE_NAME} should be a dependency")
     }
-    // TODO(#4170) - enable this code
-    // if stdout.contains(format!(" {AWS_LC_RS_CRATE_NAME} ").as_str())
-    // {
-    //     bail!("{AWS_LC_RS_CRATE_NAME} should **not** be a dependency")
-    // }
+    if pruned && stdout.contains(format!(" {AWS_LC_RS_CRATE_NAME} ").as_str()) {
+        bail!("{AWS_LC_RS_CRATE_NAME} should **not** be a dependency")
+    }
     Ok(())
 }
 


### PR DESCRIPTION
By default we enable the default crypto provider in our dependencies. We need some mechanism to completely prune them, because (a) some customers cannot use `aws-lc-rs` (contains C code), and (b) some customers cannot use `ring` (not FIPS compliant).

Fixes #4235 
