### PR TITLE
cleanup(gax-internal): use `RequestOptionsExt`

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -284,16 +284,16 @@ impl Client {
         #[cfg(google_cloud_unstable_tracing)]
         {
             use crate::observability::grpc_tracing::{AttemptCount, ResourceName};
+            use google_cloud_gax::options::internal::{
+                RequestOptionsExt, ResourceName as GaxResourceName,
+            };
             request
                 .extensions_mut()
                 .insert(AttemptCount::new(prior_attempt_count));
-            if let Some(resource_name) =
-                google_cloud_gax::options::internal::get_resource_name(options)
-                    .map(|s| s.to_string())
-            {
+            if let Some(n) = options.get_extension::<GaxResourceName>() {
                 request
                     .extensions_mut()
-                    .insert(ResourceName::new(resource_name));
+                    .insert(ResourceName::new(n.0.to_string()));
             }
         }
         #[cfg(not(google_cloud_unstable_tracing))]

--- a/src/gax-internal/src/observability/http_tracing.rs
+++ b/src/gax-internal/src/observability/http_tracing.rs
@@ -16,10 +16,8 @@ use crate::observability::attributes::keys::*;
 use crate::observability::attributes::*;
 use crate::observability::errors::ErrorType;
 use crate::options::InstrumentationClientInfo;
-use google_cloud_gax::options::{
-    RequestOptions,
-    internal::{get_path_template, get_resource_name},
-};
+use google_cloud_gax::options::RequestOptions;
+use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt, ResourceName};
 use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
 use std::collections::HashSet;
 use tracing::{Span, field};
@@ -49,12 +47,13 @@ pub(crate) fn create_http_attempt_span(
     let url = cleanup_url(request.url());
     let method = request.method();
 
-    let url_template = get_path_template(options);
-    let resource_name = get_resource_name(options);
-    let otel_name = url_template.map_or_else(
-        || method.to_string(),
-        |template| format!("{} {}", method, template),
-    );
+    let resource_name = options
+        .get_extension::<ResourceName>()
+        .map(|e| e.0.as_str());
+    let url_template = options.get_extension::<PathTemplate>().map(|e| e.0);
+    let otel_name = url_template
+        .map(|template| format!("{method} {template}"))
+        .unwrap_or_else(|| method.to_string());
 
     let http_request_resend_count = if prior_attempt_count > 0 {
         Some(prior_attempt_count as i64)
@@ -244,7 +243,7 @@ mod tests {
         rpc::{Code, Status, StatusDetails},
     };
     use google_cloud_gax::options::RequestOptions;
-    use google_cloud_gax::options::internal::{set_path_template, set_resource_name};
+    use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt, ResourceName};
     use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer, TestLayerGuard};
     use http::Method;
     use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
@@ -274,9 +273,11 @@ mod tests {
         let guard = TestLayer::initialize();
         let request =
             reqwest::Request::new(Method::GET, "https://example.com/test".parse().unwrap());
-        let options = set_path_template(RequestOptions::default(), "/test");
-        let options =
-            set_resource_name(options, "//example.com/projects/p/resources/r".to_string());
+        let options = RequestOptions::default()
+            .insert_extension(PathTemplate("/test"))
+            .insert_extension(ResourceName(
+                "//example.com/projects/p/resources/r".to_string(),
+            ));
         let _span = create_http_attempt_span(&request, &options, Some(&TEST_INFO), 1);
 
         let want: BTreeMap<String, AttributeValue> = [
@@ -357,9 +358,11 @@ mod tests {
     fn cleanup_url_query(input: &str, want: Vec<&str>) -> anyhow::Result<()> {
         let guard = TestLayer::initialize();
         let request = reqwest::Request::new(Method::GET, input.parse()?);
-        let options = set_path_template(RequestOptions::default(), "/test");
-        let options =
-            set_resource_name(options, "//example.com/projects/p/resources/r".to_string());
+        let options = RequestOptions::default()
+            .insert_extension(PathTemplate("/test"))
+            .insert_extension(ResourceName(
+                "//example.com/projects/p/resources/r".to_string(),
+            ));
         let _span = create_http_attempt_span(&request, &options, Some(&TEST_INFO), 1);
 
         let captured = TestLayer::capture(&guard);

--- a/src/gax-internal/tests/grpc_observability.rs
+++ b/src/gax-internal/tests/grpc_observability.rs
@@ -15,7 +15,8 @@
 #[cfg(all(test, feature = "_internal-grpc-client", google_cloud_unstable_tracing))]
 mod tests {
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
-    use google_cloud_gax::options::{RequestOptions, internal::set_resource_name};
+    use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
     use google_cloud_gax::retry_policy::Aip194Strict;
     use google_cloud_gax_internal::grpc;
     use google_cloud_test_utils::test_layer::TestLayer;
@@ -652,8 +653,9 @@ mod tests {
         config.cred = Some(test_credentials());
         let client = grpc::Client::new(config, &endpoint).await?;
 
-        let options = RequestOptions::default();
-        let options = set_resource_name(options, "projects/p/locations/l/resources/r".into());
+        let options = RequestOptions::default().insert_extension(ResourceName(
+            "projects/p/locations/l/resources/r".to_string(),
+        ));
 
         let extensions = {
             let mut e = tonic::Extensions::new();

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -17,7 +17,7 @@ mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::Result;
     use google_cloud_gax::options::RequestOptions;
-    use google_cloud_gax::options::internal::set_path_template;
+    use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
     use google_cloud_gax::response::Response;
     use google_cloud_gax_internal::client_request_span;
     use google_cloud_gax_internal::http::{NoBody, ReqwestClient};
@@ -81,7 +81,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/test");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
         let request = client.builder(Method::GET, "/test".to_string());
         let _response: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
@@ -165,7 +165,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/error");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/error"));
         let request = client.builder(Method::GET, "/error".to_string());
         let _response: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
@@ -223,7 +223,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/test");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
         let request = client.builder(Method::POST, "/test".to_string());
         let body = serde_json::json!({"name": "test"});
         let _response: Result<Response<TestResponse>> =
@@ -297,7 +297,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/error-info");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/error-info"));
         let request = client.builder(Method::GET, "/error-info".to_string());
         let result: Result<Response<TestResponse>> =
             client.execute(request, None::<NoBody>, options).await;
@@ -363,7 +363,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/test");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
         let request = client.builder(Method::GET, "/test".to_string());
 
         // Create a parent span (T3) with the marker field
@@ -426,7 +426,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/test");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
         let request = client.builder(Method::GET, "/test".to_string());
 
         // Create a user span that happens to have the same fields, but NO marker
@@ -469,7 +469,7 @@ mod tests {
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = set_path_template(RequestOptions::default(), "/test");
+        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
         let request = client.builder(Method::GET, "/test".to_string());
 
         // 1. Create the T3 span using the helper


### PR DESCRIPTION
Part of the work for #4772 