### PR TITLE
cleanup(gax-internal): use `gax` full name

### DIFF
--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -92,7 +92,7 @@ _internal-http-multipart = ["_internal-http-client", "reqwest?/multipart"]
 # used by the `google-cloud-storage` crate to stream upload data.
 _internal-http-stream = ["_internal-http-client", "reqwest?/stream"]
 # Common features required by both HTTP and gRPC clients.
-_internal-common = ["dep:gax", "dep:google-cloud-auth", "dep:percent-encoding", "dep:thiserror"]
+_internal-common = ["dep:google-cloud-auth", "dep:google-cloud-gax", "dep:percent-encoding", "dep:thiserror"]
 # Enables the default rustls crypto provider for whatever client(s) are enabled.
 _default-rustls-provider = ["google-cloud-auth?/default-rustls-provider", "tonic?/tls-aws-lc"]
 
@@ -120,7 +120,7 @@ tower                              = { workspace = true, optional = true }
 tracing                            = { workspace = true, optional = true }
 # Local crates
 google-cloud-auth = { workspace = true, optional = true }
-gax               = { workspace = true, optional = true }
+google-cloud-gax  = { workspace = true, optional = true }
 google-cloud-rpc  = { workspace = true, optional = true }
 wkt               = { workspace = true, optional = true }
 

--- a/src/gax-internal/src/grpc/from_status.rs
+++ b/src/gax-internal/src/grpc/from_status.rs
@@ -14,8 +14,8 @@
 
 use crate::as_inner::as_inner;
 use crate::grpc::status::status_from_proto;
-use gax::error::Error;
-use gax::error::rpc::Status;
+use google_cloud_gax::error::Error;
+use google_cloud_gax::error::rpc::Status;
 use prost::Message;
 use std::error::Error as _;
 
@@ -72,7 +72,7 @@ impl std::fmt::Display for GrpcError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gax::error::rpc::{Code, StatusDetails};
+    use google_cloud_gax::error::rpc::{Code, StatusDetails};
     use test_case::test_case;
 
     #[test_case(tonic::Code::Ok, Code::Ok)]

--- a/src/gax-internal/src/host.rs
+++ b/src/gax-internal/src/host.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use gax::client_builder::Error as BuilderError;
+use google_cloud_gax::client_builder::{Error as BuilderError, Result as ClientBuilderResult};
 use http::Uri;
 use std::str::FromStr;
 
