### PR TITLE
chore(auth): pass new semver checks

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -72,7 +72,7 @@ mutants.workspace     = true
 default = ["default-idtoken-backend", "default-rustls-provider"]
 # The `idtoken` feature enables support to create and validate OIDC ID Tokens.
 # See the create top-level documentation for more information.
-idtoken = ["dep:jsonwebtoken"]
+idtoken = ["dep:jsonwebtoken", "jsonwebtoken"]
 # By default this crate enables the `aws_lc_rs` backend. Applications can
 # link `google-cloud-auth` with `default-features = false, features = ["idtoken"]
 # and then directly configure the `jsonwebtoken` features to select the


### PR DESCRIPTION
With `cargo-semver-checks@0.46.0` we need to preserve backwards compatibility for `idtoken` features.