### PR TITLE
feat(gax): make `error::rpc::Code::name()` be `&'static str`

### DIFF
--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -231,7 +231,7 @@ pub enum Code {
 }
 
 impl Code {
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'static str {
         match self {
             Code::Ok => "OK",
             Code::Cancelled => "CANCELLED",


### PR DESCRIPTION
Makes them usuable in more contexts without copying.