### PR TITLE
cleanup(auth): gate unused symbol in tests

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -1007,6 +1007,7 @@ pub(crate) mod tests {
             .expect("Failed to create RsaPrivateKey from primes")
     });
 
+    #[cfg(feature = "idtoken")]
     pub static ES256_PRIVATE_KEY: LazyLock<p256::SecretKey> = LazyLock::new(|| {
         let secret_key_bytes = [
             0x4c, 0x0c, 0x11, 0x6e, 0x6e, 0xb0, 0x07, 0xbd, 0x48, 0x0c, 0xc0, 0x48, 0xc0, 0x1f,


### PR DESCRIPTION
This constant is only used by the idtoken tests.

Noticed when running `cargo clippy -p google-cloud-auth --profile=test`