### PR TITLE
doc: rm cargo update --workspace in generate steps

### DIFF
--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -77,7 +77,6 @@ V=$(sed -n 's/^version: *//p' librarian.yaml)
 go run github.com/googleapis/librarian/cmd/librarian@${V} update discovery
 go run github.com/googleapis/librarian/cmd/librarian@${V} update googleapis
 go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
-cargo update --workspace
 git commit -m"chore: update discovery and googleapis SHA circa $(date +%Y-%m-%d)" .
 ```
 


### PR DESCRIPTION
This `cargo update --workspace` step is added into librarian generate. 
See https://github.com/googleapis/librarian/issues/3683