### PR TITLE
refactor(pubsub): rename `AckResult` -> `Action` (internal)

### DIFF
--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -44,7 +44,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 /// The action an application does with a message.
 #[derive(Debug, PartialEq)]
-pub(super) enum AckResult {
+pub(super) enum Action {
     Ack(String),
     Nack(String),
     // TODO(#3964) - support exactly once acking
@@ -110,16 +110,16 @@ impl Handler {
 #[derive(Debug)]
 struct AtLeastOnceImpl {
     ack_id: String,
-    ack_tx: UnboundedSender<AckResult>,
+    ack_tx: UnboundedSender<Action>,
 }
 
 impl AtLeastOnceImpl {
     fn ack(self) {
-        let _ = self.ack_tx.send(AckResult::Ack(self.ack_id));
+        let _ = self.ack_tx.send(Action::Ack(self.ack_id));
     }
 
     fn nack(self) {
-        let _ = self.ack_tx.send(AckResult::Nack(self.ack_id));
+        let _ = self.ack_tx.send(Action::Nack(self.ack_id));
     }
 }
 
@@ -130,7 +130,7 @@ pub struct AtLeastOnce {
 }
 
 impl AtLeastOnce {
-    pub(super) fn new(ack_id: String, ack_tx: UnboundedSender<AckResult>) -> Self {
+    pub(super) fn new(ack_id: String, ack_tx: UnboundedSender<Action>) -> Self {
         Self {
             inner: Some(AtLeastOnceImpl { ack_id, ack_tx }),
         }
@@ -178,7 +178,7 @@ pub struct ExactlyOnce {
 impl ExactlyOnce {
     pub(super) fn new(
         ack_id: String,
-        ack_tx: UnboundedSender<AckResult>,
+        ack_tx: UnboundedSender<Action>,
         // TODO(#3964): support confirmed acks
     ) -> Self {
         Self {
@@ -220,18 +220,18 @@ impl Drop for ExactlyOnce {
 #[derive(Debug)]
 struct ExactlyOnceImpl {
     pub(super) ack_id: String,
-    pub(super) ack_tx: UnboundedSender<AckResult>,
+    pub(super) ack_tx: UnboundedSender<Action>,
     // TODO(#3964): support confirmed acks
 }
 
 #[cfg(test)] // TODO(#3964): implementation in progress...
 impl ExactlyOnceImpl {
     pub fn ack(self) {
-        let _ = self.ack_tx.send(AckResult::Ack(self.ack_id));
+        let _ = self.ack_tx.send(Action::Ack(self.ack_id));
     }
 
     pub fn nack(self) {
-        let _ = self.ack_tx.send(AckResult::Nack(self.ack_id));
+        let _ = self.ack_tx.send(Action::Nack(self.ack_id));
     }
 
     // TODO(#3964): add confirmed_ack()
@@ -252,7 +252,7 @@ mod tests {
 
         h.ack();
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Ack(test_id(1)));
+        assert_eq!(ack, Action::Ack(test_id(1)));
 
         Ok(())
     }
@@ -265,7 +265,7 @@ mod tests {
 
         drop(h);
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Nack(test_id(1)));
+        assert_eq!(ack, Action::Nack(test_id(1)));
 
         Ok(())
     }
@@ -278,7 +278,7 @@ mod tests {
 
         h.ack();
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Ack(test_id(1)));
+        assert_eq!(ack, Action::Ack(test_id(1)));
 
         Ok(())
     }
@@ -291,7 +291,7 @@ mod tests {
 
         drop(h);
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Nack(test_id(1)));
+        assert_eq!(ack, Action::Nack(test_id(1)));
 
         Ok(())
     }
@@ -304,7 +304,7 @@ mod tests {
 
         h.ack();
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Ack(test_id(1)));
+        assert_eq!(ack, Action::Ack(test_id(1)));
 
         Ok(())
     }
@@ -317,7 +317,7 @@ mod tests {
 
         drop(h);
         let ack = ack_rx.try_recv()?;
-        assert_eq!(ack, AckResult::Nack(test_id(1)));
+        assert_eq!(ack, Action::Nack(test_id(1)));
 
         Ok(())
     }

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::handler::AckResult;
+use super::handler::Action;
 use super::lease_state::{LeaseEvent, LeaseOptions, LeaseState, NewMessage};
 use super::leaser::Leaser;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
@@ -25,7 +25,7 @@ pub(super) struct LeaseLoop {
     /// For sending messages from the stream to the lease loop.
     pub(super) message_tx: UnboundedSender<NewMessage>,
     /// For sending acks/nacks from the application to the lease loop.
-    pub(super) ack_tx: UnboundedSender<AckResult>,
+    pub(super) ack_tx: UnboundedSender<Action>,
 }
 
 impl LeaseLoop {
@@ -56,8 +56,8 @@ impl LeaseLoop {
                     ack_id = ack_rx.recv() => {
                         match ack_id {
                             None => break,
-                            Some(AckResult::Ack(ack_id)) => state.ack(ack_id),
-                            Some(AckResult::Nack(ack_id)) => state.nack(ack_id),
+                            Some(Action::Ack(ack_id)) => state.ack(ack_id),
+                            Some(Action::Nack(ack_id)) => state.nack(ack_id),
                         }
                     },
                 }
@@ -75,12 +75,12 @@ impl LeaseLoop {
 //
 // Processes any acks from the application that we already know about and
 // triggers a shutdown of the lease state.
-async fn shutdown<L>(mut state: LeaseState<L>, mut ack_rx: UnboundedReceiver<AckResult>)
+async fn shutdown<L>(mut state: LeaseState<L>, mut ack_rx: UnboundedReceiver<Action>)
 where
     L: Leaser + Clone + Send + 'static,
 {
     while let Ok(r) = ack_rx.try_recv() {
-        if let AckResult::Ack(ack_id) = r {
+        if let Action::Ack(ack_id) = r {
             state.ack(ack_id);
         }
     }
@@ -129,7 +129,7 @@ mod tests {
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
         }
 
         // Confirm initial state
@@ -152,7 +152,7 @@ mod tests {
 
         // Nack 10 messages
         for i in 10..20 {
-            lease_loop.ack_tx.send(AckResult::Nack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Nack(test_id(i)))?;
         }
 
         // Advance to and validate the second flush
@@ -172,11 +172,11 @@ mod tests {
 
         // Ack 5 messages
         for i in 20..25 {
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
         }
         // Nack 5 messages
         for i in 25..30 {
-            lease_loop.ack_tx.send(AckResult::Nack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Nack(test_id(i)))?;
         }
 
         // Advance to the third flush
@@ -246,7 +246,7 @@ mod tests {
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
         }
 
         // Advance to and validate the second extension
@@ -282,7 +282,7 @@ mod tests {
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
         }
 
         // Drop the lease_loop.
@@ -325,7 +325,7 @@ mod tests {
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
         }
 
         // Shutdown the lease_loop.
@@ -366,7 +366,7 @@ mod tests {
             // Seed the lease loop with a message
             lease_loop.message_tx.send(test_message(1))?;
             // Immediately ack the message
-            lease_loop.ack_tx.send(AckResult::Ack(test_id(1)))?;
+            lease_loop.ack_tx.send(Action::Ack(test_id(1)))?;
 
             // Advance to and validate the first flush
             {

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::builder::StreamingPull;
-use super::handler::{AckResult, AtLeastOnce, Handler};
+use super::handler::{Action, AtLeastOnce, Handler};
 use super::lease_loop::LeaseLoop;
 use super::lease_state::{LeaseInfo, LeaseOptions, NewMessage};
 use super::leaser::DefaultLeaser;
@@ -82,7 +82,7 @@ pub struct MessageStream {
 
     /// A sender for forwarding acks/nacks from the application to the lease
     /// management task. Each `Handler` holds a clone of this.
-    ack_tx: UnboundedSender<AckResult>,
+    ack_tx: UnboundedSender<Action>,
 
     /// A handle on the lease loop task.
     ///


### PR DESCRIPTION
Related to #3964 

I have come to hate this name. Call it a `handler::Action` instead of a `handler::AckResult`.

I want to use the name `AckResult` for the result of a confirmed ack. (much more appropriate).