### PR TITLE
docs: default `rustls` crypto provider changes

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -70,13 +70,18 @@ default = ["default-idtoken-backend", "default-rustls-provider"]
 # The `idtoken` feature enables support to create and validate OIDC ID Tokens.
 # See the create top-level documentation for more information.
 idtoken = ["dep:jsonwebtoken"]
-# By default this crate enables the `rust_crypto` backend. Applications can
-# link `google-cloud-auth` with `default-features = false, feature = ["idtoken"]
-# to select the backend themselves.
+# By default this crate enables the `aws_lc_rs` backend. Applications can
+# link `google-cloud-auth` with `default-features = false, features = ["idtoken"]
+# and then directly configure the `jsonwebtoken` features to select the
+# `rust_crypto` backend.
 default-idtoken-backend = ["jsonwebtoken?/aws_lc_rs"]
-# Enable a default TLS configuration for `reqwest`.
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
 default-rustls-provider = ["reqwest/default-tls", "rustls/aws-lc-rs"]
-# Do not use, this was a mistake in the 1.3 release.
+# Do not use, this was a mistake in the 1.3 release. We accidentally introduced
+# this feature. The intent was to only introduce `idtoken`.
 jsonwebtoken = ["dep:jsonwebtoken"]
 
 [lints]

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -16,16 +16,16 @@ also describes the common terminology used with authentication, such as
 
 # Features
 
-- `default-rustls-provider`: enabled by default. This feature selects a default
-  crypto provider and trusted root certificate selection for TLS. Applications
-  that have specific requirements for TLS (such as exclusively using the
-  [aws-lc-rs], or [ring] crates) should disable this default and configure the
-  `reqwest` crate features to fit their needs.
+- `default-rustls-provider`: enabled by default. Use the default rustls crypto
+  provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+  requirements for cryptography (such as exclusively using the [ring] crate)
+  should disable this default and call
+  `rustls::CryptoProvider::install_default()`.
 - `idtoken`: disabled by default, this feature enables support to create and
   verify [OIDC ID Tokens].
 - `default-idtoken-backend`: enabled by default, this feature enables a default
   backend for the `idtoken` feature. Currently the feature is implemented using
-  the [jsonwebtoken] crate and uses `rust_crypto` as its default backend. We may
+  the [jsonwebtoken] crate and uses `aws-lc-rs` as its default backend. We may
   change the default backend at any time, applications that have specific needs
   for this backend should not rely on the current default. To control the
   backend selection:

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -26,16 +26,16 @@
 //!
 //! # Features
 //!
-//! - `default-rustls-provider`: enabled by default. This feature selects a default
-//!   crypto provider and trusted root certificate selection for TLS. Applications
-//!   that have specific requirements for TLS (such as exclusively using the
-//!   [aws-lc-rs], or [ring] crates) should disable this default and configure the
-//!   `reqwest` crate features to fit their needs.
+//! - `default-rustls-provider`: enabled by default. Use the default rustls
+//!   crypto provider ([aws-lc-rs]) for TLS and authentication. Applications
+//!   with specific requirements for cryptography (such as exclusively using the
+//!   [ring] crate) should disable this default and call
+//!   `rustls::CryptoProvider::install_default()`.
 //! - `idtoken`: disabled by default, this feature enables support to create and
 //!   verify [OIDC ID Tokens].
 //! - `default-idtoken-backend`: enabled by default, this feature enables a default
 //!   backend for the `idtoken` feature. Currently the feature is implemented using
-//!   the [jsonwebtoken] crate and uses `rust_crypto` as its default backend. We may
+//!   the [jsonwebtoken] crate and uses `aws-lc-rs` as its default backend. We may
 //!   change the default backend at any time, applications that have specific needs
 //!   for this backend should not rely on the current default. To control the
 //!   backend selection:

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -48,11 +48,10 @@ wkt.workspace   = true
 
 [features]
 default = ["default-rustls-provider"]
