### PR TITLE
feat(gax): add with_user_agent to ClientBuilder

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -69,6 +69,7 @@ pub struct Client {
     retry_throttler: SharedRetryThrottler,
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
+    user_agent: Option<String>,
 }
 
 impl Client {
@@ -136,6 +137,7 @@ impl Client {
             polling_backoff_policy: config
                 .polling_backoff_policy
                 .unwrap_or_else(|| Arc::new(ExponentialBackoff::default())),
+            user_agent: config.user_agent,
         })
     }
 
@@ -153,7 +155,9 @@ impl Client {
         Request: prost::Message + Clone + 'static,
         Response: prost::Message + Default + 'static,
     {
-        let headers = Self::make_headers(api_client_header, request_params, &options).await?;
+        let headers = self
+            .make_headers(api_client_header, request_params, &options)
+            .await?;
         self.retry_loop::<Request, Response>(extensions, path, request, options, headers)
             .await
     }
@@ -203,7 +207,9 @@ impl Client {
         Response: prost::Message + Default + 'static,
     {
         use ::tonic::IntoStreamingRequest;
-        let headers = Self::make_headers(api_client_header, request_params, &options).await?;
+        let headers = self
+            .make_headers(api_client_header, request_params, &options)
+            .await?;
         let headers = self.add_auth_headers(headers).await?;
         let metadata = tonic::MetadataMap::from_headers(headers);
         let request = ::tonic::Request::from_parts(metadata, extensions, request);
@@ -412,12 +418,17 @@ impl Client {
     }
 
     async fn make_headers(
+        &self,
         api_client_header: &'static str,
         request_params: &str,
         options: &RequestOptions,
     ) -> Result<http::header::HeaderMap> {
         let mut headers = HeaderMap::new();
-        if let Some(user_agent) = options.user_agent() {
+        let user_agent = options
+            .user_agent()
+            .as_deref()
+            .or(self.user_agent.as_deref());
+        if let Some(user_agent) = user_agent {
             headers.append(
                 http::header::USER_AGENT,
                 http::header::HeaderValue::from_str(user_agent).map_err(Error::ser)?,
@@ -498,12 +509,84 @@ where
 }
 
 #[cfg(test)]
-#[cfg(google_cloud_unstable_tracing)]
 mod tests {
     use super::Client;
+    #[cfg(google_cloud_unstable_tracing)]
     use crate::options::InstrumentationClientInfo;
+    use google_cloud_gax::options::RequestOptions;
+
+    #[tokio::test]
+    async fn test_make_headers_user_agent_none() {
+        let config = crate::options::ClientConfig::default();
+        let client = Client::new(config, "http://example.com").await.unwrap();
+        let options = RequestOptions::default();
+
+        let headers = client
+            .make_headers("api_header", "", &options)
+            .await
+            .unwrap();
+
+        assert!(headers.get(http::header::USER_AGENT).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_make_headers_user_agent_client_only() {
+        let client_agent = "client-agent/1.0.0";
+        let mut config = crate::options::ClientConfig::default();
+        config.user_agent = Some(client_agent.to_string());
+        let client = Client::new(config, "http://example.com").await.unwrap();
+        let options = RequestOptions::default();
+
+        let headers = client
+            .make_headers("api_header", "", &options)
+            .await
+            .unwrap();
+
+        assert_eq!(headers.get(http::header::USER_AGENT).unwrap(), client_agent);
+    }
+
+    #[tokio::test]
+    async fn test_make_headers_user_agent_request_only() {
+        let request_agent = "request-agent/1.0.0";
+        let config = crate::options::ClientConfig::default();
+        let client = Client::new(config, "http://example.com").await.unwrap();
+        let mut options = RequestOptions::default();
+        options.set_user_agent(request_agent);
+
+        let headers = client
+            .make_headers("api_header", "", &options)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            headers.get(http::header::USER_AGENT).unwrap(),
+            request_agent
+        );
+    }
+
+    #[tokio::test]
+    async fn test_make_headers_user_agent_override() {
+        let client_agent = "client-agent/1.0.0";
+        let request_agent = "request-agent/1.0.0";
+        let mut config = crate::options::ClientConfig::default();
+        config.user_agent = Some(client_agent.to_string());
+        let client = Client::new(config, "http://example.com").await.unwrap();
+        let mut options = RequestOptions::default();
+        options.set_user_agent(request_agent);
+
+        let headers = client
+            .make_headers("api_header", "", &options)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            headers.get(http::header::USER_AGENT).unwrap(),
+            request_agent
+        );
+    }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg(google_cloud_unstable_tracing)]
     async fn test_new_with_instrumentation() {
         let config = crate::options::ClientConfig::default();
         static TEST_INFO: InstrumentationClientInfo = InstrumentationClientInfo {

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -70,6 +70,7 @@ pub struct ReqwestClient {
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
     instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
+    user_agent: Option<String>,
     _tracing_enabled: bool,
 }
 
@@ -119,6 +120,7 @@ impl ReqwestClient {
                 .polling_backoff_policy
                 .unwrap_or_else(|| Arc::new(ExponentialBackoff::default())),
             instrumentation: None,
+            user_agent: config.user_agent,
             _tracing_enabled: tracing_enabled,
         })
     }
@@ -291,7 +293,11 @@ impl ReqwestClient {
         mut builder: reqwest::RequestBuilder,
         options: &RequestOptions,
     ) -> Result<reqwest::RequestBuilder> {
-        if let Some(user_agent) = options.user_agent() {
+        let user_agent = options
+            .user_agent()
+            .as_deref()
+            .or(self.user_agent.as_deref());
+        if let Some(user_agent) = user_agent {
             builder = builder.header(
                 ::reqwest::header::USER_AGENT,
                 reqwest::HeaderValue::from_str(user_agent).map_err(Error::ser)?,
@@ -886,6 +892,96 @@ mod tests {
             }
         );
         assert_eq!(result.err().unwrap().http_status_code(), Some(308));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_configure_builder_user_agent_none() -> TestResult {
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        let client = ReqwestClient::new(config, "https://test.googleapis.com").await?;
+        let builder = client.builder(Method::GET, "foo".to_string());
+        let options = RequestOptions::default();
+
+        let builder = client.configure_builder(builder, &options)?;
+
+        let request = builder.build().unwrap();
+        assert!(
+            !request
+                .headers()
+                .contains_key(::reqwest::header::USER_AGENT)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_configure_builder_user_agent_client_only() -> TestResult {
+        let client_agent = "client-agent/1.0.0";
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        config.user_agent = Some(client_agent.to_string());
+        let client = ReqwestClient::new(config, "https://test.googleapis.com").await?;
+        let builder = client.builder(Method::GET, "foo".to_string());
+        let options = RequestOptions::default();
+
+        let builder = client.configure_builder(builder, &options)?;
+
+        let request = builder.build().unwrap();
+        assert_eq!(
+            request
+                .headers()
+                .get(::reqwest::header::USER_AGENT)
+                .unwrap(),
+            client_agent
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_configure_builder_user_agent_request_only() -> TestResult {
+        let request_agent = "request-agent/1.0.0";
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        let client = ReqwestClient::new(config, "https://test.googleapis.com").await?;
+        let builder = client.builder(Method::GET, "foo".to_string());
+        let mut options = RequestOptions::default();
+        options.set_user_agent(request_agent.to_string());
+
+        let builder = client.configure_builder(builder, &options)?;
+
+        let request = builder.build().unwrap();
+        assert_eq!(
+            request
+                .headers()
+                .get(::reqwest::header::USER_AGENT)
+                .unwrap(),
+            request_agent
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_configure_builder_user_agent_override() -> TestResult {
+        let client_agent = "client-agent/1.0.0";
+        let request_agent = "request-agent/1.0.0";
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        config.user_agent = Some(client_agent.to_string());
+        let client = ReqwestClient::new(config, "https://test.googleapis.com").await?;
+        let builder = client.builder(Method::GET, "foo".to_string());
+        let mut options = RequestOptions::default();
+        options.set_user_agent(request_agent.to_string());
+
+        let builder = client.configure_builder(builder, &options)?;
+
+        let request = builder.build().unwrap();
+        assert_eq!(
+            request
+                .headers()
+                .get(::reqwest::header::USER_AGENT)
+                .unwrap(),
+            request_agent
+        );
         Ok(())
     }
 }

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -380,6 +380,25 @@ impl<F, Cr> ClientBuilder<F, Cr> {
         self.config.polling_backoff_policy = Some(v.into().0);
         self
     }
+
+    /// Sets the user-agent.
+    ///
+    /// The user-agent header is set in all requests made by the client.
+    ///
+    /// ```
+    /// # use google_cloud_gax::client_builder::examples;
+    /// # use google_cloud_gax::client_builder::Result;
+    /// # tokio_test::block_on(async {
+    /// use examples::Client; // Placeholder for examples
+    /// let client = Client::builder()
+    ///     .with_user_agent("my-app/1.0.0")
+    ///     .build().await?;
+    /// # Result::<()>::Ok(()) });
+    /// ```
+    pub fn with_user_agent<V: Into<String>>(mut self, v: V) -> Self {
+        self.config.user_agent = Some(v.into());
+        self
+    }
 }
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
@@ -427,6 +446,7 @@ pub mod internal {
         pub disable_follow_redirects: bool,
         pub grpc_subchannel_count: Option<usize>,
         pub grpc_request_buffer_capacity: Option<usize>,
+        pub user_agent: Option<String>,
     }
 
     impl<Cr> std::default::Default for ClientConfig<Cr> {
@@ -446,6 +466,7 @@ pub mod internal {
                 disable_follow_redirects: false,
                 grpc_subchannel_count: None,
                 grpc_request_buffer_capacity: None,
+                user_agent: None,
             }
         }
     }
@@ -567,6 +588,7 @@ pub mod examples {
             assert!(config.polling_backoff_policy.is_none(), "{config:?}");
             assert!(!config.disable_automatic_decompression, "{config:?}");
             assert!(!config.disable_follow_redirects, "{config:?}");
+            assert!(config.user_agent.is_none(), "{config:?}");
         }
 
         #[tokio::test]
@@ -704,6 +726,18 @@ pub mod examples {
                 .unwrap();
             let config = client.0;
             assert!(config.polling_backoff_policy.is_some(), "{config:?}");
+        }
+
+        #[tokio::test]
+        async fn user_agent() {
+            let user_agent = "my-app/1.0.0";
+            let client = Client::builder()
+                .with_user_agent(user_agent)
+                .build()
+                .await
+                .unwrap();
+            let config = client.0;
+            assert_eq!(config.user_agent.as_deref(), Some(user_agent));
         }
     }
 }


### PR DESCRIPTION
Splitting the changes to `gax-internal` and `gax` into its own PR as requested in https://github.com/googleapis/google-cloud-rust/pull/4601#pullrequestreview-3777432667 .