### PR TITLE
docs: update librarian development instructions

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -189,7 +189,7 @@ the normal commands to use the directory where your librarian changes live. For
 example:
 
 ```bash
-go -C ../librarian/cmd/librarian build && ../librarian/cmd/librarian/librarian generate --all
+go -C ../librarian/cmd/librarian build && ../librarian/cmd/librarian/librarian -f generate --all
 ```
 
 Once the changes work then send a PR in the librarian repo to make your changes.


### PR DESCRIPTION
When testing how a librarian change works, we need to use `-f` to ignore the `version` field in `librarian.yaml`.