### PR TITLE
cleanup: simplify integration test maintenance

### DIFF
--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -42,38 +42,20 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -e
-      cargo test --features run-integration-tests \
-        --package integration-tests \
-        --package user-guide-samples \
-        --package storage-samples \
-        --package pubsub-samples
-      cargo test --features run-integration-tests \
-        --package integration-tests-dns-v1
-      cargo build --package storage-samples --profile=test --all-features
-      cargo build --package pubsub-samples --profile=test --all-features
+      cargo test --features run-integration-tests --workspace --tests
   - id: Validate default crypto provider behavior
     name: 'rust:${_RUST_VERSION}-bookworm'
+    # For these tests, we need to run them one package at a time. Otherwise all
+    # the features are unified, and these tests are trying to test one feature
+    # at a time.
     script: |
       #!/usr/bin/env bash
       set -e
       rustup component add clippy
       echo "Verify crypto providers behavior"
-      directories=(
-        tests/crypto-providers/auth-with-default
-        tests/crypto-providers/auth-without-default
-        tests/crypto-providers/idtoken-with-default
-        tests/crypto-providers/idtoken-with-aws-lc-rs
-        tests/crypto-providers/idtoken-with-rust-crypto
-        tests/crypto-providers/gaxi-with-default
-        tests/crypto-providers/gaxi-with-aws-lc-rs
-        tests/crypto-providers/gaxi-with-ring
-        tests/crypto-providers/secret-manager-with-default
-        tests/crypto-providers/secret-manager-with-aws-lc-rs
-        tests/crypto-providers/secret-manager-with-ring
-        tests/crypto-providers/storage-with-default
-        tests/crypto-providers/storage-with-aws-lc-rs
-        tests/crypto-providers/storage-with-ring
-      )
+      mapfile -t directories < <(git ls-files -- 'tests/crypto-providers/**Cargo.toml' |
+          xargs -I{} dirname {} |
+          grep -v test-)
       for dir in "${directories[@]}"; do
         echo "Running test in ${dir}"
         # Handle problems updating the `Cargo.lock` files. The first

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,29 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "auth-integration-tests"
-version = "0.0.0"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "google-cloud-auth",
- "google-cloud-bigquery-v2",
- "google-cloud-gax",
- "google-cloud-iam-credentials-v1",
- "google-cloud-language-v2",
- "google-cloud-secretmanager-v1",
- "httptest",
- "reqwest",
- "scoped-env",
- "serde_json",
- "serial_test",
- "tempfile",
- "test-case",
- "tokio",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5820,6 +5797,29 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "integration-tests-auth"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "google-cloud-auth",
+ "google-cloud-bigquery-v2",
+ "google-cloud-gax",
+ "google-cloud-iam-credentials-v1",
+ "google-cloud-language-v2",
+ "google-cloud-secretmanager-v1",
+ "httptest",
+ "reqwest",
+ "scoped-env",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "test-case",
+ "tokio",
 ]
 
 [[package]]

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -38,7 +38,8 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -e
-      cargo test --features run-integration-tests -p auth-integration-tests
+      cargo test --features run-auth-integration-tests \
+        --package integration-tests-auth
   - id: 'Run External Account integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
     env:
@@ -48,7 +49,10 @@ steps:
     script: |
       #!/usr/bin/env bash
       set -e
-      cargo test run_workload_ --features run-integration-tests --features run-byoid-integration-tests -p auth-integration-tests
+      cargo test run_workload_ \
+        --features run-auth-integration-tests \
+        --features run-byoid-integration-tests \
+        --package integration-tests-auth
 substitutions:
   _RUST_VERSION: '1.92'
   _SCCACHE_VERSION: 'v0.12.0'

--- a/tests/integration-auth/Cargo.toml
+++ b/tests/integration-auth/Cargo.toml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 [package]
-name              = "auth-integration-tests"
+name              = "integration-tests-auth"
 description       = "Integration tests for google-cloud-auth."
 version           = "0.0.0"
 edition.workspace = true
 publish           = false
 
 [features]
-run-integration-tests       = []
+run-auth-integration-tests  = []
 run-byoid-integration-tests = []
 
 [dependencies]

--- a/tests/integration-auth/README.md
+++ b/tests/integration-auth/README.md
@@ -8,7 +8,8 @@ The resources needed should already exist. We can just run the tests.
 
 ```sh
 env GOOGLE_CLOUD_PROJECT=rust-auth-testing \
-  cargo test --features run-integration-tests -p auth-integration-tests
+  cargo test --features run-auth-integration-tests \
+    --package integration-tests-auth
 ```
 
 ### Workload Identity integration tests
@@ -32,7 +33,10 @@ GOOGLE_PROJECT_NUMBER=$(gcloud projects describe ${GOOGLE_CLOUD_PROJECT} --forma
 env GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT} \
 EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL=testsa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com \
 GOOGLE_WORKLOAD_IDENTITY_OIDC_AUDIENCE=//iam.googleapis.com/projects/${GOOGLE_PROJECT_NUMBER}/locations/global/workloadIdentityPools/google-idp/providers/google-idp \
