### PR TITLE
cleanup(storage): use tonic reexports in handcrafted code

### DIFF
--- a/src/storage/src/retry_policy.rs
+++ b/src/storage/src/retry_policy.rs
@@ -142,6 +142,7 @@ mod tests {
     use super::*;
     use gax::error::rpc::Code;
     use gax::throttle_result::ThrottleResult;
+    use gaxi::grpc::tonic::Status;
     use http::HeaderMap;
     use test_case::test_case;
 
@@ -285,12 +286,11 @@ mod tests {
         let status = gax::error::rpc::Status::default().set_code(code);
         Error::service(status)
     }
-
     fn timeout_error() -> Error {
-        Error::timeout(tonic::Status::deadline_exceeded("try again"))
+        Error::timeout(Status::deadline_exceeded("try again"))
     }
 
     fn io_error() -> Error {
-        Error::io(tonic::Status::unavailable("try again"))
+        Error::io(Status::unavailable("try again"))
     }
 }

--- a/src/storage/src/storage/bidi/redirect.rs
+++ b/src/storage/src/storage/bidi/redirect.rs
@@ -18,13 +18,11 @@ use crate::google::storage::v2::{BidiReadObjectRedirectedError, BidiReadObjectSp
 use gax::error::rpc::Code;
 use gaxi::as_inner::as_inner;
 use gaxi::grpc::from_status::to_gax_error;
+use gaxi::grpc::tonic::Status;
 use prost::Message;
 use std::sync::{Arc, Mutex};
 
-pub fn handle_redirect(
-    spec: Arc<Mutex<BidiReadObjectSpec>>,
-    status: tonic::Status,
-) -> crate::Error {
+pub fn handle_redirect(spec: Arc<Mutex<BidiReadObjectSpec>>, status: Status) -> crate::Error {
     if let Ok(status) = RpcStatus::decode(status.details()) {
         for d in status.details {
             if let Ok(redirect) = d.to_msg::<BidiReadObjectRedirectedError>() {
@@ -43,7 +41,7 @@ pub fn is_redirect(error: &Error) -> bool {
     if error.status().is_none_or(|s| s.code != Code::Aborted) {
         return false;
     }
-    let Some(status) = as_inner::<tonic::Status, _>(error) else {
+    let Some(status) = as_inner::<Status, _>(error) else {
         return false;
     };
 
@@ -61,8 +59,8 @@ mod tests {
     use super::super::tests::{permanent_error, redirect_error, transient_error};
     use super::*;
     use crate::google::storage::v2::BidiReadHandle;
+    use gaxi::grpc::tonic::Code;
     use test_case::test_case;
-    use tonic::Code;
 
     #[test_case(Some("routing"), Some("handle"))]
     #[test_case(None, Some("handle"))]
@@ -83,7 +81,7 @@ mod tests {
             details: vec![redirect],
         };
         let details = bytes::Bytes::from_owner(status.encode_to_vec());
-        let status = tonic::Status::with_details(Code::Aborted, "test-only", details);
+        let status = Status::with_details(Code::Aborted, "test-only", details);
         let spec = BidiReadObjectSpec {
             routing_token: Some("initial-token".into()),
             read_handle: Some(BidiReadHandle {
@@ -108,7 +106,7 @@ mod tests {
             ..Default::default()
         };
         let details = bytes::Bytes::from_owner(status.encode_to_vec());
-        let status = tonic::Status::with_details(Code::Aborted, "test-only", details);
+        let status = Status::with_details(Code::Aborted, "test-only", details);
         let initial_handle = BidiReadHandle {
             handle: bytes::Bytes::from_static(b"initial-handle"),
         };
@@ -130,9 +128,9 @@ mod tests {
     #[test_case(transient_error(), false)]
     #[test_case(non_grpc_abort_error(), false)]
     #[test_case(redirect_error("r1"), true)]
-    #[test_case(to_gax_error(tonic::Status::aborted("without-details")), false)]
+    #[test_case(to_gax_error(Status::aborted("without-details")), false)]
     #[test_case(
-        to_gax_error(tonic::Status::with_details(
+        to_gax_error(Status::with_details(
             Code::Aborted,
             "with bad details",
             bytes::Bytes::from_static(b"\x01")

--- a/src/storage/src/storage/open_object.rs
+++ b/src/storage/src/storage/open_object.rs
@@ -400,6 +400,7 @@ mod tests {
     use crate::model_ext::tests::create_key_helper;
     use anyhow::Result;
     use gax::retry_policy::NeverRetry;
+    use gaxi::grpc::tonic::{Response as TonicResponse, Result as TonicResult};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use http::HeaderValue;
     use static_assertions::assert_impl_all;
@@ -438,7 +439,7 @@ mod tests {
     async fn open_object_normal() -> Result<()> {
         const BUCKET_NAME: &str = "projects/_/buckets/test-bucket";
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<BidiReadObjectResponse>>(1);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TonicResult<BidiReadObjectResponse>>(1);
         let initial = BidiReadObjectResponse {
             metadata: Some(ProtoObject {
                 bucket: BUCKET_NAME.to_string(),
@@ -453,7 +454,7 @@ mod tests {
 
         let mut mock = MockStorage::new();
         mock.expect_bidi_read_object()
-            .return_once(|_| Ok(tonic::Response::from(rx)));
+            .return_once(|_| Ok(TonicResponse::from(rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
 
         let client = Storage::builder()
@@ -582,7 +583,7 @@ mod tests {
         };
         use storage_grpc_mock::{MockStorage, start};
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<BidiReadObjectResponse>>(1);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TonicResult<BidiReadObjectResponse>>(1);
         let initial = BidiReadObjectResponse {
             metadata: Some(ProtoObject {
                 bucket: "projects/_/buckets/test-bucket".to_string(),
@@ -596,7 +597,7 @@ mod tests {
 
         let mut mock = MockStorage::new();
         mock.expect_bidi_read_object()
-            .return_once(|_| Ok(tonic::Response::from(rx)));
+            .return_once(|_| Ok(TonicResponse::from(rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
 
         let client = Storage::builder()
@@ -627,7 +628,7 @@ mod tests {
     async fn send_and_read() -> anyhow::Result<()> {
         use storage_grpc_mock::{MockStorage, start};
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<BidiReadObjectResponse>>(1);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TonicResult<BidiReadObjectResponse>>(1);
         let payload = Vec::from_iter((0..32).map(|i| i as u8));
         let initial = BidiReadObjectResponse {
             metadata: Some(ProtoObject {
@@ -653,7 +654,7 @@ mod tests {
 
         let mut mock = MockStorage::new();
         mock.expect_bidi_read_object()
-            .return_once(|_| Ok(tonic::Response::from(rx)));
+            .return_once(|_| Ok(TonicResponse::from(rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
 
         let client = Storage::builder()
@@ -691,11 +692,11 @@ mod tests {
         use storage_grpc_mock::google::storage::v2::BidiReadObjectResponse;
         use storage_grpc_mock::{MockStorage, start};
 
-        let (_tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<BidiReadObjectResponse>>(1);
+        let (_tx, rx) = tokio::sync::mpsc::channel::<TonicResult<BidiReadObjectResponse>>(1);
 
         let mut mock = MockStorage::new();
         mock.expect_bidi_read_object()
-            .return_once(|_| Ok(tonic::Response::from(rx)));
+            .return_once(|_| Ok(TonicResponse::from(rx)));
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
 
         let client = Storage::builder()


### PR DESCRIPTION
Fixes #4488 