### PR TITLE
fix(user-guide): samples need auth default features

### DIFF
--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -34,7 +34,7 @@ httptest.workspace                      = true
 futures.workspace                       = true
 reqwest.workspace                       = true
 google-cloud-aiplatform-v1              = { workspace = true, default-features = false, features = ["prediction-service"] }
-google-cloud-auth                       = { workspace = true, features = ["idtoken"] }
+google-cloud-auth                       = { workspace = true, features = ["default-idtoken-backend", "idtoken"] }
 google-cloud-gax                        = { workspace = true, features = ["unstable-stream"] }
 google-cloud-iam-v1                     = { workspace = true }
 google-cloud-language-v2.workspace      = true


### PR DESCRIPTION
Our CI largely uses  `cargo test --workspace` which works. Meanwhile, `cargo test --package user-guide-samples` does not.
