### PR TITLE
cleanup(auth): remove usage of jsonwebtoken in idtoken tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6876,6 +6876,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "spki",
  "subtle",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -58,7 +58,7 @@ anyhow.workspace      = true
 httptest.workspace    = true
 mockall.workspace     = true
 regex.workspace       = true
-rsa                   = { workspace = true, features = ["pem"] }
+rsa                   = { workspace = true, features = ["pem", "sha2"] }
 scoped-env.workspace  = true
 serial_test.workspace = true
 tempfile.workspace    = true

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -70,7 +70,7 @@
 //! [Service Account]: https://cloud.google.com/iam/docs/service-account-overview
 //! [service account key]: https://cloud.google.com/iam/docs/keys-create-delete#creating
 
-mod jws;
+pub(crate) mod jws;
 
 use crate::build_errors::Error as BuilderError;
 use crate::constants::DEFAULT_SCOPE;
@@ -549,7 +549,7 @@ impl ServiceAccountTokenGenerator {
         let header = JwsHeader {
             alg: "RS256",
             typ: "JWT",
-            kid: &self.service_account_key.private_key_id,
+            kid: Some(self.service_account_key.private_key_id.clone()),
         };
         let encoded_header_claims = format!("{}.{}", header.encode()?, claims.encode()?);
         let sig = signer

--- a/src/auth/src/credentials/service_account/jws.rs
+++ b/src/auth/src/credentials/service_account/jws.rs
@@ -14,7 +14,7 @@
 
 use crate::credentials::Result;
 use crate::errors;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use time::OffsetDateTime;
 
@@ -69,12 +69,12 @@ impl JwsClaims {
 }
 
 /// The header that describes who, what, and how a token was created.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct JwsHeader<'a> {
     pub alg: &'a str,
     pub typ: &'a str,
-    #[serde(skip_serializing_if = "str::is_empty")]
-    pub kid: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
 }
 
 impl JwsHeader<'_> {
@@ -210,7 +210,7 @@ mod tests {
         let header = JwsHeader {
             alg: "RS256",
             typ: "JWT",
-            kid: "some_key_id",
+            kid: Some("some_key_id".to_string()),
         };
         let encoded = header.encode().unwrap();
         let decoded = String::from_utf8(
@@ -231,7 +231,7 @@ mod tests {
         let header = JwsHeader {
             alg: "RS256",
             typ: "JWT",
-            kid: "",
+            kid: None,
         };
         let encoded = header.encode().unwrap();
         let decoded = String::from_utf8(


### PR DESCRIPTION
Towards #3947