### PR TITLE
chore(dialogflow/cx/v3)!: service breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,7 +2442,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-dialogflow-cx-v3"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -630,7 +630,7 @@ libraries:
     version: 1.4.0
     copyright_year: "2025"
   - name: google-cloud-dialogflow-cx-v3
-    version: 1.6.0
+    version: 2.0.0
     copyright_year: "2025"
     rust:
       per_service_features: true

--- a/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
+++ b/src/generated/cloud/dialogflow/cx/v3/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-dialogflow-cx-v3"
-version                = "1.6.0"
+version                = "2.0.0"
 description            = "Google Cloud Client Libraries for Rust - Dialogflow API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/dialogflow/cx/v3/README.md
+++ b/src/generated/cloud/dialogflow/cx/v3/README.md
@@ -55,27 +55,27 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[Agents]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Agents.html
-[Changelogs]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Changelogs.html
-[Deployments]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Deployments.html
-[EntityTypes]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.EntityTypes.html
-[Environments]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Environments.html
-[Examples]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Examples.html
-[Experiments]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Experiments.html
-[Flows]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Flows.html
-[Generators]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Generators.html
-[Intents]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Intents.html
-[Pages]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Pages.html
-[Playbooks]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Playbooks.html
-[SecuritySettingsService]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.SecuritySettingsService.html
-[Sessions]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Sessions.html
-[SessionEntityTypes]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.SessionEntityTypes.html
-[TestCases]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.TestCases.html
-[Tools]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Tools.html
-[TransitionRouteGroups]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.TransitionRouteGroups.html
-[Versions]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Versions.html
-[Webhooks]: https://docs.rs/google-cloud-dialogflow-cx-v3/1.6.0/google_cloud_dialogflow_cx_v3/client/struct.Webhooks.html
+[Agents]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Agents.html
+[Changelogs]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Changelogs.html
+[Deployments]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Deployments.html
+[EntityTypes]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.EntityTypes.html
+[Environments]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Environments.html
+[Examples]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Examples.html
+[Experiments]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Experiments.html
+[Flows]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Flows.html
+[Generators]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Generators.html
+[Intents]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Intents.html
+[Pages]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Pages.html
+[Playbooks]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Playbooks.html
+[SecuritySettingsService]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.SecuritySettingsService.html
+[Sessions]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Sessions.html
+[SessionEntityTypes]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.SessionEntityTypes.html
+[TestCases]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.TestCases.html
+[Tools]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Tools.html
+[TransitionRouteGroups]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.TransitionRouteGroups.html
+[Versions]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Versions.html
+[Webhooks]: https://docs.rs/google-cloud-dialogflow-cx-v3/2.0.0/google_cloud_dialogflow_cx_v3/client/struct.Webhooks.html


### PR DESCRIPTION
Update the version because the service had a number of breaking changes, including moved and removed fields.