### PR TITLE
impl(pubsub): exactly-once leases flush

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -161,7 +161,7 @@ where
 
     /// Flush pending acks/nacks
     pub(super) async fn flush(&mut self) {
-        let (to_ack, to_nack) = self.leases.flush();
+        let (to_ack, to_nack) = self.leases.drain();
 
         // TODO(#3975) - await these concurrently.
         if !to_ack.is_empty() {
@@ -191,7 +191,7 @@ where
         self.leases.evict();
 
         // TODO(#3975) - await these concurrently.
-        let (to_ack, to_nack) = self.leases.flush();
+        let (to_ack, to_nack) = self.leases.drain();
         if !to_ack.is_empty() {
             self.leaser.ack(to_ack).await;
         }

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -60,8 +60,8 @@ impl Leases {
         self.to_ack.len() >= MAX_IDS_PER_RPC || self.to_nack.len() >= MAX_IDS_PER_RPC
     }
 
-    /// Returns a pair of pending (acks, nacks) to flush.
-    pub fn flush(&mut self) -> (Vec<String>, Vec<String>) {
+    /// Drain the pending (acks, nacks) for the lease state to flush.
+    pub fn drain(&mut self) -> (Vec<String>, Vec<String>) {
         (
             std::mem::take(&mut self.to_ack),
             std::mem::take(&mut self.to_nack),
@@ -233,7 +233,7 @@ mod tests {
     }
 
     #[test]
-    fn flush() {
+    fn drain() {
         let mut leases = Leases::default();
         for i in 0..100 {
             leases.add(test_id(i), Instant::now());
@@ -253,7 +253,7 @@ mod tests {
             leases
         );
 
-        let (to_ack, to_nack) = leases.flush();
+        let (to_ack, to_nack) = leases.drain();
         assert_eq!(to_ack, test_ids(0..10));
         assert_eq!(to_nack, test_ids(10..20));
 

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -77,8 +77,8 @@ impl Leases {
         self.to_ack.len() >= MAX_IDS_PER_RPC || self.to_nack.len() >= MAX_IDS_PER_RPC
     }
 
-    /// Returns a pair of pending (acks, nacks) to flush.
-    pub fn flush(&mut self) -> (Vec<String>, Vec<String>) {
+    /// Drain the pending (acks, nacks) for the lease state to flush.
+    pub fn drain(&mut self) -> (Vec<String>, Vec<String>) {
         (
             std::mem::take(&mut self.to_ack),
             std::mem::take(&mut self.to_nack),
@@ -285,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn flush() {
+    fn drain() {
         let mut leases = Leases::default();
         for i in 0..100 {
             leases.add(test_id(i), test_info());
@@ -305,7 +305,7 @@ mod tests {
             leases
         );
 
-        let (to_ack, to_nack) = leases.flush();
+        let (to_ack, to_nack) = leases.drain();
         assert_eq!(to_ack, test_ids(10..20));
         assert_eq!(to_nack, test_ids(0..10));
 


### PR DESCRIPTION
Part of the work for #3964 