### PR TITLE
cleanup(pubsub)!: rename PublishHandle to PublishFuture

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -126,17 +126,17 @@ pub mod model_ext {
 ///
 /// // Publish several messages.
 /// // The client will automatically batch them in the background.
-/// let mut handles = Vec::new();
+/// let mut futures = Vec::new();
 /// for i in 0..10 {
 ///     let msg = PubsubMessage::new().set_data(format!("message {}", i));
-///     handles.push(publisher.publish(msg));
+///     futures.push(publisher.publish(msg));
 /// }
 ///
-/// // The handles are futures that resolve to the server-assigned message IDs.
+/// // The futures resolve to the server-assigned message IDs.
 /// // You can await them to get the results. Messages will still be sent even
-/// // if the handles are dropped.
-/// for (i, handle) in handles.into_iter().enumerate() {
-///     let message_id = handle.await?;
+/// // if the futures are dropped.
+/// for (i, future) in futures.into_iter().enumerate() {
+///     let message_id = future.await?;
 ///     println!("Message {} sent with ID: {}", i, message_id);
 /// }
 /// # Ok(())

--- a/src/pubsub/src/publisher/actor.rs
+++ b/src/pubsub/src/publisher/actor.rs
@@ -42,7 +42,7 @@ pub(crate) enum ToBatchActor {
 
 /// Object that is passed to the actor tasks over the
 /// main channel. This represents a single message and the sender
-/// half of the channel to resolve the [PublishHandle].
+/// half of the channel to resolve the [PublishFuture].
 #[derive(Debug)]
 pub(crate) struct BundledMessage {
     pub msg: crate::model::PubsubMessage,
@@ -288,7 +288,7 @@ impl ConcurrentBatchActor {
                         }
                         None => {
                             // This isn't guaranteed to execute if a user does not .await on the
-                            // corresponding PublishHandles.
+                            // corresponding PublishFutures.
                             self.flush(&mut inflight);
                             inflight.join_all().await;
                             break;
@@ -417,7 +417,7 @@ impl SequentialBatchActor {
                         },
                         None => {
                             // This isn't guaranteed to execute if a user does not .await on the
-                            // corresponding PublishHandles.
+                            // corresponding PublishFutures.
                             self.flush(inflight).await;
                             break;
                         }

--- a/src/pubsub/src/publisher/client.rs
+++ b/src/pubsub/src/publisher/client.rs
@@ -67,11 +67,11 @@ impl Publisher {
     /// let message_id = publisher.publish(PubsubMessage::new().set_data("Hello, World")).await?;
     /// # Ok(()) }
     /// ```
-    pub fn publish(&self, msg: crate::model::PubsubMessage) -> crate::model_ext::PublishHandle {
+    pub fn publish(&self, msg: crate::model::PubsubMessage) -> crate::model_ext::PublishFuture {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         // If this fails, the Dispatcher is gone, which indicates something bad has happened.
-        // The PublishHandle will automatically receive an error when `tx` is dropped.
+        // The PublishFuture will automatically receive an error when `tx` is dropped.
         if self
             .tx
             .send(ToDispatcher::Publish(BundledMessage { msg, tx }))
@@ -79,7 +79,7 @@ impl Publisher {
         {
             // `tx` is dropped here if the send errors.
         }
-        crate::model_ext::PublishHandle { rx }
+        crate::model_ext::PublishFuture { rx }
     }
 
     /// Flushes all outstanding messages.
@@ -94,7 +94,7 @@ impl Publisher {
     ///
     /// After flush()` returns, the final result of each individual publish
     /// operation (i.e., a success with a message ID or a terminal error) will
-    /// be available on its corresponding [PublishHandle](crate::model_ext::PublishHandle).
+    /// be available on its corresponding [PublishFuture](crate::model_ext::PublishFuture).
     ///
     /// Messages published after `flush()` is called will be buffered for a
     /// subsequent batch and are not included in this flush operation.


### PR DESCRIPTION
The PublishHandle doesn't have many of the properties of a handle (aborting, etc) and just implements Future. By updating the naming to be PublishFuture, the naming more accurately represents the type.

Fixes #4635 