### PR TITLE
feat(gax-internal): re-export tonic symbols

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -159,7 +159,7 @@ impl Client {
         options: gax::options::RequestOptions,
         api_client_header: &'static str,
         request_params: &str,
-    ) -> Result<tonic::Response<::tonic::Streaming<Response>>>
+    ) -> Result<tonic::Response<tonic::Streaming<Response>>>
     where
         Request: prost::Message + 'static,
         Response: prost::Message + Default + 'static,

--- a/src/gax-internal/src/grpc/tonic.rs
+++ b/src/gax-internal/src/grpc/tonic.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #4489 