### PR TITLE
ci: enable automatic updates for go toolchains

### DIFF
--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -106,6 +106,8 @@ steps:
       V=$(cat .librarian-version.txt)
       go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
     waitFor: ['-']
+    env:
+      - GOTOOLCHAIN=auto
   - name: 'ubuntu:24.04'
     id: 'Format Protobuf files'
     script: |


### PR DESCRIPTION
`librarian` routinely requires newer versions of `go`. One of the CI builds disabled automatic updates by default. Enabling the updates will reduce our effort to keep the builds working.

Fixes https://github.com/googleapis/librarian/issues/3799
