### PR TITLE
cleanup(pubsub): fix clippy warning

### DIFF
--- a/src/pubsub/examples/tests/integration.rs
+++ b/src/pubsub/examples/tests/integration.rs
@@ -55,7 +55,7 @@ mod tests {
     async fn quickstart_publisher() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
         let (topic_admin, topic) = pubsub_samples::create_test_topic().await?;
-        let topic_id = topic.name.split('/').last().unwrap();
+        let topic_id = topic.name.split('/').next_back().unwrap();
 
         let result = quickstart_publisher::sample(&project_id, topic_id).await;
 
@@ -73,7 +73,7 @@ mod tests {
         let (subscription_admin, subscription) =
             pubsub_samples::create_test_subscription(topic.name.clone()).await?;
 
-        let subscription_id = subscription.name.split('/').last().unwrap();
+        let subscription_id = subscription.name.split('/').next_back().unwrap();
 
         let result = quickstart_subscriber::sample(&project_id, subscription_id).await;
 


### PR DESCRIPTION
Without this we get:

```
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will
needlessly iterate the entire iterator
--> src/pubsub/examples/tests/integration.rs:76:31
|
76 |         let subscription_id =
subscription.name.split('/').last().unwrap();
|                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^------
|                                                            |
|                                                            help: try: `next_back()`
|
= help: for further information visit
https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#double_ended_iterator_last
```

I will figure out why the CI build did not catch this.