### PR TITLE
feat(gax): bump version to 1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,7 +451,7 @@ tokio-test        = { default-features = false, version = "0.4" }
 
 # Local packages used as dependencies.
 google-cloud-auth        = { default-features = false, version = "1.5", path = "src/auth" }
-google-cloud-gax         = { default-features = false, version = "1.7", path = "src/gax" }
+google-cloud-gax         = { default-features = false, version = "1.8", path = "src/gax" }
 gaxi                     = { default-features = false, version = "0.7.10", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 wkt                      = { default-features = false, version = "1", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-wkt         = { default-features = false, version = "1", path = "src/wkt", package = "google-cloud-wkt" }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -18,7 +18,7 @@ name = "google-cloud-gax"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version     = "1.7.0"
+version     = "1.8.0"
 description = "Google Cloud Client Libraries for Rust"
 # Inherit other attributes from the workspace.
 authors.workspace      = true


### PR DESCRIPTION
Bumps `google-cloud-gax` to 1.7

Splitting version bump from PR #4601 as requested in [this comment](https://github.com/googleapis/google-cloud-rust/pull/4601#issuecomment-3881661410).