### PR TITLE
test(guide): `--all-features` and non-Linux targets

### DIFF
--- a/guide/samples/tests/storage/striped.rs
+++ b/guide/samples/tests/storage/striped.rs
@@ -244,7 +244,8 @@ pub async fn test(bucket_name: &str, destination: &str) -> anyhow::Result<()> {
         destination,
     )
     .await?;
-    #[cfg(feature = "run-large-downloads")]
+    // These only work on Linux because they use /dev/shm.
+    #[cfg(all(target_os = "linux", feature = "run-large-downloads"))]
     {
         let destination = "/dev/shm/output";
         download(


### PR DESCRIPTION
One of the features uses `/dev/shm` which is (mostly) a Linux-only thing.