### PR TITLE
refactor(pubsub): simplify ConcurrentBatchActor

### DIFF
--- a/src/pubsub/src/publisher/actor.rs
+++ b/src/pubsub/src/publisher/actor.rs
@@ -550,7 +550,7 @@ mod tests {
             msg: PubsubMessage::new().set_data("hello"),
             tx: publish_tx,
         };
-        let _ = actor_tx.send(ToBatchActor::Publish(bundle))?;
+        actor_tx.send(ToBatchActor::Publish(bundle))?;
         let res = publish_rx.await;
         assert!(matches!(res, Ok(Ok(ref msg)) if msg == "hello"), "{res:?}");
         Ok(())
@@ -576,8 +576,8 @@ mod tests {
 
         // Flush on empty.
         let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
-        let _ = actor_tx.send(ToBatchActor::Flush(flush_tx))?;
-        let _ = flush_rx.await?;
+        actor_tx.send(ToBatchActor::Flush(flush_tx))?;
+        flush_rx.await?;
 
         // Publish a message then Flush.
         let (publish_tx, publish_rx) = tokio::sync::oneshot::channel();
@@ -585,10 +585,10 @@ mod tests {
             msg: PubsubMessage::new().set_data("hello"),
             tx: publish_tx,
         };
-        let _ = actor_tx.send(ToBatchActor::Publish(bundle))?;
+        actor_tx.send(ToBatchActor::Publish(bundle))?;
         let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
-        let _ = actor_tx.send(ToBatchActor::Flush(flush_tx))?;
-        let _ = flush_rx.await?;
+        actor_tx.send(ToBatchActor::Flush(flush_tx))?;
+        flush_rx.await?;
         let res = publish_rx.await;
         assert!(matches!(res, Ok(Ok(ref msg)) if msg == "hello"), "{res:?}");
 
@@ -608,7 +608,7 @@ mod tests {
             .run(),
         );
 
-        let _ = actor_tx.send(ToBatchActor::ResumePublish())?;
+        actor_tx.send(ToBatchActor::ResumePublish())?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR simplify ConcurrentBatchActor by removing pause and the pending_msgs queue. A followup PR will cleanup SequentialBatchActor.