### PR TITLE
chore(librarian): rename rust.modules.source to api_path

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 language: rust
-version: v0.8.4-0.20260218181222-507378f20682
+version: v0.8.4-0.20260218212125-3fe3c93e7dae
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6


### PR DESCRIPTION
The rust.modules.source field is being renamed to api_path as part of the effort for https://github.com/googleapis/librarian/issues/3820.

Consequently, the field name in librarian.yaml is being updated to reflect this change.