### PR TITLE
build(librarian): remove documentation override for google_artifact_registry

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -658,11 +658,6 @@ libraries:
   - name: google-cloud-developerconnect-v1
     version: 1.7.0
     copyright_year: "2025"
-    rust:
-      documentation_overrides:
-        - id: .google.cloud.developerconnect.v1.ArtifactConfig.google_artifact_registry
-          match: regsitry
-          replace: registry
   - name: google-cloud-devicestreaming-v1
     version: 1.6.0
     copyright_year: "2025"


### PR DESCRIPTION
Override is not needed anymore, documentation is fixed in main source https://github.com/googleapis/googleapis/blob/7ed997c15ea081c509db910b4ea06c9a79cf009e/google/cloud/developerconnect/v1/insights_config.proto#L336.