### PR TITLE
docs: Generate sample for List RPCs

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 language: rust
-version: v0.8.1-0.20260210085010-c90909642f33
+version: v0.8.2-0.20260210215157-685a942c8534
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -154,6 +154,26 @@ impl Folders {
     /// of their display_name.
     /// The caller must have `resourcemanager.folders.list` permission on the
     /// identified parent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &Folders,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_folders()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_folders(&self) -> super::builder::folders::ListFolders {
         super::builder::folders::ListFolders::new(self.inner.clone())
     }
@@ -164,6 +184,25 @@ impl Folders {
     ///
     /// This will only return folders on which the caller has the
     /// permission `resourcemanager.folders.get`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Folders;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &Folders
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .search_folders()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_folders(&self) -> super::builder::folders::SearchFolders {
         super::builder::folders::SearchFolders::new(self.inner.clone())
     }
@@ -663,6 +702,25 @@ impl Organizations {
     ///
     /// Search will only return organizations on which the user has the permission
     /// `resourcemanager.organizations.get`
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Organizations;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &Organizations
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .search_organizations()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_organizations(&self) -> super::builder::organizations::SearchOrganizations {
         super::builder::organizations::SearchOrganizations::new(self.inner.clone())
     }
@@ -907,6 +965,26 @@ impl Projects {
     /// projects sorted based upon the (ascending) lexical ordering of their
     /// `display_name`. The caller must have `resourcemanager.projects.list`
     /// permission on the identified parent.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &Projects,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_projects()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_projects(&self) -> super::builder::projects::ListProjects {
         super::builder::projects::ListProjects::new(self.inner.clone())
     }
@@ -923,6 +1001,25 @@ impl Projects {
     /// [GetProject][google.cloud.resourcemanager.v3.Projects.GetProject] method.
     ///
     /// [google.cloud.resourcemanager.v3.Projects.GetProject]: crate::client::Projects::get_project
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::Projects;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &Projects
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .search_projects()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn search_projects(&self) -> super::builder::projects::SearchProjects {
         super::builder::projects::SearchProjects::new(self.inner.clone())
     }
@@ -1408,6 +1505,26 @@ impl TagBindings {
     ///
     /// NOTE: The `parent` field is expected to be a full resource name:
     /// <https://cloud.google.com/apis/design/resource_names#full_resource_name>
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagBindings;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &TagBindings,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_tag_bindings()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_tag_bindings(&self) -> super::builder::tag_bindings::ListTagBindings {
         super::builder::tag_bindings::ListTagBindings::new(self.inner.clone())
     }
@@ -1482,6 +1599,25 @@ impl TagBindings {
 
     /// Return a list of effective tags for the given Google Cloud resource, as
     /// specified in `parent`.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagBindings;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &TagBindings
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_effective_tags()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_effective_tags(&self) -> super::builder::tag_bindings::ListEffectiveTags {
         super::builder::tag_bindings::ListEffectiveTags::new(self.inner.clone())
     }
@@ -1687,6 +1823,26 @@ impl TagHolds {
     }
 
     /// Lists TagHolds under a TagValue.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagHolds;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &TagHolds,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_tag_holds()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_tag_holds(&self) -> super::builder::tag_holds::ListTagHolds {
         super::builder::tag_holds::ListTagHolds::new(self.inner.clone())
     }
@@ -1819,6 +1975,26 @@ impl TagKeys {
     }
 
     /// Lists all TagKeys for a parent resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagKeys;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &TagKeys,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_tag_keys()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_tag_keys(&self) -> super::builder::tag_keys::ListTagKeys {
         super::builder::tag_keys::ListTagKeys::new(self.inner.clone())
     }
@@ -2186,6 +2362,26 @@ impl TagValues {
     }
 
     /// Lists all TagValues for a specific TagKey.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_resourcemanager_v3::client::TagValues;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_resourcemanager_v3::Result;
+    /// async fn sample(
+    ///    client: &TagValues,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_tag_values()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_tag_values(&self) -> super::builder::tag_values::ListTagValues {
         super::builder::tag_values::ListTagValues::new(self.inner.clone())
     }

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -131,6 +131,26 @@ impl SecretManagerService {
     /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
     ///
     /// [google.cloud.secretmanager.v1.Secret]: crate::model::Secret
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_secretmanager_v1::Result;
+    /// async fn sample(
+    ///    client: &SecretManagerService,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_secrets()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_secrets(&self) -> super::builder::secret_manager_service::ListSecrets {
         super::builder::secret_manager_service::ListSecrets::new(self.inner.clone())
     }
@@ -266,6 +286,26 @@ impl SecretManagerService {
     /// call does not return secret data.
     ///
     /// [google.cloud.secretmanager.v1.SecretVersion]: crate::model::SecretVersion
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_secretmanager_v1::Result;
+    /// async fn sample(
+    ///    client: &SecretManagerService,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_secret_versions()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_secret_versions(
         &self,
     ) -> super::builder::secret_manager_service::ListSecretVersions {
@@ -513,6 +553,25 @@ impl SecretManagerService {
     }
 
     /// Lists information about the supported locations for this service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_secretmanager_v1::Result;
+    /// async fn sample(
+    ///    client: &SecretManagerService
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_locations()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_locations(&self) -> super::builder::secret_manager_service::ListLocations {
         super::builder::secret_manager_service::ListLocations::new(self.inner.clone())
     }

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -155,6 +155,26 @@ impl Speech {
     }
 
     /// Lists Recognizers.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_speech_v2::Result;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_recognizers()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_recognizers(&self) -> super::builder::speech::ListRecognizers {
         super::builder::speech::ListRecognizers::new(self.inner.clone())
     }
@@ -442,6 +462,26 @@ impl Speech {
     }
 
     /// Lists CustomClasses.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_speech_v2::Result;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_custom_classes()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_custom_classes(&self) -> super::builder::speech::ListCustomClasses {
         super::builder::speech::ListCustomClasses::new(self.inner.clone())
     }
@@ -619,6 +659,26 @@ impl Speech {
     }
 
     /// Lists PhraseSets.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_speech_v2::Result;
+    /// async fn sample(
+    ///    client: &Speech,
+    ///    parent: &str
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_phrase_sets()
+    ///         .set_parent(parent)
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_phrase_sets(&self) -> super::builder::speech::ListPhraseSets {
         super::builder::speech::ListPhraseSets::new(self.inner.clone())
     }
@@ -760,6 +820,25 @@ impl Speech {
     }
 
     /// Lists information about the supported locations for this service.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_speech_v2::Result;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_locations()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_locations(&self) -> super::builder::speech::ListLocations {
         super::builder::speech::ListLocations::new(self.inner.clone())
     }
