### PR TITLE
cleanup: update flate2 to first version with feature zlib-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -390,7 +390,7 @@ aws-lc-rs = { default-features = false, version = "1.15.4" }
 # Test packages
 anyhow            = { default-features = false, version = "1.0.100", features = ["std"] }
 axum              = { default-features = false, version = "0.8" }
-flate2            = { default-features = false, version = "1" }
+flate2            = { default-features = false, version = "1.0.29" }
 httptest          = { default-features = false, version = "0.16.4" }
 md5               = { default-features = false, version = "0.8" }
 mockall           = { default-features = false, version = "0.14" }


### PR DESCRIPTION
We use the zlib-rs feature, which doesn't exist until v1.0.29.

Found while testing direct-minimal-versions: #4400