-# Enabled by default. Use the default rustls crypto provider ([ring]) for TLS
-# and authentication. Applications with specific requirements for cryptography
-# (such as exclusively using the [aws-lc-rs], or [ring] crates) should disable
-# this default and install the default crypto provider in `rustls` to fit their
-# requirements.
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
 default-rustls-provider = ["gaxi/_default-rustls-provider"]
 
 [dev-dependencies]

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -52,11 +52,10 @@ wkt.workspace          = true
 
 [features]
 default = ["default-rustls-provider"]
-# Enabled by default. Use the default rustls crypto provider ([ring]) for TLS
-# and authentication. Applications with specific requirements for cryptography
-# (such as exclusively using the [aws-lc-rs], or [ring] crates) should disable
-# this default and install the default crypto provider in `rustls` to fit their
-# requirements.
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
 default-rustls-provider = ["gaxi/_default-rustls-provider"]
 
 [dev-dependencies]

--- a/src/pubsub/README.md
+++ b/src/pubsub/README.md
@@ -17,10 +17,10 @@ Receiving messages is not yet supported by this crate.
 ## Features
 
 - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-  provider ([ring]) for TLS and authentication. Applications with specific
-  requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-  [ring] crates) should disable this default and install the default crypto
-  provider in `rustls` to fit their requirements.
+  provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+  requirements for cryptography (such as exclusively using the [ring] crate)
+  should disable this default and call
+  `rustls::crypto::CryptoProvider::install_default()`.
 - `unstable-stream`: enable the (unstable) features to convert several types to
   a `future::Stream`.
 

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -44,10 +44,10 @@
 //! # Features
 //!
 //! - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-//!   provider ([ring]) for TLS and authentication. Applications with specific
-//!   requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-//!   [ring] crates) should disable this default and install the default crypto
-//!   provider in `rustls` to fit their requirements.
+//!   provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+//!   requirements for cryptography (such as exclusively using the [ring] crate)
+//!   should disable this default and call
+//!   `rustls::crypto::CryptoProvider::install_default()`.
 //! - `unstable-stream`: enable the (unstable) features to convert several types to
 //!   a `future::Stream`.
 //!

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -73,11 +73,10 @@ wkt.workspace         = true
 [features]
 default         = ["default-rustls-provider"]
 unstable-stream = ["reqwest/stream"]
-# Enabled by default. Use the default rustls crypto provider ([ring]) for TLS
-# and authentication. Applications with specific requirements for cryptography
-# (such as exclusively using the [aws-lc-rs], or [ring] crates) should disable
-# this default and install the default crypto provider in `rustls` to fit their
-# requirements.
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
 default-rustls-provider = ["google-cloud-auth/default-rustls-provider"]
 
 [dev-dependencies]

--- a/src/storage/README.md
+++ b/src/storage/README.md
@@ -22,10 +22,10 @@ should not introduce breaking changes to the client libraries.
 ## Features
 
 - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-  provider ([ring]) for TLS and authentication. Applications with specific
-  requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-  [ring] crates) should disable this default and install the default crypto
-  provider in `rustls` to fit their requirements.
+  provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+  requirements for cryptography (such as exclusively using the [ring] crate)
+  should disable this default and call
+  `rustls::crypto::CryptoProvider::install_default()`.
 - `unstable-stream`: enable the (unstable) features to convert several types to
   a `future::Stream`.
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -30,10 +30,10 @@
 //! # Features
 //!
 //! - `default-rustls-provider`: enabled by default. Use the default rustls crypto
-//!   provider ([ring]) for TLS and authentication. Applications with specific
-//!   requirements for cryptography (such as exclusively using the [aws-lc-rs], or
-//!   [ring] crates) should disable this default and install the default crypto
-//!   provider in `rustls` to fit their requirements.
+//!   provider ([aws-lc-rs]) for TLS and authentication. Applications with specific
+//!   requirements for cryptography (such as exclusively using the [ring] crate)
+//!   should disable this default and call
+//!   `rustls::crypto::CryptoProvider::install_default()`.
 //! - `unstable-stream`: enable the (unstable) features to convert several types to
 //!   a `future::Stream`.
 //!


### PR DESCRIPTION
With the update to `reqwest` 0.13 the default crypto provider changes to `aws-lc-rs`. Update all the documentation to reflect this change.

part of the work for #4367 