### PR TITLE
impl(storage): use HTTP request from `gax-internal`

### DIFF
--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use super::request_options::RequestOptions;
-use crate::Error;
 use crate::builder::storage::ReadObject;
 use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
@@ -22,11 +21,10 @@ use crate::storage::common_options::CommonOptions;
 use crate::streaming_source::Payload;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
-use gaxi::http::reqwest::RequestBuilder;
+use gaxi::http::HttpRequestBuilder;
 use gaxi::options::{ClientConfig, Credentials};
-use google_cloud_auth::credentials::{Builder as CredentialsBuilder, CacheableResource};
+use google_cloud_auth::credentials::Builder as CredentialsBuilder;
 use google_cloud_gax::client_builder::{Error as BuilderError, Result as BuilderResult};
-use http::Extensions;
 use std::sync::Arc;
 
 /// Implements a client for the Cloud Storage API.
@@ -102,7 +100,6 @@ where
 #[derive(Clone, Debug)]
 pub(crate) struct StorageInner {
     pub client: gaxi::http::ReqwestClient,
-    pub cred: Credentials,
     pub options: RequestOptions,
     pub grpc: gaxi::grpc::Client,
 }
@@ -302,13 +299,11 @@ impl StorageInner {
     /// Builds a client assuming `config.cred` and `config.endpoint` are initialized, panics otherwise.
     pub(self) fn new(
         client: gaxi::http::ReqwestClient,
-        cred: Credentials,
         options: RequestOptions,
         grpc: gaxi::grpc::Client,
     ) -> Self {
         Self {
             client,
-            cred,
             options,
             grpc,
         }
@@ -317,42 +312,16 @@ impl StorageInner {
     pub(self) async fn from_parts(builder: ClientBuilder) -> BuilderResult<Self> {
         let (mut config, options) = builder.into_parts()?;
         config.disable_automatic_decompression = true;
-        let cred = config
-            .cred
-            .clone()
-            .expect("into_parts() assigns default credentials");
+        config.disable_follow_redirects = true;
 
         let client = gaxi::http::ReqwestClient::new(config.clone(), super::DEFAULT_HOST).await?;
 
         let inner = StorageInner::new(
             client,
-            cred,
             options,
             gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?,
         );
         Ok(inner)
-    }
-
-    // Helper method to apply authentication headers to the request builder.
-    pub async fn apply_auth_headers(
-        &self,
-        builder: RequestBuilder,
-    ) -> crate::Result<RequestBuilder> {
-        let cached_auth_headers = self
-            .cred
-            .headers(Extensions::new())
-            .await
-            .map_err(Error::authentication)?;
-
-        let auth_headers = match cached_auth_headers {
-            CacheableResource::New { data, .. } => data,
-            CacheableResource::NotModified => {
-                unreachable!("headers are not cached");
-            }
-        };
-
-        let builder = builder.headers(auth_headers);
-        Ok(builder)
     }
 }
 
@@ -775,9 +744,9 @@ pub(crate) fn enc(value: &str) -> String {
 }
 
 pub(crate) fn apply_customer_supplied_encryption_headers(
-    builder: RequestBuilder,
+    builder: HttpRequestBuilder,
     common_object_request_params: &Option<crate::model::CommonObjectRequestParams>,
-) -> RequestBuilder {
+) -> HttpRequestBuilder {
     common_object_request_params.iter().fold(builder, |b, v| {
         b.header(
             "x-goog-encryption-algorithm",

--- a/src/storage/src/storage/perform_upload.rs
+++ b/src/storage/src/storage/perform_upload.rs
@@ -20,7 +20,9 @@ use crate::storage::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::v1;
 use crate::streaming_source::{IterSource, Seek, SizeHint, StreamingSource};
 use crate::{Error, Result};
-use gaxi::http::reqwest::{HeaderMap, HeaderValue, Method, RequestBuilder, Response, StatusCode};
+use gaxi::attempt_info::AttemptInfo;
+use gaxi::http::HttpRequestBuilder;
+use gaxi::http::reqwest::{HeaderMap, HeaderValue, Method, Response, StatusCode};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -69,11 +71,15 @@ impl<S> PerformUpload<S> {
 
     async fn start_resumable_upload_attempt(&self) -> Result<String> {
         let builder = self.start_resumable_upload_request().await?;
-        let response = builder.send().await.map_err(Error::io)?;
+        let options = self.options.gax();
+        let response = builder
+            .send(options, AttemptInfo::new(0))
+            .await
+            .map_err(Error::io)?;
         self::handle_start_resumable_upload_response(response).await
     }
 
-    async fn start_resumable_upload_request(&self) -> Result<RequestBuilder> {
+    async fn start_resumable_upload_request(&self) -> Result<HttpRequestBuilder> {
         let bucket = &self.resource().bucket;
         let bucket_id = bucket.strip_prefix("projects/_/buckets/").ok_or_else(|| {
             Error::binding(format!(
@@ -84,9 +90,9 @@ impl<S> PerformUpload<S> {
         let builder = self
             .inner
             .client
-            .builder(Method::POST, format!("/upload/storage/v1/b/{bucket_id}/o"))
-            .query(&[("uploadType", "resumable")])
-            .query(&[("name", object)])
+            .http_builder(Method::POST, &format!("/upload/storage/v1/b/{bucket_id}/o"))
+            .query("uploadType", "resumable")
+            .query("name", object)
             .header("content-type", "application/json")
             .header(
                 "x-goog-api-client",
@@ -95,19 +101,20 @@ impl<S> PerformUpload<S> {
 
         let builder = self.apply_preconditions(builder);
         let builder = apply_customer_supplied_encryption_headers(builder, &self.params);
-        let builder = self.inner.apply_auth_headers(builder).await?;
-        let builder = builder.json(&v1::insert_body(self.resource()));
+        let builder = builder.body(v1::insert_body(self.resource()).to_string());
         Ok(builder)
     }
 
     async fn query_resumable_upload_attempt(
         &self,
         upload_url: &str,
+        attempt_count: u32,
     ) -> Result<ResumableUploadStatus> {
+        let options = self.options.gax();
         let builder = self
             .inner
             .client
-            .builder_with_url(Method::PUT, upload_url)
+            .http_builder_with_url(Method::PUT, upload_url, crate::storage::DEFAULT_HOST)?
             .header("content-type", "application/octet-stream")
             .header("Content-Range", "bytes */*")
             .header("content-length", 0)
@@ -115,32 +122,34 @@ impl<S> PerformUpload<S> {
                 "x-goog-api-client",
                 HeaderValue::from_static(&X_GOOG_API_CLIENT_HEADER),
             );
-        let builder = self.inner.apply_auth_headers(builder).await?;
-        let response = builder.send().await.map_err(Error::io)?;
+        let response = builder
+            .send(options, AttemptInfo::new(attempt_count))
+            .await
+            .map_err(Error::io)?;
         self::query_resumable_upload_handle_response(response).await
     }
 
-    fn apply_preconditions(&self, builder: RequestBuilder) -> RequestBuilder {
+    fn apply_preconditions(&self, builder: HttpRequestBuilder) -> HttpRequestBuilder {
         let builder = self
             .spec
             .if_generation_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifGenerationMatch", v)]));
+            .fold(builder, |b, v| b.query("ifGenerationMatch", v));
         let builder = self
             .spec
             .if_generation_not_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifGenerationNotMatch", v)]));
+            .fold(builder, |b, v| b.query("ifGenerationNotMatch", v));
         let builder = self
             .spec
             .if_metageneration_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifMetagenerationMatch", v)]));
+            .fold(builder, |b, v| b.query("ifMetagenerationMatch", v));
         let builder = self
             .spec
             .if_metageneration_not_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifMetagenerationNotMatch", v)]));
+            .fold(builder, |b, v| b.query("ifMetagenerationNotMatch", v));
 
         [
             ("kmsKeyName", self.resource().kms_key.as_str()),
@@ -149,7 +158,7 @@ impl<S> PerformUpload<S> {
         .into_iter()
         .fold(
             builder,
-            |b, (k, v)| if v.is_empty() { b } else { b.query(&[(k, v)]) },
+            |b, (k, v)| if v.is_empty() { b } else { b.query(k, v) },
         )
     }
 }

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -21,10 +21,9 @@ use crate::error::WriteError;
 use crate::storage::checksum::details::{
     Checksum, update as checksum_update, validate as checksum_validate,
 };
-use gaxi::http::{
-    map_send_error,
-    reqwest::{HeaderValue, Method, RequestBuilder},
-};
+use gaxi::attempt_info::AttemptInfo;
+use gaxi::http::HttpRequestBuilder;
+use gaxi::http::reqwest::{HeaderValue, Method};
 use progress::InProgressUpload;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -87,7 +86,7 @@ where
         };
 
         if progress.needs_query() {
-            match self.query_resumable_upload_attempt(upload_url).await? {
+            match self.query_resumable_upload_attempt(upload_url, 0).await? {
                 ResumableUploadStatus::Finalized(object) => return Ok(*object),
                 ResumableUploadStatus::Partial(persisted_size) => {
                     progress.handle_partial(persisted_size)?;
@@ -95,12 +94,16 @@ where
             };
         }
 
+        let mut count = 0;
         loop {
             progress
                 .next_buffer(&mut *self.payload.lock().await)
                 .await?;
             let builder = self.partial_upload_request(upload_url, progress).await?;
-            let response = builder.send().await.map_err(map_send_error)?;
+            let response = builder
+                .send(self.options.gax(), AttemptInfo::new(count))
+                .await?;
+            count += 1;
             match super::query_resumable_upload_handle_response(response).await {
                 Err(e) => {
                     progress.handle_error();
@@ -120,12 +123,12 @@ where
         &self,
         upload_url: &str,
         progress: &mut InProgressUpload,
-    ) -> Result<RequestBuilder> {
+    ) -> Result<HttpRequestBuilder> {
         let range = progress.range_header();
         let builder = self
             .inner
             .client
-            .builder_with_url(Method::PUT, upload_url)
+            .http_builder_with_url(Method::PUT, upload_url, crate::storage::DEFAULT_HOST)?
             .header("content-type", "application/octet-stream")
             .header("Content-Range", range)
             .header(
@@ -134,7 +137,6 @@ where
             );
 
         let builder = apply_customer_supplied_encryption_headers(builder, &self.params);
-        let builder = self.inner.apply_auth_headers(builder).await?;
         Ok(builder.body(progress.put_body()))
     }
 
@@ -239,7 +241,8 @@ mod tests {
         let request = perform_upload(inner, builder)
             .start_resumable_upload_request()
             .await?
-            .build()?;
+            .build_for_tests()
+            .await?;
 
         let got = request
             .url()

--- a/src/storage/src/storage/perform_upload/tests.rs
+++ b/src/storage/src/storage/perform_upload/tests.rs
@@ -66,7 +66,8 @@ async fn start_resumable_upload() -> Result {
     let mut request = perform_upload(inner, builder)
         .start_resumable_upload_request()
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(
@@ -99,7 +100,8 @@ async fn start_resumable_upload_headers() -> Result {
     let request = perform_upload(inner, builder)
         .start_resumable_upload_request()
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(
@@ -171,7 +173,8 @@ async fn start_resumable_upload_metadata_in_request() -> Result {
     let mut request = perform_upload(inner, builder)
         .start_resumable_upload_request()
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     let want_pairs: BTreeMap<String, String> = [
@@ -233,6 +236,8 @@ async fn start_resumable_upload_credentials() -> Result {
     );
     let _ = perform_upload(inner, builder)
         .start_resumable_upload_request()
+        .await?
+        .build_for_tests()
         .await
         .inspect_err(|e| assert!(e.is_authentication()))
         .expect_err("invalid credentials should err");

--- a/src/storage/src/storage/perform_upload/unbuffered.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered.rs
@@ -18,9 +18,12 @@ use super::{
     handle_object_response, v1,
 };
 use futures::stream::unfold;
-use gaxi::http::{
-    map_send_error,
-    reqwest::{Body, HeaderValue, Method, RequestBuilder, multipart},
+use gaxi::{
+    attempt_info::AttemptInfo,
+    http::{
+        HttpRequestBuilder,
+        reqwest::{Body, HeaderValue, Method, multipart},
+    },
 };
 use std::sync::Arc;
 
@@ -51,8 +54,15 @@ where
         let throttler = self.options.retry_throttler.clone();
         let retry = Arc::new(ContinueOn308::new(self.options.retry_policy.clone()));
         let backoff = self.options.backoff_policy.clone();
+        let mut count = 0_u32;
+        let inner = async move |_| {
+            let previous = count;
+            count += 1;
+            self.resumable_attempt(&mut upload_url, hint.clone(), previous)
+                .await
+        };
         google_cloud_gax::retry_loop_internal::retry_loop(
-            async move |_| self.resumable_attempt(&mut upload_url, hint.clone()).await,
+            inner,
             async |duration| tokio::time::sleep(duration).await,
             true,
             throttler,
@@ -62,9 +72,17 @@ where
         .await
     }
 
-    async fn resumable_attempt(&self, url: &mut Option<String>, hint: SizeHint) -> Result<Object> {
-        let (offset, url_ref) = if let Some(upload_url) = url.as_deref() {
-            match self.query_resumable_upload_attempt(upload_url).await? {
+    async fn resumable_attempt(
+        &self,
+        url: &mut Option<String>,
+        hint: SizeHint,
+        attempt_count: u32,
+    ) -> Result<Object> {
+        let (offset, upload_url) = if let Some(upload_url) = url.as_deref() {
+            match self
+                .query_resumable_upload_attempt(upload_url, attempt_count)
+                .await?
+            {
                 ResumableUploadStatus::Finalized(object) => {
                     return Ok(*object);
                 }
@@ -83,7 +101,7 @@ where
         let builder = self
             .inner
             .client
-            .builder_with_url(Method::PUT, url_ref)
+            .http_builder_with_url(Method::PUT, upload_url, crate::storage::DEFAULT_HOST)?
             .header("content-type", "application/octet-stream")
             .header("Content-Range", range)
             .header(
@@ -92,7 +110,6 @@ where
             );
 
         let builder = apply_customer_supplied_encryption_headers(builder, &self.params);
-        let builder = self.inner.apply_auth_headers(builder).await?;
 
         self.payload
             .lock()
@@ -102,7 +119,9 @@ where
             .map_err(Error::ser)?;
         let payload = self.payload_to_body().await?;
         let builder = builder.body(payload);
-        let response = builder.send().await.map_err(map_send_error)?;
+        let response = builder
+            .send(self.options.gax(), AttemptInfo::new(attempt_count))
+            .await?;
         let object = self::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }
@@ -115,9 +134,15 @@ where
         let throttler = self.options.retry_throttler.clone();
         let retry = self.options.retry_policy.clone();
         let backoff = self.options.backoff_policy.clone();
+        let mut count = 0;
+        // TODO(#2044) - we need to apply any timeouts here.
+        let inner = async move |_| {
+            let previous = count;
+            count += 1;
+            self.single_shot_attempt(hint.clone(), previous).await
+        };
         google_cloud_gax::retry_loop_internal::retry_loop(
-            // TODO(#2044) - we need to apply any timeouts here.
-            async move |_| self.single_shot_attempt(hint.clone()).await,
+            inner,
             async |duration| tokio::time::sleep(duration).await,
             idempotent,
             throttler,
@@ -127,14 +152,17 @@ where
         .await
     }
 
-    async fn single_shot_attempt(&self, hint: SizeHint) -> Result<Object> {
+    async fn single_shot_attempt(&self, hint: SizeHint, attempt_count: u32) -> Result<Object> {
         let builder = self.single_shot_builder(hint).await?;
-        let response = builder.send().await.map_err(map_send_error)?;
+        let options = self.options.gax();
+        let response = builder
+            .send(options, AttemptInfo::new(attempt_count))
+            .await?;
         let object = super::handle_object_response(response).await?;
         self.validate_response_object(object).await
     }
 
-    async fn single_shot_builder(&self, hint: SizeHint) -> Result<RequestBuilder> {
+    async fn single_shot_builder(&self, hint: SizeHint) -> Result<HttpRequestBuilder> {
         let bucket = &self.resource().bucket;
         let bucket_id = bucket.strip_prefix("projects/_/buckets/").ok_or_else(|| {
             Error::binding(format!(
@@ -145,9 +173,9 @@ where
         let builder = self
             .inner
             .client
-            .builder(Method::POST, format!("/upload/storage/v1/b/{bucket_id}/o"))
-            .query(&[("uploadType", "multipart")])
-            .query(&[("name", object)])
+            .http_builder(Method::POST, &format!("/upload/storage/v1/b/{bucket_id}/o"))
+            .query("uploadType", "multipart")
+            .query("name", object)
             .header(
                 "x-goog-api-client",
                 HeaderValue::from_static(&X_GOOG_API_CLIENT_HEADER),
@@ -155,7 +183,6 @@ where
 
         let builder = self.apply_preconditions(builder);
         let builder = apply_customer_supplied_encryption_headers(builder, &self.params);
-        let builder = self.inner.apply_auth_headers(builder).await?;
 
         let metadata = multipart::Part::text(v1::insert_body(self.resource()).to_string())
             .mime_str("application/json; charset=UTF-8")

--- a/src/storage/src/storage/perform_upload/unbuffered/single_shot_tests.rs
+++ b/src/storage/src/storage/perform_upload/unbuffered/single_shot_tests.rs
@@ -246,7 +246,8 @@ async fn upload_object_bytes() -> Result {
     let request = perform_upload(inner, builder)
         .single_shot_builder(SizeHint::with_exact(PAYLOAD.len() as u64))
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(
@@ -274,7 +275,8 @@ async fn upload_object_metadata() -> Result {
     let request = perform_upload(inner, builder)
         .single_shot_builder(SizeHint::new())
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(
@@ -303,7 +305,8 @@ async fn upload_object_stream() -> Result {
     let request = perform_upload(inner, builder)
         .single_shot_builder(SizeHint::new())
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(
@@ -329,6 +332,8 @@ async fn upload_object_error_credentials() -> Result {
     );
     let _ = perform_upload(inner, builder)
         .single_shot_builder(SizeHint::new())
+        .await?
+        .build_for_tests()
         .await
         .inspect_err(|e| assert!(e.is_authentication()))
         .expect_err("invalid credentials should err");
@@ -367,7 +372,8 @@ async fn upload_object_headers() -> Result {
     let request = perform_upload(inner, builder)
         .single_shot_builder(SizeHint::new())
         .await?
-        .build()?;
+        .build_for_tests()
+        .await?;
 
     assert_eq!(request.method(), Method::POST);
     assert_eq!(

--- a/src/storage/src/storage/read_object.rs
+++ b/src/storage/src/storage/read_object.rs
@@ -23,10 +23,9 @@ use crate::read_object::ReadObjectResponse;
 use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::checksum::details::Md5;
 use crate::storage::request_options::RequestOptions;
-use gaxi::http::{
-    map_send_error,
-    reqwest::{HeaderValue, Method, RequestBuilder, Response},
-};
+use gaxi::attempt_info::AttemptInfo;
+use gaxi::http::HttpRequestBuilder;
+use gaxi::http::reqwest::{HeaderValue, Method, Response};
 
 /// The request builder for [Storage::read_object][crate::client::Storage::read_object] calls.
 ///
@@ -426,9 +425,14 @@ impl Reader {
         let throttler = self.options.retry_throttler.clone();
         let retry = self.options.retry_policy.clone();
         let backoff = self.options.backoff_policy.clone();
+        let mut count = 0;
+        let inner = async move |_| {
+            count += 1;
+            self.read_attempt(count).await
+        };
 
         google_cloud_gax::retry_loop_internal::retry_loop(
-            async move |_| self.read_attempt().await,
+            inner,
             async |duration| tokio::time::sleep(duration).await,
             true,
             throttler,
@@ -438,16 +442,19 @@ impl Reader {
         .await
     }
 
-    async fn read_attempt(&self) -> Result<Response> {
+    async fn read_attempt(&self, attempt_count: u32) -> Result<Response> {
         let builder = self.http_request_builder().await?;
-        let response = builder.send().await.map_err(map_send_error)?;
+        let options = self.options.gax();
+        let response = builder
+            .send(options, AttemptInfo::new(attempt_count))
+            .await?;
         if !response.status().is_success() {
             return gaxi::http::to_http_error(response).await;
         }
         Ok(response)
     }
 
-    async fn http_request_builder(&self) -> Result<RequestBuilder> {
+    async fn http_request_builder(&self) -> Result<HttpRequestBuilder> {
         // Collect the required bucket and object parameters.
         let bucket = &self.request.bucket;
         let bucket_id = bucket
@@ -464,11 +471,11 @@ impl Reader {
         let builder = self
             .inner
             .client
-            .builder(
+            .http_builder(
                 Method::GET,
-                format!("/storage/v1/b/{bucket_id}/o/{}", enc(object)),
+                &format!("/storage/v1/b/{bucket_id}/o/{}", enc(object)),
             )
-            .query(&[("alt", "media")])
+            .query("alt", "media")
             .header(
                 "x-goog-api-client",
                 HeaderValue::from_static(&self::info::X_GOOG_API_CLIENT_HEADER),
@@ -487,7 +494,7 @@ impl Reader {
 
         // Add the optional query parameters.
         let builder = if self.request.generation != 0 {
-            builder.query(&[("generation", self.request.generation)])
+            builder.query("generation", self.request.generation)
         } else {
             builder
         };
@@ -495,22 +502,22 @@ impl Reader {
             .request
             .if_generation_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifGenerationMatch", v)]));
+            .fold(builder, |b, v| b.query("ifGenerationMatch", v));
         let builder = self
             .request
             .if_generation_not_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifGenerationNotMatch", v)]));
+            .fold(builder, |b, v| b.query("ifGenerationNotMatch", v));
         let builder = self
             .request
             .if_metageneration_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifMetagenerationMatch", v)]));
+            .fold(builder, |b, v| b.query("ifMetagenerationMatch", v));
         let builder = self
             .request
             .if_metageneration_not_match
             .iter()
-            .fold(builder, |b, v| b.query(&[("ifMetagenerationNotMatch", v)]));
+            .fold(builder, |b, v| b.query("ifMetagenerationNotMatch", v));
 
         let builder = apply_customer_supplied_encryption_headers(
             builder,
@@ -539,7 +546,7 @@ impl Reader {
             (o, l) => builder.header("range", format!("bytes={o}-{}", o + l - 1)),
         };
 
-        self.inner.apply_auth_headers(builder).await
+        Ok(builder)
     }
 
     fn is_gunzipped(response: &Response) -> bool {
@@ -608,7 +615,7 @@ mod tests {
     async fn http_request_builder(
         inner: Arc<StorageInner>,
         builder: ReadObject,
-    ) -> crate::Result<RequestBuilder> {
+    ) -> crate::Result<HttpRequestBuilder> {
         let reader = Reader {
             inner,
             request: builder.request,
@@ -963,7 +970,10 @@ mod tests {
             "object",
             inner.options.clone(),
         );
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         assert_eq!(
@@ -985,6 +995,8 @@ mod tests {
             inner.options.clone(),
         );
         let _ = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
             .await
             .inspect_err(|e| assert!(e.is_authentication()))
             .expect_err("invalid credentials should err");
@@ -1017,7 +1029,10 @@ mod tests {
         .set_if_generation_not_match(20)
         .set_if_metageneration_match(30)
         .set_if_metageneration_not_match(40);
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         let want_pairs: HashMap<String, String> = [
@@ -1052,7 +1067,10 @@ mod tests {
             "object",
             inner.options.clone(),
         );
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         assert_eq!(
@@ -1084,7 +1102,10 @@ mod tests {
             inner.options.clone(),
         )
         .with_automatic_decompression(true);
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         assert_eq!(
@@ -1112,7 +1133,10 @@ mod tests {
             inner.options.clone(),
         )
         .set_key(KeyAes256::new(&key)?);
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         assert_eq!(
@@ -1152,7 +1176,10 @@ mod tests {
             inner.options.clone(),
         )
         .set_read_range(input.clone());
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
 
         assert_eq!(request.method(), Method::GET);
         assert_eq!(
@@ -1186,7 +1213,10 @@ mod tests {
             name,
             inner.options.clone(),
         );
-        let request = http_request_builder(inner, builder).await?.build()?;
+        let request = http_request_builder(inner, builder)
+            .await?
+            .build_for_tests()
+            .await?;
         let got = request.url().path_segments().unwrap().next_back().unwrap();
         assert_eq!(got, want);
         Ok(())


### PR DESCRIPTION
Switch the storage client to use the HTTP request builder from `gaxi`. That
moves all the authorization to `gaxi` too, and simplifies the client a bit.