### PR TITLE
cleanup(pubsub): fix broken tests

### DIFF
--- a/src/pubsub/src/publisher/client.rs
+++ b/src/pubsub/src/publisher/client.rs
@@ -309,7 +309,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn worker_handles_forced_shutdown_gracefully() {
         let mock = MockGapicPublisher::new();
 
@@ -320,8 +320,8 @@ mod tests {
                 .build_return_handle();
 
         let messages = [
-            PubsubMessage::new().set_data("hello"),
-            PubsubMessage::new().set_data("world"),
+            Message::new().set_data("hello"),
+            Message::new().set_data("world"),
         ];
         let mut handles = Vec::new();
         for msg in messages {

--- a/src/pubsub/src/publisher/model_ext.rs
+++ b/src/pubsub/src/publisher/model_ext.rs
@@ -54,7 +54,7 @@ impl Future for PublishFuture {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let result = ready!(Pin::new(&mut self.rx).poll(cx));
         // An error will only occur if the sender of the self.rx was dropped,
-        // which can happen when the background worker is dropped.
+        // which can happen when the Dispatcher is dropped.
         match result {
             Ok(result) => Poll::Ready(result.map_err(convert_error)),
             Err(_) => Poll::Ready(Err(Arc::new(google_cloud_gax::error::Error::io(


### PR DESCRIPTION
The PR that added this test was incorrectly merged and used the stale name for Message. This also fixes a potential source of flakiness where the timer for a batch fires before the task is aborted.