### PR TITLE
chore: lro and wkt only need patch version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "1.4.0"
+version = "1.3.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "1.3.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -929,7 +929,7 @@ libraries:
           ignore: true
           package: ""
   - name: google-cloud-lro
-    version: 1.4.0
+    version: 1.3.1
     copyright_year: "2025"
     output: src/lro
     veneer: true
@@ -1533,7 +1533,7 @@ libraries:
     version: 1.5.0
     copyright_year: "2025"
   - name: google-cloud-wkt
-    version: 1.3.0
+    version: 1.2.1
     copyright_year: "2025"
     output: src/wkt
     veneer: true

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -19,7 +19,7 @@ name        = "google-cloud-lro"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version = "1.4.0"
+version = "1.3.1"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -19,7 +19,7 @@ name        = "google-cloud-wkt"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version = "1.3.0"
+version = "1.2.1"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true


### PR DESCRIPTION
Manually downgrade the bumps to patch changes. We are only modifying the `Cargo.toml` file, and then only renaming some stuff.  In hindsight, I should have done this in #4493 