### PR TITLE
cleanup(integration-auth): full name for local deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -488,17 +488,14 @@ accesscontextmanager_type     = { default-features = false, version = "1", path 
 # Used in integration tests
 google-cloud-speech-v2          = { default-features = false, version = "1", path = "src/generated/cloud/speech/v2" }
 google-cloud-secretmanager-v1   = { default-features = false, path = "src/generated/cloud/secretmanager/v1" }
-secretmanager                   = { default-features = false, path = "src/generated/cloud/secretmanager/v1", package = "google-cloud-secretmanager-v1" }
 google-cloud-aiplatform-v1      = { default-features = false, path = "src/generated/cloud/aiplatform/v1" }
 google-cloud-compute-v1         = { default-features = false, version = "2", path = "src/generated/cloud/compute/v1" }
 google-cloud-storage            = { default-features = false, version = "1.7", path = "src/storage" }
 google-cloud-pubsub             = { default-features = false, path = "src/pubsub" }
 google-cloud-bigquery-v2        = { default-features = false, version = "1", path = "src/generated/cloud/bigquery/v2" }
 bigquery                        = { default-features = false, version = "1", path = "src/generated/cloud/bigquery/v2", package = "google-cloud-bigquery-v2" }
-google-cloud-iam-credentials-v1 = { default-features = false, version = "1", path = "src/generated/iam/credentials/v1" }
-iamcredentials                  = { default-features = false, version = "1", path = "src/generated/iam/credentials/v1", package = "google-cloud-iam-credentials-v1" }
-google-cloud-language-v2        = { default-features = false, version = "1", path = "src/generated/cloud/language/v2" }
-language                        = { default-features = false, version = "1", path = "src/generated/cloud/language/v2", package = "google-cloud-language-v2" }
+google-cloud-iam-credentials-v1 = { default-features = false, path = "src/generated/iam/credentials/v1" }
+google-cloud-language-v2        = { default-features = false, path = "src/generated/cloud/language/v2" }
 google-cloud-dns-v1             = { default-features = false, path = "src/generated/cloud/dns/v1" }
 google-cloud-firestore          = { default-features = false, path = "src/firestore" }
 google-cloud-showcase-v1beta1   = { default-features = false, path = "src/generated/showcase" }

--- a/tests/integration-auth/Cargo.toml
+++ b/tests/integration-auth/Cargo.toml
@@ -35,12 +35,12 @@ test-case.workspace  = true
 base64.workspace     = true
 reqwest.workspace    = true
 # Local dependencies
-google-cloud-auth        = { workspace = true, features = ["default", "idtoken"] }
-gax.workspace            = true
-language.workspace       = true
-secretmanager.workspace  = true
-iamcredentials.workspace = true
-bigquery.workspace       = true
+gax.workspace                   = true
+google-cloud-auth               = { workspace = true, features = ["default", "idtoken"] }
+google-cloud-bigquery-v2        = { workspace = true, features = ["default"] }
+google-cloud-iam-credentials-v1 = { workspace = true, features = ["default"] }
+google-cloud-language-v2        = { workspace = true, features = ["default"] }
+google-cloud-secretmanager-v1   = { workspace = true, features = ["default"] }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/tests/integration-auth/src/lib.rs
+++ b/tests/integration-auth/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bigquery::client::DatasetService;
 use gax::error::rpc::Code;
 use google_cloud_auth::credentials::idtoken::{
     Builder as IDTokenCredentialBuilder, impersonated::Builder as ImpersonatedIDTokenBuilder,
@@ -32,12 +31,13 @@ use google_cloud_auth::credentials::{
     subject_token::{Builder as SubjectTokenBuilder, SubjectToken, SubjectTokenProvider},
 };
 use google_cloud_auth::errors::SubjectTokenProviderError;
+use google_cloud_bigquery_v2::client::DatasetService;
+use google_cloud_iam_credentials_v1::client::IAMCredentials;
+use google_cloud_language_v2::client::LanguageService;
+use google_cloud_language_v2::model::{Document, document::Type};
+use google_cloud_secretmanager_v1::{client::SecretManagerService, model::SecretPayload};
 use httptest::{Expectation, Server, matchers::*, responders::*};
-use iamcredentials::client::IAMCredentials;
-use language::client::LanguageService;
-use language::model::Document;
 use scoped_env::ScopedEnv;
-use secretmanager::{client::SecretManagerService, model::SecretPayload};
 use std::sync::Arc;
 
 pub async fn service_account() -> anyhow::Result<()> {
@@ -194,7 +194,7 @@ pub async fn api_key() -> anyhow::Result<()> {
     // Make a request using the API key.
     let d = Document::new()
         .set_content("Hello, world!")
-        .set_type(language::model::document::Type::PlainText);
+        .set_type(Type::PlainText);
     client.analyze_sentiment().set_document(d).send().await?;
 
     Ok(())


### PR DESCRIPTION
Use the full name for local dependencies such as
`google-cloud-secretmanager-v1`.