### PR TITLE
cleanup(gax-internal): use `client_request_span!()`

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -424,7 +424,7 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 mod tests {
     use super::*;
     #[cfg(google_cloud_unstable_tracing)]
-    use crate::observability::create_client_request_span;
+    use crate::client_request_span;
     use crate::options::ClientConfig;
     use crate::options::InstrumentationClientInfo;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
@@ -651,8 +651,7 @@ mod tests {
     #[cfg(google_cloud_unstable_tracing)]
     async fn test_t3_span_enrichment() {
         let guard = TestLayer::initialize();
-        let t3_span =
-            create_client_request_span("t3_span", "test_method", &TEST_INSTRUMENTATION_INFO);
+        let t3_span = client_request_span!("Service", "test_method", &TEST_INSTRUMENTATION_INFO);
 
         // Simulate T4 span scope ending before calling to_http_response
         {
@@ -686,7 +685,7 @@ mod tests {
             t3_captured
                 .attributes
                 .get(crate::observability::attributes::keys::OTEL_NAME),
-            Some(&"t3_span".into())
+            Some(&"google_cloud_gax_internal::Service::test_method".into())
         );
 
         assert_eq!(

--- a/src/gax-internal/src/observability.rs
+++ b/src/gax-internal/src/observability.rs
@@ -41,4 +41,4 @@ pub mod grpc_tracing;
 mod client_tracing;
 
 #[cfg(google_cloud_unstable_tracing)]
-pub use client_tracing::{ResultExt, create_client_request_span, record_client_request_span};
+pub use client_tracing::{ResultExt, record_client_request_span};

--- a/src/gax-internal/src/observability/attributes.rs
+++ b/src/gax-internal/src/observability/attributes.rs
@@ -65,6 +65,13 @@ pub mod keys {
     ///
     /// 1 for the first retry.
     pub const GCP_GRPC_RESEND_COUNT: &str = "gcp.grpc.resend_count";
+
+    // Re-export these symbols so we can use them in the `client_request_span!()`
+    // macro.
+    pub use opentelemetry_semantic_conventions::trace::{
+        ERROR_TYPE, HTTP_REQUEST_METHOD, HTTP_REQUEST_RESEND_COUNT, HTTP_RESPONSE_STATUS_CODE,
+        RPC_METHOD, RPC_SERVICE, RPC_SYSTEM, SERVER_ADDRESS, SERVER_PORT, URL_FULL,
+    };
 }
 
 /// Value for [keys::OTEL_KIND].

--- a/src/gax-internal/src/observability/http_tracing.rs
+++ b/src/gax-internal/src/observability/http_tracing.rs
@@ -201,7 +201,7 @@ pub(crate) fn record_intermediate_client_request(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::observability::client_tracing::create_client_request_span;
+    use crate::client_request_span;
     use crate::options::InstrumentationClientInfo;
     use google_cloud_gax::error::{
         Error,
@@ -553,7 +553,7 @@ mod tests {
     #[tokio::test]
     async fn test_record_intermediate_client_request() {
         let guard = TestLayer::initialize();
-        let span = create_client_request_span("test_span", "test_method", &TEST_INFO);
+        let span = client_request_span!("Service", "test_method", &TEST_INFO);
         let _enter = span.enter();
 
         let url = "https://example.com/test".parse::<reqwest::Url>().unwrap();
@@ -613,7 +613,7 @@ mod tests {
     #[tokio::test]
     async fn test_record_intermediate_client_request_error() {
         let guard = TestLayer::initialize();
-        let span = create_client_request_span("test_span", "test_method", &TEST_INFO);
+        let span = client_request_span!("Service", "test_method", &TEST_INFO);
         let _enter = span.enter();
 
         let url = "https://example.com/test".parse::<reqwest::Url>().unwrap();


### PR DESCRIPTION
Only use the macro and remove the previous function. The macro automatically captures the crate name, module, file, and line number.

Not breaking because the removed function is protected by a `#[cfg(google_cloud_unstable_*)]` configuration.

Motivated by #3178 