### PR TITLE
impl(pubsub): exactly-once leases evict

### DIFF
--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -21,7 +21,8 @@ use tokio::sync::oneshot::Sender;
 use tokio::time::{Duration, Instant};
 
 // TODO(#4868) - mention alternative shutdown options, when implemented.
-const NACK_SHUTDOWN_ERROR: &str = "subscriber is configured to nack all pending messages on shutdown.";
+const NACK_SHUTDOWN_ERROR: &str =
+    "subscriber is configured to nack all pending messages on shutdown.";
 
 #[derive(Debug)]
 pub(super) struct ExactlyOnceInfo {


### PR DESCRIPTION
Part of the work for #3964 

Support the `NackImmediatly` shutdown behavior for exactly-once leases.