### PR TITLE
refactor: consolidate LRO integration tests

### DIFF
--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -24,7 +24,6 @@ pub mod error_details;
 pub mod firestore;
 pub mod secret_manager;
 pub mod storage;
-pub mod workflows;
 
 pub const VM_ID_LENGTH: usize = 63;
 

--- a/tests/integration/tests/driver.rs
+++ b/tests/integration/tests/driver.rs
@@ -289,28 +289,4 @@ mod driver {
             .await
             .map_err(integration_tests::report_error)
     }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_until_done() -> integration_tests::Result<()> {
-        let _guard = enable_tracing();
-        integration_tests::workflows::until_done()
-            .await
-            .map_err(integration_tests::report_error)
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_explicit() -> integration_tests::Result<()> {
-        let _guard = enable_tracing();
-        integration_tests::workflows::explicit_loop()
-            .await
-            .map_err(integration_tests::report_error)
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn workflows_manual() -> integration_tests::Result<()> {
-        let _guard = enable_tracing();
-        integration_tests::workflows::until_done()
-            .await
-            .map_err(integration_tests::report_error)
-    }
 }

--- a/tests/lro/src/lib.rs
+++ b/tests/lro/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod fake;
+pub mod production;
 
 #[cfg(test)]
 mod tests {

--- a/tests/lro/tests/driver.rs
+++ b/tests/lro/tests/driver.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod lro {
+    use google_cloud_test_utils::tracing::enable_tracing;
+
+    #[tokio::test]
+    async fn workflows_until_done() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_lro::production::until_done().await
+    }
+
+    #[tokio::test]
+    async fn workflows_explicit() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_lro::production::explicit_loop().await
+    }
+
+    #[tokio::test]
+    async fn workflows_manual() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_lro::production::until_done().await
+    }
+}


### PR DESCRIPTION
Move the LRO integration tests to the `integration-tests-lro` crate.