### PR TITLE
impl(pubsub): introduce AckError

### DIFF
--- a/src/pubsub/src/error.rs
+++ b/src/pubsub/src/error.rs
@@ -56,13 +56,14 @@ pub enum PublishError {
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum AckError {
-    /// The message expired before the client could attempt an acknowledgement.
+    /// The message's lease expired before the client could acknowledge it.
     ///
-    /// The message has not been acknowledged, and will be redelivered.
+    /// The message has not been acknowledged, and will be redelivered, maybe to
+    /// another client.
     #[error(
-        "the message has already expired. It has not been acknowledged, and will be redelivered."
+        "the message's lease has already expired. It was not acknowledged, and will be redelivered."
     )]
-    MessageExpired,
+    LeaseExpired,
 
     /// The underlying RPC failed.
     #[error("the acknowledgement failed{}. RPC error: {source}",


### PR DESCRIPTION
Part of the work for #3964 

This is a soon-to-be public error type which we will use for exactly-once confirmed acks.

I have other PRs blocked on an `AckError` existing, but not the particular representation. We do not need to get it perfect in this PR. I opened #4809 to track stabilizing the interface.

With that being said, feedback on this interface is appreciated. I think the `details` field deserves scrutiny. I mostly did not want to lose context we could potentially forward to the application.