### PR TITLE
fix(pubsub): retry acks when channel closes

### DIFF
--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -23,17 +23,24 @@ pub struct StreamingPull {
     pub(super) inner: Arc<Transport>,
     pub(super) subscription: String,
     pub(super) client_id: String,
+    pub(super) grpc_subchannel_count: usize,
     pub(super) ack_deadline_seconds: i32,
     pub(super) max_outstanding_messages: i64,
     pub(super) max_outstanding_bytes: i64,
 }
 
 impl StreamingPull {
-    pub(super) fn new(inner: Arc<Transport>, subscription: String, client_id: String) -> Self {
+    pub(super) fn new(
+        inner: Arc<Transport>,
+        subscription: String,
+        client_id: String,
+        grpc_subchannel_count: usize,
+    ) -> Self {
         Self {
             inner,
             subscription,
             client_id,
+            grpc_subchannel_count,
             ack_deadline_seconds: 10,
             max_outstanding_messages: 1000,
             max_outstanding_bytes: 100 * MIB,
@@ -170,11 +177,13 @@ mod tests {
             test_inner().await?,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             "client-id".to_string(),
+            1_usize,
         );
         assert_eq!(
             builder.subscription,
             "projects/my-project/subscriptions/my-subscription"
         );
+        assert_eq!(builder.grpc_subchannel_count, 1);
         assert_eq!(builder.ack_deadline_seconds, 10);
         assert!(
             100_000 > builder.max_outstanding_messages && builder.max_outstanding_messages > 100,
@@ -196,6 +205,7 @@ mod tests {
             test_inner().await?,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             "client-id".to_string(),
+            1_usize,
         )
         .set_ack_deadline_seconds(20)
         .set_max_outstanding_messages(12345)
@@ -204,6 +214,7 @@ mod tests {
             builder.subscription,
             "projects/my-project/subscriptions/my-subscription"
         );
+        assert_eq!(builder.grpc_subchannel_count, 1);
         assert_eq!(builder.ack_deadline_seconds, 20);
         assert_eq!(builder.max_outstanding_messages, 12345);
         assert_eq!(builder.max_outstanding_bytes, 6789 * KIB);

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::retry_policy::at_least_once_options;
 use super::stub::Stub;
 use crate::model::{AcknowledgeRequest, ModifyAckDeadlineRequest};
 use gax::options::RequestOptions;
-use gax::retry_policy::NeverRetry;
 use std::sync::Arc;
 
 /// A trait representing leaser actions.
@@ -61,20 +61,19 @@ impl<T> DefaultLeaser<T>
 where
     T: Stub,
 {
-    pub(super) fn new(inner: Arc<T>, subscription: String, ack_deadline_seconds: i32) -> Self {
+    pub(super) fn new(
+        inner: Arc<T>,
+        subscription: String,
+        ack_deadline_seconds: i32,
+        grpc_subchannel_count: usize,
+    ) -> Self {
         DefaultLeaser {
             inner,
-            options: no_retry(),
+            options: at_least_once_options(grpc_subchannel_count),
             subscription,
             ack_deadline_seconds,
         }
     }
-}
-
-fn no_retry() -> RequestOptions {
-    let mut o = RequestOptions::default();
-    o.set_retry_policy(NeverRetry);
-    o
 }
 
 #[async_trait::async_trait]
@@ -113,6 +112,7 @@ where
 #[cfg(test)]
 pub(super) mod tests {
     use super::super::lease_state::tests::test_ids;
+    use super::super::retry_policy::tests::verify_policies;
     use super::super::stub::tests::MockStub;
     use super::*;
     use gax::response::Response;
@@ -162,6 +162,7 @@ pub(super) mod tests {
             Arc::new(MockStub::new()),
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
+            1_usize,
         );
 
         let clone = leaser.clone();
@@ -179,10 +180,7 @@ pub(super) mod tests {
                 "projects/my-project/subscriptions/my-subscription"
             );
             assert_eq!(r.ack_ids, test_ids(0..10));
-            assert!(
-                format!("{o:?}").contains("NeverRetry"),
-                "Basic acks should not have a retry policy. o={o:?}"
-            );
+            verify_policies(o, 16);
             Ok(Response::from(()))
         });
 
@@ -190,6 +188,7 @@ pub(super) mod tests {
             Arc::new(mock),
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
+            16_usize,
         );
         leaser.ack(test_ids(0..10)).await;
     }
@@ -206,10 +205,7 @@ pub(super) mod tests {
                     "projects/my-project/subscriptions/my-subscription"
                 );
                 assert_eq!(r.ack_ids, test_ids(0..10));
-                assert!(
-                    format!("{o:?}").contains("NeverRetry"),
-                    "Basic modacks should not have a retry policy. o={o:?}"
-                );
+                verify_policies(o, 16);
                 Ok(Response::from(()))
             });
 
@@ -217,6 +213,7 @@ pub(super) mod tests {
             Arc::new(mock),
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
+            16_usize,
         );
         leaser.nack(test_ids(0..10)).await;
     }
@@ -233,10 +230,7 @@ pub(super) mod tests {
                     "projects/my-project/subscriptions/my-subscription"
                 );
                 assert_eq!(r.ack_ids, test_ids(0..10));
-                assert!(
-                    format!("{o:?}").contains("NeverRetry"),
-                    "Basic acks should not have a retry policy. o={o:?}"
-                );
+                verify_policies(o, 16);
                 Ok(Response::from(()))
             });
 
@@ -244,6 +238,7 @@ pub(super) mod tests {
             Arc::new(mock),
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
+            16_usize,
         );
         leaser.extend(test_ids(0..10)).await;
     }

--- a/src/pubsub/src/subscriber/retry_policy.rs
+++ b/src/pubsub/src/subscriber/retry_policy.rs
@@ -80,7 +80,6 @@ impl BackoffPolicy for NoBackoff {
     }
 }
 
-#[allow(dead_code)] // TODO(#4471) - use in DefaultLeaser
 /// The policies for lease management RPCs in at-least-once delivery.
 ///
 /// Specifically, these are the `Acknowledge` and `ModifyAckDeadline` RPCs.

--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -100,6 +100,7 @@ impl Session {
             inner.clone(),
             subscription.clone(),
             builder.ack_deadline_seconds,
+            builder.grpc_subchannel_count,
         );
         let LeaseLoop {
             handle: _lease_loop,


### PR DESCRIPTION
Fixes #4471 

Use the at least once policies in the default leaser. The policies depend on the gRPC subchannel count, so plumb that through all the layers.

The effect is that we retry acks that fail with transport errors when a channel closes, and the application avoids frozen messages every hour or so.