### PR TITLE
chore: upgrade librarian to v0.8.4-0.20260227165934-e799a3e235e3 and run generate --all

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 language: rust
-version: v0.8.4-0.20260227045407-dacc1d13e5aa
+version: v0.8.4-0.20260227165934-e799a3e235e3
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6


### PR DESCRIPTION
This PR upgrades librarian to version v0.8.4-0.20260227165934-e799a3e235e3 and runs `librarian generate --all`.