### PR TITLE
cleanup: use rustls/aws_lc_rs feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5909,9 +5909,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -82,7 +82,7 @@ default-idtoken-backend = ["dep:aws-lc-rs", "jsonwebtoken?/aws_lc_rs"]
 # TLS and authentication. Applications with specific requirements for
 # cryptography (such as exclusively using the [ring] crate) should disable this
 # default and call `rustls::CryptoProvider::install_default()`.
-default-rustls-provider = ["reqwest/default-tls", "rustls/aws-lc-rs"]
+default-rustls-provider = ["reqwest/default-tls", "rustls/aws_lc_rs"]
 # Do not use, this was a mistake in the 1.3 release. We accidentally introduced
 # this feature. The intent was to only introduce `idtoken`.
 jsonwebtoken = ["dep:jsonwebtoken"]

--- a/tests/crypto-providers/gaxi-with-aws-lc-rs/Cargo.toml
+++ b/tests/crypto-providers/gaxi-with-aws-lc-rs/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow        = { workspace = true, features = ["std"] }
-rustls        = { workspace = true, features = ["aws-lc-rs"] }
+rustls        = { workspace = true, features = ["aws_lc_rs"] }
 tokio         = { workspace = true, features = ["test-util"] }
 test-gaxi     = { path = "../test-gaxi" }
 test-metadata = { path = "../test-metadata" }

--- a/tests/crypto-providers/secret-manager-with-aws-lc-rs/Cargo.toml
+++ b/tests/crypto-providers/secret-manager-with-aws-lc-rs/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow              = { workspace = true, features = ["std"] }
-rustls              = { workspace = true, features = ["aws-lc-rs"] }
+rustls              = { workspace = true, features = ["aws_lc_rs"] }
 tokio               = { workspace = true, features = ["test-util"] }
 test-metadata       = { path = "../test-metadata" }
 test-secret-manager = { path = "../test-secret-manager" }

--- a/tests/crypto-providers/storage-with-aws-lc-rs/Cargo.toml
+++ b/tests/crypto-providers/storage-with-aws-lc-rs/Cargo.toml
@@ -28,7 +28,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow        = { workspace = true, features = ["std"] }
-rustls        = { workspace = true, features = ["aws-lc-rs"] }
+rustls        = { workspace = true, features = ["aws_lc_rs"] }
 tokio         = { workspace = true, features = ["test-util"] }
 test-metadata = { path = "../test-metadata" }
 test-storage  = { path = "../test-storage" }

--- a/tests/crypto-providers/test-metadata/src/lib.rs
+++ b/tests/crypto-providers/test-metadata/src/lib.rs
@@ -21,7 +21,7 @@ use semver::{Comparator, Op};
 const RING_CRATE_NAME: &str = "ring";
 const AWS_LC_RS_CRATE_NAME: &str = "aws-lc-rs";
 const REQWEST_DEFAULT_FEATURE: &str = "default-tls";
-const RUSTLS_DEFAULT_FEATURE: &str = "aws-lc-rs";
+const RUSTLS_DEFAULT_FEATURE: &str = "aws_lc_rs";
 // Use `google-cloud-auth` to find the versions of key dependencies. Changing
 // this test code as we update the dependency requirements (via renovatebot)
 // it would be tedious to manual update this code too.


### PR DESCRIPTION
The `aws-lc-rs` feature name did not appear in rustls until v0.23.2 and it is just an alternate name for `aws_lc_rs`. Use the default name instead to make the crates compatible with all versions of rustls v0.23.*.

Found while adding  #4400