### PR TITLE
refactor: split enum query parameters test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5831,7 +5831,6 @@ dependencies = [
  "google-cloud-telcoautomation-v1",
  "google-cloud-test-utils",
  "google-cloud-wkt",
- "google-cloud-workflows-executions-v1",
  "google-cloud-workflows-v1",
  "http",
  "httptest",
@@ -5886,6 +5885,23 @@ dependencies = [
  "google-cloud-lro",
  "google-cloud-test-utils",
  "rand 0.9.2",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "integration-tests-enums-query-parameters"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "futures",
+ "google-cloud-gax",
+ "google-cloud-lro",
+ "google-cloud-test-utils",
+ "google-cloud-workflows-executions-v1",
+ "google-cloud-workflows-v1",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -292,6 +292,7 @@ members = [
   "tests/crypto-providers/test-storage",
   "tests/dns",
   "tests/endurance",
+  "tests/enums-query-parameters",
   "tests/integration",
   "tests/integration-auth",
   "tests/o11y",
@@ -472,6 +473,9 @@ language                        = { default-features = false, version = "1", pat
 google-cloud-dns-v1             = { default-features = false, path = "src/generated/cloud/dns/v1" }
 google-cloud-showcase-v1beta1   = { default-features = false, path = "src/generated/showcase" }
 google-cloud-trace-v1           = { default-features = false, path = "src/generated/devtools/cloudtrace/v1" }
+# The names on these are too long, I do not want to reformat the whole file for them.
+google-cloud-workflows-v1            = { default-features = false, path = "src/generated/cloud/workflows/v1" }
+google-cloud-workflows-executions-v1 = { default-features = false, path = "src/generated/cloud/workflows/executions/v1" }
 
 # Local test packages (never add a version)
 google-cloud-test-utils = { default-features = false, path = "src/test-utils" }

--- a/src/test-utils/src/resource_names.rs
+++ b/src/test-utils/src/resource_names.rs
@@ -16,7 +16,7 @@
 
 use rand::{
     Rng,
-    distr::{Distribution, Uniform},
+    distr::{Alphanumeric, Distribution, Uniform},
 };
 
 /// A common prefix for resource ids.
@@ -26,9 +26,21 @@ pub const PREFIX: &str = "rust-sdk-testing-";
 
 const BUCKET_ID_LENGTH: usize = 63;
 
-/// Generate a random bucket id
+const WORKFLOW_ID_LENGTH: usize = 64;
+
+/// Generate a random bucket id.
 pub fn random_bucket_id() -> String {
     let id = LowercaseAlphanumeric.random_string(BUCKET_ID_LENGTH - PREFIX.len());
+    format!("{PREFIX}{id}")
+}
+
+/// Generate a random workflow id.
+pub fn random_workflow_id() -> String {
+    let id: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(WORKFLOW_ID_LENGTH - PREFIX.len())
+        .map(char::from)
+        .collect();
     format!("{PREFIX}{id}")
 }
 
@@ -81,6 +93,22 @@ mod tests {
         assert!(suffix.is_some(), "{got} should start with {PREFIX}");
         let test = is_ascii_lowercase_alphanumeric(suffix.unwrap());
         assert!(test.is_ok(), "{test:?}");
+    }
+
+    #[test]
+    fn workflow_id() {
+        let got = random_workflow_id();
+        assert!(
+            got.len() <= WORKFLOW_ID_LENGTH,
+            "{got} has more than {WORKFLOW_ID_LENGTH} characters"
+        );
+        let suffix = got
+            .strip_prefix(PREFIX)
+            .expect("{got} should start with {PREFIX}");
+        assert!(
+            suffix.chars().all(|c| c.is_alphanumeric()),
+            "the suffix should be alphanumeric: {suffix}"
+        );
     }
 
     #[test]

--- a/tests/enums-query-parameters/Cargo.toml
+++ b/tests/enums-query-parameters/Cargo.toml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+description       = "Integration tests for enums in query parameters."
+edition.workspace = true
+name              = "integration-tests-enums-query-parameters"
+publish           = false
+version           = "0.0.0"
+
+[features]
+# These are normally disabled because they run against production.
+run-integration-tests = []
+# Logging enables more verbose output for the tests.
+log-integration-tests = []
+
+[dependencies]
+anyhow.workspace                     = true
+chrono                               = { workspace = true, features = ["now"] }
+futures.workspace                    = true
+google-cloud-workflows-v1            = { workspace = true, features = ["default"] }
+google-cloud-workflows-executions-v1 = { workspace = true, features = ["default"] }
+google-cloud-gax.workspace           = true
+google-cloud-test-utils              = { workspace = true }
+google-cloud-lro.workspace           = true
+tokio.workspace                      = true
+tracing.workspace                    = true
+tracing-subscriber                   = { workspace = true, features = ["fmt"] }

--- a/tests/enums-query-parameters/README.md
+++ b/tests/enums-query-parameters/README.md
@@ -1,0 +1,6 @@
+# Integration tests for enum query parameters
+
+This is an integration test for enum values in query parameters. We use the
+`google-cloud-workflow-executions-v1` library because it uses the feature. We
+also use the `google-cloud-workflow-v1` library to create data (workflow
+executions) for the tests.

--- a/tests/enums-query-parameters/tests/driver.rs
+++ b/tests/enums-query-parameters/tests/driver.rs
@@ -1,0 +1,21 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod enums_query_parameters {
+    #[tokio::test]
+    async fn run() -> anyhow::Result<()> {
+        integration_tests_enums_query_parameters::run().await
+    }
+}

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -102,10 +102,6 @@ path    = "../../src/generated/cloud/telcoautomation/v1"
 package = "google-cloud-workflows-v1"
 path    = "../../src/generated/cloud/workflows/v1"
 
-[dependencies.wfe]
-package = "google-cloud-workflows-executions-v1"
-path    = "../../src/generated/cloud/workflows/executions/v1"
-
 [dev-dependencies]
 anyhow.workspace            = true
 httptest.workspace          = true

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -14,7 +14,7 @@
 
 use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
 use google_cloud_test_utils::resource_names::random_bucket_id;
-use rand::{Rng, distr::Alphanumeric};
+pub(crate) use google_cloud_test_utils::resource_names::random_workflow_id;
 
 pub type Result<T> = anyhow::Result<T>;
 pub mod aiplatform;
@@ -26,30 +26,15 @@ pub mod secret_manager;
 pub mod showcase;
 pub mod storage;
 pub mod workflows;
-pub mod workflows_executions;
 
 pub const SECRET_ID_LENGTH: usize = 64;
 
 pub const VM_ID_LENGTH: usize = 63;
 
-pub const WORKFLOW_ID_LENGTH: usize = 64;
-
 pub fn report_error(e: anyhow::Error) -> anyhow::Error {
     eprintln!("\n\nERROR {e:?}\n");
     tracing::error!("ERROR {e:?}");
     e
-}
-
-pub(crate) fn random_workflow_id() -> String {
-    // Workflow ids must start with a letter, we use `wf-` as a prefix to
-    // meet this requirement.
-    const PREFIX: &str = "wf-";
-    let workflow_id: String = rand::rng()
-        .sample_iter(&Alphanumeric)
-        .take(WORKFLOW_ID_LENGTH - PREFIX.len())
-        .map(char::from)
-        .collect();
-    format!("{PREFIX}{workflow_id}")
 }
 
 pub(crate) fn random_image_name() -> String {

--- a/tests/integration/tests/driver.rs
+++ b/tests/integration/tests/driver.rs
@@ -329,12 +329,4 @@ mod driver {
             .await
             .map_err(integration_tests::report_error)
     }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_executions() -> integration_tests::Result<()> {
-        let _guard = enable_tracing();
-        integration_tests::workflows_executions::list()
-            .await
-            .map_err(integration_tests::report_error)
-    }
 }


### PR DESCRIPTION
Reduce the size (and dependencies) of the `integration-tests` crate by moving
one of the tests out. I decided to name the new test crate for the feature it
tests, not for the library we use to run the tests.