@@ -32,7 +32,7 @@ pub(crate) fn from_endpoint<T>(
     endpoint: Option<&str>,
     default_endpoint: &str,
     f: impl FnOnce(Uri, String) -> T,
-) -> gax::client_builder::Result<T> {
+) -> ClientBuilderResult<T> {
     let default_origin = Uri::from_str(default_endpoint).map_err(BuilderError::transport)?;
     let default_host = default_origin
         .authority()

--- a/src/gax-internal/src/observability/grpc_tracing.rs
+++ b/src/gax-internal/src/observability/grpc_tracing.rs
@@ -355,7 +355,7 @@ fn record_status_from_headers(span: &tracing::Span, headers: &http::HeaderMap) {
 
 fn record_error_status<Error: std::fmt::Display>(span: &tracing::Span, error: &Error) {
     span.record(OTEL_STATUS_CODE, otel_status_codes::ERROR);
-    let gax_error = gax::error::Error::io(error.to_string());
+    let gax_error = google_cloud_gax::error::Error::io(error.to_string());
     span.record(
         otel_trace::ERROR_TYPE,
         ErrorType::from_gax_error(&gax_error).as_str(),

--- a/src/gax-internal/src/options.rs
+++ b/src/gax-internal/src/options.rs
@@ -15,7 +15,7 @@
 pub use google_cloud_auth::credentials::Credentials;
 
 // The client configuration for [crate::http::ReqwestClient] and [crate::grpc::Client].
-pub type ClientConfig = gax::client_builder::internal::ClientConfig<Credentials>;
+pub type ClientConfig = google_cloud_gax::client_builder::internal::ClientConfig<Credentials>;
 
 pub(crate) const LOGGING_VAR: &str = "GOOGLE_CLOUD_RUST_LOGGING";
 

--- a/src/gax-internal/src/path_parameter.rs
+++ b/src/gax-internal/src/path_parameter.rs
@@ -20,7 +20,7 @@
 //! a small helper function makes the generated code easier to read.
 
 use crate::routing_parameter::Segment;
-use gax::error::binding::{PathMismatch, SubstitutionFail, SubstitutionMismatch};
+use google_cloud_gax::error::binding::{PathMismatch, SubstitutionFail, SubstitutionMismatch};
 
 /// A trait to simplify generated code for path fields
 ///
@@ -174,8 +174,8 @@ pub enum Error {
     MissingRequiredParameter(String),
 }
 
-pub fn missing(name: &str) -> gax::error::Error {
-    gax::error::Error::binding(Error::MissingRequiredParameter(name.to_string()))
+pub fn missing(name: &str) -> google_cloud_gax::error::Error {
+    google_cloud_gax::error::Error::binding(Error::MissingRequiredParameter(name.to_string()))
 }
 
 #[cfg(test)]

--- a/src/gax-internal/src/unimplemented.rs
+++ b/src/gax-internal/src/unimplemented.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use google_cloud_gax::Result;
+use google_cloud_gax::response::Response;
+
 pub const UNIMPLEMENTED: &str = concat!(
     "to prevent breaking changes as services gain new RPCs, the stub ",
     "traits provide default implementations of each method. In the client ",
@@ -24,6 +27,6 @@ pub const UNIMPLEMENTED: &str = concat!(
     "https://github.com/googleapis/google-cloud-rust/issues"
 );
 
-pub async fn unimplemented_stub<T: Send>() -> gax::Result<gax::response::Response<T>> {
+pub async fn unimplemented_stub<T: Send>() -> Result<Response<T>> {
     unimplemented!("{UNIMPLEMENTED}");
 }

--- a/src/gax-internal/tests/client_builder.rs
+++ b/src/gax-internal/tests/client_builder.rs
@@ -20,6 +20,10 @@ mod tests {
     #[cfg(feature = "_internal-grpc-client")]
     mod grpc {
         use google_cloud_auth::credentials::Credentials;
+        use google_cloud_gax::client_builder::{
+            Result as ClientBuilderResult,
+            internal::{ClientFactory, new_builder},
+        };
         use google_cloud_gax_internal as gaxi;
 
         #[tokio::test]
@@ -38,29 +42,29 @@ mod tests {
         }
         impl FakeClient {
             pub fn builder() -> ClientBuilder {
-                gax::client_builder::internal::new_builder(fake_client::Factory)
+                new_builder(fake_client::Factory)
             }
 
-            async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+            async fn new(config: gaxi::options::ClientConfig) -> ClientBuilderResult<Self> {
                 let inner = gaxi::grpc::Client::new(config, super::DEFAULT_ENDPOINT).await?;
                 Ok(Self { inner })
             }
         }
         /// Make this visible for documentation purposes.
         pub type ClientBuilder =
-            gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
+            google_cloud_gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
         // Note the pub(self), the types in this module are not accessible to
         // application developers.
         mod fake_client {
             use super::gaxi;
             pub struct Factory;
-            impl gax::client_builder::internal::ClientFactory for Factory {
+            impl super::ClientFactory for Factory {
                 type Client = super::FakeClient;
                 type Credentials = super::Credentials;
                 async fn build(
                     self,
                     config: gaxi::options::ClientConfig,
-                ) -> gax::client_builder::Result<Self::Client> {
+                ) -> super::ClientBuilderResult<Self::Client> {
                     Self::Client::new(config).await
                 }
             }
@@ -70,6 +74,10 @@ mod tests {
     #[cfg(feature = "_internal-http-client")]
     mod http {
         use google_cloud_auth::credentials::Credentials;
+        use google_cloud_gax::client_builder::{
+            Result as ClientBuilderResult,
+            internal::{ClientFactory, new_builder},
+        };
         use google_cloud_gax_internal as gaxi;
 
         #[tokio::test]
@@ -88,29 +96,29 @@ mod tests {
         }
         impl FakeClient {
             pub fn builder() -> ClientBuilder {
-                gax::client_builder::internal::new_builder(fake_client::Factory)
+                new_builder(fake_client::Factory)
             }
 
-            async fn new(config: gaxi::options::ClientConfig) -> gax::client_builder::Result<Self> {
+            async fn new(config: gaxi::options::ClientConfig) -> ClientBuilderResult<Self> {
                 let inner = gaxi::http::ReqwestClient::new(config, super::DEFAULT_ENDPOINT).await?;
                 Ok(Self { inner })
             }
         }
         /// Make this visible for documentation purposes.
         pub type ClientBuilder =
-            gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
+            google_cloud_gax::client_builder::ClientBuilder<fake_client::Factory, Credentials>;
         // Note the pub(self), the types in this module are not accessible to
         // application developers.
         mod fake_client {
             use super::gaxi;
             pub struct Factory;
-            impl gax::client_builder::internal::ClientFactory for Factory {
+            impl super::ClientFactory for Factory {
                 type Client = super::FakeClient;
                 type Credentials = super::Credentials;
                 async fn build(
                     self,
                     config: gaxi::options::ClientConfig,
-                ) -> gax::client_builder::Result<Self::Client> {
+                ) -> super::ClientBuilderResult<Self::Client> {
                     Self::Client::new(config).await
                 }
             }

--- a/src/gax-internal/tests/grpc_auth.rs
+++ b/src/gax-internal/tests/grpc_auth.rs
@@ -14,12 +14,14 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_auth::credentials::{
         CacheableResource, Credentials, CredentialsProvider, EntityTag,
     };
     use google_cloud_auth::errors::CredentialsError;
+    use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
+    use google_cloud_gax::options::*;
+    use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_gax_internal::grpc;
     use grpc_server::{builder, google, start_echo_server};
     use http::header::{HeaderName, HeaderValue};
@@ -140,9 +142,9 @@ mod tests {
         Ok(())
     }
 
-    fn test_backoff() -> impl gax::backoff_policy::BackoffPolicy {
+    fn test_backoff() -> impl BackoffPolicy {
         use std::time::Duration;
-        gax::exponential_backoff::ExponentialBackoffBuilder::new()
+        ExponentialBackoffBuilder::new()
             .with_initial_delay(Duration::from_micros(1))
             .with_maximum_delay(Duration::from_micros(1))
             .build()
@@ -152,7 +154,7 @@ mod tests {
     async fn send_request(
         client: grpc::Client,
         msg: &str,
-    ) -> gax::Result<google::test::v1::EchoResponse> {
+    ) -> google_cloud_gax::Result<google::test::v1::EchoResponse> {
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(

--- a/src/gax-internal/tests/grpc_client_polling.rs
+++ b/src/gax-internal/tests/grpc_client_polling.rs
@@ -14,8 +14,13 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use gax::polling_state::PollingState;
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
+    use google_cloud_gax::error::Error;
+    use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy;
+    use google_cloud_gax::polling_error_policy::PollingErrorPolicy;
+    use google_cloud_gax::polling_state::PollingState;
+    use google_cloud_gax::retry_result::RetryResult;
     use grpc_server::{builder, start_echo_server};
 
     type TestResult = Result<(), Box<dyn std::error::Error>>;
@@ -30,13 +35,9 @@ mod tests {
     struct TestErrorPolicy {
         pub _name: String,
     }
-    impl gax::polling_error_policy::PollingErrorPolicy for TestErrorPolicy {
-        fn on_error(
-            &self,
-            _state: &PollingState,
-            error: gax::error::Error,
-        ) -> gax::retry_result::RetryResult {
-            gax::retry_result::RetryResult::Continue(error)
+    impl PollingErrorPolicy for TestErrorPolicy {
+        fn on_error(&self, _state: &PollingState, error: Error) -> RetryResult {
+            RetryResult::Continue(error)
         }
     }
 
@@ -44,7 +45,7 @@ mod tests {
     struct TestBackoffPolicy {
         pub _name: String,
     }
-    impl gax::polling_backoff_policy::PollingBackoffPolicy for TestBackoffPolicy {
+    impl PollingBackoffPolicy for TestBackoffPolicy {
         fn wait_period(&self, _state: &PollingState) -> std::time::Duration {
             std::time::Duration::from_millis(1)
         }
@@ -58,7 +59,7 @@ mod tests {
             .build()
             .await?;
 
-        let options = gax::options::RequestOptions::default();
+        let options = RequestOptions::default();
         // Verify the functions are callable from outside the crate.
         let _ = client.get_polling_error_policy(&options);
         let _ = client.get_polling_backoff_policy(&options);
@@ -79,7 +80,7 @@ mod tests {
             .build()
             .await?;
 
-        let options = gax::options::RequestOptions::default();
+        let options = RequestOptions::default();
         let polling = client.get_polling_error_policy(&options);
         let fmt = format!("{polling:?}");
         assert!(fmt.contains("client-polling-error"), "{polling:?}");
@@ -104,7 +105,7 @@ mod tests {
             .build()
             .await?;
 
-        let mut options = gax::options::RequestOptions::default();
+        let mut options = RequestOptions::default();
         options.set_polling_error_policy(TestErrorPolicy {
             _name: "request-options-polling-error".to_string(),
         });

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -14,11 +14,12 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::NeverRetry;
     use google_cloud_auth::credentials::{
         Credentials, anonymous::Builder as Anonymous, testing::error_credentials,
     };
+    use google_cloud_gax::error::rpc::Code;
+    use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::retry_policy::NeverRetry;
     use google_cloud_gax_internal::grpc;
     use google_cloud_gax_internal::options::ClientConfig;
     use grpc_server::{builder, google, start_echo_server, start_echo_server_with_address};
@@ -119,7 +120,7 @@ mod tests {
         .await
         .into_iter()
         .map(|r| r.map(|e| e.client_address))
-        .collect::<gax::Result<HashSet<_>>>()?;
+        .collect::<google_cloud_gax::Result<HashSet<_>>>()?;
 
         assert!(addresses.len() > 1, "{addresses:?}");
         Ok(())
@@ -187,10 +188,7 @@ mod tests {
 
         let response = send_request(client, "", "").await;
         let err = response.unwrap_err();
-        assert_eq!(
-            err.status().map(|s| s.code),
-            Some(gax::error::rpc::Code::InvalidArgument)
-        );
+        assert_eq!(err.status().map(|s| s.code), Some(Code::InvalidArgument));
         Ok(())
     }
 
@@ -198,7 +196,7 @@ mod tests {
         client: grpc::Client,
         msg: &str,
         request_params: &str,
-    ) -> gax::Result<google::test::v1::EchoResponse> {
+    ) -> google_cloud_gax::Result<google::test::v1::EchoResponse> {
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(

--- a/src/gax-internal/tests/grpc_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_streaming_request.rs
@@ -14,11 +14,11 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::NeverRetry;
     use google_cloud_auth::credentials::{
         Credentials, anonymous::Builder as Anonymous, testing::error_credentials,
     };
+    use google_cloud_gax::options::*;
+    use google_cloud_gax::retry_policy::NeverRetry;
     use google_cloud_gax_internal::grpc;
     use grpc_server::google::test::v1::{EchoRequest, EchoResponse};
     use grpc_server::{builder, start_echo_server};
@@ -158,7 +158,7 @@ mod tests {
         client: grpc::Client,
         rx: tokio::sync::mpsc::Receiver<EchoRequest>,
         request_params: &str,
-    ) -> gax::Result<tonic::Response<tonic::codec::Streaming<EchoResponse>>> {
+    ) -> google_cloud_gax::Result<tonic::Response<tonic::codec::Streaming<EchoResponse>>> {
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(
@@ -188,7 +188,9 @@ mod tests {
         client: grpc::Client,
         rx: tokio::sync::mpsc::Receiver<EchoRequest>,
         request_params: &str,
-    ) -> gax::Result<tonic::Result<tonic::Response<tonic::codec::Streaming<EchoResponse>>>> {
+    ) -> google_cloud_gax::Result<
+        tonic::Result<tonic::Response<tonic::codec::Streaming<EchoResponse>>>,
+    > {
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(

--- a/src/gax-internal/tests/grpc_user_agent.rs
+++ b/src/gax-internal/tests/grpc_user_agent.rs
@@ -14,8 +14,9 @@
 
 #[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
-    use gax::options::*;
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
+    use google_cloud_gax::Result;
+    use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax_internal::grpc;
     use grpc_server::{builder, google, start_echo_server};
 
@@ -52,8 +53,8 @@ mod tests {
 
     async fn send_request(
         client: grpc::Client,
-        options: gax::options::RequestOptions,
-    ) -> gax::Result<google::test::v1::EchoResponse> {
+        options: RequestOptions,
+    ) -> Result<google::test::v1::EchoResponse> {
         let extensions = {
             let mut e = tonic::Extensions::new();
             e.insert(tonic::GrpcMethod::new(

--- a/src/gax-internal/tests/http_auth.rs
+++ b/src/gax-internal/tests/http_auth.rs
@@ -14,12 +14,14 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_auth::credentials::{
         CacheableResource, Credentials, CredentialsProvider, EntityTag,
     };
     use google_cloud_auth::errors::CredentialsError;
+    use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
+    use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use http::header::{HeaderName, HeaderValue};
     use http::{Extensions, HeaderMap};
     use serde_json::json;
@@ -158,9 +160,9 @@ mod tests {
         Ok(())
     }
 
-    fn test_backoff() -> impl gax::backoff_policy::BackoffPolicy {
+    fn test_backoff() -> impl BackoffPolicy {
         use std::time::Duration;
-        gax::exponential_backoff::ExponentialBackoffBuilder::new()
+        ExponentialBackoffBuilder::new()
             .with_initial_delay(Duration::from_micros(1))
             .with_maximum_delay(Duration::from_micros(1))
             .build()

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -14,9 +14,9 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::NeverRetry;
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
+    use google_cloud_gax::options::*;
+    use google_cloud_gax::retry_policy::NeverRetry;
     use google_cloud_gax_internal::http::ReqwestClient;
     use google_cloud_gax_internal::options::ClientConfig;
     use serde_json::{Value, json};

--- a/src/gax-internal/tests/http_metadata.rs
+++ b/src/gax-internal/tests/http_metadata.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::options::RequestOptions;
+    use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax_internal::http::ReqwestClient;
     use google_cloud_gax_internal::options::ClientConfig;
     use http::HeaderValue;

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -14,9 +14,11 @@
 
 #[cfg(all(test, feature = "_internal-http-client", google_cloud_unstable_tracing))]
 mod tests {
-    use gax::options::RequestOptions;
-    use gax::response::Response;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_gax::Result;
+    use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::options::internal::set_path_template;
+    use google_cloud_gax::response::Response;
     use google_cloud_gax_internal::http::{NoBody, ReqwestClient};
     use google_cloud_gax_internal::observability::attributes::keys::*;
     use google_cloud_gax_internal::options::{ClientConfig, InstrumentationClientInfo};
@@ -77,9 +79,9 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = gax::options::internal::set_path_template(RequestOptions::default(), "/test");
+        let options = set_path_template(RequestOptions::default(), "/test");
         let request = client.builder(Method::GET, "/test".to_string());
-        let _response: gax::Result<Response<TestResponse>> =
+        let _response: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
 
         let captured = TestLayer::capture(&guard);
@@ -130,7 +132,7 @@ mod tests {
         let guard = TestLayer::initialize();
 
         let request = client.builder(Method::GET, "/test".to_string());
-        let _response: gax::Result<Response<TestResponse>> = client
+        let _response: Result<Response<TestResponse>> = client
             .execute(request, None::<NoBody>, RequestOptions::default())
             .await;
 
@@ -161,10 +163,9 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options =
-            gax::options::internal::set_path_template(RequestOptions::default(), "/error");
+        let options = set_path_template(RequestOptions::default(), "/error");
         let request = client.builder(Method::GET, "/error".to_string());
-        let _response: gax::Result<Response<TestResponse>> =
+        let _response: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
 
         let captured = TestLayer::capture(&guard);
@@ -220,10 +221,10 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = gax::options::internal::set_path_template(RequestOptions::default(), "/test");
+        let options = set_path_template(RequestOptions::default(), "/test");
         let request = client.builder(Method::POST, "/test".to_string());
         let body = serde_json::json!({"name": "test"});
-        let _response: gax::Result<Response<TestResponse>> =
+        let _response: Result<Response<TestResponse>> =
             client.execute(request, Some(body), options).await;
 
         let captured = TestLayer::capture(&guard);
@@ -294,10 +295,9 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options =
-            gax::options::internal::set_path_template(RequestOptions::default(), "/error-info");
+        let options = set_path_template(RequestOptions::default(), "/error-info");
         let request = client.builder(Method::GET, "/error-info".to_string());
-        let result: gax::Result<Response<TestResponse>> =
+        let result: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
 
         assert!(result.is_err(), "{result:?}");
@@ -361,7 +361,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = gax::options::internal::set_path_template(RequestOptions::default(), "/test");
+        let options = set_path_template(RequestOptions::default(), "/test");
         let request = client.builder(Method::GET, "/test".to_string());
 
         // Create a parent span (T3) with the marker field
@@ -373,7 +373,7 @@ mod tests {
         );
 
         // Execute the request within the T3 span
-        let _response: gax::Result<Response<TestResponse>> = client
+        let _response: Result<Response<TestResponse>> = client
             .execute(request, None::<NoBody>, options)
             .instrument(t3_span.clone())
             .await;
@@ -424,7 +424,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = gax::options::internal::set_path_template(RequestOptions::default(), "/test");
+        let options = set_path_template(RequestOptions::default(), "/test");
         let request = client.builder(Method::GET, "/test".to_string());
 
         // Create a user span that happens to have the same fields, but NO marker
@@ -435,7 +435,7 @@ mod tests {
         );
 
         // Execute the request within the user span
-        let _response: gax::Result<Response<TestResponse>> = client
+        let _response: Result<Response<TestResponse>> = client
             .execute(request, None::<NoBody>, options)
             .instrument(user_span.clone())
             .await;
@@ -471,7 +471,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = gax::options::internal::set_path_template(RequestOptions::default(), "/test");
+        let options = set_path_template(RequestOptions::default(), "/test");
         let request = client.builder(Method::GET, "/test".to_string());
 
         // 1. Create the T3 span using the helper
@@ -482,7 +482,7 @@ mod tests {
         );
 
         // 2. Execute the request within the T3 span
-        let result: gax::Result<Response<TestResponse>> = client
+        let result: Result<Response<TestResponse>> = client
             .execute(request, None::<NoBody>, options)
             .instrument(t3_span.clone())
             .await;

--- a/src/gax-internal/tests/http_query_parameters.rs
+++ b/src/gax-internal/tests/http_query_parameters.rs
@@ -118,7 +118,7 @@ mod tests {
 
     // A new version of the generator will generate code as follows for query parameters.
     fn add_query_parameters(request: &FakeRequest) -> Result<reqwest::RequestBuilder> {
-        use gax::error::Error;
+        use google_cloud_gax::error::Error;
         let client = reqwest::Client::builder().build()?;
         let builder = client.get("https://test.googleapis.com/v1/unused");
 

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -23,10 +23,10 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::backoff_policy::BackoffPolicy;
-    use gax::exponential_backoff::ExponentialBackoffBuilder;
-    use gax::options::*;
-    use gax::retry_policy::{Aip194Strict, RetryPolicyExt};
+    use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
+    use google_cloud_gax::options::*;
+    use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_gax_internal::http::ReqwestClient;
     use google_cloud_gax_internal::options::ClientConfig;
     use http::StatusCode;

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -14,10 +14,11 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::options::*;
-    use gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-    use gax::retry_state::RetryState;
-    use gax::retry_throttler::{CircuitBreaker, RetryThrottlerArg};
+    use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::options::*;
+    use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
+    use google_cloud_gax::retry_state::RetryState;
+    use google_cloud_gax::retry_throttler::{CircuitBreaker, RetryThrottlerArg};
     use google_cloud_gax_internal::http::ReqwestClient;
     use google_cloud_gax_internal::options::ClientConfig;
     use serde_json::json;
@@ -166,7 +167,7 @@ mod tests {
             pub elapsed_on_failure: Arc<Mutex<Option<Duration>>>,
         }
 
-        impl gax::backoff_policy::BackoffPolicy for TestBackoffPolicy {
+        impl BackoffPolicy for TestBackoffPolicy {
             fn on_failure(&self, state: &RetryState) -> std::time::Duration {
                 if state.attempt_count == 1 {
                     *self.elapsed_on_failure.lock().unwrap() =

--- a/src/gax-internal/tests/http_user_agent.rs
+++ b/src/gax-internal/tests/http_user_agent.rs
@@ -14,8 +14,8 @@
 
 #[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
-    use gax::options::*;
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
+    use google_cloud_gax::options::*;
     use serde_json::json;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
Part of the work for #4598 