### PR TITLE
cleanup(auth): use full name for `google-cloud-gax`

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -51,7 +51,7 @@ jsonwebtoken          = { workspace = true, optional = true }
 # See: https://github.com/Keats/jsonwebtoken/pull/481
 aws-lc-rs = { workspace = true, optional = true }
 # Local dependencies
-gax.workspace = true
+google-cloud-gax.workspace = true
 
 [dev-dependencies]
 anyhow.workspace      = true

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -115,7 +115,7 @@ pub struct Credentials {
     // will not do.
     //
     // They also need to derive `Clone`, as the
-    // `gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
+    // `google_cloud_gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
     // `Box` will not do.
     inner: Arc<dyn dynamic::CredentialsProvider>,
 }
@@ -156,7 +156,7 @@ pub struct AccessTokenCredentials {
     // will not do.
     //
     // They also need to derive `Clone`, as the
-    // `gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
+    // `google_cloud_gax::http_client::ReqwestClient`s which hold them derive `Clone`. So a
     // `Box` will not do.
     inner: Arc<dyn dynamic::AccessTokenCredentialsProvider>,
 }
@@ -856,11 +856,11 @@ pub mod testing {
 pub(crate) mod tests {
     use super::*;
     use base64::Engine;
-    use gax::backoff_policy::BackoffPolicy;
-    use gax::retry_policy::RetryPolicy;
-    use gax::retry_result::RetryResult;
-    use gax::retry_state::RetryState;
-    use gax::retry_throttler::RetryThrottler;
+    use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::retry_policy::RetryPolicy;
+    use google_cloud_gax::retry_result::RetryResult;
+    use google_cloud_gax::retry_state::RetryState;
+    use google_cloud_gax::retry_throttler::RetryThrottler;
     use mockall::mock;
     use reqwest::header::AUTHORIZATION;
     use rsa::BigUint;
@@ -893,7 +893,7 @@ pub(crate) mod tests {
             fn on_error(
                 &self,
                 state: &RetryState,
-                error: gax::error::Error,
+                error: google_cloud_gax::error::Error,
             ) -> RetryResult;
         }
     }

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -69,8 +69,8 @@
 //! # use http::Extensions;
 //! # use std::time::Duration;
 //! # tokio_test::block_on(async {
-//! use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-//! use gax::exponential_backoff::ExponentialBackoff;
+//! use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+//! use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 //! # let project_id = "your-gcp-project-id";
 //! # let pool_id = "your-workload-identity-pool-id";
 //! # let provider_id = "your-provider-id";
@@ -126,9 +126,9 @@ use crate::retry::Builder as RetryTokenProviderBuilder;
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -555,7 +555,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::external_account::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let config = serde_json::json!({
     ///     "type": "external_account",
     ///     "audience": "audience",
@@ -581,7 +581,7 @@ impl Builder {
     /// # use google_cloud_auth::credentials::external_account::Builder;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// let config = serde_json::json!({
     ///     "type": "external_account",
     ///     "audience": "audience",
@@ -614,7 +614,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::external_account::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let config = serde_json::json!({
     ///     "type": "external_account",
     ///     "audience": "audience",
@@ -1124,7 +1124,7 @@ impl ProgrammaticBuilder {
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let provider = Arc::new(MyTokenProvider);
     /// let credentials = ProgrammaticBuilder::new(provider)
     ///     .with_audience("test-audience")
@@ -1167,7 +1167,7 @@ impl ProgrammaticBuilder {
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// let provider = Arc::new(MyTokenProvider);
     /// let policy = ExponentialBackoff::default();
     /// let credentials = ProgrammaticBuilder::new(provider)
@@ -1218,7 +1218,7 @@ impl ProgrammaticBuilder {
     /// # }
     /// #
     /// # tokio_test::block_on(async {
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let provider = Arc::new(MyTokenProvider);
     /// let credentials = ProgrammaticBuilder::new(provider)
     ///     .with_audience("test-audience")

--- a/src/auth/src/credentials/external_account_sources/executable_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/executable_sourced.rs
@@ -20,7 +20,7 @@ use crate::{
         Builder as SubjectTokenBuilder, SubjectToken, SubjectTokenProvider,
     },
 };
-use gax::error::CredentialsError;
+use google_cloud_gax::error::CredentialsError;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},

--- a/src/auth/src/credentials/external_account_sources/file_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/file_sourced.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gax::error::CredentialsError;
+use google_cloud_gax::error::CredentialsError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 

--- a/src/auth/src/credentials/external_account_sources/url_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/url_sourced.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gax::error::CredentialsError;
+use google_cloud_gax::error::CredentialsError;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/src/auth/src/credentials/idtoken/impersonated.rs
+++ b/src/auth/src/credentials/idtoken/impersonated.rs
@@ -27,7 +27,7 @@
 //! ```
 //! # use google_cloud_auth::credentials::idtoken;
 //! # use serde_json::json;
-//! # use reqwest;    
+//! # use reqwest;
 //! # tokio_test::block_on(async {
 //! let source_credentials = json!({
 //!     "type": "authorized_user",
@@ -83,10 +83,10 @@ use crate::{
     token_cache::TokenCache,
 };
 use async_trait::async_trait;
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::error::CredentialsError;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::error::CredentialsError;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use reqwest::Client;
 use serde_json::Value;
@@ -128,7 +128,7 @@ impl Builder {
     /// [application default login] with the [impersonation flag].
     ///
     /// [impersonation flag]: https://cloud.google.com/docs/authentication/use-service-account-impersonation#adc
-    /// [application default login]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login  
+    /// [application default login]: https://cloud.google.com/sdk/gcloud/reference/auth/application-default/login
     pub fn new<S: Into<String>>(target_audience: S, impersonated_credential: Value) -> Self {
         Self {
             source: BuilderSource::FromJson(impersonated_credential),
@@ -158,7 +158,7 @@ impl Builder {
     /// # Ok::<(), anyhow::Error>(())
     /// # }
     /// // Now you can use credentials.id_token().await to fetch the token.
-    /// ```    
+    /// ```
     pub fn from_source_credentials<SA: Into<String>, SP: Into<String>>(
         target_audience: SA,
         target_principal: SP,
@@ -200,7 +200,7 @@ impl Builder {
     ///     .with_include_email()
     ///     .build();
     /// // Now you can use credentials.id_token().await to fetch the token.
-    /// ```    
+    /// ```
     pub fn with_include_email(mut self) -> Self {
         self.include_email = Some(true);
         self
@@ -240,7 +240,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     ///
     /// let impersonated_credential = json!({ /* add details here */ });
     ///
@@ -263,7 +263,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     ///
     /// let impersonated_credential = json!({ /* add details here */ });
     ///
@@ -293,7 +293,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     ///
     /// let impersonated_credential = json!({ /* add details here */ });
     ///

--- a/src/auth/src/credentials/idtoken/mds.rs
+++ b/src/auth/src/credentials/idtoken/mds.rs
@@ -53,7 +53,7 @@
 //!     .await?;
 //! # Ok::<(), anyhow::Error>(())
 //! # });
-//! ```    
+//! ```
 //!
 //! [Application Default Credentials]: https://cloud.google.com/docs/authentication/application-default-credentials
 //! [OIDC ID Tokens]: https://cloud.google.com/docs/authentication/token-types#identity-tokens
@@ -77,9 +77,9 @@ use crate::{
     credentials::idtoken::{IDTokenCredentials, parse_id_token_from_str},
 };
 use async_trait::async_trait;
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::Extensions;
 use std::sync::Arc;
 
@@ -156,7 +156,7 @@ impl Builder {
 
     /// Sets the endpoint for this credentials.
     ///
-    /// A trailing slash is significant, so specify the base URL without a trailing  
+    /// A trailing slash is significant, so specify the base URL without a trailing
     /// slash. If not set, the credentials use `http://metadata.google.internal`.
     ///
     /// # Example
@@ -233,7 +233,7 @@ impl Builder {
     ///
     /// ```no_run
     /// # use google_cloud_auth::credentials::idtoken;
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     ///
     /// let audience = "https://my-service.a.run.app";
     /// let credentials = idtoken::mds::Builder::new(audience)
@@ -253,7 +253,7 @@ impl Builder {
     ///
     /// ```no_run
     /// # use google_cloud_auth::credentials::idtoken;
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     ///
     /// let audience = "https://my-service.a.run.app";
     /// let credentials = idtoken::mds::Builder::new(audience)
@@ -280,7 +280,7 @@ impl Builder {
     ///
     /// ```no_run
     /// # use google_cloud_auth::credentials::idtoken;
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     ///
     /// let audience = "https://my-service.a.run.app";
     /// let credentials = idtoken::mds::Builder::new(audience)

--- a/src/auth/src/credentials/idtoken/service_account.rs
+++ b/src/auth/src/credentials/idtoken/service_account.rs
@@ -73,7 +73,7 @@ use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, credentials::idtoken::IDTokenCredentials};
 use async_trait::async_trait;
-use gax::error::CredentialsError;
+use google_cloud_gax::error::CredentialsError;
 use http::Extensions;
 use reqwest::Client;
 use serde_json::Value;

--- a/src/auth/src/credentials/idtoken/user_account.rs
+++ b/src/auth/src/credentials/idtoken/user_account.rs
@@ -70,10 +70,10 @@ use crate::{
     },
 };
 use async_trait::async_trait;
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::error::CredentialsError;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::error::CredentialsError;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::Extensions;
 use serde_json::Value;
 use std::sync::Arc;
@@ -171,13 +171,13 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     ///
     /// let authorized_user = json!({ /* add details here */ });
     ///
     /// let credentials = idtoken::user_account::Builder::new(authorized_user)
     ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
-    ///     .build();    
+    ///     .build();
     /// ```
     pub fn with_retry_policy<V: Into<RetryPolicyArg>>(mut self, v: V) -> Self {
         self.retry_builder = self.retry_builder.with_retry_policy(v.into());
@@ -193,7 +193,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     ///
     /// let authorized_user = json!({ /* add details here */ });
     ///
@@ -222,7 +222,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::idtoken;
     /// # use serde_json::json;
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     ///
     /// let authorized_user = json!({ /* add details here */ });
     ///

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -61,8 +61,8 @@
 //! # use std::time::Duration;
 //! # use http::Extensions;
 //! # tokio_test::block_on(async {
-//! use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-//! use gax::exponential_backoff::ExponentialBackoff;
+//! use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+//! use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 //! # let source_credentials = json!({
 //! #     "type": "authorized_user",
 //! #     "client_id": "test-client-id",
@@ -107,9 +107,9 @@ use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
 use async_trait::async_trait;
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use reqwest::Client;
 use serde_json::Value;
@@ -345,7 +345,7 @@ impl Builder {
     /// # use google_cloud_auth::credentials::impersonated::Builder;
     /// # use serde_json::json;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let impersonated_credential = json!({ /* add details here */ });
     /// let credentials = Builder::new(impersonated_credential.into())
     ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
@@ -366,7 +366,7 @@ impl Builder {
     /// # use serde_json::json;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// let policy = ExponentialBackoff::default();
     /// let impersonated_credential = json!({ /* add details here */ });
     /// let credentials = Builder::new(impersonated_credential.into())
@@ -394,7 +394,7 @@ impl Builder {
     /// # use google_cloud_auth::credentials::impersonated::Builder;
     /// # use serde_json::json;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let impersonated_credential = json!({ /* add details here */ });
     /// let credentials = Builder::new(impersonated_credential.into())
     ///     .with_retry_throttler(AdaptiveThrottler::default())

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -54,8 +54,8 @@
 //! # use http::Extensions;
 //! # use std::time::Duration;
 //! # tokio_test::block_on(async {
-//! use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-//! use gax::exponential_backoff::ExponentialBackoff;
+//! use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+//! use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 //! let backoff = ExponentialBackoff::default();
 //! let credentials: Credentials = Builder::default()
 //!     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
@@ -83,10 +83,10 @@ use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
 use async_trait::async_trait;
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::error::CredentialsError;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::error::CredentialsError;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::{Extensions, HeaderMap};
 use std::default::Default;
 use std::sync::Arc;
@@ -187,7 +187,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let credentials = Builder::default()
     ///     .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
     ///     .build();
@@ -206,7 +206,7 @@ impl Builder {
     /// # use google_cloud_auth::credentials::mds::Builder;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// let policy = ExponentialBackoff::default();
     /// let credentials = Builder::default()
     ///     .with_backoff_policy(policy)
@@ -232,7 +232,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::mds::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let credentials = Builder::default()
     ///     .with_retry_throttler(AdaptiveThrottler::default())
     ///     .build();

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -67,8 +67,8 @@
 //! # use http::Extensions;
 //! # use std::time::Duration;
 //! # tokio_test::block_on(async {
-//! use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-//! use gax::exponential_backoff::ExponentialBackoff;
+//! use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+//! use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 //! let authorized_user = serde_json::json!({
 //!     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
 //!     "client_secret": "YOUR_CLIENT_SECRET",
@@ -104,9 +104,9 @@ use crate::retry::Builder as RetryTokenProviderBuilder;
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
 use crate::{BuildResult, Result};
-use gax::backoff_policy::BackoffPolicyArg;
-use gax::retry_policy::RetryPolicyArg;
-use gax::retry_throttler::RetryThrottlerArg;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 use http::header::CONTENT_TYPE;
 use http::{Extensions, HeaderMap, HeaderValue};
 use reqwest::{Client, Method};
@@ -229,7 +229,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",
@@ -254,7 +254,7 @@ impl Builder {
     /// # use google_cloud_auth::credentials::user_account::Builder;
     /// # use std::time::Duration;
     /// # tokio_test::block_on(async {
-    /// use gax::exponential_backoff::ExponentialBackoff;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",
@@ -285,7 +285,7 @@ impl Builder {
     /// ```
     /// # use google_cloud_auth::credentials::user_account::Builder;
     /// # tokio_test::block_on(async {
-    /// use gax::retry_throttler::AdaptiveThrottler;
+    /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let authorized_user = serde_json::json!({
     ///     "client_id": "YOUR_CLIENT_ID.apps.googleusercontent.com",
     ///     "client_secret": "YOUR_CLIENT_SECRET",

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -17,7 +17,7 @@
 use http::StatusCode;
 use std::error::Error;
 
-pub use gax::error::CredentialsError;
+pub use google_cloud_gax::error::CredentialsError;
 
 /// Represents an error using [SubjectTokenProvider].
 ///

--- a/src/auth/src/retry.rs
+++ b/src/auth/src/retry.rs
@@ -17,11 +17,13 @@
 use crate::errors::CredentialsError;
 use crate::token::{Token, TokenProvider};
 use crate::{Result, constants};
-use gax::backoff_policy::{BackoffPolicy, BackoffPolicyArg};
-use gax::exponential_backoff::ExponentialBackoff;
-use gax::retry_loop_internal::retry_loop;
-use gax::retry_policy::{AlwaysRetry, RetryPolicy, RetryPolicyArg, RetryPolicyExt};
-use gax::retry_throttler::{AdaptiveThrottler, RetryThrottlerArg, SharedRetryThrottler};
+use google_cloud_gax::backoff_policy::{BackoffPolicy, BackoffPolicyArg};
+use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+use google_cloud_gax::retry_loop_internal::retry_loop;
+use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicy, RetryPolicyArg, RetryPolicyExt};
+use google_cloud_gax::retry_throttler::{
+    AdaptiveThrottler, RetryThrottlerArg, SharedRetryThrottler,
+};
 use std::error::Error;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::{Arc, Mutex};
@@ -112,7 +114,7 @@ where
                 inner
                     .token()
                     .await
-                    .map_err(gax::error::Error::authentication)
+                    .map_err(google_cloud_gax::error::Error::authentication)
             }
         };
 
@@ -128,7 +130,7 @@ where
         .map_err(Self::map_retry_error)
     }
 
-    fn map_retry_error(e: gax::error::Error) -> CredentialsError {
+    fn map_retry_error(e: google_cloud_gax::error::Error) -> CredentialsError {
         if !e.is_authentication() {
             return CredentialsError::from_source(false, e);
         }
@@ -149,10 +151,10 @@ mod tests {
     use super::*;
     use crate::credentials::tests::find_source_error;
     use crate::token::{Token, TokenProvider, tests::MockTokenProvider};
-    use gax::retry_policy::RetryPolicy;
-    use gax::retry_result::RetryResult;
-    use gax::retry_state::RetryState;
-    use gax::retry_throttler::RetryThrottler;
+    use google_cloud_gax::retry_policy::RetryPolicy;
+    use google_cloud_gax::retry_result::RetryResult;
+    use google_cloud_gax::retry_state::RetryState;
+    use google_cloud_gax::retry_throttler::RetryThrottler;
     use mockall::{Sequence, mock};
     use static_assertions::assert_impl_all;
     use std::error::Error;
@@ -177,7 +179,11 @@ mod tests {
     }
 
     impl RetryPolicy for AuthRetryPolicy {
-        fn on_error(&self, state: &RetryState, error: gax::error::Error) -> RetryResult {
+        fn on_error(
+            &self,
+            state: &RetryState,
+            error: google_cloud_gax::error::Error,
+        ) -> RetryResult {
             if state.attempt_count >= self.max_attempts {
                 return RetryResult::Exhausted(error);
             }
@@ -478,7 +484,7 @@ mod tests {
     #[test]
     fn test_map_retry_error_non_auth_error() {
         // 1. Create a non-authentication error.
-        let original_error = gax::error::Error::io("test-io-error");
+        let original_error = google_cloud_gax::error::Error::io("test-io-error");
         let original_error_string = original_error.to_string();
 
         // 2. Call the function under test.

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -148,7 +148,7 @@ mod tests {
     use super::*;
     use crate::errors;
     use crate::token::tests::MockTokenProvider;
-    use gax::error::CredentialsError;
+    use google_cloud_gax::error::CredentialsError;
     use std::ops::{Add, Sub};
     use std::sync::{Arc, Mutex};
     use tokio::time::{Duration, Instant};


### PR DESCRIPTION
Using the `gax` alias introduces the alias into the examples, which can be confusing.