### PR TITLE
cleanup(integration-tests): prefer full dep names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -498,6 +498,7 @@ google-cloud-language-v2        = { default-features = false, path = "src/genera
 google-cloud-dns-v1             = { default-features = false, path = "src/generated/cloud/dns/v1" }
 google-cloud-firestore          = { default-features = false, path = "src/firestore" }
 google-cloud-showcase-v1beta1   = { default-features = false, path = "src/generated/showcase" }
+google-cloud-telcoautomation-v1 = { default-features = false, path = "src/generated/cloud/telcoautomation/v1" }
 google-cloud-trace-v1           = { default-features = false, path = "src/generated/devtools/cloudtrace/v1" }
 secretmanager-openapi-v1        = { default-features = false, path = "src/generated/openapi-validation" }
 # The names on these are too long, I do not want to reformat the whole file for them.

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -27,41 +27,26 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 run-integration-tests = []
 
 [dependencies]
-anyhow.workspace        = true
-bytes.workspace         = true
-futures.workspace       = true
-google-cloud-auth       = { workspace = true, features = ["default"] }
-gax                     = { workspace = true, features = ["unstable-stream"] }
-gaxi                    = { workspace = true, features = ["_internal-http-client"] }
-google-cloud-test-utils = { workspace = true }
-http.workspace          = true
-rand                    = { workspace = true, features = ["thread_rng"] }
-reqwest.workspace       = true
-serde_json.workspace    = true
-tokio                   = { workspace = true, features = ["process", "test-util"] }
-tracing.workspace       = true
-tracing-subscriber      = { workspace = true, features = ["env-filter", "fmt", "std"] }
-uuid                    = { workspace = true, features = ["std", "v4"] }
-wkt.workspace           = true
-
-[dependencies.aiplatform]
-package          = "google-cloud-aiplatform-v1"
-path             = "../../src/generated/cloud/aiplatform/v1"
-default-features = false
-features         = ["prediction-service"]
-
-[dependencies.storage]
-package  = "google-cloud-storage"
-path     = "../../src/storage"
-features = ["unstable-stream"]
-
-[dependencies.ta]
-package = "google-cloud-telcoautomation-v1"
-path    = "../../src/generated/cloud/telcoautomation/v1"
-
-[dependencies.wf]
-package = "google-cloud-workflows-v1"
-path    = "../../src/generated/cloud/workflows/v1"
+anyhow.workspace                = true
+bytes.workspace                 = true
+futures.workspace               = true
+google-cloud-auth               = { workspace = true, features = ["default"] }
+google-cloud-gax                = { workspace = true, features = ["unstable-stream"] }
+gaxi                            = { workspace = true, features = ["_internal-http-client"] }
+google-cloud-test-utils         = { workspace = true }
+google-cloud-aiplatform-v1      = { workspace = true, features = ["default-rustls-provider", "prediction-service"] }
+google-cloud-storage            = { workspace = true, features = ["default"] }
+google-cloud-telcoautomation-v1 = { workspace = true, features = ["default"] }
+google-cloud-workflows-v1       = { workspace = true, features = ["default"] }
+http.workspace                  = true
+rand                            = { workspace = true, features = ["thread_rng"] }
+reqwest.workspace               = true
+serde_json.workspace            = true
+tokio                           = { workspace = true, features = ["process", "test-util"] }
+tracing.workspace               = true
+tracing-subscriber              = { workspace = true, features = ["env-filter", "fmt", "std"] }
+uuid                            = { workspace = true, features = ["std", "v4"] }
+wkt.workspace                   = true
 
 [dev-dependencies]
 anyhow.workspace            = true

--- a/tests/integration/src/error_details.rs
+++ b/tests/integration/src/error_details.rs
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Result;
-use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+use anyhow::Result;
+use google_cloud_gax::error::rpc::Code;
+use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+use google_cloud_storage::client::StorageControl;
+use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+use google_cloud_test_utils::resource_names::{random_bucket_id, random_workflow_id};
 use google_cloud_test_utils::runtime_config::{project_id, region_id};
-use storage::client::StorageControl;
+use google_cloud_workflows_v1::client::Workflows;
 
 pub async fn error_details_http() -> Result<()> {
     let project_id = project_id()?;
     let region_id = region_id();
-    let client = ta::client::TelcoAutomation::builder()
+    let client = TelcoAutomation::builder()
         .with_tracing()
         .with_retry_policy(AlwaysRetry.with_attempt_limit(2))
         .build()
@@ -60,20 +64,17 @@ pub async fn error_details_grpc() -> Result<()> {
 pub async fn check_code_for_http() -> Result<()> {
     let project_id = project_id()?;
     let location_id = region_id();
-    let workflow_id = crate::random_workflow_id();
+    let workflow_id = random_workflow_id();
     let workflow_name =
         format!("projects/{project_id}/locations/{location_id}/workflows/{workflow_id}");
-    let client = wf::client::Workflows::builder()
-        .with_tracing()
-        .build()
-        .await?;
+    let client = Workflows::builder().with_tracing().build().await?;
 
     match client.get_workflow().set_name(&workflow_name).send().await {
         Ok(g) => panic!("unexpected success {g:?}"),
         Err(e) => match e.status() {
             None => panic!("expected service error, got {e:?}"),
             Some(status) => {
-                let want = gax::error::rpc::Code::NotFound;
+                let want = Code::NotFound;
                 assert_eq!(status.code, want, "{e:?}");
                 tracing::info!("service error = {e}");
             }
@@ -84,7 +85,7 @@ pub async fn check_code_for_http() -> Result<()> {
 }
 
 pub async fn check_code_for_grpc() -> Result<()> {
-    let bucket_id = crate::random_bucket_id();
+    let bucket_id = random_bucket_id();
     let bucket_name = format!("projects/_/buckets/{bucket_id}");
     let client = StorageControl::builder().with_tracing().build().await?;
 
@@ -93,7 +94,7 @@ pub async fn check_code_for_grpc() -> Result<()> {
         Err(e) => match e.status() {
             None => panic!("expected service error, got {e:?}"),
             Some(status) => {
-                let want = gax::error::rpc::Code::NotFound;
+                let want = Code::NotFound;
                 assert_eq!(status.code, want, "{e:?}");
                 tracing::info!("service error = {e}");
             }

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -12,14 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use google_cloud_test_utils::resource_names::random_bucket_id;
-pub(crate) use google_cloud_test_utils::resource_names::random_workflow_id;
-
-pub type Result<T> = anyhow::Result<T>;
 pub mod error_details;
-
-pub fn report_error(e: anyhow::Error) -> anyhow::Error {
-    eprintln!("\n\nERROR {e:?}\n");
-    tracing::error!("ERROR {e:?}");
-    e
-}

--- a/tests/integration/tests/bindings.rs
+++ b/tests/integration/tests/bindings.rs
@@ -48,10 +48,11 @@
 /// message Response {}
 /// ```
 mod bindings {
-    use gax::error::{Error, binding::BindingError};
     use gaxi::path_parameter::{PathMismatchBuilder, try_match};
     use gaxi::routing_parameter::Segment;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_gax::Result as GaxResult;
+    use google_cloud_gax::error::{Error, binding::BindingError};
 
     /// A stand in for a generated request message.
     #[derive(Default, serde::Serialize)]
@@ -84,7 +85,7 @@ mod bindings {
         /// The code was copied exactly from `transport.rs`.
         ///
         /// TODO(#2523) - have the generator own this code, so it stays in sync.
-        pub fn builder(&self, req: Request) -> gax::Result<reqwest::RequestBuilder> {
+        pub fn builder(&self, req: Request) -> GaxResult<reqwest::RequestBuilder> {
             let builder = None
                 .or_else(|| {
                     let path = format!(
@@ -272,7 +273,7 @@ mod bindings {
                         );
                         paths.push(builder.build());
                     }
-                    gax::error::Error::binding(BindingError { paths })
+                    Error::binding(BindingError { paths })
                 })??;
 
             Ok(builder)
@@ -284,7 +285,9 @@ mod bindings {
 mod tests {
     use super::bindings::*;
     use anyhow::Result;
-    use gax::error::binding::{BindingError, PathMismatch, SubstitutionFail, SubstitutionMismatch};
+    use google_cloud_gax::error::binding::{
+        BindingError, PathMismatch, SubstitutionFail, SubstitutionMismatch,
+    };
     use std::collections::HashSet;
     use std::error::Error as _;
 

--- a/tests/integration/tests/driver.rs
+++ b/tests/integration/tests/driver.rs
@@ -17,34 +17,26 @@ mod driver {
     use google_cloud_test_utils::tracing::enable_tracing;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_error_details_http() -> integration_tests::Result<()> {
+    async fn run_error_details_http() -> anyhow::Result<()> {
         let _guard = enable_tracing();
-        integration_tests::error_details::error_details_http()
-            .await
-            .map_err(integration_tests::report_error)
+        integration_tests::error_details::error_details_http().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_error_details_grpc() -> integration_tests::Result<()> {
+    async fn run_error_details_grpc() -> anyhow::Result<()> {
         let _guard = enable_tracing();
-        integration_tests::error_details::error_details_grpc()
-            .await
-            .map_err(integration_tests::report_error)
+        integration_tests::error_details::error_details_grpc().await
+    }
+
+    #[tokio::test]
+    async fn run_check_code_for_http() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests::error_details::check_code_for_http().await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_check_code_for_http() -> integration_tests::Result<()> {
+    async fn run_check_code_for_grpc() -> anyhow::Result<()> {
         let _guard = enable_tracing();
-        integration_tests::error_details::check_code_for_http()
-            .await
-            .map_err(integration_tests::report_error)
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn run_check_code_for_grpc() -> integration_tests::Result<()> {
-        let _guard = enable_tracing();
-        integration_tests::error_details::check_code_for_grpc()
-            .await
-            .map_err(integration_tests::report_error)
+        integration_tests::error_details::check_code_for_grpc().await
     }
 }

--- a/tests/integration/tests/requests.rs
+++ b/tests/integration/tests/requests.rs
@@ -16,6 +16,7 @@
 
 #[cfg(test)]
 mod requests {
+    use google_cloud_aiplatform_v1::client::PredictionService;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use httptest::{Expectation, Server, matchers::*, responders::*};
     use serde_json::json;
@@ -25,7 +26,7 @@ mod requests {
         let server = start();
         let endpoint = server.url_str("/ui");
 
-        let client = aiplatform::client::PredictionService::builder()
+        let client = PredictionService::builder()
             .with_endpoint(&endpoint)
             .with_credentials(Anonymous::new().build())
             .build()


### PR DESCRIPTION
We can use the dependencies from the workspace and avoid dups.
