### PR TITLE
cleanup(pubsub): re-export clients and builders from publisher and subscriber modules

### DIFF
--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -80,7 +80,7 @@ pub(crate) use google_cloud_gax::response::Response;
 pub mod builder {
     /// Request and client builders for the [Publisher][crate::client::Publisher] client.
     pub mod publisher {
-        pub use crate::publisher::base_publisher::BasePublisherBuilder;
+        pub use crate::publisher::builder::BasePublisherBuilder;
         pub use crate::publisher::builder::PublisherBuilder;
         pub use crate::publisher::builder::PublisherPartialBuilder;
     }
@@ -88,8 +88,8 @@ pub mod builder {
     pub use crate::generated::gapic::builder::schema_service;
     /// Request and client builders for the [Subscriber][crate::client::Subscriber] client.
     pub mod subscriber {
+        pub use crate::subscriber::builder::ClientBuilder;
         pub use crate::subscriber::builder::StreamingPull;
-        pub use crate::subscriber::client_builder::ClientBuilder;
     }
     /// Request and client builders for the [SubscriptionAdmin][crate::client::SubscriptionAdmin] client.
     pub use crate::generated::gapic::builder::subscription_admin;
@@ -164,7 +164,7 @@ pub mod model {
 /// ```
 pub mod client {
     pub use crate::generated::gapic::client::*;
-    pub use crate::publisher::implementation::Publisher;
+    pub use crate::publisher::client::Publisher;
     pub use crate::subscriber::client::Subscriber;
 }
 

--- a/src/pubsub/src/publisher.rs
+++ b/src/pubsub/src/publisher.rs
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod actor;
-pub(crate) mod backoff_policy;
-pub(crate) mod base_publisher;
-pub(crate) mod batch;
-pub(crate) mod builder;
-pub(crate) mod client_builder;
-pub(crate) mod constants;
-pub(crate) mod future;
-pub(crate) mod implementation;
-pub(crate) mod options;
-pub(crate) mod retry_policy;
-
 pub use future::PublishFuture;
+/// Request and client builders for the [Publisher][crate::client::Publisher] client.
+pub mod builder;
+/// Clients to publish messages.
+pub mod client;
 
-/// Contains clients for publishing messages.
-pub mod client {
-    pub use super::base_publisher::BasePublisher;
-    pub use super::implementation::Publisher;
-}
+mod actor;
+mod backoff_policy;
+mod base_publisher;
+mod batch;
+mod client_builder;
+mod constants;
+mod future;
+mod options;
+mod retry_policy;

--- a/src/pubsub/src/publisher/builder.rs
+++ b/src/pubsub/src/publisher/builder.rs
@@ -16,12 +16,14 @@ use super::options::BatchingOptions;
 use crate::client::Publisher;
 use crate::generated::gapic_dataplane::client::Publisher as GapicPublisher;
 use crate::publisher::actor::Dispatcher;
-use crate::publisher::base_publisher::{BasePublisher, BasePublisherBuilder};
+use crate::publisher::base_publisher::BasePublisher;
 use google_cloud_gax::{
     backoff_policy::BackoffPolicyArg, retry_policy::RetryPolicyArg,
     retry_throttler::RetryThrottlerArg,
 };
 use std::time::Duration;
+
+pub use super::base_publisher::BasePublisherBuilder;
 
 /// A builder for a [`Publisher`].
 #[derive(Clone, Debug)]

--- a/src/pubsub/src/publisher/client.rs
+++ b/src/pubsub/src/publisher/client.rs
@@ -20,6 +20,8 @@ use crate::publisher::builder::PublisherBuilder;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
+pub use super::base_publisher::BasePublisher;
+
 /// A Publisher client for the [Cloud Pub/Sub] API.
 ///
 /// A `Publisher` sends messages to a specific topic. It manages message batching

--- a/src/pubsub/src/subscriber.rs
+++ b/src/pubsub/src/subscriber.rs
@@ -15,11 +15,12 @@
 pub mod handler;
 
 pub use message_stream::MessageStream;
-
+/// Request and client builders for the [Subscriber][crate::client::Subscriber] client.
+pub mod builder;
+/// Clients to receive messages.
 pub mod client;
 
-pub(super) mod builder;
-pub(super) mod client_builder;
+mod client_builder;
 mod keepalive;
 mod lease_loop;
 mod lease_state;

--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 
 const MIB: i64 = 1024 * 1024;
 
+pub use super::client_builder::ClientBuilder;
+
 /// Builder for the `client::Subscriber::streaming_pull` method.
 pub struct StreamingPull {
     pub(super) inner: Arc<Transport>,


### PR DESCRIPTION
This change re-exports the publisher and subscriber clients and builders from the publisher and client modules respectively. By exporting in both locations this provides discoverability at the main client and builder crates, but also easy navigation when users are looking in the publisher and subscriber modules for more advanced use cases.