@@ -789,6 +868,25 @@ impl Speech {
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: google-cloud-longrunning::client::Operations
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_speech_v2::client::Speech;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_speech_v2::Result;
+    /// async fn sample(
+    ///    client: &Speech
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_operations()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_operations(&self) -> super::builder::speech::ListOperations {
         super::builder::speech::ListOperations::new(self.inner.clone())
     }

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -149,6 +149,25 @@ impl Iam {
     /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that belongs to a specific project.
     ///
     /// [google.iam.admin.v1.ServiceAccount]: crate::model::ServiceAccount
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_iam_admin_v1::Result;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_service_accounts()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_service_accounts(&self) -> super::builder::iam::ListServiceAccounts {
         super::builder::iam::ListServiceAccounts::new(self.inner.clone())
     }
@@ -740,6 +759,25 @@ impl Iam {
     /// Lists roles that can be granted on a Google Cloud resource. A role is
     /// grantable if the IAM policy for the resource can contain bindings to the
     /// role.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_iam_admin_v1::Result;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .query_grantable_roles()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_grantable_roles(&self) -> super::builder::iam::QueryGrantableRoles {
         super::builder::iam::QueryGrantableRoles::new(self.inner.clone())
     }
@@ -748,6 +786,25 @@ impl Iam {
     /// that is defined for an organization or project.
     ///
     /// [google.iam.admin.v1.Role]: crate::model::Role
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_iam_admin_v1::Result;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .list_roles()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn list_roles(&self) -> super::builder::iam::ListRoles {
         super::builder::iam::ListRoles::new(self.inner.clone())
     }
@@ -895,6 +952,25 @@ impl Iam {
     /// Lists every permission that you can test on a resource. A permission is
     /// testable if you can check whether a principal has that permission on the
     /// resource.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_iam_admin_v1::client::Iam;
+    /// use google_cloud_gax::paginator::ItemPaginator as _;
+    /// use google_cloud_iam_admin_v1::Result;
+    /// async fn sample(
+    ///    client: &Iam
+    /// ) -> Result<()> {
+    ///     let mut list = client
+    ///         .query_testable_permissions()
+    ///         /* set fields */
+    ///         .by_item();
+    ///     while let Some(item) = list.next().await.transpose()? {
+    ///         println!("{:?}", item);
+    ///     }
+    ///     Ok(())
+    /// }
+    /// ```
     pub fn query_testable_permissions(&self) -> super::builder::iam::QueryTestablePermissions {
         super::builder::iam::QueryTestablePermissions::new(self.inner.clone())
     }


### PR DESCRIPTION
Note that for list like operations (e.g. search_folders in resourcemanager v3) we also generate the sample stub, we just don't know (yet) which fields to initialize.