### PR TITLE
cleanup(pubsub): remove internal builders from public API

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1162,6 +1162,7 @@ libraries:
             - .google.pubsub.v1.Subscriber.StreamingPull
             - .google.pubsub.v1.Subscriber.Acknowledge
             - .google.pubsub.v1.Subscriber.ModifyAckDeadline
+          internal_builders: true
           output: src/pubsub/src/generated/gapic_dataplane
           service_config: google/pubsub/v1/pubsub_v1.yaml
           source: google/pubsub/v1

--- a/src/pubsub/src/generated/gapic_dataplane/builder.rs
+++ b/src/pubsub/src/generated/gapic_dataplane/builder.rs
@@ -41,23 +41,8 @@ pub mod publisher {
     }
 
     /// The request builder for [Publisher::publish][crate::client::Publisher::publish] calls.
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_pubsub::builder::publisher::Publish;
-    /// # async fn sample() -> gax::Result<()> {
-    ///
-    /// let builder = prepare_request_builder();
-    /// let response = builder.send().await?;
-    /// # Ok(()) }
-    ///
-    /// fn prepare_request_builder() -> Publish {
-    ///   # panic!();
-    ///   // ... details omitted ...
-    /// }
-    /// ```
     #[derive(Clone, Debug)]
-    pub struct Publish(RequestBuilder<crate::model::PublishRequest>);
+    pub(crate) struct Publish(RequestBuilder<crate::model::PublishRequest>);
 
     impl Publish {
         pub(crate) fn new(
@@ -143,23 +128,8 @@ pub mod subscriber {
     }
 
     /// The request builder for [Subscriber::modify_ack_deadline][crate::client::Subscriber::modify_ack_deadline] calls.
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_pubsub::builder::subscriber::ModifyAckDeadline;
-    /// # async fn sample() -> gax::Result<()> {
-    ///
-    /// let builder = prepare_request_builder();
-    /// let response = builder.send().await?;
-    /// # Ok(()) }
-    ///
-    /// fn prepare_request_builder() -> ModifyAckDeadline {
-    ///   # panic!();
-    ///   // ... details omitted ...
-    /// }
-    /// ```
     #[derive(Clone, Debug)]
-    pub struct ModifyAckDeadline(RequestBuilder<crate::model::ModifyAckDeadlineRequest>);
+    pub(crate) struct ModifyAckDeadline(RequestBuilder<crate::model::ModifyAckDeadlineRequest>);
 
     impl ModifyAckDeadline {
         pub(crate) fn new(
@@ -229,23 +199,8 @@ pub mod subscriber {
     }
 
     /// The request builder for [Subscriber::acknowledge][crate::client::Subscriber::acknowledge] calls.
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_pubsub::builder::subscriber::Acknowledge;
-    /// # async fn sample() -> gax::Result<()> {
-    ///
-    /// let builder = prepare_request_builder();
-    /// let response = builder.send().await?;
-    /// # Ok(()) }
-    ///
-    /// fn prepare_request_builder() -> Acknowledge {
-    ///   # panic!();
-    ///   // ... details omitted ...
-    /// }
-    /// ```
     #[derive(Clone, Debug)]
-    pub struct Acknowledge(RequestBuilder<crate::model::AcknowledgeRequest>);
+    pub(crate) struct Acknowledge(RequestBuilder<crate::model::AcknowledgeRequest>);
 
     impl Acknowledge {
         pub(crate) fn new(

--- a/src/pubsub/src/generated/gapic_dataplane/client.rs
+++ b/src/pubsub/src/generated/gapic_dataplane/client.rs
@@ -68,7 +68,7 @@ impl Publisher {
 
     /// Adds one or more messages to the topic. Returns `NOT_FOUND` if the topic
     /// does not exist.
-    pub fn publish(&self) -> super::builder::publisher::Publish {
+    pub(crate) fn publish(&self) -> super::builder::publisher::Publish {
         super::builder::publisher::Publish::new(self.inner.clone())
     }
 }
@@ -128,7 +128,7 @@ impl Subscriber {
     /// subscriber, or to make the message available for redelivery if the
     /// processing was interrupted. Note that this does not modify the
     /// subscription-level `ackDeadlineSeconds` used for subsequent messages.
-    pub fn modify_ack_deadline(&self) -> super::builder::subscriber::ModifyAckDeadline {
+    pub(crate) fn modify_ack_deadline(&self) -> super::builder::subscriber::ModifyAckDeadline {
         super::builder::subscriber::ModifyAckDeadline::new(self.inner.clone())
     }
 
@@ -139,7 +139,7 @@ impl Subscriber {
     /// Acknowledging a message whose ack deadline has expired may succeed,
     /// but such a message may be redelivered later. Acknowledging a message more
     /// than once will not result in an error.
-    pub fn acknowledge(&self) -> super::builder::subscriber::Acknowledge {
+    pub(crate) fn acknowledge(&self) -> super::builder::subscriber::Acknowledge {
         super::builder::subscriber::Acknowledge::new(self.inner.clone())
     }
 }

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -71,9 +71,6 @@ pub use gax::error::Error;
 pub mod builder {
     /// Request and client builders for the [Publisher][crate::client::Publisher] client.
     pub mod publisher {
-        // TODO(#3959) - remove internal types from the public API.
-        #[doc(hidden)]
-        pub use crate::generated::gapic_dataplane::builder::publisher::*;
         pub use crate::publisher::base_publisher::BasePublisherBuilder;
         pub use crate::publisher::builder::PublisherBuilder;
         pub use crate::publisher::builder::PublisherPartialBuilder;
@@ -82,9 +79,6 @@ pub mod builder {
     pub use crate::generated::gapic::builder::schema_service;
     /// Request and client builders for the [Subscriber][crate::client::Subscriber] client.
     pub mod subscriber {
-        // TODO(#3959) - remove internal types from the public API.
-        #[doc(hidden)]
-        pub use crate::generated::gapic_dataplane::builder::subscriber::*;
         pub use crate::subscriber::builder::StreamingPull;
         pub use crate::subscriber::client_builder::ClientBuilder;
     }


### PR DESCRIPTION
Use `internal_builders` config in librarian.yaml to generate `pub(crate)` visibility for pubsub dataplane builders. This also removes the previous `#[doc(hidden)]` workaround used to avoid `doctest` failures.

Fix #3959