### PR TITLE
cleanup: update tokio-stream to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -407,7 +407,7 @@ serial_test       = { default-features = false, version = "3" }
 static_assertions = { default-features = false, version = "1.1" }
 tempfile          = { default-features = false, version = "3.24" }
 test-case         = { default-features = false, version = "3.3" }
-tokio-stream      = { default-features = false, version = "0.1" }
+tokio-stream      = { default-features = false, version = "0.1.1" }
 tokio-test        = { default-features = false, version = "0.4" }
 
 # Local packages used as dependencies


### PR DESCRIPTION
The integration tests use the "net" feature which is added in 0.1.1.

Found while adding #4400 