### PR TITLE
refactor: move (some) jsonwebtoken backend tests to workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5687,6 +5687,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "idtoken-with-aws-lc-rs"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "google-cloud-auth",
+ "jsonwebtoken",
+ "test-metadata",
+]
+
+[[package]]
+name = "idtoken-with-default"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "google-cloud-auth",
+ "test-metadata",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,6 +279,10 @@ members = [
   "tests/crypto-providers/gaxi-with-aws-lc-rs",
   "tests/crypto-providers/gaxi-with-default",
   "tests/crypto-providers/gaxi-with-ring",
+  "tests/crypto-providers/idtoken-with-aws-lc-rs",
+  "tests/crypto-providers/idtoken-with-default",
+  # excluded because jsonwebtoken cannot have two backends:
+  # "tests/crypto-providers/idtoken-with-rust-crypto",
   "tests/crypto-providers/secret-manager-with-aws-lc-rs",
   "tests/crypto-providers/secret-manager-with-default",
   "tests/crypto-providers/secret-manager-with-ring",

--- a/tests/crypto-providers/idtoken-with-aws-lc-rs/Cargo.toml
+++ b/tests/crypto-providers/idtoken-with-aws-lc-rs/Cargo.toml
@@ -13,24 +13,21 @@
 # limitations under the License.
 
 [package]
-name         = "idtoken-with-aws-lc-rs"
-version      = "0.0.0"
-publish      = false
-edition      = "2024"
-authors      = ["Google LLC"]
-description  = "Google Cloud Client Libraries for Rust"
-license      = "Apache-2.0"
-repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
-keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
-categories   = ["network-programming"]
-rust-version = "1.92.0"
-
-# This test needs to be its own workspace so it is isolated from any features
-# enabled in the top-level Cargo.toml file (and its dependencies).
-[workspace]
+name        = "idtoken-with-aws-lc-rs"
+version     = "0.0.0"
+publish     = false
+description = "Use the `google-cloud-storage` library with `aws_lc_rs` as the jsonwebtoken backend"
+# Inherit other attributes from the workspace.
+edition.workspace      = true
+authors.workspace      = true
+license.workspace      = true
+repository.workspace   = true
+keywords.workspace     = true
+categories.workspace   = true
+rust-version.workspace = true
 
 [dependencies]
-anyhow            = { default-features = false, version = "1", features = ["std"] }
+anyhow            = { workspace = true, features = ["std"] }
+jsonwebtoken      = { workspace = true, features = ["aws_lc_rs"] }
+google-cloud-auth = { workspace = true, features = ["idtoken"] }
 test-metadata     = { path = "../test-metadata" }
-google-cloud-auth = { default-features = false, path = "../../../src/auth", features = ["idtoken"] }
-jsonwebtoken      = { default-features = false, version = "10", features = ["aws_lc_rs"] }

--- a/tests/crypto-providers/idtoken-with-default/Cargo.toml
+++ b/tests/crypto-providers/idtoken-with-default/Cargo.toml
@@ -13,23 +13,20 @@
 # limitations under the License.
 
 [package]
-name         = "idtoken-with-default"
-version      = "0.0.0"
-publish      = false
-edition      = "2024"
-authors      = ["Google LLC"]
-description  = "Google Cloud Client Libraries for Rust"
-license      = "Apache-2.0"
-repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
-keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
-categories   = ["network-programming"]
-rust-version = "1.92.0"
-
-# This test needs to be its own workspace so it is isolated from any features
-# enabled in the top-level Cargo.toml file (and its dependencies).
-[workspace]
+name        = "idtoken-with-default"
+version     = "0.0.0"
+publish     = false
+description = "Use the `google-cloud-auth` library with the default jsonwebtoken backend"
+# Inherit other attributes from the workspace.
+edition.workspace      = true
+authors.workspace      = true
+license.workspace      = true
+repository.workspace   = true
+keywords.workspace     = true
+categories.workspace   = true
+rust-version.workspace = true
 
 [dependencies]
-anyhow            = { default-features = false, version = "1", features = ["std"] }
+anyhow            = { workspace = true, features = ["std"] }
+google-cloud-auth = { workspace = true, features = ["default", "idtoken"] }
 test-metadata     = { path = "../test-metadata" }
-google-cloud-auth = { default-features = true, path = "../../../src/auth", features = ["idtoken"] }


### PR DESCRIPTION
These two tests can be part of the workspace. That speeds up the build and makes it easier to maintain the tests. With this change, only `idtoken-with-rust-crypto` is outside the workspace, which cannot be moved because it enables both backends which `jsonwebtoken` does not support.