### PR TITLE
refactor(pubsub): Stream holder

### DIFF
--- a/src/pubsub/src/subscriber/stub.rs
+++ b/src/pubsub/src/subscriber/stub.rs
@@ -25,7 +25,7 @@ pub(super) trait TonicStreaming: std::fmt::Debug + Send + 'static {
 /// An internal trait for mocking the transport layer.
 #[async_trait::async_trait]
 pub(super) trait Stub: std::fmt::Debug + Send + Sync {
-    type Stream: Sized;
+    type Stream: Sized + std::fmt::Debug;
     async fn streaming_pull(
         &self,
         request_rx: Receiver<StreamingPullRequest>,


### PR DESCRIPTION
Part of the work for #4097 

Consolidate the tonic stream and the drop guard for the keepalive task in a single type.

When we recreate a stream, we need to create a new keepalive task, with a new `CancellationToken`. So it makes sense to hold these things together.

Note that we cannot spawn the keepalive task after a stream is created for reasons. And we cannot signal a shutdown of the stream by dropping the receiver for reasons. This is the simplest solution I came up with.