### PR TITLE
chore: replace googleapis-auth with cloud-sdk-auth-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 *           @googleapis/cloud-sdk-rust-team
-/src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/googleapis-auth
+/src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-auth-team


### PR DESCRIPTION
This PR replaces the old googleapis-auth team with the new cloud-sdk-auth-team.

b/478003109