### PR TITLE
feat(pubsub): use configured retry policy for ordering key

### DIFF
--- a/src/pubsub/src/publisher/actor.rs
+++ b/src/pubsub/src/publisher/actor.rs
@@ -371,7 +371,7 @@ impl SequentialBatchActor {
         // a single inflight task at any given time, the use of JoinSet
         // simplify the managing the inflight JoinHandle.
         let mut inflight: JoinSet<crate::Result<()>> = JoinSet::new();
-        let mut batch = Batch::new_with_ordering_key(
+        let mut batch = Batch::new(
             self.context.topic.len() as u32,
             self.context.batching_options.clone(),
         );
@@ -1133,81 +1133,12 @@ mod tests {
         )
     )]
     #[cfg_attr(not(tokio_unstable), tokio::test(start_paused = true))]
-    async fn sequential_actor_overrides_retry() -> anyhow::Result<()> {
-        let mut mock = MockGapicPublisherWithFuture::new();
-        let mut seq = Sequence::new();
-        mock.expect_publish()
-            .times(1)
-            .in_sequence(&mut seq)
-            .withf(|_, o| o.retry_policy().is_some())
-            .returning(|r, o| Box::pin(async { publish_ok(r, o) }));
-
-        let (actor_tx, actor_rx) = tokio::sync::mpsc::unbounded_channel();
-        tokio::spawn(
-            SequentialBatchActor::new(
-                TOPIC.to_string(),
-                GapicPublisher::from_stub(mock),
-                BatchingOptions::default().set_message_count_threshold(1_u32),
-                actor_rx,
-            )
-            .run(),
-        );
-
-        assert_publish_is_ok!(actor_tx, 1);
-        Ok(())
-    }
-
-    #[cfg_attr(
-        tokio_unstable,
-        tokio::test(
-            start_paused = true,
-            flavor = "current_thread",
-            unhandled_panic = "shutdown_runtime"
-        )
-    )]
-    #[cfg_attr(not(tokio_unstable), tokio::test(start_paused = true))]
-    async fn concurrent_actor_uses_default_retry() -> anyhow::Result<()> {
-        let mut mock = MockGapicPublisherWithFuture::new();
-        let mut seq = Sequence::new();
-        mock.expect_publish()
-            .times(1)
-            .in_sequence(&mut seq)
-            .withf(|_, o| o.retry_policy().is_none())
-            .returning(|r, o| Box::pin(async { publish_ok(r, o) }));
-
-        let (actor_tx, actor_rx) = tokio::sync::mpsc::unbounded_channel();
-        tokio::spawn(
-            ConcurrentBatchActor::new(
-                TOPIC.to_string(),
-                GapicPublisher::from_stub(mock),
-                BatchingOptions::default().set_message_count_threshold(1_u32),
-                actor_rx,
-            )
-            .run(),
-        );
-
-        assert_publish_is_ok!(actor_tx, 1);
-        Ok(())
-    }
-
-    #[cfg_attr(
-        tokio_unstable,
-        tokio::test(
-            start_paused = true,
-            flavor = "current_thread",
-            unhandled_panic = "shutdown_runtime"
-        )
-    )]
-    #[cfg_attr(not(tokio_unstable), tokio::test(start_paused = true))]
     async fn sequential_actor_byte_count_threshold() -> anyhow::Result<()> {
         let mut mock = MockGapicPublisher::new();
         mock.expect_publish()
             .withf(|req, _o| {
                 // Recreate the batch from req to calculate the batch size.
-                let mut batch = Batch::new_with_ordering_key(
-                    req.topic.len() as u32,
-                    BatchingOptions::default(),
-                );
+                let mut batch = Batch::new(req.topic.len() as u32, BatchingOptions::default());
                 req.messages.iter().for_each(|msg| {
                     let (tx, _rx) = tokio::sync::oneshot::channel();
                     batch.push(BundledMessage {

--- a/src/pubsub/src/publisher/batch.rs
+++ b/src/pubsub/src/publisher/batch.rs
@@ -26,7 +26,6 @@ pub(crate) struct Batch {
     initial_size: u32,
     messages_byte_size: u32,
     batching_options: BatchingOptions,
-    has_ordering_key: bool,
 }
 
 impl Batch {
@@ -35,21 +34,7 @@ impl Batch {
             initial_size,
             messages_byte_size: initial_size,
             batching_options,
-            has_ordering_key: false,
-            messages: Vec::new(),
-        }
-    }
-
-    pub(crate) fn new_with_ordering_key(
-        initial_size: u32,
-        batching_options: BatchingOptions,
-    ) -> Self {
-        Batch {
-            initial_size,
-            messages_byte_size: initial_size,
-            batching_options,
-            has_ordering_key: true,
-            messages: Vec::new(),
+            ..Batch::default()
         }
     }
 
@@ -112,7 +97,6 @@ impl Batch {
             messages: self.messages.drain(..).collect(),
             messages_byte_size: self.messages_byte_size,
             batching_options: self.batching_options.clone(),
-            has_ordering_key: self.has_ordering_key,
         };
         self.messages_byte_size = self.initial_size;
         inflight.spawn(batch_to_send.send(client, topic));
@@ -125,12 +109,7 @@ impl Batch {
             .into_iter()
             .map(|msg| (msg.msg, msg.tx))
             .unzip();
-        let mut request = client.publish().set_topic(topic).set_messages(msgs);
-        if self.has_ordering_key {
-            use google_cloud_gax::options::RequestOptionsBuilder;
-            request =
-                request.with_retry_policy(super::retry_policy::default_ordering_retry_policy());
-        }
+        let request = client.publish().set_topic(topic).set_messages(msgs);
 
         // Handle the response by extracting the message ID on success.
         match request.send().await {
@@ -260,93 +239,6 @@ mod tests {
         inflight.join_all().await;
 
         Ok(())
-    }
-
-    #[cfg_attr(
-        tokio_unstable,
-        tokio::test(
-            start_paused = true,
-            flavor = "current_thread",
-            unhandled_panic = "shutdown_runtime"
-        )
-    )]
-    #[cfg_attr(not(tokio_unstable), tokio::test(start_paused = true))]
-    async fn send_overrides_ordering_retry_policy() {
-        let mut mock = MockGapicPublisher::new();
-        mock.expect_publish()
-            .withf(|r, o| r.topic == "topic" && o.retry_policy().is_some())
-            .times(2)
-            .returning(|_, _| Ok(crate::Response::from(PublishResponse::new())));
-        let client = GapicPublisher::from_stub(mock);
-
-        let mut batch =
-            Batch::new_with_ordering_key("topic".len() as u32, BatchingOptions::default());
-        assert!(batch.is_empty());
-
-        let (message_a, _rx_a) = create_bundled_message_from_bytes("hello");
-        batch.push(message_a);
-        assert_eq!(batch.len(), 1);
-
-        let mut inflight = JoinSet::new();
-        batch.flush(client.clone(), "topic".to_string(), &mut inflight);
-        assert_eq!(batch.len(), 0);
-        inflight.join_all().await;
-
-        let (message_b, _rx_b) = create_bundled_message_from_bytes(", ");
-        batch.push(message_b);
-        assert_eq!(batch.len(), 1);
-
-        let (message_c, _rx_c) = create_bundled_message_from_bytes("world");
-        batch.push(message_c);
-        assert_eq!(batch.len(), 2);
-
-        let mut inflight = JoinSet::new();
-        batch.flush(client, "topic".to_string(), &mut inflight);
-        assert_eq!(batch.len(), 0);
-        inflight.join_all().await;
-    }
-
-    #[cfg_attr(
-        tokio_unstable,
-        tokio::test(
-            start_paused = true,
-            flavor = "current_thread",
-            unhandled_panic = "shutdown_runtime"
-        )
-    )]
-    #[cfg_attr(not(tokio_unstable), tokio::test(start_paused = true))]
-    async fn send_uses_default_retry() {
-        let mut mock = MockGapicPublisher::new();
-        mock.expect_publish()
-            .withf(|r, o| r.topic == "topic" && o.retry_policy().is_none())
-            .times(2)
-            .returning(|_, _| Ok(crate::Response::from(PublishResponse::new())));
-        let client = GapicPublisher::from_stub(mock);
-
-        let mut batch = Batch::new("topic".len() as u32, BatchingOptions::default());
-        assert!(batch.is_empty());
-
-        let (message_a, _rx_a) = create_bundled_message_from_bytes("hello");
-        batch.push(message_a);
-        assert_eq!(batch.len(), 1);
-
-        let mut inflight = JoinSet::new();
-        batch.flush(client.clone(), "topic".to_string(), &mut inflight);
-        assert_eq!(batch.len(), 0);
-        inflight.join_all().await;
-
-        let (message_b, _rx_b) = create_bundled_message_from_bytes(", ");
-        batch.push(message_b);
-        assert_eq!(batch.len(), 1);
-
-        let (message_c, _rx_c) = create_bundled_message_from_bytes("world");
-        batch.push(message_c);
-        assert_eq!(batch.len(), 2);
-
-        let mut inflight = JoinSet::new();
-        batch.flush(client, "topic".to_string(), &mut inflight);
-        assert_eq!(batch.len(), 0);
-        inflight.join_all().await;
     }
 
     fn create_bundled_message_from_bytes<T: Into<::bytes::Bytes>>(

--- a/src/pubsub/src/publisher/retry_policy.rs
+++ b/src/pubsub/src/publisher/retry_policy.rs
@@ -47,15 +47,6 @@ pub(crate) fn default_retry_policy() -> impl RetryPolicy {
     RetryableErrors.with_time_limit(Duration::from_secs(600))
 }
 
-/// The default retry policy for messages with ordering keys in the Pub/Sub
-/// publisher.
-///
-/// The client will retry all the errors shown as retryable in the service
-/// documentation forever.
-pub(crate) fn default_ordering_retry_policy() -> impl RetryPolicy {
-    RetryableErrors
-}
-
 /// Follows the retry strategy recommended by the Cloud Pub/Sub guides on
 /// [error codes].
 ///


### PR DESCRIPTION
This reverts commit dcc3edd48c9e50a0ce44e435e40f4d59afa01fec.

For #4013
