### PR TITLE
chore: make `cargo update` respect the MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [workspace]
-resolver = "2"
+resolver = "3"
 
 default-members = [
   "guide/samples",


### PR DESCRIPTION
TIL, one can configure the resolver to [respect the MSRV]. It requires rust >= 1.84 and the 2024 edition. Neither of those is a problem for us.

[respect the MSRV]:
https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

Fixes #4428 