### PR TITLE
feat(pubsub): retries starting subscribe stream

### DIFF
--- a/src/pubsub/src/subscriber/stream.rs
+++ b/src/pubsub/src/subscriber/stream.rs
@@ -13,13 +13,22 @@
 // limitations under the License.
 
 use super::keepalive;
+use super::retry_policy::StreamRetryPolicy;
 use super::stub::{Stub, TonicStreaming};
 use crate::google::pubsub::v1::{StreamingPullRequest, StreamingPullResponse};
 use crate::{Error, Result};
+use gax::backoff_policy::BackoffPolicy;
+use gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use gax::options::RequestOptions;
-use std::sync::Arc;
+use gax::retry_loop_internal::retry_loop;
+use gax::retry_throttler::CircuitBreaker;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::{CancellationToken, DropGuard};
+
+pub(super) const INITIAL_DELAY: Duration = Duration::from_millis(100);
+pub(super) const MAXIMUM_DELAY: Duration = Duration::from_secs(60);
 
 /// Representation for the `StreamingPull` RPC.
 #[derive(Debug)]
@@ -54,8 +63,32 @@ where
     ///
     /// This method includes retries, and spawns a keepalive task.
     pub(super) async fn new(inner: Arc<T>, initial_req: StreamingPullRequest) -> Result<Self> {
-        // TODO(#4097) - add a retry loop.
-        open_stream(inner, initial_req).await
+        Self::new_with_backoff(inner, initial_req, default_backoff_policy()).await
+    }
+
+    async fn new_with_backoff(
+        inner: Arc<T>,
+        initial_req: StreamingPullRequest,
+        // The default backoff policy is non-deterministic. Exposing the backoff
+        // policy in this interface helps us set better test expectations.
+        backoff: Arc<dyn BackoffPolicy>,
+    ) -> Result<Self> {
+        let sleep = async |d| tokio::time::sleep(d).await;
+        let attempt = move |_| {
+            let inner = inner.clone();
+            let initial_req = initial_req.clone();
+            async move { open_stream(inner, initial_req).await }
+        };
+
+        retry_loop(
+            attempt,
+            sleep,
+            true,
+            default_retry_throttler(),
+            default_retry_policy(),
+            backoff,
+        )
+        .await
     }
 }
 
@@ -92,14 +125,63 @@ where
     })
 }
 
+fn default_retry_policy() -> Arc<StreamRetryPolicy> {
+    Arc::new(StreamRetryPolicy)
+}
+
+fn default_retry_throttler() -> Arc<Mutex<CircuitBreaker>> {
+    // Effectively disable throttling. Opening a stream is done infrequently
+    // enough that a throttler is unnecessary.
+    Arc::new(Mutex::new(
+        CircuitBreaker::new(1000, 0, 0).expect("This is a valid configuration"),
+    ))
+}
+
+fn default_backoff_policy() -> Arc<ExponentialBackoff> {
+    Arc::new(
+        ExponentialBackoffBuilder::new()
+            .with_initial_delay(INITIAL_DELAY)
+            .with_maximum_delay(MAXIMUM_DELAY)
+            .with_scaling(4)
+            .build()
+            .expect("This is a valid configuration"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::keepalive::KEEPALIVE_PERIOD;
     use super::super::lease_state::tests::test_ids;
-    use super::super::stub::TonicStreaming;
     use super::super::stub::tests::MockStub;
     use super::*;
     use crate::google::pubsub::v1::{ReceivedMessage, StreamingPullResponse};
+    use gax::backoff_policy::BackoffPolicy;
+    use gax::error::rpc::{Code, Status};
+    use gax::retry_state::RetryState;
+
+    mockall::mock! {
+        #[derive(Debug)]
+        BackoffPolicy {}
+        impl BackoffPolicy for BackoffPolicy {
+            fn on_failure(&self, state: &RetryState) -> Duration;
+        }
+    }
+
+    fn transient_error() -> Error {
+        Error::service(
+            Status::default()
+                .set_code(Code::Unavailable)
+                .set_message("try again"),
+        )
+    }
+
+    fn permanent_error() -> Error {
+        Error::service(
+            Status::default()
+                .set_code(Code::FailedPrecondition)
+                .set_message("fail"),
+        )
+    }
 
     fn test_response(range: std::ops::Range<i32>) -> StreamingPullResponse {
         StreamingPullResponse {
@@ -204,6 +286,97 @@ mod tests {
             .await
             .expect_err("open_stream should fail");
         assert!(err.is_io(), "{err:?}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_then_success() -> anyhow::Result<()> {
+        let mut seq = mockall::Sequence::new();
+        let mut mock_stub = MockStub::new();
+        let mut mock_backoff = MockBackoffPolicy::new();
+        for attempt in 1..20 {
+            // Simulate N transient errors + N backoffs.
+            mock_stub
+                .expect_streaming_pull()
+                .times(1)
+                .in_sequence(&mut seq)
+                .return_once(|_, _| Err(transient_error()));
+            mock_backoff
+                .expect_on_failure()
+                .times(1)
+                .withf(move |s| s.attempt_count == attempt)
+                .in_sequence(&mut seq)
+                .return_const(Duration::ZERO);
+        }
+        // Simulate a success.
+        let (response_tx, response_rx) = mpsc::channel(10);
+        response_tx.send(Ok(test_response(1..10))).await?;
+        drop(response_tx);
+
+        mock_stub
+            .expect_streaming_pull()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_r, _o| Ok(tonic::Response::from(response_rx)));
+
+        let mut stream = Stream::new_with_backoff(
+            Arc::new(mock_stub),
+            initial_request(),
+            Arc::new(mock_backoff),
+        )
+        .await?;
+        assert_eq!(stream.next_message().await?, Some(test_response(1..10)));
+        assert_eq!(stream.next_message().await?, None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_then_permanent_failure() -> anyhow::Result<()> {
+        let mut seq = mockall::Sequence::new();
+        let mut mock_stub = MockStub::new();
+        let mut mock_backoff = MockBackoffPolicy::new();
+        for attempt in 1..20 {
+            // Simulate N transient errors + N backoffs.
+            mock_stub
+                .expect_streaming_pull()
+                .times(1)
+                .in_sequence(&mut seq)
+                .return_once(|_, _| Err(transient_error()));
+            mock_backoff
+                .expect_on_failure()
+                .times(1)
+                .withf(move |s| s.attempt_count == attempt)
+                .in_sequence(&mut seq)
+                .return_const(Duration::ZERO);
+        }
+        // Simulate a permanent error.
+        mock_stub
+            .expect_streaming_pull()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(|_, _| Err(permanent_error()));
+        // The retry loop calculates the backoff delay before determining
+        // whether a retry should occur. Hence, we expect this extra call to
+        // `on_failure()`.
+        mock_backoff
+            .expect_on_failure()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_const(Duration::ZERO);
+
+        let err = Stream::new_with_backoff(
+            Arc::new(mock_stub),
+            initial_request(),
+            Arc::new(mock_backoff),
+        )
+        .await
+        .expect_err("opening stream should fail");
+        assert!(err.status().is_some(), "{err:?}");
+        let status = err.status().unwrap();
+        assert_eq!(status.code, gax::error::rpc::Code::FailedPrecondition);
+        assert_eq!(status.message, "fail");
 
         Ok(())
     }


### PR DESCRIPTION
Part of the work for #4097 

Retry attempts to start a stream using default policies.

I do not have plans to let applications set custom policies, but if we need to, we can add support for custom policies later.