### PR TITLE
ci: only use `nightly` where needed

### DIFF
--- a/.gcb/scripts/docs-rs.sh
+++ b/.gcb/scripts/docs-rs.sh
@@ -15,6 +15,10 @@
 
 set -ev
 
+# This is the only case where using `nightly` for CI is acceptable. Or maybe
+# "we must do, with regrets". The rationale is that docs.rs uses nightly to
+# generate the documentation, our releases would break if this test does not
+# pass.
 rustup toolchain install nightly
 cargo install --locked cargo-docs-rs
 cargo install --locked cargo-workspaces

--- a/.gcb/scripts/lint-unstable.sh
+++ b/.gcb/scripts/lint-unstable.sh
@@ -15,8 +15,6 @@
 
 set -ev
 
-rustup toolchain install nightly
-rustup default nightly
 rustup component add clippy
 cargo version
 rustup show active-toolchain -v

--- a/.gcb/scripts/test-unstable-cfg.sh
+++ b/.gcb/scripts/test-unstable-cfg.sh
@@ -15,8 +15,6 @@
 
 set -ev
 
-rustup toolchain install nightly
-rustup default nightly
 rustup component add clippy rustfmt
 cargo version
 rustup show active-toolchain -v


### PR DESCRIPTION
Using `nightly` makes the builds non-hermetic. In plain English,
it causes build breaks for reasons outside our control. There is
only one case where we **must** use nightly, everwhere else
we should avoid using it.