### PR TITLE
cleanup(integration-tests-auth): use full crate names

### DIFF
--- a/tests/integration-auth/Cargo.toml
+++ b/tests/integration-auth/Cargo.toml
@@ -35,7 +35,7 @@ test-case.workspace  = true
 base64.workspace     = true
 reqwest.workspace    = true
 # Local dependencies
-gax.workspace                   = true
+google-cloud-gax.workspace      = true
 google-cloud-auth               = { workspace = true, features = ["default", "idtoken"] }
 google-cloud-bigquery-v2        = { workspace = true, features = ["default"] }
 google-cloud-iam-credentials-v1 = { workspace = true, features = ["default"] }

--- a/tests/integration-auth/src/lib.rs
+++ b/tests/integration-auth/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gax::error::rpc::Code;
 use google_cloud_auth::credentials::idtoken::{
     Builder as IDTokenCredentialBuilder, impersonated::Builder as ImpersonatedIDTokenBuilder,
     mds::Builder as IDTokenMDSBuilder, mds::Format,
@@ -32,6 +31,7 @@ use google_cloud_auth::credentials::{
 };
 use google_cloud_auth::errors::SubjectTokenProviderError;
 use google_cloud_bigquery_v2::client::DatasetService;
+use google_cloud_gax::error::rpc::Code;
 use google_cloud_iam_credentials_v1::client::IAMCredentials;
 use google_cloud_language_v2::client::LanguageService;
 use google_cloud_language_v2::model::{Document, document::Type};


### PR DESCRIPTION
Part of the work for #4598 