-cargo test run_workload_ --features run-integration-tests --features run-byoid-integration-tests -p auth-integration-tests
+cargo test run_workload_ \
+    --features run-auth-integration-tests \
+    --features run-byoid-integration-tests \
+    --package integration-tests-auth
 ```
 
 #### Rotating the service account key
@@ -166,7 +170,10 @@ GOOGLE_PROJECT_NUMBER=$(gcloud projects describe ${GOOGLE_CLOUD_PROJECT} --forma
 env GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT} \
     EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL=testsa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com \
     GOOGLE_WORKLOAD_IDENTITY_OIDC_AUDIENCE=//iam.googleapis.com/projects/${GOOGLE_PROJECT_NUMBER}/locations/global/workloadIdentityPools/google-idp/providers/google-idp \
-    cargo test run_workload_ --features run-integration-tests --features run-byoid-integration-tests -p auth-integration-tests
+    cargo test run_workload_ \
+        --features run-auth-integration-tests \
+        --features run-byoid-integration-tests \
+        --package integration-tests-auth
 ```
 
 If you are done with the resources, you can destroy them with:

--- a/tests/integration-auth/tests/driver.rs
+++ b/tests/integration-auth/tests/driver.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "run-integration-tests"))]
+#[cfg(all(test, feature = "run-auth-integration-tests"))]
 mod driver {
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
     use test_case::test_case;
@@ -20,25 +20,25 @@ mod driver {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_service_account() -> anyhow::Result<()> {
-        auth_integration_tests::service_account().await
+        integration_tests_auth::service_account().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_service_account_with_audience() -> anyhow::Result<()> {
-        auth_integration_tests::service_account_with_audience().await
+        integration_tests_auth::service_account_with_audience().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_impersonated() -> anyhow::Result<()> {
-        auth_integration_tests::impersonated().await
+        integration_tests_auth::impersonated().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_api_key() -> anyhow::Result<()> {
-        auth_integration_tests::api_key().await
+        integration_tests_auth::api_key().await
     }
 
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
@@ -48,7 +48,7 @@ mod driver {
     async fn run_workload_identity_provider_url_sourced(
         with_impersonation: bool,
     ) -> anyhow::Result<()> {
-        auth_integration_tests::workload_identity_provider_url_sourced(with_impersonation).await
+        integration_tests_auth::workload_identity_provider_url_sourced(with_impersonation).await
     }
 
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
@@ -56,7 +56,7 @@ mod driver {
     #[serial_test::serial]
     async fn run_workload_identity_provider_executable_sourced_with_impersonation()
     -> anyhow::Result<()> {
-        auth_integration_tests::workload_identity_provider_executable_sourced(true).await
+        integration_tests_auth::workload_identity_provider_executable_sourced(true).await
     }
 
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
@@ -64,14 +64,14 @@ mod driver {
     #[serial_test::serial]
     async fn run_workload_identity_provider_executable_sourced_without_impersonation()
     -> anyhow::Result<()> {
-        auth_integration_tests::workload_identity_provider_executable_sourced(false).await
+        integration_tests_auth::workload_identity_provider_executable_sourced(false).await
     }
 
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_workload_identity_provider_programmatic_sourced() -> anyhow::Result<()> {
-        auth_integration_tests::workload_identity_provider_programmatic_sourced().await
+        integration_tests_auth::workload_identity_provider_programmatic_sourced().await
     }
 
     #[cfg(all(test, feature = "run-byoid-integration-tests"))]
@@ -81,20 +81,20 @@ mod driver {
     async fn run_workload_identity_provider_file_sourced(
         with_impersonation: bool,
     ) -> anyhow::Result<()> {
-        auth_integration_tests::workload_identity_provider_file_sourced(with_impersonation).await
+        integration_tests_auth::workload_identity_provider_file_sourced(with_impersonation).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_mds_id_token() -> anyhow::Result<()> {
-        auth_integration_tests::mds_id_token().await
+        integration_tests_auth::mds_id_token().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_id_token_adc() -> anyhow::Result<()> {
         let with_impersonation = false;
-        auth_integration_tests::id_token_adc(with_impersonation).await
+        integration_tests_auth::id_token_adc(with_impersonation).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -103,18 +103,18 @@ mod driver {
     // builder and email claim is included in the token.
     async fn run_id_token_adc_impersonated() -> anyhow::Result<()> {
         let with_impersonation = true;
-        auth_integration_tests::id_token_adc(with_impersonation).await
+        integration_tests_auth::id_token_adc(with_impersonation).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_id_token_service_account() -> anyhow::Result<()> {
-        auth_integration_tests::id_token_service_account().await
+        integration_tests_auth::id_token_service_account().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[serial_test::serial]
     async fn run_id_token_impersonated() -> anyhow::Result<()> {
-        auth_integration_tests::id_token_impersonated().await
+        integration_tests_auth::id_token_impersonated().await
     }
 }


### PR DESCRIPTION
Rename the feature to enable the `auth`. Then we can run all the integration tests in the workspace with a single command. That makes it easier to maintain the build scripts. That in turn makes it easier to refactor integration tests to different crates and reduce build dependencies.