### PR TITLE
impl(pubsub): remove PublishError from the public API

### DIFF
--- a/src/pubsub/src/error.rs
+++ b/src/pubsub/src/error.rs
@@ -20,7 +20,7 @@
 /// Represents an error that can occur when publishing a message.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
-pub enum PublishError {
+pub(crate) enum PublishError {
     /// Publish operation failed sending the RPC.
     #[error("the publish operation was interrupted by an error: {0}")]
     SendError(#[source] std::sync::Arc<crate::Error>),

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -140,7 +140,7 @@ pub mod client {
     pub use crate::subscriber::client::Subscriber;
 }
 
-pub mod error;
+pub(crate) mod error;
 
 /// Traits to mock the clients in this library.
 pub mod stub {


### PR DESCRIPTION
This error is only exposed as the source of an error. We may want to add it back to expose the error type, but we want to unwrapping the SendError to return the Arc<Error> at the top level, so this enum will not want to expose that enum variant at least.

Fixes #4611 