### PR TITLE
cleanup(pubsub)!: move the BasePublisher out of crate::client::*

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -29,7 +29,7 @@
 //! * [SchemaService][client::SchemaService]
 //!
 //! For publishing messages:
-//! * [BasePublisher][client::BasePublisher] and [Publisher][client::Publisher]
+//! * [BasePublisher][publisher::client::BasePublisher] and [Publisher][client::Publisher]
 //!
 //! For receiving messages:
 //! * [Subscriber][client::Subscriber]
@@ -61,7 +61,8 @@
 #[allow(rustdoc::broken_intra_doc_links)]
 pub(crate) mod generated;
 
-pub(crate) mod publisher;
+/// Types related to publishing messages.
+pub mod publisher;
 /// Types related to receiving messages with a [Subscriber][client::Subscriber]
 /// client.
 pub mod subscriber;
@@ -167,8 +168,7 @@ pub mod model_ext {
 /// ```
 pub mod client {
     pub use crate::generated::gapic::client::*;
-    pub use crate::publisher::base_publisher::BasePublisher;
-    pub use crate::publisher::client::Publisher;
+    pub use crate::publisher::implementation::Publisher;
     pub use crate::subscriber::client::Subscriber;
 }
 

--- a/src/pubsub/src/publisher.rs
+++ b/src/pubsub/src/publisher.rs
@@ -17,9 +17,14 @@ pub(crate) mod backoff_policy;
 pub(crate) mod base_publisher;
 pub(crate) mod batch;
 pub(crate) mod builder;
-pub(crate) mod client;
 pub(crate) mod client_builder;
 pub(crate) mod constants;
+pub(crate) mod implementation;
 pub(crate) mod model_ext;
 pub(crate) mod options;
 pub(crate) mod retry_policy;
+
+/// Contains clients for publishing messages.
+pub mod client {
+    pub use super::base_publisher::BasePublisher;
+}

--- a/src/pubsub/src/publisher/base_publisher.rs
+++ b/src/pubsub/src/publisher/base_publisher.rs
@@ -14,7 +14,7 @@
 
 use crate::publisher::builder::PublisherPartialBuilder;
 
-/// Creates [`Publisher`](super::client::Publisher) instances.
+/// Creates [`Publisher`](crate::client::Publisher) instances.
 ///
 /// A single `BasePublisher` can be used to create multiple `Publisher` clients
 /// for different topics. It manages the underlying gRPC connection and
@@ -24,11 +24,11 @@ use crate::publisher::builder::PublisherPartialBuilder;
 ///
 /// ```
 /// # async fn sample() -> anyhow::Result<()> {
-/// # use google_cloud_pubsub::client::BasePublisher;
+/// # use google_cloud_pubsub::publisher::client::BasePublisher;
 /// # use google_cloud_pubsub::model::Message;
 ///
 /// // Create a client.
-/// let client = BasePublisher::builder().build().await?;
+/// let client: BasePublisher = BasePublisher::builder().build().await?;
 ///
 /// // Create a publisher for a specific topic.
 /// let publisher = client.publisher("projects/my-project/topics/my-topic").build();
@@ -51,7 +51,7 @@ pub struct BasePublisher {
 /// # async fn sample() -> anyhow::Result<()> {
 /// # use google_cloud_pubsub::*;
 /// # use builder::publisher::BasePublisherBuilder;
-/// # use client::BasePublisher;
+/// # use google_cloud_pubsub::publisher::client::BasePublisher;
 /// let builder: BasePublisherBuilder = BasePublisher::builder();
 /// let client = builder
 ///     .with_endpoint("https://pubsub.googleapis.com")
@@ -65,8 +65,8 @@ impl BasePublisher {
     ///
     /// ```no_run
     /// # tokio_test::block_on(async {
-    /// # use google_cloud_pubsub::client::BasePublisher;
-    /// let client = BasePublisher::builder().build().await?;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
+    /// let client: BasePublisher = BasePublisher::builder().build().await?;
     /// # google_cloud_gax::client_builder::Result::<()>::Ok(()) });
     /// ```
     pub fn builder() -> BasePublisherBuilder {
@@ -86,7 +86,7 @@ impl BasePublisher {
     /// # async fn sample() -> anyhow::Result<()> {
     /// # use google_cloud_pubsub::*;
     /// # use builder::publisher::BasePublisherBuilder;
-    /// # use client::BasePublisher;
+    /// # use publisher::client::BasePublisher;
     /// # use model::Message;
     /// let client = BasePublisher::builder().build().await?;
     /// let publisher = client.publisher("projects/my-project/topics/my-topic").build();

--- a/src/pubsub/src/publisher/builder.rs
+++ b/src/pubsub/src/publisher/builder.rs
@@ -277,8 +277,8 @@ impl PublisherBuilder {
 /// ```
 /// # async fn sample() -> anyhow::Result<()> {
 /// # use google_cloud_pubsub::*;
-/// # use google_cloud_pubsub::client::BasePublisher;
-/// let client = BasePublisher::builder().build().await?;
+/// # use google_cloud_pubsub::publisher::client::BasePublisher;
+/// let client: BasePublisher = BasePublisher::builder().build().await?;
 /// let publisher = client.publisher("projects/my-project/topics/topic").build();
 /// # Ok(()) }
 /// ```
@@ -307,9 +307,9 @@ impl PublisherPartialBuilder {
     /// # Example
     ///
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// # let client = BasePublisher::builder().build().await?;
+    /// # let client: BasePublisher = BasePublisher::builder().build().await?;
     /// let publisher = client
     ///     .publisher("projects/my-project/topics/my-topic")
     ///     .set_message_count_threshold(100)
@@ -329,9 +329,9 @@ impl PublisherPartialBuilder {
     /// # Example
     ///
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// # let client = BasePublisher::builder().build().await?;
+    /// # let client: BasePublisher = BasePublisher::builder().build().await?;
     /// let publisher = client
     ///     .publisher("projects/my-project/topics/my-topic")
     ///     .set_byte_threshold(1024) // 1 KiB
@@ -351,10 +351,10 @@ impl PublisherPartialBuilder {
     /// # Example
     ///
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # use std::time::Duration;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// # let client = BasePublisher::builder().build().await?;
+    /// # let client: BasePublisher = BasePublisher::builder().build().await?;
     /// let publisher = client
     ///     .publisher("projects/my-project/topics/my-topic")
     ///     .set_delay_threshold(Duration::from_millis(50))
@@ -417,7 +417,7 @@ mod tests {
 
     #[tokio::test]
     async fn builder() -> anyhow::Result<()> {
-        let client = BasePublisher::builder().build().await?;
+        let client: BasePublisher = BasePublisher::builder().build().await?;
         let builder = client.publisher("projects/my-project/topics/my-topic");
         let publisher = builder.set_message_count_threshold(1_u32).build();
         assert_eq!(publisher.batching_options.message_count_threshold, 1_u32);

--- a/src/pubsub/src/publisher/client_builder.rs
+++ b/src/pubsub/src/publisher/client_builder.rs
@@ -23,7 +23,7 @@ use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 ///
 /// # Example
 /// ```
-/// # use google_cloud_pubsub::client::BasePublisher;
+/// # use google_cloud_pubsub::publisher::client::BasePublisher;
 /// # async fn sample() -> anyhow::Result<()> {
 /// let builder = BasePublisher::builder();
 /// let client = builder
@@ -53,7 +53,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = BasePublisher::builder().build().await?;
     /// # Ok(()) }
@@ -66,7 +66,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = BasePublisher::builder()
     ///     .with_endpoint("https://private.googleapis.com")
@@ -86,7 +86,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = BasePublisher::builder()
     ///     .with_tracing()
@@ -110,7 +110,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use google_cloud_auth::credentials::mds;
     /// let client = BasePublisher::builder()
@@ -137,7 +137,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
     /// let client = BasePublisher::builder()
@@ -158,7 +158,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     /// use std::time::Duration;
@@ -187,7 +187,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use google_cloud_gax::retry_throttler::AdaptiveThrottler;
     /// let client = BasePublisher::builder()
@@ -205,7 +205,7 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # use google_cloud_pubsub::publisher::client::BasePublisher;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let client = BasePublisher::builder()
     ///     .with_grpc_subchannel_count(4)

--- a/src/pubsub/src/publisher/implementation.rs
+++ b/src/pubsub/src/publisher/implementation.rs
@@ -16,6 +16,7 @@ use super::options::BatchingOptions;
 use crate::publisher::actor::BundledMessage;
 use crate::publisher::actor::ToDispatcher;
 use crate::publisher::builder::PublisherBuilder;
+
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
@@ -159,8 +160,8 @@ impl Publisher {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::BasePublisher;
     use crate::publisher::builder::PublisherPartialBuilder;
+    use crate::publisher::client::BasePublisher;
     use crate::publisher::constants::*;
     use crate::publisher::options::BatchingOptions;
     use crate::{


### PR DESCRIPTION
Resource sharing between publishers is an advanced use case. Moving the BasePublisher out of the main entry point (crate::client::*) simplifies the discoverability of the Publisher for most of our users while still leaving it accessible. It is likely we will also want to export the Publisher from this module as well (and do the same with the Subscriber).

For #4282