### PR TITLE
cleanup: standardize 'mod tests' naming

### DIFF
--- a/src/auth/src/credentials/external_account_sources/file_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/file_sourced.rs
@@ -81,7 +81,7 @@ impl SubjectTokenProvider for FileSourcedCredentials {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use serde_json::json;
     use std::{error::Error, io::Write};

--- a/src/gax-internal/tests/grpc_user_agent.rs
+++ b/src/gax-internal/tests/grpc_user_agent.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
-mod test {
+mod tests {
     use gax::options::*;
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
     use google_cloud_gax_internal::grpc;


### PR DESCRIPTION
Throughout google-cloud-rust, we prefer `mod tests` to `mod test` as the naming convention for modules containing tests. This change updates the only two modules that don't conform.