### PR TITLE
cleanup(pubsub): fix background panic in test

### DIFF
--- a/src/pubsub/src/subscriber/session.rs
+++ b/src/pubsub/src/subscriber/session.rs
@@ -751,6 +751,8 @@ mod tests {
             });
             Ok(TonicResponse::from(response_rx))
         });
+        mock.expect_modify_ack_deadline()
+            .returning(|_| Ok(TonicResponse::from(())));
 
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let client = test_client(endpoint).await?;


### PR DESCRIPTION
The client sends lease extensions in the `ModifyAckDeadline` rpc. Our background task was silently panicking on exit, because the mock did not expect these calls.

Found with:

```
cargo test -p google-cloud-pubsub subscriber:: -- --no-capture
```

Note that handling lease extensions is not the point of the test. It verified the thing it needed to verify. The background panic was just messy.