### PR TITLE
chore: update `cargo-semver-checks`

### DIFF
--- a/.gcb/scripts/semver-checks.sh
+++ b/.gcb/scripts/semver-checks.sh
@@ -15,7 +15,7 @@
 
 set -ev
 
-cargo install --locked cargo-semver-checks@0.44.0
+cargo install --locked cargo-semver-checks@0.46.0
 cargo version
 rustup show active-toolchain -v
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -39,7 +39,7 @@ release:
   tools:
     cargo:
       - name: cargo-semver-checks
-        version: 0.44.0
+        version: 0.46.0
       - name: cargo-workspaces
         version: 0.4.0
 default:


### PR DESCRIPTION
This is needed for Rust 1.93.