### PR TITLE
cleanup: leaf node `opentelemetry` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,9 +367,10 @@ humantime             = { default-features = false, version = "2" }
 hyper                 = { default-features = false, version = "1.6" }
 jsonwebtoken          = { default-features = false, version = "10.2" }
 lazy_static           = { default-features = false, version = "1.2" }
-opentelemetry         = { default-features = false, version = "0.31", features = ["trace"] }
-opentelemetry-proto   = { default-features = false, version = "0.31", features = ["gen-tonic", "trace"] }
-opentelemetry_sdk     = { default-features = false, version = "0.31", features = ["rt-tokio", "trace"] }
+opentelemetry         = { default-features = false, version = "0.31" }
+opentelemetry-proto   = { default-features = false, version = "0.31" }
+opentelemetry_sdk     = { default-features = false, version = "0.31" }
+opentelemetry-otlp    = { default-features = false, version = "0.31" }
 parse-size            = { default-features = false, version = "1.1" }
 percent-encoding      = { default-features = false, version = "2.3" }
 pin-project           = { default-features = false, version = "1.0.11" }
@@ -394,15 +395,7 @@ tracing-subscriber    = { default-features = false, version = "0.3.22" }
 url                   = { default-features = false, version = "2.4" }
 uuid                  = { default-features = false, version = "1", features = ["v4"] }
 
-opentelemetry-otlp = { default-features = false, version = "0.31", features = [
-  "grpc-tonic",
-  "tls",
-  "tls-roots",
-  "trace",
-] }
-opentelemetry-semantic-conventions = { default-features = false, version = "0.31.0", features = [
-  "semconv_experimental",
-] }
+opentelemetry-semantic-conventions = { default-features = false, version = "0.31.0" }
 
 # WARNING: When this changes to 0.2 we need to bump the google-cloud-gax-internal major version.
 http-body-util = { default-features = false, version = "0.1.3" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -105,7 +105,7 @@ http-body                          = { workspace = true, optional = true }
 http-body-util                     = { workspace = true, optional = true }
 hyper                              = { workspace = true, optional = true }
 lazy_static                        = { workspace = true, optional = true }
-opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true, features = ["semconv_experimental"] }
 percent-encoding                   = { workspace = true, optional = true }
 pin-project                        = { workspace = true, optional = true }
 prost                              = { workspace = true, optional = true }

--- a/tests/o11y/Cargo.toml
+++ b/tests/o11y/Cargo.toml
@@ -41,16 +41,20 @@ storage-samples               = { workspace = true }
 google-cloud-trace-v1         = { workspace = true, features = ["default"] }
 http.workspace                = true
 httptest.workspace            = true
-opentelemetry.workspace       = true
-opentelemetry_sdk.workspace   = true
-opentelemetry-otlp.workspace  = true
-opentelemetry-proto.workspace = true
+opentelemetry                 = { workspace = true, features = ["trace"] }
+opentelemetry_sdk             = { workspace = true, features = ["rt-tokio", "trace"] }
+opentelemetry-proto           = { workspace = true, features = ["gen-tonic", "trace"] }
 tokio                         = { workspace = true, features = ["test-util", "time"] }
 tokio-stream                  = { workspace = true, features = ["net"] }
 tonic                         = { workspace = true, features = ["codegen", "router", "server", "transport"] }
 tracing.workspace             = true
 tracing-subscriber            = { workspace = true, features = ["fmt"] }
 tracing-opentelemetry         = { workspace = true }
+
+# Separate for cleaner formatting.
+[dependencies.opentelemetry-otlp]
+workspace = true
+features  = ["grpc-tonic", "tls", "tls-roots", "trace"]
 
 [dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
The workspace manifest disables all features for `opentelemetry*` crates, and we only enable what we need in each package. In the future, we can add features in a crate without fear of impacting other crates.

Motivated by #3178 