### PR TITLE
fix(pubsub): handle batch actor shutdown gracefully

### DIFF
--- a/src/pubsub/src/publisher/constants.rs
+++ b/src/pubsub/src/publisher/constants.rs
@@ -19,5 +19,3 @@ pub(crate) const MAX_DELAY: Duration = Duration::from_secs(60 * 60 * 24); // 1 d
 // Client libraries are expected to enforce these limits on batch siziing.
 pub(crate) const MAX_MESSAGES: u32 = 1000;
 pub(crate) const MAX_BYTES: u32 = 1e7 as u32; // 10MB
-pub(crate) const BATCH_ACTOR_SEND_ERROR_MSG: &str =
-    "batch actors should not close the receiver from the Dispatcher";

--- a/src/pubsub/src/publisher/implementation.rs
+++ b/src/pubsub/src/publisher/implementation.rs
@@ -126,11 +126,9 @@ impl Publisher {
     /// ```
     pub async fn flush(&self) {
         let (tx, rx) = oneshot::channel();
-        if self.tx.send(ToDispatcher::Flush(tx)).is_err() {
-            // `tx` is dropped here if the send errors.
+        if self.tx.send(ToDispatcher::Flush(tx)).is_ok() {
+            let _ = rx.await;
         }
-        rx.await
-            .expect("the client library should not release the sender");
     }
 
     /// Resume accepting publish for a paused ordering key.


### PR DESCRIPTION
During shutdown, tasks may be aborted in any order. This means that we cannot expect that any particular task is alive at a given time. To handle shutdown of the tasks that handle batching, we shut the publisher down completely. Any dropped receiver handles for messages that were not yet sent will receive a ShutdownError when the sender half is dropped.

Shutting down the Dispatcher completely is the cleanest way to handle this and we only expect this to come up when the whole program is shutting down or there is another serious error and we want to stop publishing to indicate that things are not in a good state to continue publishing.

Fixes #4716 