### PR TITLE
impl(pubsub): add exactly-once handler branch

### DIFF
--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -78,7 +78,7 @@ pub(super) enum Action {
 /// To acknowledge (ack) a message, you call [`Handler::ack()`].
 ///
 /// To reject (nack) a message, you [`drop()`][Drop::drop] the handler. The
-/// message will be redelivered.
+/// service will redeliver the message.
 ///
 /// ## Exactly-once delivery
 ///


### PR DESCRIPTION
Part of the work for #3964 

Add a branch for exactly-once delivery to the handler.

Currently, nothing creates exactly-once handlers outside of unit tests.