### PR TITLE
fix(auth): force minimum version for `aws-lc-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-lc-rs",
  "base64",
  "bytes",
  "google-cloud-gax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,7 +323,7 @@ http-body             = { default-features = false, version = "1" }
 http-body-util        = { default-features = false, version = "0.1.3" }
 humantime             = { default-features = false, version = "2" }
 hyper                 = { default-features = false, version = "1" }
-jsonwebtoken          = { default-features = false, version = "10" }
+jsonwebtoken          = { default-features = false, version = "10.2" }
 lazy_static           = { default-features = false, version = "1.2" }
 opentelemetry         = { default-features = false, version = "0.31", features = ["trace"] }
 opentelemetry-proto   = { default-features = false, version = "0.31", features = ["gen-tonic", "trace"] }
@@ -371,8 +371,11 @@ opentelemetry-semantic-conventions = { default-features = false, version = "0.31
 ] }
 
 
-# Transitive dependencies. Used for minimal version selection.
-mime = { default-features = false, version = "0.3.17" }
+# Some of our direct dependencies fail to declare the minimum version
+# requirements correctly. Force a higher version so we can test our own minimum
+# version requirements in the minimal-versions build.
+mime      = { default-features = false, version = "0.3.17" }
+aws-lc-rs = { default-features = false, version = "1.15.4" }
 
 # Test packages
 anyhow            = { default-features = false, version = "1.0.100", features = ["std"] }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -47,6 +47,9 @@ thiserror.workspace   = true
 time                  = { workspace = true, features = ["serde"] }
 tokio                 = { workspace = true, features = ["fs", "process"] }
 jsonwebtoken          = { workspace = true, optional = true }
+# We do not use this directly, but without it the minimal-versions build breaks.
+# See: https://github.com/Keats/jsonwebtoken/pull/481
+aws-lc-rs = { workspace = true, optional = true }
 # Local dependencies
 gax.workspace = true
 
@@ -74,7 +77,7 @@ idtoken = ["dep:jsonwebtoken"]
 # link `google-cloud-auth` with `default-features = false, features = ["idtoken"]
 # and then directly configure the `jsonwebtoken` features to select the
 # `rust_crypto` backend.
-default-idtoken-backend = ["jsonwebtoken?/aws_lc_rs"]
+default-idtoken-backend = ["dep:aws-lc-rs", "jsonwebtoken?/aws_lc_rs"]
 # Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
 # TLS and authentication. Applications with specific requirements for
 # cryptography (such as exclusively using the [ring] crate) should disable this


### PR DESCRIPTION
The `jsonwebtoken` crate declares the wrong minimum version, so we need to workaround that to test our own minimums.

See also: https://github.com/Keats/jsonwebtoken/pull/481