### PR TITLE
feat(gax): retry policy decorator for 429 errors

### DIFF
--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -196,17 +196,17 @@ pub trait RetryPolicyExt: RetryPolicy + Sized {
     /// status code "429 - TOO_MANY_REQUESTS" **or** where the service returns
     /// an error with code [ResourceExhausted].
     ///
-    /// For other errors it returns thesame value as the inner policy.
+    /// For other errors it returns the same value as the inner policy.
     ///
     /// Note that [ResourceExhausted] is ambiguous and may cause problems with
-    /// some services. The code is used for both "too many requests" or for
-    /// and for "quota exceeded" problems. If the quota in question is some
-    /// kind of rate limit, then using this policy may be helpful. If the quota
-    /// is not a rate limit, then this retry policy may needlessly send the
-    /// same RPC multiple times.
+    /// some services. The code is used for both "too many requests"  and for
+    /// "quota exceeded" problems. If the quota in question is some kind of rate
+    /// limit, then using this policy may be helpful. If the quota is not a rate
+    /// limit, then this retry policy may needlessly send the same RPC multiple
+    /// times.
     ///
-    /// You **MUST** consult the documentation for the service and RPC in
-    /// question before using this policy.
+    /// You should consult the documentation for the service and RPC in question
+    /// before using this policy.
     ///
     /// # Example
     /// ```

--- a/src/gax/src/retry_policy/too_many_requests.rs
+++ b/src/gax/src/retry_policy/too_many_requests.rs
@@ -16,7 +16,8 @@ use super::{Error, RetryPolicy, RetryResult, RetryState, ThrottleResult};
 use crate::error::rpc::Code;
 use std::time::Duration;
 
-/// A retry policy decorator continues on `ResourceExhausted` or `TOO_MANY_REQUESTS`.
+/// A retry policy decorator that continues on `ResourceExhausted` or
+/// `TOO_MANY_REQUESTS`.
 ///
 /// This policy returns [RetryResult::Continue] when the error is a
 /// `ResourceExhausted` (or `TOO_MANY_REQUESTS` if received from the HTTP layer).


### PR DESCRIPTION
Someday we will document how to use the `RetryPolicy` trait in applications and add your own policies. This may become duplicative (but still convenient) at that time.

Likewise, we may add a generic decorator that ignores specific HTTP status codes or gRPC status codes. But the API for that is unclear at the moment. If that happens this will still be convenient, but would duplicate some code.

At the moment, this seems like useful thing for customers to have.  The most common case would be `Aip194Strict.continue_on_too_many_requests().with_...`. That is a reasonable policy for services that use `ResourceExhausted` to signal that a rate-based quota limit has been breached.
 