### PR TITLE
impl(pubsub): resume streams on transport errors

### DIFF
--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -166,7 +166,7 @@ impl Session {
             // (responses with an empty message list). Hence the loop.
             if let Err(e) = self.read_from_stream().await? {
                 // Handle errors opening or reading from the stream.
-                match StreamRetryPolicy::is_transient(e) {
+                match StreamRetryPolicy::on_midstream_error(e) {
                     RetryResult::Continue(_) => {
                         // The stream failed with a transient error. Reset the stream.
                         self.stream = None;


### PR DESCRIPTION
Fixes #4097 

Resume streams that fail with transport errors.

This is maybe too conservative, as we could probably retry attempts to open a stream that fail with transient errors... but it is more generous than before. And we know `RST_STREAM` errors are a thing that surface as transport errors.

We can further improve the retry policy, as I try to catch more failure modes in the wild.