### PR TITLE
docs: Generate QuickStarts for all APIs

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 language: rust
-version: v0.8.4-0.20260227165934-e799a3e235e3
+version: v0.8.4-0.20260304185555-c8223b70bb72
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6
@@ -128,7 +128,6 @@ libraries:
     roots:
       - src/wkt/tests/protos
     skip_release: true
-    veneer: true
     rust:
       modules:
         - disabled_rustdoc_warnings: []
@@ -186,6 +185,7 @@ libraries:
         - vertex-rag-data-service
         - vertex-rag-service
         - vizier-service
+      quickstart_service_override: PredictionService
   - name: google-cloud-aiplatform-v1-schema-predict-instance
     version: 1.0.0
     copyright_year: "2025"
@@ -445,7 +445,6 @@ libraries:
     version: 1.7.0
     copyright_year: "2025"
     output: src/auth
-    veneer: true
   - name: google-cloud-backupdr-v1
     version: 1.7.0
     copyright_year: "2025"
@@ -474,7 +473,6 @@ libraries:
     copyright_year: "2025"
     output: src/bigquery
     skip_release: true
-    veneer: true
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.7.0
     copyright_year: "2025"
@@ -506,7 +504,6 @@ libraries:
     copyright_year: "2025"
     output: src/bigtable
     skip_release: true
-    veneer: true
   - name: google-cloud-bigtable-admin-v2
     version: 1.7.0
     apis:
@@ -594,6 +591,7 @@ libraries:
             method_id: .google.cloud.compute.v1.globalOperations.get
           - prefix: compute/v1/
             method_id: .google.cloud.compute.v1.globalOrganizationOperations.get
+      quickstart_service_override: Instances
   - name: google-cloud-confidentialcomputing-v1
     version: 1.6.0
     copyright_year: "2025"
@@ -643,7 +641,6 @@ libraries:
     copyright_year: "2025"
     output: src/datastore
     skip_release: true
-    veneer: true
   - name: google-cloud-datastore-admin-v1
     version: 1.7.0
     apis:
@@ -792,7 +789,6 @@ libraries:
     copyright_year: "2025"
     output: src/firestore
     skip_release: true
-    veneer: true
     rust:
       modules:
         - module_path: crate::generated::gapic::model
@@ -832,12 +828,10 @@ libraries:
     version: 1.8.0
     copyright_year: "2025"
     output: src/gax
-    veneer: true
   - name: google-cloud-gax-internal
     version: 0.7.10
     copyright_year: "2025"
     output: src/gax-internal
-    veneer: true
     rust:
       modules:
         - module_path: google_cloud_rpc::model
@@ -1044,7 +1038,6 @@ libraries:
     version: 1.3.1
     copyright_year: "2025"
     output: src/lro
-    veneer: true
   - name: google-cloud-lustre-v1
     version: 1.7.0
     copyright_year: "2025"
@@ -1202,7 +1195,6 @@ libraries:
     version: 0.32.4-preview
     copyright_year: "2025"
     output: src/pubsub
-    veneer: true
     rust:
       modules:
         - included_ids:
@@ -1373,7 +1365,6 @@ libraries:
     copyright_year: "2026"
     output: src/spanner
     skip_release: true
-    veneer: true
     rust:
       modules:
         - module_path: crate::generated::gapic_dataplane::model
@@ -1444,11 +1435,11 @@ libraries:
       pagination_overrides:
         - id: .google.cloud.sql.v1.SqlInstancesService.List
           item_field: items
+      quickstart_service_override: SqlInstancesService
   - name: google-cloud-storage
     version: 1.9.0
     copyright_year: "2025"
     output: src/storage
-    veneer: true
     rust:
       modules:
         - module_path: crate::generated::gapic_control::model
@@ -1596,7 +1587,6 @@ libraries:
     copyright_year: "2025"
     output: src/test-utils
     skip_release: true
-    veneer: true
   - name: google-cloud-texttospeech-v1
     version: 1.8.0
     copyright_year: "2025"
@@ -1668,7 +1658,6 @@ libraries:
     output: src/wkt
     roots:
       - protobuf-src
-    veneer: true
     rust:
       modules:
         - include_list: api.proto,source_context.proto,type.proto,descriptor.proto
@@ -1695,14 +1684,12 @@ libraries:
     copyright_year: "2025"
     output: src/gax-internal/grpc-server
     skip_release: true
-    veneer: true
   - name: protojson-conformance
     copyright_year: "2025"
     output: tests/protojson-conformance
     roots:
       - conformance
     skip_release: true
-    veneer: true
     rust:
       modules:
         - include_list: conformance.proto
@@ -1732,12 +1719,10 @@ libraries:
     copyright_year: "2025"
     output: src/pubsub/grpc-mock
     skip_release: true
-    veneer: true
   - name: pubsub-samples
     copyright_year: "2025"
     output: src/pubsub/examples
     skip_release: true
-    veneer: true
   - name: secretmanager-openapi-v1
     version: 1.0.0
     apis:
@@ -1752,24 +1737,19 @@ libraries:
     copyright_year: "2025"
     output: src/storage/grpc-mock
     skip_release: true
-    veneer: true
   - name: storage-random
     copyright_year: "2025"
     output: src/storage/benchmarks/random
     skip_release: true
-    veneer: true
   - name: storage-samples
     copyright_year: "2025"
     output: src/storage/examples
     skip_release: true
-    veneer: true
   - name: storage-scenarios
     copyright_year: "2025"
     output: src/storage/tests/scenarios
     skip_release: true
-    veneer: true
   - name: storage-w1r3
     copyright_year: "2025"
     output: src/storage/benchmarks/w1r3
     skip_release: true
-    veneer: true

--- a/src/firestore/src/generated/gapic/client.rs
+++ b/src/firestore/src/generated/gapic/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_firestore::client::Firestore;
-/// let client = Firestore::builder().build().await?;
-/// // use `client` to make requests to the Cloud Firestore API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Firestore::builder().build().await?;
+///     let response = client.get_document()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/apikeys/v2/src/client.rs
+++ b/src/generated/api/apikeys/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apikeys_v2::client::ApiKeys;
-/// let client = ApiKeys::builder().build().await?;
-/// // use `client` to make requests to the API Keys API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiKeys::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/apikeys/v2/src/lib.rs
+++ b/src/generated/api/apikeys/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apikeys_v2::client::ApiKeys;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiKeys::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/api/cloudquotas/v1/src/client.rs
+++ b/src/generated/api/cloudquotas/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
-/// let client = CloudQuotas::builder().build().await?;
-/// // use `client` to make requests to the Cloud Quotas API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudQuotas::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_quota_infos()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/cloudquotas/v1/src/lib.rs
+++ b/src/generated/api/cloudquotas/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_api_cloudquotas_v1::client::CloudQuotas;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudQuotas::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_quota_infos()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/api/servicecontrol/v1/src/client.rs
+++ b/src/generated/api/servicecontrol/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_servicecontrol_v1::client::QuotaController;
-/// let client = QuotaController::builder().build().await?;
-/// // use `client` to make requests to the Service Control API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = QuotaController::builder().build().await?;
+///     let response = client.allocate_quota()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -156,10 +159,13 @@ impl QuotaController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
-/// let client = ServiceController::builder().build().await?;
-/// // use `client` to make requests to the Service Control API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceController::builder().build().await?;
+///     let response = client.check()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/servicecontrol/v1/src/lib.rs
+++ b/src/generated/api/servicecontrol/v1/src/lib.rs
@@ -52,6 +52,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_api_servicecontrol_v1::client::ServiceController;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceController::builder().build().await?;
+///     let response = client.check()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/api/servicecontrol/v2/src/client.rs
+++ b/src/generated/api/servicecontrol/v2/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
-/// let client = ServiceController::builder().build().await?;
-/// // use `client` to make requests to the Service Control API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceController::builder().build().await?;
+///     let response = client.check()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/servicecontrol/v2/src/lib.rs
+++ b/src/generated/api/servicecontrol/v2/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_api_servicecontrol_v2::client::ServiceController;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceController::builder().build().await?;
+///     let response = client.check()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/api/servicemanagement/v1/src/client.rs
+++ b/src/generated/api/servicemanagement/v1/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
-/// let client = ServiceManager::builder().build().await?;
-/// // use `client` to make requests to the Service Management API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceManager::builder().build().await?;
+///     let mut list = client.list_services()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -53,6 +53,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_api_servicemanagement_v1::client::ServiceManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceManager::builder().build().await?;
+///     let mut list = client.list_services()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/api/serviceusage/v1/src/client.rs
+++ b/src/generated/api/serviceusage/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
-/// let client = ServiceUsage::builder().build().await?;
-/// // use `client` to make requests to the Service Usage API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceUsage::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/api/serviceusage/v1/src/lib.rs
+++ b/src/generated/api/serviceusage/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_api_serviceusage_v1::client::ServiceUsage;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceUsage::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/appengine/v1/src/client.rs
+++ b/src/generated/appengine/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::Applications;
-/// let client = Applications::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Applications::builder().build().await?;
+///     let response = client.get_application()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -303,10 +306,16 @@ impl Applications {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::Services;
-/// let client = Services::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Services::builder().build().await?;
+///     let mut list = client.list_services()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -557,10 +566,16 @@ impl Services {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::Versions;
-/// let client = Versions::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Versions::builder().build().await?;
+///     let mut list = client.list_versions()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -879,10 +894,17 @@ impl Versions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::Instances;
-/// let client = Instances::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Instances::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1154,10 +1176,16 @@ impl Instances {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::Firewall;
-/// let client = Firewall::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Firewall::builder().build().await?;
+///     let mut list = client.list_ingress_rules()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1439,10 +1467,16 @@ impl Firewall {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::AuthorizedDomains;
-/// let client = AuthorizedDomains::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AuthorizedDomains::builder().build().await?;
+///     let mut list = client.list_authorized_domains()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1617,10 +1651,16 @@ impl AuthorizedDomains {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::AuthorizedCertificates;
-/// let client = AuthorizedCertificates::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AuthorizedCertificates::builder().build().await?;
+///     let mut list = client.list_authorized_certificates()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1891,10 +1931,16 @@ impl AuthorizedCertificates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_appengine_v1::client::DomainMappings;
-/// let client = DomainMappings::builder().build().await?;
-/// // use `client` to make requests to the App Engine Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DomainMappings::builder().build().await?;
+///     let mut list = client.list_domain_mappings()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/appengine/v1/src/lib.rs
+++ b/src/generated/appengine/v1/src/lib.rs
@@ -58,6 +58,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_appengine_v1::client::Instances;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Instances::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/bigtable/admin/v2/src/client.rs
+++ b/src/generated/bigtable/admin/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
-/// let client = BigtableInstanceAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Bigtable Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BigtableInstanceAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1047,10 +1054,17 @@ impl BigtableInstanceAdmin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigtable_admin_v2::client::BigtableTableAdmin;
-/// let client = BigtableTableAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Bigtable Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BigtableTableAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tables()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigtable_admin_v2::client::BigtableInstanceAdmin;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BigtableInstanceAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/accessapproval/v1/src/client.rs
+++ b/src/generated/cloud/accessapproval/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_accessapproval_v1::client::AccessApproval;
-/// let client = AccessApproval::builder().build().await?;
-/// // use `client` to make requests to the Access Approval API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AccessApproval::builder().build().await?;
+///     let response = client.get_access_approval_settings()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/accessapproval/v1/src/lib.rs
+++ b/src/generated/cloud/accessapproval/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_accessapproval_v1::client::AccessApproval;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AccessApproval::builder().build().await?;
+///     let response = client.get_access_approval_settings()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/advisorynotifications/v1/src/client.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
-/// let client = AdvisoryNotificationsService::builder().build().await?;
-/// // use `client` to make requests to the Advisory Notifications API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AdvisoryNotificationsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_notifications()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/advisorynotifications/v1/src/lib.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_advisorynotifications_v1::client::AdvisoryNotificationsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AdvisoryNotificationsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_notifications()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/aiplatform/v1/src/client.rs
+++ b/src/generated/cloud/aiplatform/v1/src/client.rs
@@ -21,10 +21,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::DataFoundryService;
-/// let client = DataFoundryService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataFoundryService::builder().build().await?;
+///     let response = client.generate_synthetic_data()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -375,10 +378,17 @@ impl DataFoundryService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::DatasetService;
-/// let client = DatasetService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatasetService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_datasets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1211,10 +1221,17 @@ impl DatasetService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::DeploymentResourcePoolService;
-/// let client = DeploymentResourcePoolService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DeploymentResourcePoolService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployment_resource_pools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1746,10 +1763,17 @@ impl DeploymentResourcePoolService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::EndpointService;
-/// let client = EndpointService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EndpointService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_endpoints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2342,10 +2366,13 @@ impl EndpointService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::EvaluationService;
-/// let client = EvaluationService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EvaluationService::builder().build().await?;
+///     let response = client.evaluate_instances()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2694,10 +2721,17 @@ impl EvaluationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreAdminService;
-/// let client = FeatureOnlineStoreAdminService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FeatureOnlineStoreAdminService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_feature_online_stores()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3452,10 +3486,13 @@ impl FeatureOnlineStoreAdminService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::FeatureOnlineStoreService;
-/// let client = FeatureOnlineStoreService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FeatureOnlineStoreService::builder().build().await?;
+///     let response = client.fetch_feature_values()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3862,10 +3899,17 @@ impl FeatureOnlineStoreService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::FeatureRegistryService;
-/// let client = FeatureRegistryService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FeatureRegistryService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_feature_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4529,10 +4573,13 @@ impl FeatureRegistryService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::FeaturestoreOnlineServingService;
-/// let client = FeaturestoreOnlineServingService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FeaturestoreOnlineServingService::builder().build().await?;
+///     let response = client.read_feature_values()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -4942,10 +4989,17 @@ impl FeaturestoreOnlineServingService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::FeaturestoreService;
-/// let client = FeaturestoreService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FeaturestoreService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_featurestores()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5912,10 +5966,17 @@ impl FeaturestoreService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::GenAiCacheService;
-/// let client = GenAiCacheService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GenAiCacheService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cached_contents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6363,10 +6424,17 @@ impl GenAiCacheService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::GenAiTuningService;
-/// let client = GenAiTuningService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GenAiTuningService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tuning_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6831,10 +6899,17 @@ impl GenAiTuningService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::IndexEndpointService;
-/// let client = IndexEndpointService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IndexEndpointService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_index_endpoints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7405,10 +7480,17 @@ impl IndexEndpointService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::IndexService;
-/// let client = IndexService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IndexService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_indexes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7926,10 +8008,17 @@ impl IndexService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::JobService;
-/// let client = JobService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = JobService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_custom_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -9188,10 +9277,13 @@ impl JobService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::LlmUtilityService;
-/// let client = LlmUtilityService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LlmUtilityService::builder().build().await?;
+///     let response = client.count_tokens()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -9560,10 +9652,13 @@ impl LlmUtilityService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::MatchService;
-/// let client = MatchService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MatchService::builder().build().await?;
+///     let response = client.find_neighbors()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -9933,10 +10028,17 @@ impl MatchService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::MetadataService;
-/// let client = MetadataService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetadataService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_metadata_stores()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -11070,10 +11172,16 @@ impl MetadataService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::MigrationService;
-/// let client = MigrationService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MigrationService::builder().build().await?;
+///     let mut list = client.search_migratable_resources()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -11464,10 +11572,14 @@ impl MigrationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::ModelGardenService;
-/// let client = ModelGardenService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelGardenService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_publisher_model()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -11847,10 +11959,17 @@ impl ModelGardenService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::ModelService;
-/// let client = ModelService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_models()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -12687,10 +12806,17 @@ impl ModelService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::NotebookService;
-/// let client = NotebookService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NotebookService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_notebook_runtime_templates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -13482,10 +13608,17 @@ impl NotebookService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::PersistentResourceService;
-/// let client = PersistentResourceService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PersistentResourceService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_persistent_resources()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -14015,10 +14148,17 @@ impl PersistentResourceService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::PipelineService;
-/// let client = PipelineService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PipelineService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_training_pipelines()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -14698,10 +14838,13 @@ impl PipelineService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::PredictionService;
-/// let client = PredictionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PredictionService::builder().build().await?;
+///     let response = client.predict()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -15199,10 +15342,13 @@ impl PredictionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::ReasoningEngineExecutionService;
-/// let client = ReasoningEngineExecutionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReasoningEngineExecutionService::builder().build().await?;
+///     let response = client.query_reasoning_engine()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -15578,10 +15724,17 @@ impl ReasoningEngineExecutionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::ReasoningEngineService;
-/// let client = ReasoningEngineService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReasoningEngineService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_reasoning_engines()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -16067,10 +16220,17 @@ impl ReasoningEngineService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::ScheduleService;
-/// let client = ScheduleService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ScheduleService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_schedules()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -16582,10 +16742,17 @@ impl ScheduleService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::SessionService;
-/// let client = SessionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sessions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -17104,10 +17271,17 @@ impl SessionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::SpecialistPoolService;
-/// let client = SpecialistPoolService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SpecialistPoolService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_specialist_pools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -17598,10 +17772,17 @@ impl SpecialistPoolService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::TensorboardService;
-/// let client = TensorboardService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TensorboardService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tensorboards()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -18690,10 +18871,17 @@ impl TensorboardService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::VertexRagDataService;
-/// let client = VertexRagDataService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VertexRagDataService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_rag_corpora()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -19348,10 +19536,13 @@ impl VertexRagDataService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::VertexRagService;
-/// let client = VertexRagService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VertexRagService::builder().build().await?;
+///     let response = client.retrieve_contexts()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -19743,10 +19934,17 @@ impl VertexRagService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_aiplatform_v1::client::VizierService;
-/// let client = VizierService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VizierService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_studies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/aiplatform/v1/src/lib.rs
+++ b/src/generated/cloud/aiplatform/v1/src/lib.rs
@@ -96,6 +96,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_aiplatform_v1::client::PredictionService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PredictionService::builder().build().await?;
+///     let response = client.predict()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/alloydb/v1/src/client.rs
+++ b/src/generated/cloud/alloydb/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_alloydb_v1::client::AlloyDBCSQLAdmin;
-/// let client = AlloyDBCSQLAdmin::builder().build().await?;
-/// // use `client` to make requests to the AlloyDB API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AlloyDBCSQLAdmin::builder().build().await?;
+///     let response = client.restore_from_cloud_sql()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -289,10 +293,17 @@ impl AlloyDBCSQLAdmin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
-/// let client = AlloyDBAdmin::builder().build().await?;
-/// // use `client` to make requests to the AlloyDB API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AlloyDBAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/alloydb/v1/src/lib.rs
+++ b/src/generated/cloud/alloydb/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_alloydb_v1::client::AlloyDBAdmin;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AlloyDBAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/apigateway/v1/src/client.rs
+++ b/src/generated/cloud/apigateway/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apigateway_v1::client::ApiGatewayService;
-/// let client = ApiGatewayService::builder().build().await?;
-/// // use `client` to make requests to the API Gateway API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiGatewayService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/apigateway/v1/src/lib.rs
+++ b/src/generated/cloud/apigateway/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apigateway_v1::client::ApiGatewayService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiGatewayService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/apigeeconnect/v1/src/client.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apigeeconnect_v1::client::ConnectionService;
-/// let client = ConnectionService::builder().build().await?;
-/// // use `client` to make requests to the Apigee Connect API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConnectionService::builder().build().await?;
+///     let mut list = client.list_connections()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/apigeeconnect/v1/src/lib.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/lib.rs
@@ -58,6 +58,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apigeeconnect_v1::client::ConnectionService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConnectionService::builder().build().await?;
+///     let mut list = client.list_connections()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/apihub/v1/src/client.rs
+++ b/src/generated/cloud/apihub/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHub;
-/// let client = ApiHub::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_apis()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1354,10 +1361,17 @@ impl ApiHub {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHubDependencies;
-/// let client = ApiHubDependencies::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHubDependencies::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_dependencies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1717,10 +1731,14 @@ impl ApiHubDependencies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHubCollect;
-/// let client = ApiHubCollect::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHubCollect::builder().build().await?;
+///     let response = client.collect_api_data()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1985,10 +2003,17 @@ impl ApiHubCollect {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHubCurate;
-/// let client = ApiHubCurate::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHubCurate::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_curations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2349,10 +2374,17 @@ impl ApiHubCurate {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHubDiscovery;
-/// let client = ApiHubDiscovery::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHubDiscovery::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_discovered_api_observations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2682,10 +2714,17 @@ impl ApiHubDiscovery {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::HostProjectRegistrationService;
-/// let client = HostProjectRegistrationService::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HostProjectRegistrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_host_project_registrations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3012,10 +3051,14 @@ impl HostProjectRegistrationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::LintingService;
-/// let client = LintingService::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LintingService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_style_guide()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3336,10 +3379,17 @@ impl LintingService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::ApiHubPlugin;
-/// let client = ApiHubPlugin::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHubPlugin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_plugins()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3970,10 +4020,14 @@ impl ApiHubPlugin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::Provisioning;
-/// let client = Provisioning::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Provisioning::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_api_hub_instance()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -4311,10 +4365,17 @@ impl Provisioning {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apihub_v1::client::RuntimeProjectAttachmentService;
-/// let client = RuntimeProjectAttachmentService::builder().build().await?;
-/// // use `client` to make requests to the API hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RuntimeProjectAttachmentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_runtime_project_attachments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/apihub/v1/src/lib.rs
+++ b/src/generated/cloud/apihub/v1/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apihub_v1::client::ApiHub;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ApiHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_apis()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/apiregistry/v1/src/client.rs
+++ b/src/generated/cloud/apiregistry/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apiregistry_v1::client::CloudApiRegistry;
-/// let client = CloudApiRegistry::builder().build().await?;
-/// // use `client` to make requests to the Cloud API Registry API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudApiRegistry::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_mcp_servers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/apiregistry/v1/src/lib.rs
+++ b/src/generated/cloud/apiregistry/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apiregistry_v1::client::CloudApiRegistry;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudApiRegistry::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_mcp_servers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/apphub/v1/src/client.rs
+++ b/src/generated/cloud/apphub/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_apphub_v1::client::AppHub;
-/// let client = AppHub::builder().build().await?;
-/// // use `client` to make requests to the App Hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_service_project_attachments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/apphub/v1/src/lib.rs
+++ b/src/generated/cloud/apphub/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_apphub_v1::client::AppHub;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_service_project_attachments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/asset/v1/src/client.rs
+++ b/src/generated/cloud/asset/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_asset_v1::client::AssetService;
-/// let client = AssetService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Asset API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AssetService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_assets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/asset/v1/src/lib.rs
+++ b/src/generated/cloud/asset/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_asset_v1::client::AssetService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AssetService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_assets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/assuredworkloads/v1/src/client.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
-/// let client = AssuredWorkloadsService::builder().build().await?;
-/// // use `client` to make requests to the Assured Workloads API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AssuredWorkloadsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workloads()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_assuredworkloads_v1::client::AssuredWorkloadsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AssuredWorkloadsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workloads()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/auditmanager/v1/src/client.rs
+++ b/src/generated/cloud/auditmanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_auditmanager_v1::client::AuditManager;
-/// let client = AuditManager::builder().build().await?;
-/// // use `client` to make requests to the Audit Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AuditManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_audit_reports()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/auditmanager/v1/src/lib.rs
+++ b/src/generated/cloud/auditmanager/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_auditmanager_v1::client::AuditManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AuditManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_audit_reports()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/backupdr/v1/src/client.rs
+++ b/src/generated/cloud/backupdr/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_backupdr_v1::client::BackupDR;
-/// let client = BackupDR::builder().build().await?;
-/// // use `client` to make requests to the Backup and DR Service API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackupDR::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_management_servers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1353,10 +1360,17 @@ impl BackupDR {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_backupdr_v1::client::BackupDrProtectionSummary;
-/// let client = BackupDrProtectionSummary::builder().build().await?;
-/// // use `client` to make requests to the Backup and DR Service API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackupDrProtectionSummary::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_resource_backup_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/backupdr/v1/src/lib.rs
+++ b/src/generated/cloud/backupdr/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_backupdr_v1::client::BackupDR;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackupDR::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_management_servers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/baremetalsolution/v2/src/client.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
-/// let client = BareMetalSolution::builder().build().await?;
-/// // use `client` to make requests to the Bare Metal Solution API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BareMetalSolution::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/baremetalsolution/v2/src/lib.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_baremetalsolution_v2::client::BareMetalSolution;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BareMetalSolution::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
-/// let client = AppConnectionsService::builder().build().await?;
-/// // use `client` to make requests to the BeyondCorp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppConnectionsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_beyondcorp_appconnections_v1::client::AppConnectionsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppConnectionsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
-/// let client = AppConnectorsService::builder().build().await?;
-/// // use `client` to make requests to the BeyondCorp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppConnectorsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_beyondcorp_appconnectors_v1::client::AppConnectorsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppConnectorsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
-/// let client = AppGatewaysService::builder().build().await?;
-/// // use `client` to make requests to the BeyondCorp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppGatewaysService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_beyondcorp_appgateways_v1::client::AppGatewaysService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AppGatewaysService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_app_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
-/// let client = ClientConnectorServicesService::builder().build().await?;
-/// // use `client` to make requests to the BeyondCorp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClientConnectorServicesService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_client_connector_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_beyondcorp_clientconnectorservices_v1::client::ClientConnectorServicesService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClientConnectorServicesService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_client_connector_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
-/// let client = ClientGatewaysService::builder().build().await?;
-/// // use `client` to make requests to the BeyondCorp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClientGatewaysService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_client_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_beyondcorp_clientgateways_v1::client::ClientGatewaysService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClientGatewaysService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_client_gateways()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/biglake/v1/src/client.rs
+++ b/src/generated/cloud/biglake/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_biglake_v1::client::IcebergCatalogService;
-/// let client = IcebergCatalogService::builder().build().await?;
-/// // use `client` to make requests to the BigLake API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IcebergCatalogService::builder().build().await?;
+///     let response = client.get_iceberg_catalog_config()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/biglake/v1/src/lib.rs
+++ b/src/generated/cloud/biglake/v1/src/lib.rs
@@ -58,6 +58,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_biglake_v1::client::IcebergCatalogService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IcebergCatalogService::builder().build().await?;
+///     let response = client.get_iceberg_catalog_config()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
-/// let client = AnalyticsHubService::builder().build().await?;
-/// // use `client` to make requests to the Analytics Hub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AnalyticsHubService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_exchanges()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_analyticshub_v1::client::AnalyticsHubService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AnalyticsHubService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_exchanges()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/connection/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
-/// let client = ConnectionService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Connection API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConnectionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_connection_v1::client::ConnectionService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConnectionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
-/// let client = DataPolicyService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Data Policy API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_datapolicies_v1::client::DataPolicyService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/datapolicies/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
-/// let client = DataPolicyService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Data Policy API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/datapolicies/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_datapolicies_v2::client::DataPolicyService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
-/// let client = DataTransferService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Data Transfer API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataTransferService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_sources()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_datatransfer_v1::client::DataTransferService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataTransferService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_sources()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/migration/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_migration_v2::client::MigrationService;
-/// let client = MigrationService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Migration API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MigrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_migration_workflows()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/migration/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_migration_v2::client::MigrationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MigrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_migration_workflows()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/reservation/v1/src/client.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
-/// let client = ReservationService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery Reservation API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReservationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_reservations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_reservation_v1::client::ReservationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReservationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_reservations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/bigquery/v2/src/client.rs
+++ b/src/generated/cloud/bigquery/v2/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::DatasetService;
-/// let client = DatasetService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatasetService::builder().build().await?;
+///     let response = client.get_dataset()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -276,10 +279,13 @@ impl DatasetService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::JobService;
-/// let client = JobService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = JobService::builder().build().await?;
+///     let response = client.cancel_job()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -540,10 +546,13 @@ impl JobService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::ModelService;
-/// let client = ModelService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelService::builder().build().await?;
+///     let response = client.get_model()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -727,10 +736,13 @@ impl ModelService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::ProjectService;
-/// let client = ProjectService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProjectService::builder().build().await?;
+///     let response = client.get_service_account()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -851,10 +863,13 @@ impl ProjectService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::RoutineService;
-/// let client = RoutineService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RoutineService::builder().build().await?;
+///     let response = client.get_routine()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1058,10 +1073,13 @@ impl RoutineService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::RowAccessPolicyService;
-/// let client = RowAccessPolicyService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RowAccessPolicyService::builder().build().await?;
+///     let response = client.get_row_access_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1297,10 +1315,13 @@ impl RowAccessPolicyService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_bigquery_v2::client::TableService;
-/// let client = TableService::builder().build().await?;
-/// // use `client` to make requests to the BigQuery API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TableService::builder().build().await?;
+///     let response = client.get_table()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -59,6 +59,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_v2::client::DatasetService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatasetService::builder().build().await?;
+///     let response = client.get_dataset()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/billing/v1/src/client.rs
+++ b/src/generated/cloud/billing/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_billing_v1::client::CloudBilling;
-/// let client = CloudBilling::builder().build().await?;
-/// // use `client` to make requests to the Cloud Billing API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudBilling::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_billing_accounts()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -437,10 +444,17 @@ impl CloudBilling {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_billing_v1::client::CloudCatalog;
-/// let client = CloudCatalog::builder().build().await?;
-/// // use `client` to make requests to the Cloud Billing API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudCatalog::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_skus()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/billing/v1/src/lib.rs
+++ b/src/generated/cloud/billing/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_billing_v1::client::CloudBilling;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudBilling::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_billing_accounts()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/binaryauthorization/v1/src/client.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
-/// let client = BinauthzManagementServiceV1::builder().build().await?;
-/// // use `client` to make requests to the Binary Authorization API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BinauthzManagementServiceV1::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attestors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -325,10 +332,14 @@ impl BinauthzManagementServiceV1 {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_binaryauthorization_v1::client::SystemPolicyV1;
-/// let client = SystemPolicyV1::builder().build().await?;
-/// // use `client` to make requests to the Binary Authorization API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SystemPolicyV1::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_system_policy()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -448,10 +459,13 @@ impl SystemPolicyV1 {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_binaryauthorization_v1::client::ValidationHelperV1;
-/// let client = ValidationHelperV1::builder().build().await?;
-/// // use `client` to make requests to the Binary Authorization API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ValidationHelperV1::builder().build().await?;
+///     let response = client.validate_attestation_occurrence()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/binaryauthorization/v1/src/lib.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_binaryauthorization_v1::client::BinauthzManagementServiceV1;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BinauthzManagementServiceV1::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attestors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/certificatemanager/v1/src/client.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_certificatemanager_v1::client::CertificateManager;
-/// let client = CertificateManager::builder().build().await?;
-/// // use `client` to make requests to the Certificate Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CertificateManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_certificates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/certificatemanager/v1/src/lib.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_certificatemanager_v1::client::CertificateManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CertificateManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_certificates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/chronicle/v1/src/client.rs
+++ b/src/generated/cloud/chronicle/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_chronicle_v1::client::DataAccessControlService;
-/// let client = DataAccessControlService::builder().build().await?;
-/// // use `client` to make requests to the Chronicle API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataAccessControlService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_access_labels()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -471,10 +478,17 @@ impl DataAccessControlService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_chronicle_v1::client::EntityService;
-/// let client = EntityService::builder().build().await?;
-/// // use `client` to make requests to the Chronicle API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EntityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_watchlists()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -777,10 +791,14 @@ impl EntityService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_chronicle_v1::client::InstanceService;
-/// let client = InstanceService::builder().build().await?;
-/// // use `client` to make requests to the Chronicle API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_instance()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -989,10 +1007,17 @@ impl InstanceService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_chronicle_v1::client::ReferenceListService;
-/// let client = ReferenceListService::builder().build().await?;
-/// // use `client` to make requests to the Chronicle API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReferenceListService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_reference_lists()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1281,10 +1306,17 @@ impl ReferenceListService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_chronicle_v1::client::RuleService;
-/// let client = RuleService::builder().build().await?;
-/// // use `client` to make requests to the Chronicle API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RuleService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_rules()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/chronicle/v1/src/lib.rs
+++ b/src/generated/cloud/chronicle/v1/src/lib.rs
@@ -55,6 +55,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_chronicle_v1::client::DataAccessControlService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataAccessControlService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_access_labels()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
-/// let client = CloudControlsPartnerCore::builder().build().await?;
-/// // use `client` to make requests to the Cloud Controls Partner API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudControlsPartnerCore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workloads()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -374,10 +381,17 @@ impl CloudControlsPartnerCore {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerMonitoring;
-/// let client = CloudControlsPartnerMonitoring::builder().build().await?;
-/// // use `client` to make requests to the Cloud Controls Partner API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudControlsPartnerMonitoring::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_violations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_cloudcontrolspartner_v1::client::CloudControlsPartnerCore;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudControlsPartnerCore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workloads()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/clouddms/v1/src/client.rs
+++ b/src/generated/cloud/clouddms/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_clouddms_v1::client::DataMigrationService;
-/// let client = DataMigrationService::builder().build().await?;
-/// // use `client` to make requests to the Database Migration API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataMigrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_migration_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/clouddms/v1/src/lib.rs
+++ b/src/generated/cloud/clouddms/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_clouddms_v1::client::DataMigrationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataMigrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_migration_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/cloudsecuritycompliance/v1/src/client.rs
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
-/// let client = Audit::builder().build().await?;
-/// // use `client` to make requests to the Cloud Security Compliance API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Audit::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_framework_audits()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -355,10 +362,20 @@ impl Audit {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudsecuritycompliance_v1::client::CmEnrollmentService;
-/// let client = CmEnrollmentService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Security Compliance API.
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_cloudsecuritycompliance_v1::model::CmEnrollment;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CmEnrollmentService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_cm_enrollment()
+///         .set_cm_enrollment(
+///             CmEnrollment::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -650,10 +667,17 @@ impl CmEnrollmentService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudsecuritycompliance_v1::client::Config;
-/// let client = Config::builder().build().await?;
-/// // use `client` to make requests to the Cloud Security Compliance API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Config::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_frameworks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1167,10 +1191,17 @@ impl Config {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudsecuritycompliance_v1::client::Deployment;
-/// let client = Deployment::builder().build().await?;
-/// // use `client` to make requests to the Cloud Security Compliance API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Deployment::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_framework_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1567,10 +1598,17 @@ impl Deployment {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_cloudsecuritycompliance_v1::client::Monitoring;
-/// let client = Monitoring::builder().build().await?;
-/// // use `client` to make requests to the Cloud Security Compliance API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Monitoring::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_framework_compliance_summaries()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/cloudsecuritycompliance/v1/src/lib.rs
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/src/lib.rs
@@ -57,6 +57,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_cloudsecuritycompliance_v1::client::Audit;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Audit::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_framework_audits()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/client.rs
@@ -20,10 +20,20 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
-/// let client = LicenseManagementService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Commerce Consumer Procurement API.
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_commerce_consumer_procurement_v1::model::LicensePool;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LicenseManagementService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_license_pool()
+///         .set_license_pool(
+///             LicensePool::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -260,10 +270,17 @@ impl LicenseManagementService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_commerce_consumer_procurement_v1::client::ConsumerProcurementService;
-/// let client = ConsumerProcurementService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Commerce Consumer Procurement API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConsumerProcurementService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_orders()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/lib.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/lib.rs
@@ -52,6 +52,25 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_commerce_consumer_procurement_v1::client::LicenseManagementService;
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_commerce_consumer_procurement_v1::model::LicensePool;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LicenseManagementService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_license_pool()
+///         .set_license_pool(
+///             LicensePool::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/compute/v1/src/client.rs
+++ b/src/generated/cloud/compute/v1/src/client.rs
@@ -21,10 +21,10 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::AcceleratorTypes;
-/// let client = AcceleratorTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AcceleratorTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -147,10 +147,10 @@ impl AcceleratorTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Addresses;
-/// let client = Addresses::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Addresses::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -304,10 +304,10 @@ impl Addresses {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Advice;
-/// let client = Advice::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Advice::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -418,10 +418,10 @@ impl Advice {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Autoscalers;
-/// let client = Autoscalers::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Autoscalers::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -578,10 +578,10 @@ impl Autoscalers {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::BackendBuckets;
-/// let client = BackendBuckets::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackendBuckets::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -761,10 +761,10 @@ impl BackendBuckets {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::BackendServices;
-/// let client = BackendServices::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackendServices::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -987,10 +987,10 @@ impl BackendServices {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::CrossSiteNetworks;
-/// let client = CrossSiteNetworks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CrossSiteNetworks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1128,10 +1128,10 @@ impl CrossSiteNetworks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::DiskTypes;
-/// let client = DiskTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DiskTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1253,10 +1253,10 @@ impl DiskTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Disks;
-/// let client = Disks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Disks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1486,10 +1486,10 @@ impl Disks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ExternalVpnGateways;
-/// let client = ExternalVpnGateways::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ExternalVpnGateways::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1635,10 +1635,10 @@ impl ExternalVpnGateways {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::FirewallPolicies;
-/// let client = FirewallPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FirewallPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1842,10 +1842,10 @@ impl FirewallPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Firewalls;
-/// let client = Firewalls::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Firewalls::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -1996,10 +1996,10 @@ impl Firewalls {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ForwardingRules;
-/// let client = ForwardingRules::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ForwardingRules::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2159,10 +2159,10 @@ impl ForwardingRules {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::FutureReservations;
-/// let client = FutureReservations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FutureReservations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2310,10 +2310,10 @@ impl FutureReservations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalAddresses;
-/// let client = GlobalAddresses::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalAddresses::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2458,10 +2458,10 @@ impl GlobalAddresses {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalForwardingRules;
-/// let client = GlobalForwardingRules::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalForwardingRules::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2615,10 +2615,10 @@ impl GlobalForwardingRules {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalNetworkEndpointGroups;
-/// let client = GlobalNetworkEndpointGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalNetworkEndpointGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2789,10 +2789,10 @@ impl GlobalNetworkEndpointGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalOperations;
-/// let client = GlobalOperations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalOperations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -2942,10 +2942,10 @@ impl GlobalOperations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalOrganizationOperations;
-/// let client = GlobalOrganizationOperations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalOrganizationOperations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3067,10 +3067,10 @@ impl GlobalOrganizationOperations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::GlobalPublicDelegatedPrefixes;
-/// let client = GlobalPublicDelegatedPrefixes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GlobalPublicDelegatedPrefixes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3209,10 +3209,10 @@ impl GlobalPublicDelegatedPrefixes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::HealthChecks;
-/// let client = HealthChecks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HealthChecks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3370,10 +3370,10 @@ impl HealthChecks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::HttpHealthChecks;
-/// let client = HttpHealthChecks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HttpHealthChecks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3523,10 +3523,10 @@ impl HttpHealthChecks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::HttpsHealthChecks;
-/// let client = HttpsHealthChecks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HttpsHealthChecks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3676,10 +3676,10 @@ impl HttpsHealthChecks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ImageFamilyViews;
-/// let client = ImageFamilyViews::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ImageFamilyViews::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3789,10 +3789,10 @@ impl ImageFamilyViews {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Images;
-/// let client = Images::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Images::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -3971,10 +3971,10 @@ impl Images {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstanceGroupManagerResizeRequests;
-/// let client = InstanceGroupManagerResizeRequests::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceGroupManagerResizeRequests::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -4122,10 +4122,10 @@ impl InstanceGroupManagerResizeRequests {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstanceGroupManagers;
-/// let client = InstanceGroupManagers::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceGroupManagers::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -4566,10 +4566,10 @@ impl InstanceGroupManagers {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstanceGroups;
-/// let client = InstanceGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -4756,10 +4756,10 @@ impl InstanceGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstanceSettings;
-/// let client = InstanceSettings::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceSettings::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -4878,10 +4878,10 @@ impl InstanceSettings {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstanceTemplates;
-/// let client = InstanceTemplates::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceTemplates::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -5043,10 +5043,10 @@ impl InstanceTemplates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Instances;
-/// let client = Instances::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Instances::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -5501,10 +5501,10 @@ impl Instances {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InstantSnapshots;
-/// let client = InstantSnapshots::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstantSnapshots::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -5673,10 +5673,10 @@ impl InstantSnapshots {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InterconnectAttachmentGroups;
-/// let client = InterconnectAttachmentGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InterconnectAttachmentGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -5845,10 +5845,10 @@ impl InterconnectAttachmentGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InterconnectAttachments;
-/// let client = InterconnectAttachments::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InterconnectAttachments::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6002,10 +6002,10 @@ impl InterconnectAttachments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InterconnectGroups;
-/// let client = InterconnectGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InterconnectGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6174,10 +6174,10 @@ impl InterconnectGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InterconnectLocations;
-/// let client = InterconnectLocations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InterconnectLocations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6293,10 +6293,10 @@ impl InterconnectLocations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::InterconnectRemoteLocations;
-/// let client = InterconnectRemoteLocations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InterconnectRemoteLocations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6413,10 +6413,10 @@ impl InterconnectRemoteLocations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Interconnects;
-/// let client = Interconnects::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Interconnects::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6581,10 +6581,10 @@ impl Interconnects {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::LicenseCodes;
-/// let client = LicenseCodes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LicenseCodes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6704,10 +6704,10 @@ impl LicenseCodes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Licenses;
-/// let client = Licenses::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Licenses::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -6886,10 +6886,10 @@ impl Licenses {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::MachineImages;
-/// let client = MachineImages::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MachineImages::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7046,10 +7046,10 @@ impl MachineImages {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::MachineTypes;
-/// let client = MachineTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MachineTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7171,10 +7171,10 @@ impl MachineTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NetworkAttachments;
-/// let client = NetworkAttachments::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkAttachments::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7338,10 +7338,10 @@ impl NetworkAttachments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NetworkEdgeSecurityServices;
-/// let client = NetworkEdgeSecurityServices::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkEdgeSecurityServices::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7483,10 +7483,10 @@ impl NetworkEdgeSecurityServices {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NetworkEndpointGroups;
-/// let client = NetworkEndpointGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkEndpointGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7668,10 +7668,10 @@ impl NetworkEndpointGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NetworkFirewallPolicies;
-/// let client = NetworkFirewallPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkFirewallPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -7907,10 +7907,10 @@ impl NetworkFirewallPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NetworkProfiles;
-/// let client = NetworkProfiles::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkProfiles::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8024,10 +8024,10 @@ impl NetworkProfiles {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Networks;
-/// let client = Networks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Networks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8200,10 +8200,10 @@ impl Networks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NodeGroups;
-/// let client = NodeGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NodeGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8399,10 +8399,10 @@ impl NodeGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NodeTemplates;
-/// let client = NodeTemplates::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NodeTemplates::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8557,10 +8557,10 @@ impl NodeTemplates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::NodeTypes;
-/// let client = NodeTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NodeTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8682,10 +8682,10 @@ impl NodeTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::OrganizationSecurityPolicies;
-/// let client = OrganizationSecurityPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrganizationSecurityPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -8962,10 +8962,10 @@ impl OrganizationSecurityPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::PacketMirrorings;
-/// let client = PacketMirrorings::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PacketMirrorings::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9117,10 +9117,10 @@ impl PacketMirrorings {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::PreviewFeatures;
-/// let client = PreviewFeatures::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PreviewFeatures::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9244,10 +9244,10 @@ impl PreviewFeatures {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Projects;
-/// let client = Projects::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Projects::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9469,10 +9469,10 @@ impl Projects {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::PublicAdvertisedPrefixes;
-/// let client = PublicAdvertisedPrefixes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PublicAdvertisedPrefixes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9621,10 +9621,10 @@ impl PublicAdvertisedPrefixes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::PublicDelegatedPrefixes;
-/// let client = PublicDelegatedPrefixes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PublicDelegatedPrefixes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9781,10 +9781,10 @@ impl PublicDelegatedPrefixes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionAutoscalers;
-/// let client = RegionAutoscalers::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionAutoscalers::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -9934,10 +9934,10 @@ impl RegionAutoscalers {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionBackendServices;
-/// let client = RegionBackendServices::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionBackendServices::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10126,10 +10126,10 @@ impl RegionBackendServices {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionCommitments;
-/// let client = RegionCommitments::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionCommitments::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10270,10 +10270,10 @@ impl RegionCommitments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionDiskTypes;
-/// let client = RegionDiskTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionDiskTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10386,10 +10386,10 @@ impl RegionDiskTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionDisks;
-/// let client = RegionDisks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionDisks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10601,10 +10601,10 @@ impl RegionDisks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionHealthAggregationPolicies;
-/// let client = RegionHealthAggregationPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionHealthAggregationPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10767,10 +10767,10 @@ impl RegionHealthAggregationPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionHealthCheckServices;
-/// let client = RegionHealthCheckServices::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionHealthCheckServices::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -10917,10 +10917,10 @@ impl RegionHealthCheckServices {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionHealthChecks;
-/// let client = RegionHealthChecks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionHealthChecks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -11070,10 +11070,10 @@ impl RegionHealthChecks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionInstanceGroupManagers;
-/// let client = RegionInstanceGroupManagers::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionInstanceGroupManagers::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -11513,10 +11513,10 @@ impl RegionInstanceGroupManagers {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionInstanceGroups;
-/// let client = RegionInstanceGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionInstanceGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -11656,10 +11656,10 @@ impl RegionInstanceGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionInstanceTemplates;
-/// let client = RegionInstanceTemplates::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionInstanceTemplates::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -11791,10 +11791,10 @@ impl RegionInstanceTemplates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionInstances;
-/// let client = RegionInstances::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionInstances::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -11908,10 +11908,10 @@ impl RegionInstances {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionInstantSnapshots;
-/// let client = RegionInstantSnapshots::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionInstantSnapshots::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12074,10 +12074,10 @@ impl RegionInstantSnapshots {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionNetworkEndpointGroups;
-/// let client = RegionNetworkEndpointGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionNetworkEndpointGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12248,10 +12248,10 @@ impl RegionNetworkEndpointGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionNetworkFirewallPolicies;
-/// let client = RegionNetworkFirewallPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionNetworkFirewallPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12463,10 +12463,10 @@ impl RegionNetworkFirewallPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionNotificationEndpoints;
-/// let client = RegionNotificationEndpoints::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionNotificationEndpoints::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12604,10 +12604,10 @@ impl RegionNotificationEndpoints {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionOperations;
-/// let client = RegionOperations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionOperations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12749,10 +12749,10 @@ impl RegionOperations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionSecurityPolicies;
-/// let client = RegionSecurityPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionSecurityPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -12920,10 +12920,10 @@ impl RegionSecurityPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionSslCertificates;
-/// let client = RegionSslCertificates::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionSslCertificates::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13056,10 +13056,10 @@ impl RegionSslCertificates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionSslPolicies;
-/// let client = RegionSslPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionSslPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13205,10 +13205,10 @@ impl RegionSslPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionTargetHttpProxies;
-/// let client = RegionTargetHttpProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionTargetHttpProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13344,10 +13344,10 @@ impl RegionTargetHttpProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionTargetHttpsProxies;
-/// let client = RegionTargetHttpsProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionTargetHttpsProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13499,10 +13499,10 @@ impl RegionTargetHttpsProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionTargetTcpProxies;
-/// let client = RegionTargetTcpProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionTargetTcpProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13633,10 +13633,10 @@ impl RegionTargetTcpProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionUrlMaps;
-/// let client = RegionUrlMaps::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionUrlMaps::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13787,10 +13787,10 @@ impl RegionUrlMaps {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::RegionZones;
-/// let client = RegionZones::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegionZones::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -13899,10 +13899,10 @@ impl RegionZones {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Regions;
-/// let client = Regions::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Regions::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14050,10 +14050,10 @@ impl Regions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ReservationBlocks;
-/// let client = ReservationBlocks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReservationBlocks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14194,10 +14194,10 @@ impl ReservationBlocks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ReservationSlots;
-/// let client = ReservationSlots::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReservationSlots::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14321,10 +14321,10 @@ impl ReservationSlots {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ReservationSubBlocks;
-/// let client = ReservationSubBlocks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReservationSubBlocks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14474,10 +14474,10 @@ impl ReservationSubBlocks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Reservations;
-/// let client = Reservations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Reservations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14649,10 +14649,10 @@ impl Reservations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ResourcePolicies;
-/// let client = ResourcePolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ResourcePolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -14812,10 +14812,10 @@ impl ResourcePolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Routers;
-/// let client = Routers::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Routers::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15020,10 +15020,10 @@ impl Routers {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Routes;
-/// let client = Routes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Routes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15157,10 +15157,10 @@ impl Routes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::SecurityPolicies;
-/// let client = SecurityPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecurityPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15344,10 +15344,10 @@ impl SecurityPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ServiceAttachments;
-/// let client = ServiceAttachments::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceAttachments::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15511,10 +15511,10 @@ impl ServiceAttachments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::SnapshotSettings;
-/// let client = SnapshotSettings::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SnapshotSettings::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15633,10 +15633,10 @@ impl SnapshotSettings {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Snapshots;
-/// let client = Snapshots::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Snapshots::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15799,10 +15799,10 @@ impl Snapshots {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::SslCertificates;
-/// let client = SslCertificates::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SslCertificates::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -15941,10 +15941,10 @@ impl SslCertificates {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::SslPolicies;
-/// let client = SslPolicies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SslPolicies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16095,10 +16095,10 @@ impl SslPolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::StoragePoolTypes;
-/// let client = StoragePoolTypes::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StoragePoolTypes::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16221,10 +16221,10 @@ impl StoragePoolTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::StoragePools;
-/// let client = StoragePools::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StoragePools::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16398,10 +16398,10 @@ impl StoragePools {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Subnetworks;
-/// let client = Subnetworks::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Subnetworks::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16583,10 +16583,10 @@ impl Subnetworks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetGrpcProxies;
-/// let client = TargetGrpcProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetGrpcProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16724,10 +16724,10 @@ impl TargetGrpcProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetHttpProxies;
-/// let client = TargetHttpProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetHttpProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -16880,10 +16880,10 @@ impl TargetHttpProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetHttpsProxies;
-/// let client = TargetHttpsProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetHttpsProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17059,10 +17059,10 @@ impl TargetHttpsProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetInstances;
-/// let client = TargetInstances::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetInstances::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17212,10 +17212,10 @@ impl TargetInstances {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetPools;
-/// let client = TargetPools::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetPools::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17396,10 +17396,10 @@ impl TargetPools {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetSslProxies;
-/// let client = TargetSslProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetSslProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17563,10 +17563,10 @@ impl TargetSslProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetTcpProxies;
-/// let client = TargetTcpProxies::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetTcpProxies::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17721,10 +17721,10 @@ impl TargetTcpProxies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::TargetVpnGateways;
-/// let client = TargetVpnGateways::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TargetVpnGateways::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -17869,10 +17869,10 @@ impl TargetVpnGateways {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::UrlMaps;
-/// let client = UrlMaps::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = UrlMaps::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -18046,10 +18046,10 @@ impl UrlMaps {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::VpnGateways;
-/// let client = VpnGateways::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VpnGateways::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -18203,10 +18203,10 @@ impl VpnGateways {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::VpnTunnels;
-/// let client = VpnTunnels::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VpnTunnels::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -18350,10 +18350,10 @@ impl VpnTunnels {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::WireGroups;
-/// let client = WireGroups::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WireGroups::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -18490,10 +18490,10 @@ impl WireGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::ZoneOperations;
-/// let client = ZoneOperations::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ZoneOperations::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///
@@ -18633,10 +18633,10 @@ impl ZoneOperations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_compute_v1::client::Zones;
-/// let client = Zones::builder().build().await?;
-/// // use `client` to make requests to the Google Compute Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Zones::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/compute/v1/src/lib.rs
+++ b/src/generated/cloud/compute/v1/src/lib.rs
@@ -170,6 +170,15 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_compute_v1::client::Instances;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Instances::builder().build().await?;
+///     // use `client` to make requests to the Google Compute Engine API.
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/confidentialcomputing/v1/src/client.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/client.rs
@@ -20,10 +20,18 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
-/// let client = ConfidentialComputing::builder().build().await?;
-/// // use `client` to make requests to the Confidential Computing API.
+/// use google_cloud_confidentialcomputing_v1::model::Challenge;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConfidentialComputing::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_challenge()
+///         .set_parent(parent)
+///         .set_challenge(
+///             Challenge::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/confidentialcomputing/v1/src/lib.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/lib.rs
@@ -51,6 +51,23 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_confidentialcomputing_v1::client::ConfidentialComputing;
+/// use google_cloud_confidentialcomputing_v1::model::Challenge;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConfidentialComputing::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_challenge()
+///         .set_parent(parent)
+///         .set_challenge(
+///             Challenge::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/config/v1/src/client.rs
+++ b/src/generated/cloud/config/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_config_v1::client::Config;
-/// let client = Config::builder().build().await?;
-/// // use `client` to make requests to the Infrastructure Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Config::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/config/v1/src/lib.rs
+++ b/src/generated/cloud/config/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_config_v1::client::Config;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Config::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/configdelivery/v1/src/client.rs
+++ b/src/generated/cloud/configdelivery/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
-/// let client = ConfigDelivery::builder().build().await?;
-/// // use `client` to make requests to the Config Delivery API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConfigDelivery::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_resource_bundles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/configdelivery/v1/src/lib.rs
+++ b/src/generated/cloud/configdelivery/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_configdelivery_v1::client::ConfigDelivery;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConfigDelivery::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_resource_bundles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/connectors/v1/src/client.rs
+++ b/src/generated/cloud/connectors/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_connectors_v1::client::Connectors;
-/// let client = Connectors::builder().build().await?;
-/// // use `client` to make requests to the Connectors API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Connectors::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/connectors/v1/src/lib.rs
+++ b/src/generated/cloud/connectors/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_connectors_v1::client::Connectors;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Connectors::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/client.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
-/// let client = ContactCenterInsights::builder().build().await?;
-/// // use `client` to make requests to the Contact Center AI Insights API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ContactCenterInsights::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_contactcenterinsights_v1::client::ContactCenterInsights;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ContactCenterInsights::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
-/// let client = Lineage::builder().build().await?;
-/// // use `client` to make requests to the Data Lineage API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Lineage::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_lineage_events()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/datacatalog/lineage/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_datacatalog_lineage_v1::client::Lineage;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Lineage::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_lineage_events()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/datacatalog/v1/src/client.rs
+++ b/src/generated/cloud/datacatalog/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datacatalog_v1::client::DataCatalog;
-/// let client = DataCatalog::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Data Catalog API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataCatalog::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entry_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1336,10 +1343,17 @@ impl DataCatalog {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
-/// let client = PolicyTagManager::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Data Catalog API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyTagManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_taxonomies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1831,10 +1845,13 @@ impl PolicyTagManager {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datacatalog_v1::client::PolicyTagManagerSerialization;
-/// let client = PolicyTagManagerSerialization::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Data Catalog API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyTagManagerSerialization::builder().build().await?;
+///     let response = client.replace_taxonomy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -55,6 +55,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_datacatalog_v1::client::PolicyTagManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyTagManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_taxonomies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dataform/v1/src/client.rs
+++ b/src/generated/cloud/dataform/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataform_v1::client::Dataform;
-/// let client = Dataform::builder().build().await?;
-/// // use `client` to make requests to the Dataform API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Dataform::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_repositories()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dataform/v1/src/lib.rs
+++ b/src/generated/cloud/dataform/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dataform_v1::client::Dataform;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Dataform::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_repositories()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/datafusion/v1/src/client.rs
+++ b/src/generated/cloud/datafusion/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datafusion_v1::client::DataFusion;
-/// let client = DataFusion::builder().build().await?;
-/// // use `client` to make requests to the Cloud Data Fusion API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataFusion::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_datafusion_v1::client::DataFusion;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataFusion::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dataplex/v1/src/client.rs
+++ b/src/generated/cloud/dataplex/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::BusinessGlossaryService;
-/// let client = BusinessGlossaryService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BusinessGlossaryService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_glossaries()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -706,10 +713,17 @@ impl BusinessGlossaryService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::CatalogService;
-/// let client = CatalogService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CatalogService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entry_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1790,10 +1804,17 @@ impl CatalogService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::CmekService;
-/// let client = CmekService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CmekService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_encryption_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2241,10 +2262,17 @@ impl CmekService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::ContentService;
-/// let client = ContentService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ContentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_content()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2667,10 +2695,17 @@ impl ContentService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::DataTaxonomyService;
-/// let client = DataTaxonomyService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataTaxonomyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_taxonomies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3457,10 +3492,17 @@ impl DataTaxonomyService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::DataScanService;
-/// let client = DataScanService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataScanService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_scans()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3998,10 +4040,17 @@ impl DataScanService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::MetadataService;
-/// let client = MetadataService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetadataService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entities()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4500,10 +4549,17 @@ impl MetadataService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataplex_v1::client::DataplexService;
-/// let client = DataplexService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataplex API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataplexService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_lakes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dataplex/v1/src/lib.rs
+++ b/src/generated/cloud/dataplex/v1/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dataplex_v1::client::DataplexService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataplexService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_lakes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dataproc/v1/src/client.rs
+++ b/src/generated/cloud/dataproc/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
-/// let client = AutoscalingPolicyService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AutoscalingPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_autoscaling_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -411,10 +418,17 @@ impl AutoscalingPolicyService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::BatchController;
-/// let client = BatchController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BatchController::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_batches()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -773,10 +787,14 @@ impl BatchController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::ClusterController;
-/// let client = ClusterController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClusterController::builder().build().await?;
+///     let response = client.create_cluster()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1291,10 +1309,13 @@ impl ClusterController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::JobController;
-/// let client = JobController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = JobController::builder().build().await?;
+///     let response = client.submit_job()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1712,10 +1733,14 @@ impl JobController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::NodeGroupController;
-/// let client = NodeGroupController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NodeGroupController::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_node_group()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2074,10 +2099,17 @@ impl NodeGroupController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::SessionTemplateController;
-/// let client = SessionTemplateController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionTemplateController::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_session_templates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2460,10 +2492,17 @@ impl SessionTemplateController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::SessionController;
-/// let client = SessionController::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionController::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sessions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2866,10 +2905,17 @@ impl SessionController {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dataproc_v1::client::WorkflowTemplateService;
-/// let client = WorkflowTemplateService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Dataproc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WorkflowTemplateService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workflow_templates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dataproc/v1/src/lib.rs
+++ b/src/generated/cloud/dataproc/v1/src/lib.rs
@@ -58,6 +58,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dataproc_v1::client::AutoscalingPolicyService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AutoscalingPolicyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_autoscaling_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/datastream/v1/src/client.rs
+++ b/src/generated/cloud/datastream/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datastream_v1::client::Datastream;
-/// let client = Datastream::builder().build().await?;
-/// // use `client` to make requests to the Datastream API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Datastream::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connection_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/datastream/v1/src/lib.rs
+++ b/src/generated/cloud/datastream/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_datastream_v1::client::Datastream;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Datastream::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connection_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/deploy/v1/src/client.rs
+++ b/src/generated/cloud/deploy/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_deploy_v1::client::CloudDeploy;
-/// let client = CloudDeploy::builder().build().await?;
-/// // use `client` to make requests to the Cloud Deploy API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudDeploy::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_delivery_pipelines()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_deploy_v1::client::CloudDeploy;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudDeploy::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_delivery_pipelines()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/developerconnect/v1/src/client.rs
+++ b/src/generated/cloud/developerconnect/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
-/// let client = DeveloperConnect::builder().build().await?;
-/// // use `client` to make requests to the Developer Connect API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DeveloperConnect::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -957,10 +964,17 @@ impl DeveloperConnect {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_developerconnect_v1::client::InsightsConfigService;
-/// let client = InsightsConfigService::builder().build().await?;
-/// // use `client` to make requests to the Developer Connect API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InsightsConfigService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_insights_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/developerconnect/v1/src/lib.rs
+++ b/src/generated/cloud/developerconnect/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_developerconnect_v1::client::DeveloperConnect;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DeveloperConnect::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/devicestreaming/v1/src/client.rs
+++ b/src/generated/cloud/devicestreaming/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
-/// let client = DirectAccessService::builder().build().await?;
-/// // use `client` to make requests to the Device Streaming API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DirectAccessService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_device_sessions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/devicestreaming/v1/src/lib.rs
+++ b/src/generated/cloud/devicestreaming/v1/src/lib.rs
@@ -58,6 +58,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_devicestreaming_v1::client::DirectAccessService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DirectAccessService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_device_sessions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/client.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Agents;
-/// let client = Agents::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Agents::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_agents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -536,10 +543,17 @@ impl Agents {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Changelogs;
-/// let client = Changelogs::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Changelogs::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_changelogs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -798,10 +812,17 @@ impl Changelogs {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Deployments;
-/// let client = Deployments::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Deployments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1066,10 +1087,17 @@ impl Deployments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::EntityTypes;
-/// let client = EntityTypes::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EntityTypes::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entity_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1471,10 +1499,17 @@ impl EntityTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Environments;
-/// let client = Environments::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Environments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_environments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2000,10 +2035,17 @@ impl Environments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Examples;
-/// let client = Examples::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Examples::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_examples()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2331,10 +2373,17 @@ impl Examples {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Experiments;
-/// let client = Experiments::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Experiments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_experiments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2725,10 +2774,17 @@ impl Experiments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Flows;
-/// let client = Flows::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Flows::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_flows()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3242,10 +3298,17 @@ impl Flows {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Generators;
-/// let client = Generators::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Generators::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_generators()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3573,10 +3636,17 @@ impl Generators {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Intents;
-/// let client = Intents::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Intents::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_intents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4002,10 +4072,17 @@ impl Intents {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Pages;
-/// let client = Pages::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Pages::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_pages()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4345,10 +4422,17 @@ impl Pages {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Playbooks;
-/// let client = Playbooks::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Playbooks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_playbooks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4848,10 +4932,17 @@ impl Playbooks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::SecuritySettingsService;
-/// let client = SecuritySettingsService::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecuritySettingsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_security_settings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5198,10 +5289,13 @@ impl SecuritySettingsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Sessions;
-/// let client = Sessions::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Sessions::builder().build().await?;
+///     let response = client.detect_intent()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -5518,10 +5612,17 @@ impl Sessions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::SessionEntityTypes;
-/// let client = SessionEntityTypes::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionEntityTypes::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_session_entity_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5861,10 +5962,17 @@ impl SessionEntityTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::TestCases;
-/// let client = TestCases::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TestCases::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_test_cases()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6433,10 +6541,17 @@ impl TestCases {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Tools;
-/// let client = Tools::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Tools::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6894,10 +7009,17 @@ impl Tools {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::TransitionRouteGroups;
-/// let client = TransitionRouteGroups::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TransitionRouteGroups::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_transition_route_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7262,10 +7384,17 @@ impl TransitionRouteGroups {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Versions;
-/// let client = Versions::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Versions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_versions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7685,10 +7814,17 @@ impl Versions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_cx_v3::client::Webhooks;
-/// let client = Webhooks::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Webhooks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_webhooks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -82,6 +82,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dialogflow_cx_v3::client::Agents;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Agents::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_agents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dialogflow/v2/src/client.rs
+++ b/src/generated/cloud/dialogflow/v2/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Agents;
-/// let client = Agents::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Agents::builder().build().await?;
+///     let mut list = client.search_agents()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -552,10 +558,17 @@ impl Agents {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::AnswerRecords;
-/// let client = AnswerRecords::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AnswerRecords::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_answer_records()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -822,10 +835,17 @@ impl AnswerRecords {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Contexts;
-/// let client = Contexts::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Contexts::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_contexts()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1174,10 +1194,17 @@ impl Contexts {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Conversations;
-/// let client = Conversations::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Conversations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1669,10 +1696,17 @@ impl Conversations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::ConversationDatasets;
-/// let client = ConversationDatasets::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConversationDatasets::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversation_datasets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2077,10 +2111,17 @@ impl ConversationDatasets {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::ConversationModels;
-/// let client = ConversationModels::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConversationModels::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversation_models()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2611,10 +2652,17 @@ impl ConversationModels {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::ConversationProfiles;
-/// let client = ConversationProfiles::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConversationProfiles::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversation_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3075,10 +3123,17 @@ impl ConversationProfiles {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Documents;
-/// let client = Documents::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Documents::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_documents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3609,10 +3664,14 @@ impl Documents {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::EncryptionSpecService;
-/// let client = EncryptionSpecService::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EncryptionSpecService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_encryption_spec()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3886,10 +3945,17 @@ impl EncryptionSpecService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::EntityTypes;
-/// let client = EntityTypes::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EntityTypes::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entity_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4453,10 +4519,17 @@ impl EntityTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Environments;
-/// let client = Environments::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Environments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_environments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4819,10 +4892,14 @@ impl Environments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Fulfillments;
-/// let client = Fulfillments::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Fulfillments::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_fulfillment()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -5084,10 +5161,17 @@ impl Fulfillments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Generators;
-/// let client = Generators::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Generators::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_generators()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5418,10 +5502,17 @@ impl Generators {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::GeneratorEvaluations;
-/// let client = GeneratorEvaluations::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GeneratorEvaluations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_generator_evaluations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5741,10 +5832,17 @@ impl GeneratorEvaluations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Intents;
-/// let client = Intents::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Intents::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_intents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6173,10 +6271,17 @@ impl Intents {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::KnowledgeBases;
-/// let client = KnowledgeBases::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = KnowledgeBases::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_knowledge_bases()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6505,10 +6610,17 @@ impl KnowledgeBases {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Participants;
-/// let client = Participants::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Participants::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_participants()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -6925,10 +7037,13 @@ impl Participants {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Sessions;
-/// let client = Sessions::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Sessions::builder().build().await?;
+///     let response = client.detect_intent()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -7181,10 +7296,17 @@ impl Sessions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::SessionEntityTypes;
-/// let client = SessionEntityTypes::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionEntityTypes::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_session_entity_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7547,10 +7669,17 @@ impl SessionEntityTypes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::SipTrunks;
-/// let client = SipTrunks::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SipTrunks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sip_trunks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -7878,10 +8007,17 @@ impl SipTrunks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Tools;
-/// let client = Tools::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Tools::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -8210,10 +8346,17 @@ impl Tools {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dialogflow_v2::client::Versions;
-/// let client = Versions::builder().build().await?;
-/// // use `client` to make requests to the Dialogflow API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Versions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_versions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dialogflow/v2/src/lib.rs
+++ b/src/generated/cloud/dialogflow/v2/src/lib.rs
@@ -84,6 +84,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dialogflow_v2::client::AnswerRecords;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AnswerRecords::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_answer_records()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/discoveryengine/v1/src/client.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::AssistantService;
-/// let client = AssistantService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AssistantService::builder().build().await?;
+///     let mut list = client.list_operations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -195,10 +201,14 @@ impl AssistantService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
-/// let client = CmekConfigService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CmekConfigService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_cmek_config()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -482,10 +492,14 @@ impl CmekConfigService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::CompletionService;
-/// let client = CompletionService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CompletionService::builder().build().await?;
+///     let response = client.import_completion_suggestions()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -825,10 +839,17 @@ impl CompletionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::ControlService;
-/// let client = ControlService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ControlService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_controls()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1136,10 +1157,17 @@ impl ControlService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::ConversationalSearchService;
-/// let client = ConversationalSearchService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConversationalSearchService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_conversations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1649,10 +1677,17 @@ impl ConversationalSearchService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::DataStoreService;
-/// let client = DataStoreService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataStoreService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_stores()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1980,10 +2015,17 @@ impl DataStoreService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::DocumentService;
-/// let client = DocumentService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DocumentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_documents()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2396,10 +2438,17 @@ impl DocumentService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::EngineService;
-/// let client = EngineService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EngineService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_engines()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2719,10 +2768,13 @@ impl EngineService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::GroundedGenerationService;
-/// let client = GroundedGenerationService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GroundedGenerationService::builder().build().await?;
+///     let response = client.generate_grounded_content()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2939,10 +2991,17 @@ impl GroundedGenerationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::IdentityMappingStoreService;
-/// let client = IdentityMappingStoreService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IdentityMappingStoreService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_identity_mapping_stores()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3329,10 +3388,14 @@ impl IdentityMappingStoreService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::ProjectService;
-/// let client = ProjectService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProjectService::builder().build().await?;
+///     let response = client.provision_project()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3542,10 +3605,13 @@ impl ProjectService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::RankService;
-/// let client = RankService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RankService::builder().build().await?;
+///     let response = client.rank()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3736,10 +3802,13 @@ impl RankService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::RecommendationService;
-/// let client = RecommendationService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RecommendationService::builder().build().await?;
+///     let response = client.recommend()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -3931,10 +4000,17 @@ impl RecommendationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::SchemaService;
-/// let client = SchemaService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SchemaService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_schemas()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4260,10 +4336,16 @@ impl SchemaService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::SearchService;
-/// let client = SearchService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SearchService::builder().build().await?;
+///     let mut list = client.search()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -4494,10 +4576,14 @@ impl SearchService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::SearchTuningService;
-/// let client = SearchTuningService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SearchTuningService::builder().build().await?;
+///     let response = client.train_custom_model()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -4720,10 +4806,20 @@ impl SearchTuningService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::ServingConfigService;
-/// let client = ServingConfigService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_discoveryengine_v1::model::ServingConfig;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServingConfigService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_serving_config()
+///         .set_serving_config(
+///             ServingConfig::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -4928,10 +5024,17 @@ impl ServingConfigService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::SessionService;
-/// let client = SessionService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SessionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sessions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5233,10 +5336,17 @@ impl SessionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::SiteSearchEngineService;
-/// let client = SiteSearchEngineService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SiteSearchEngineService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_target_sites()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -5885,10 +5995,13 @@ impl SiteSearchEngineService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::UserEventService;
-/// let client = UserEventService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = UserEventService::builder().build().await?;
+///     let response = client.write_user_event()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -6175,10 +6288,16 @@ impl UserEventService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_discoveryengine_v1::client::UserLicenseService;
-/// let client = UserLicenseService::builder().build().await?;
-/// // use `client` to make requests to the Discovery Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = UserLicenseService::builder().build().await?;
+///     let mut list = client.list_user_licenses()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/discoveryengine/v1/src/lib.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/lib.rs
@@ -83,6 +83,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_discoveryengine_v1::client::CmekConfigService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CmekConfigService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_cmek_config()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/dns/v1/src/client.rs
+++ b/src/generated/cloud/dns/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::Changes;
-/// let client = Changes::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Changes::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -186,10 +189,13 @@ impl Changes {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::DnsKeys;
-/// let client = DnsKeys::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DnsKeys::builder().build().await?;
+///     let response = client.get()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -332,10 +338,13 @@ impl DnsKeys {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::ManagedZoneOperations;
-/// let client = ManagedZoneOperations::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedZoneOperations::builder().build().await?;
+///     let response = client.get()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -479,10 +488,13 @@ impl ManagedZoneOperations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::ManagedZones;
-/// let client = ManagedZones::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedZones::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -776,10 +788,13 @@ impl ManagedZones {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::Policies;
-/// let client = Policies::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Policies::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1001,10 +1016,13 @@ impl Policies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::Projects;
-/// let client = Projects::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Projects::builder().build().await?;
+///     let response = client.get()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1124,10 +1142,13 @@ impl Projects {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::ResourceRecordSets;
-/// let client = ResourceRecordSets::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ResourceRecordSets::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1331,10 +1352,13 @@ impl ResourceRecordSets {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::ResponsePolicies;
-/// let client = ResponsePolicies::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ResponsePolicies::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1557,10 +1581,13 @@ impl ResponsePolicies {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_dns_v1::client::ResponsePolicyRules;
-/// let client = ResponsePolicyRules::builder().build().await?;
-/// // use `client` to make requests to the Cloud DNS API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ResponsePolicyRules::builder().build().await?;
+///     let response = client.create()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/dns/v1/src/lib.rs
+++ b/src/generated/cloud/dns/v1/src/lib.rs
@@ -61,6 +61,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_dns_v1::client::DnsKeys;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DnsKeys::builder().build().await?;
+///     let response = client.get()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/documentai/v1/src/client.rs
+++ b/src/generated/cloud/documentai/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_documentai_v1::client::DocumentProcessorService;
-/// let client = DocumentProcessorService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Document AI API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DocumentProcessorService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_processor_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_documentai_v1::client::DocumentProcessorService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DocumentProcessorService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_processor_types()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/domains/v1/src/client.rs
+++ b/src/generated/cloud/domains/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_domains_v1::client::Domains;
-/// let client = Domains::builder().build().await?;
-/// // use `client` to make requests to the Cloud Domains API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Domains::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_registrations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/domains/v1/src/lib.rs
+++ b/src/generated/cloud/domains/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_domains_v1::client::Domains;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Domains::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_registrations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/edgecontainer/v1/src/client.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
-/// let client = EdgeContainer::builder().build().await?;
-/// // use `client` to make requests to the Distributed Cloud Edge Container API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EdgeContainer::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/edgecontainer/v1/src/lib.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_edgecontainer_v1::client::EdgeContainer;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EdgeContainer::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/edgenetwork/v1/src/client.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
-/// let client = EdgeNetwork::builder().build().await?;
-/// // use `client` to make requests to the Distributed Cloud Edge Network API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EdgeNetwork::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_networks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/edgenetwork/v1/src/lib.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_edgenetwork_v1::client::EdgeNetwork;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EdgeNetwork::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_networks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/essentialcontacts/v1/src/client.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
-/// let client = EssentialContactsService::builder().build().await?;
-/// // use `client` to make requests to the Essential Contacts API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EssentialContactsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_contacts()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/essentialcontacts/v1/src/lib.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_essentialcontacts_v1::client::EssentialContactsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EssentialContactsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_contacts()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/eventarc/publishing/v1/src/client.rs
+++ b/src/generated/cloud/eventarc/publishing/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_eventarc_publishing_v1::client::Publisher;
-/// let client = Publisher::builder().build().await?;
-/// // use `client` to make requests to the Eventarc Publishing API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Publisher::builder().build().await?;
+///     let response = client.publish_channel_connection_events()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/eventarc/publishing/v1/src/lib.rs
+++ b/src/generated/cloud/eventarc/publishing/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_eventarc_publishing_v1::client::Publisher;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Publisher::builder().build().await?;
+///     let response = client.publish_channel_connection_events()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/eventarc/v1/src/client.rs
+++ b/src/generated/cloud/eventarc/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_eventarc_v1::client::Eventarc;
-/// let client = Eventarc::builder().build().await?;
-/// // use `client` to make requests to the Eventarc API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Eventarc::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_triggers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/eventarc/v1/src/lib.rs
+++ b/src/generated/cloud/eventarc/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_eventarc_v1::client::Eventarc;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Eventarc::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_triggers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/filestore/v1/src/client.rs
+++ b/src/generated/cloud/filestore/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
-/// let client = CloudFilestoreManager::builder().build().await?;
-/// // use `client` to make requests to the Cloud Filestore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudFilestoreManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/filestore/v1/src/lib.rs
+++ b/src/generated/cloud/filestore/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_filestore_v1::client::CloudFilestoreManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudFilestoreManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/financialservices/v1/src/client.rs
+++ b/src/generated/cloud/financialservices/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_financialservices_v1::client::Aml;
-/// let client = Aml::builder().build().await?;
-/// // use `client` to make requests to the Financial Services API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Aml::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/financialservices/v1/src/lib.rs
+++ b/src/generated/cloud/financialservices/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_financialservices_v1::client::Aml;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Aml::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/functions/v2/src/client.rs
+++ b/src/generated/cloud/functions/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_functions_v2::client::FunctionService;
-/// let client = FunctionService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Functions API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FunctionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_functions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_functions_v2::client::FunctionService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FunctionService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_functions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gkebackup/v1/src/client.rs
+++ b/src/generated/cloud/gkebackup/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkebackup_v1::client::BackupForGKE;
-/// let client = BackupForGKE::builder().build().await?;
-/// // use `client` to make requests to the Backup for GKE API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackupForGKE::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_backup_plans()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gkebackup/v1/src/lib.rs
+++ b/src/generated/cloud/gkebackup/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gkebackup_v1::client::BackupForGKE;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = BackupForGKE::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_backup_plans()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkeconnect_gateway_v1::client::GatewayControl;
-/// let client = GatewayControl::builder().build().await?;
-/// // use `client` to make requests to the Connect Gateway API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GatewayControl::builder().build().await?;
+///     let response = client.generate_credentials()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/lib.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gkeconnect_gateway_v1::client::GatewayControl;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GatewayControl::builder().build().await?;
+///     let response = client.generate_credentials()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gkehub/v1/src/client.rs
+++ b/src/generated/cloud/gkehub/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkehub_v1::client::GkeHub;
-/// let client = GkeHub::builder().build().await?;
-/// // use `client` to make requests to the GKE Hub.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GkeHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_memberships()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gkehub/v1/src/lib.rs
+++ b/src/generated/cloud/gkehub/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gkehub_v1::client::GkeHub;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GkeHub::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_memberships()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gkemulticloud/v1/src/client.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
-/// let client = AttachedClusters::builder().build().await?;
-/// // use `client` to make requests to the GKE Multi-Cloud API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AttachedClusters::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attached_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -510,10 +517,17 @@ impl AttachedClusters {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkemulticloud_v1::client::AwsClusters;
-/// let client = AwsClusters::builder().build().await?;
-/// // use `client` to make requests to the GKE Multi-Cloud API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AwsClusters::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_aws_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1218,10 +1232,17 @@ impl AwsClusters {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkemulticloud_v1::client::AzureClusters;
-/// let client = AzureClusters::builder().build().await?;
-/// // use `client` to make requests to the GKE Multi-Cloud API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AzureClusters::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_azure_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gkemulticloud/v1/src/lib.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/lib.rs
@@ -55,6 +55,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gkemulticloud_v1::client::AttachedClusters;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AttachedClusters::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attached_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gkerecommender/v1/src/client.rs
+++ b/src/generated/cloud/gkerecommender/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
-/// let client = GkeInferenceQuickstart::builder().build().await?;
-/// // use `client` to make requests to the GKE Recommender API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GkeInferenceQuickstart::builder().build().await?;
+///     let response = client.fetch_models()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gkerecommender/v1/src/lib.rs
+++ b/src/generated/cloud/gkerecommender/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gkerecommender_v1::client::GkeInferenceQuickstart;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GkeInferenceQuickstart::builder().build().await?;
+///     let response = client.fetch_models()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/gsuiteaddons/v1/src/client.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
-/// let client = GSuiteAddOns::builder().build().await?;
-/// // use `client` to make requests to the Google Workspace add-ons API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GSuiteAddOns::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/gsuiteaddons/v1/src/lib.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_gsuiteaddons_v1::client::GSuiteAddOns;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GSuiteAddOns::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_deployments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/iap/v1/src/client.rs
+++ b/src/generated/cloud/iap/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
-/// let client = IdentityAwareProxyAdminService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Identity-Aware Proxy API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IdentityAwareProxyAdminService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tunnel_dest_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -409,10 +416,13 @@ impl IdentityAwareProxyAdminService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iap_v1::client::IdentityAwareProxyOAuthService;
-/// let client = IdentityAwareProxyOAuthService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Identity-Aware Proxy API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IdentityAwareProxyOAuthService::builder().build().await?;
+///     let response = client.list_brands()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iap_v1::client::IdentityAwareProxyAdminService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IdentityAwareProxyAdminService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tunnel_dest_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/ids/v1/src/client.rs
+++ b/src/generated/cloud/ids/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_ids_v1::client::Ids;
-/// let client = Ids::builder().build().await?;
-/// // use `client` to make requests to the Cloud IDS API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Ids::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_endpoints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/ids/v1/src/lib.rs
+++ b/src/generated/cloud/ids/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_ids_v1::client::Ids;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Ids::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_endpoints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/kms/inventory/v1/src/client.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_inventory_v1::client::KeyDashboardService;
-/// let client = KeyDashboardService::builder().build().await?;
-/// // use `client` to make requests to the KMS Inventory API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = KeyDashboardService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_crypto_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -149,10 +156,14 @@ impl KeyDashboardService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_inventory_v1::client::KeyTrackingService;
-/// let client = KeyTrackingService::builder().build().await?;
-/// // use `client` to make requests to the KMS Inventory API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = KeyTrackingService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_protected_resources_summary()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/kms/inventory/v1/src/lib.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_kms_inventory_v1::client::KeyDashboardService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = KeyDashboardService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_crypto_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/kms/v1/src/client.rs
+++ b/src/generated/cloud/kms/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_v1::client::Autokey;
-/// let client = Autokey::builder().build().await?;
-/// // use `client` to make requests to the Cloud Key Management Service (KMS) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Autokey::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_key_handles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -379,10 +386,14 @@ impl Autokey {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_v1::client::AutokeyAdmin;
-/// let client = AutokeyAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Key Management Service (KMS) API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AutokeyAdmin::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_autokey_config()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -717,10 +728,17 @@ impl AutokeyAdmin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_v1::client::EkmService;
-/// let client = EkmService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Key Management Service (KMS) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EkmService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_ekm_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1151,10 +1169,17 @@ impl EkmService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_v1::client::HsmManagement;
-/// let client = HsmManagement::builder().build().await?;
-/// // use `client` to make requests to the Cloud Key Management Service (KMS) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HsmManagement::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_single_tenant_hsm_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1708,10 +1733,17 @@ impl HsmManagement {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_kms_v1::client::KeyManagementService;
-/// let client = KeyManagementService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Key Management Service (KMS) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = KeyManagementService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_key_rings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/kms/v1/src/lib.rs
+++ b/src/generated/cloud/kms/v1/src/lib.rs
@@ -57,6 +57,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_kms_v1::client::Autokey;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Autokey::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_key_handles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/language/v2/src/client.rs
+++ b/src/generated/cloud/language/v2/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_language_v2::client::LanguageService;
-/// let client = LanguageService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Natural Language API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LanguageService::builder().build().await?;
+///     let response = client.analyze_sentiment()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/language/v2/src/lib.rs
+++ b/src/generated/cloud/language/v2/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_language_v2::client::LanguageService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LanguageService::builder().build().await?;
+///     let response = client.analyze_sentiment()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/licensemanager/v1/src/client.rs
+++ b/src/generated/cloud/licensemanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_licensemanager_v1::client::LicenseManager;
-/// let client = LicenseManager::builder().build().await?;
-/// // use `client` to make requests to the License Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LicenseManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_configurations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/licensemanager/v1/src/lib.rs
+++ b/src/generated/cloud/licensemanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_licensemanager_v1::client::LicenseManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LicenseManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_configurations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/location/src/client.rs
+++ b/src/generated/cloud/location/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_location::client::Locations;
-/// let client = Locations::builder().build().await?;
-/// // use `client` to make requests to the Cloud Metadata API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Locations::builder().build().await?;
+///     let mut list = client.list_locations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -51,6 +51,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_location::client::Locations;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Locations::builder().build().await?;
+///     let mut list = client.list_locations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/locationfinder/v1/src/client.rs
+++ b/src/generated/cloud/locationfinder/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_locationfinder_v1::client::CloudLocationFinder;
-/// let client = CloudLocationFinder::builder().build().await?;
-/// // use `client` to make requests to the Cloud Location Finder API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudLocationFinder::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cloud_locations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/locationfinder/v1/src/lib.rs
+++ b/src/generated/cloud/locationfinder/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_locationfinder_v1::client::CloudLocationFinder;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudLocationFinder::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cloud_locations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/lustre/v1/src/client.rs
+++ b/src/generated/cloud/lustre/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_lustre_v1::client::Lustre;
-/// let client = Lustre::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Managed Lustre API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Lustre::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/lustre/v1/src/lib.rs
+++ b/src/generated/cloud/lustre/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_lustre_v1::client::Lustre;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Lustre::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/maintenance/api/v1/src/client.rs
+++ b/src/generated/cloud/maintenance/api/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_maintenance_api_v1::client::Maintenance;
-/// let client = Maintenance::builder().build().await?;
-/// // use `client` to make requests to the Maintenance API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Maintenance::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_resource_maintenances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/maintenance/api/v1/src/lib.rs
+++ b/src/generated/cloud/maintenance/api/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_maintenance_api_v1::client::Maintenance;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Maintenance::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_resource_maintenances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/managedidentities/v1/src/client.rs
+++ b/src/generated/cloud/managedidentities/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
-/// let client = ManagedIdentitiesService::builder().build().await?;
-/// // use `client` to make requests to the Managed Service for Microsoft Active Directory API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedIdentitiesService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_domains()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/managedidentities/v1/src/lib.rs
+++ b/src/generated/cloud/managedidentities/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_managedidentities_v1::client::ManagedIdentitiesService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedIdentitiesService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_domains()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/client.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
-/// let client = ManagedSchemaRegistry::builder().build().await?;
-/// // use `client` to make requests to the Managed Service for Apache Kafka API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedSchemaRegistry::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_schema_registry()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/lib.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/lib.rs
@@ -51,6 +51,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_managedkafka_schemaregistry_v1::client::ManagedSchemaRegistry;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedSchemaRegistry::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_schema_registry()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/managedkafka/v1/src/client.rs
+++ b/src/generated/cloud/managedkafka/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_managedkafka_v1::client::ManagedKafka;
-/// let client = ManagedKafka::builder().build().await?;
-/// // use `client` to make requests to the Managed Service for Apache Kafka API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedKafka::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -759,10 +766,17 @@ impl ManagedKafka {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_managedkafka_v1::client::ManagedKafkaConnect;
-/// let client = ManagedKafkaConnect::builder().build().await?;
-/// // use `client` to make requests to the Managed Service for Apache Kafka API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedKafkaConnect::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connect_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/managedkafka/v1/src/lib.rs
+++ b/src/generated/cloud/managedkafka/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_managedkafka_v1::client::ManagedKafka;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ManagedKafka::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/memcache/v1/src/client.rs
+++ b/src/generated/cloud/memcache/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_memcache_v1::client::CloudMemcache;
-/// let client = CloudMemcache::builder().build().await?;
-/// // use `client` to make requests to the Cloud Memorystore for Memcached API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudMemcache::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/memcache/v1/src/lib.rs
+++ b/src/generated/cloud/memcache/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_memcache_v1::client::CloudMemcache;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudMemcache::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/memorystore/v1/src/client.rs
+++ b/src/generated/cloud/memorystore/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_memorystore_v1::client::Memorystore;
-/// let client = Memorystore::builder().build().await?;
-/// // use `client` to make requests to the Memorystore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Memorystore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/memorystore/v1/src/lib.rs
+++ b/src/generated/cloud/memorystore/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_memorystore_v1::client::Memorystore;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Memorystore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/metastore/v1/src/client.rs
+++ b/src/generated/cloud/metastore/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_metastore_v1::client::DataprocMetastore;
-/// let client = DataprocMetastore::builder().build().await?;
-/// // use `client` to make requests to the Dataproc Metastore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataprocMetastore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -884,10 +891,17 @@ impl DataprocMetastore {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_metastore_v1::client::DataprocMetastoreFederation;
-/// let client = DataprocMetastoreFederation::builder().build().await?;
-/// // use `client` to make requests to the Dataproc Metastore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataprocMetastoreFederation::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_federations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_metastore_v1::client::DataprocMetastore;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataprocMetastore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/migrationcenter/v1/src/client.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
-/// let client = MigrationCenter::builder().build().await?;
-/// // use `client` to make requests to the Migration Center API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MigrationCenter::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_assets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/migrationcenter/v1/src/lib.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_migrationcenter_v1::client::MigrationCenter;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MigrationCenter::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_assets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/modelarmor/v1/src/client.rs
+++ b/src/generated/cloud/modelarmor/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_modelarmor_v1::client::ModelArmor;
-/// let client = ModelArmor::builder().build().await?;
-/// // use `client` to make requests to the Model Armor API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelArmor::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_templates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/modelarmor/v1/src/lib.rs
+++ b/src/generated/cloud/modelarmor/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_modelarmor_v1::client::ModelArmor;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelArmor::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_templates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/netapp/v1/src/client.rs
+++ b/src/generated/cloud/netapp/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_netapp_v1::client::NetApp;
-/// let client = NetApp::builder().build().await?;
-/// // use `client` to make requests to the NetApp API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetApp::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_storage_pools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/netapp/v1/src/lib.rs
+++ b/src/generated/cloud/netapp/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_netapp_v1::client::NetApp;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetApp::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_storage_pools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/networkconnectivity/v1/src/client.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
-/// let client = CrossNetworkAutomationService::builder().build().await?;
-/// // use `client` to make requests to the Network Connectivity API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CrossNetworkAutomationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_service_connection_maps()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -918,10 +925,17 @@ impl CrossNetworkAutomationService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkconnectivity_v1::client::DataTransferService;
-/// let client = DataTransferService::builder().build().await?;
-/// // use `client` to make requests to the Network Connectivity API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DataTransferService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_multicloud_data_transfer_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1594,10 +1608,17 @@ impl DataTransferService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkconnectivity_v1::client::HubService;
-/// let client = HubService::builder().build().await?;
-/// // use `client` to make requests to the Network Connectivity API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = HubService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_hubs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2539,10 +2560,17 @@ impl HubService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkconnectivity_v1::client::InternalRangeService;
-/// let client = InternalRangeService::builder().build().await?;
-/// // use `client` to make requests to the Network Connectivity API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InternalRangeService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_internal_ranges()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3002,10 +3030,17 @@ impl InternalRangeService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkconnectivity_v1::client::PolicyBasedRoutingService;
-/// let client = PolicyBasedRoutingService::builder().build().await?;
-/// // use `client` to make requests to the Network Connectivity API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyBasedRoutingService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_policy_based_routes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/networkconnectivity/v1/src/lib.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/lib.rs
@@ -57,6 +57,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_networkconnectivity_v1::client::CrossNetworkAutomationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CrossNetworkAutomationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_service_connection_maps()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/networkmanagement/v1/src/client.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
-/// let client = ReachabilityService::builder().build().await?;
-/// // use `client` to make requests to the Network Management API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReachabilityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectivity_tests()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -565,10 +572,17 @@ impl ReachabilityService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkmanagement_v1::client::VpcFlowLogsService;
-/// let client = VpcFlowLogsService::builder().build().await?;
-/// // use `client` to make requests to the Network Management API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VpcFlowLogsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_vpc_flow_logs_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1118,10 +1132,17 @@ impl VpcFlowLogsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkmanagement_v1::client::OrganizationVpcFlowLogsService;
-/// let client = OrganizationVpcFlowLogsService::builder().build().await?;
-/// // use `client` to make requests to the Network Management API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrganizationVpcFlowLogsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_vpc_flow_logs_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -55,6 +55,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_networkmanagement_v1::client::ReachabilityService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ReachabilityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectivity_tests()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/networksecurity/v1/src/client.rs
+++ b/src/generated/cloud/networksecurity/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networksecurity_v1::client::AddressGroupService;
-/// let client = AddressGroupService::builder().build().await?;
-/// // use `client` to make requests to the Network Security API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AddressGroupService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_address_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -606,10 +613,17 @@ impl AddressGroupService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networksecurity_v1::client::OrganizationAddressGroupService;
-/// let client = OrganizationAddressGroupService::builder().build().await?;
-/// // use `client` to make requests to the Network Security API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrganizationAddressGroupService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_address_groups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1231,10 +1245,17 @@ impl OrganizationAddressGroupService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
-/// let client = NetworkSecurity::builder().build().await?;
-/// // use `client` to make requests to the Network Security API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkSecurity::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_authorization_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/networksecurity/v1/src/lib.rs
+++ b/src/generated/cloud/networksecurity/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_networksecurity_v1::client::NetworkSecurity;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkSecurity::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_authorization_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/networkservices/v1/src/client.rs
+++ b/src/generated/cloud/networkservices/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkservices_v1::client::DepService;
-/// let client = DepService::builder().build().await?;
-/// // use `client` to make requests to the Network Services API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DepService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_lb_traffic_extensions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -917,10 +924,17 @@ impl DepService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_networkservices_v1::client::NetworkServices;
-/// let client = NetworkServices::builder().build().await?;
-/// // use `client` to make requests to the Network Services API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkServices::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_endpoint_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/networkservices/v1/src/lib.rs
+++ b/src/generated/cloud/networkservices/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_networkservices_v1::client::NetworkServices;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NetworkServices::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_endpoint_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/notebooks/v2/src/client.rs
+++ b/src/generated/cloud/notebooks/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_notebooks_v2::client::NotebookService;
-/// let client = NotebookService::builder().build().await?;
-/// // use `client` to make requests to the Notebooks API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NotebookService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/notebooks/v2/src/lib.rs
+++ b/src/generated/cloud/notebooks/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_notebooks_v2::client::NotebookService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NotebookService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/optimization/v1/src/client.rs
+++ b/src/generated/cloud/optimization/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_optimization_v1::client::FleetRouting;
-/// let client = FleetRouting::builder().build().await?;
-/// // use `client` to make requests to the Cloud Optimization API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FleetRouting::builder().build().await?;
+///     let response = client.optimize_tours()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -53,6 +53,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_optimization_v1::client::FleetRouting;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FleetRouting::builder().build().await?;
+///     let response = client.optimize_tours()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/oracledatabase/v1/src/client.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
-/// let client = OracleDatabase::builder().build().await?;
-/// // use `client` to make requests to the Oracle Database@Google Cloud API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OracleDatabase::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cloud_exadata_infrastructures()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/oracledatabase/v1/src/lib.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_oracledatabase_v1::client::OracleDatabase;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OracleDatabase::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cloud_exadata_infrastructures()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
-/// let client = Environments::builder().build().await?;
-/// // use `client` to make requests to the Cloud Composer API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Environments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_environments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -846,10 +853,16 @@ impl Environments {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_orchestration_airflow_service_v1::client::ImageVersions;
-/// let client = ImageVersions::builder().build().await?;
-/// // use `client` to make requests to the Cloud Composer API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ImageVersions::builder().build().await?;
+///     let mut list = client.list_image_versions()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_orchestration_airflow_service_v1::client::Environments;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Environments::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_environments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/orgpolicy/v2/src/client.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
-/// let client = OrgPolicy::builder().build().await?;
-/// // use `client` to make requests to the Organization Policy API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrgPolicy::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_constraints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_orgpolicy_v2::client::OrgPolicy;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrgPolicy::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_constraints()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/osconfig/v1/src/client.rs
+++ b/src/generated/cloud/osconfig/v1/src/client.rs
@@ -22,10 +22,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_osconfig_v1::client::OsConfigService;
-/// let client = OsConfigService::builder().build().await?;
-/// // use `client` to make requests to the OS Config API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OsConfigService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_patch_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -447,10 +454,17 @@ impl OsConfigService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_osconfig_v1::client::OsConfigZonalService;
-/// let client = OsConfigZonalService::builder().build().await?;
-/// // use `client` to make requests to the OS Config API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OsConfigZonalService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_os_policy_assignments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/osconfig/v1/src/lib.rs
+++ b/src/generated/cloud/osconfig/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_osconfig_v1::client::OsConfigService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OsConfigService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_patch_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/oslogin/v1/src/client.rs
+++ b/src/generated/cloud/oslogin/v1/src/client.rs
@@ -20,10 +20,10 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_oslogin_v1::client::OsLoginService;
-/// let client = OsLoginService::builder().build().await?;
-/// // use `client` to make requests to the Cloud OS Login API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OsLoginService::builder().build().await?;
+///     // use `client` to make requests to the Cloud OS Login API.
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/oslogin/v1/src/lib.rs
+++ b/src/generated/cloud/oslogin/v1/src/lib.rs
@@ -51,6 +51,15 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_oslogin_v1::client::OsLoginService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OsLoginService::builder().build().await?;
+///     // use `client` to make requests to the Cloud OS Login API.
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/parallelstore/v1/src/client.rs
+++ b/src/generated/cloud/parallelstore/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_parallelstore_v1::client::Parallelstore;
-/// let client = Parallelstore::builder().build().await?;
-/// // use `client` to make requests to the Parallelstore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Parallelstore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/parallelstore/v1/src/lib.rs
+++ b/src/generated/cloud/parallelstore/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_parallelstore_v1::client::Parallelstore;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Parallelstore::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/parametermanager/v1/src/client.rs
+++ b/src/generated/cloud/parametermanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_parametermanager_v1::client::ParameterManager;
-/// let client = ParameterManager::builder().build().await?;
-/// // use `client` to make requests to the Parameter Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ParameterManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_parameters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/parametermanager/v1/src/lib.rs
+++ b/src/generated/cloud/parametermanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_parametermanager_v1::client::ParameterManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ParameterManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_parameters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/policysimulator/v1/src/client.rs
+++ b/src/generated/cloud/policysimulator/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_policysimulator_v1::client::OrgPolicyViolationsPreviewService;
-/// let client = OrgPolicyViolationsPreviewService::builder().build().await?;
-/// // use `client` to make requests to the Policy Simulator API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrgPolicyViolationsPreviewService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_org_policy_violations_previews()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -334,10 +341,17 @@ impl OrgPolicyViolationsPreviewService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_policysimulator_v1::client::Simulator;
-/// let client = Simulator::builder().build().await?;
-/// // use `client` to make requests to the Policy Simulator API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Simulator::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_replay_results()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/policysimulator/v1/src/lib.rs
+++ b/src/generated/cloud/policysimulator/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_policysimulator_v1::client::OrgPolicyViolationsPreviewService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = OrgPolicyViolationsPreviewService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_org_policy_violations_previews()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_policytroubleshooter_iam_v3::client::PolicyTroubleshooter;
-/// let client = PolicyTroubleshooter::builder().build().await?;
-/// // use `client` to make requests to the Policy Troubleshooter API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyTroubleshooter::builder().build().await?;
+///     let response = client.troubleshoot_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/lib.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_policytroubleshooter_iam_v3::client::PolicyTroubleshooter;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyTroubleshooter::builder().build().await?;
+///     let response = client.troubleshoot_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/policytroubleshooter/v1/src/client.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_policytroubleshooter_v1::client::IamChecker;
-/// let client = IamChecker::builder().build().await?;
-/// // use `client` to make requests to the Policy Troubleshooter API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IamChecker::builder().build().await?;
+///     let response = client.troubleshoot_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_policytroubleshooter_v1::client::IamChecker;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IamChecker::builder().build().await?;
+///     let response = client.troubleshoot_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
-/// let client = PrivilegedAccessManager::builder().build().await?;
-/// // use `client` to make requests to the Privileged Access Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PrivilegedAccessManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entitlements()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/lib.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_privilegedaccessmanager_v1::client::PrivilegedAccessManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PrivilegedAccessManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_entitlements()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
-/// let client = RapidMigrationAssessment::builder().build().await?;
-/// // use `client` to make requests to the Rapid Migration Assessment API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RapidMigrationAssessment::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_collectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/lib.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_rapidmigrationassessment_v1::client::RapidMigrationAssessment;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RapidMigrationAssessment::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_collectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
-/// let client = RecaptchaEnterpriseService::builder().build().await?;
-/// // use `client` to make requests to the reCAPTCHA Enterprise API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RecaptchaEnterpriseService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_recaptchaenterprise_v1::client::RecaptchaEnterpriseService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RecaptchaEnterpriseService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/recommender/v1/src/client.rs
+++ b/src/generated/cloud/recommender/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_recommender_v1::client::Recommender;
-/// let client = Recommender::builder().build().await?;
-/// // use `client` to make requests to the Recommender API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Recommender::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_insights()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/recommender/v1/src/lib.rs
+++ b/src/generated/cloud/recommender/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_recommender_v1::client::Recommender;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Recommender::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_insights()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/redis/cluster/v1/src/client.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
-/// let client = CloudRedisCluster::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Memorystore for Redis API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudRedisCluster::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/redis/cluster/v1/src/lib.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_redis_cluster_v1::client::CloudRedisCluster;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudRedisCluster::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/redis/v1/src/client.rs
+++ b/src/generated/cloud/redis/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_redis_v1::client::CloudRedis;
-/// let client = CloudRedis::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Memorystore for Redis API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudRedis::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_redis_v1::client::CloudRedis;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudRedis::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/resourcemanager/v3/src/client.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::Folders;
-/// let client = Folders::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Folders::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_folders()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -549,10 +556,14 @@ impl Folders {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::Organizations;
-/// let client = Organizations::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Organizations::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_organization()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -797,10 +808,17 @@ impl Organizations {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::Projects;
-/// let client = Projects::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Projects::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_projects()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1339,10 +1357,17 @@ impl Projects {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::TagBindings;
-/// let client = TagBindings::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TagBindings::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tag_bindings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1577,10 +1602,17 @@ impl TagBindings {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::TagHolds;
-/// let client = TagHolds::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TagHolds::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tag_holds()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1795,10 +1827,17 @@ impl TagHolds {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::TagKeys;
-/// let client = TagKeys::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TagKeys::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tag_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2162,10 +2201,17 @@ impl TagKeys {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_resourcemanager_v3::client::TagValues;
-/// let client = TagValues::builder().build().await?;
-/// // use `client` to make requests to the Cloud Resource Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TagValues::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tag_values()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/resourcemanager/v3/src/lib.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/lib.rs
@@ -57,6 +57,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_resourcemanager_v3::client::Folders;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Folders::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_folders()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/retail/v2/src/client.rs
+++ b/src/generated/cloud/retail/v2/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::AnalyticsService;
-/// let client = AnalyticsService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AnalyticsService::builder().build().await?;
+///     let response = client.export_analytics_metrics()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -208,10 +212,17 @@ impl AnalyticsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::CatalogService;
-/// let client = CatalogService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CatalogService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_catalogs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -695,10 +706,14 @@ impl CatalogService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::CompletionService;
-/// let client = CompletionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CompletionService::builder().build().await?;
+///     let response = client.import_completion_data()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -913,10 +928,17 @@ impl CompletionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::ControlService;
-/// let client = ControlService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ControlService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_controls()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1196,10 +1218,16 @@ impl ControlService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::ConversationalSearchService;
-/// let client = ConversationalSearchService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConversationalSearchService::builder().build().await?;
+///     let mut list = client.list_operations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1352,10 +1380,13 @@ impl ConversationalSearchService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::GenerativeQuestionService;
-/// let client = GenerativeQuestionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GenerativeQuestionService::builder().build().await?;
+///     let response = client.update_generative_questions_feature_config()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1626,10 +1657,17 @@ impl GenerativeQuestionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::ModelService;
-/// let client = ModelService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ModelService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_models()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1984,10 +2022,13 @@ impl ModelService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::PredictionService;
-/// let client = PredictionService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PredictionService::builder().build().await?;
+///     let response = client.predict()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2155,10 +2196,17 @@ impl PredictionService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::ProductService;
-/// let client = ProductService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProductService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_products()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2886,10 +2934,16 @@ impl ProductService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::SearchService;
-/// let client = SearchService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SearchService::builder().build().await?;
+///     let mut list = client.search()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3065,10 +3119,17 @@ impl SearchService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::ServingConfigService;
-/// let client = ServingConfigService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServingConfigService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_serving_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -3396,10 +3457,13 @@ impl ServingConfigService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_retail_v2::client::UserEventService;
-/// let client = UserEventService::builder().build().await?;
-/// // use `client` to make requests to the Vertex AI Search for commerce API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = UserEventService::builder().build().await?;
+///     let response = client.write_user_event()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/retail/v2/src/lib.rs
+++ b/src/generated/cloud/retail/v2/src/lib.rs
@@ -71,6 +71,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_retail_v2::client::CatalogService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CatalogService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_catalogs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/run/v2/src/client.rs
+++ b/src/generated/cloud/run/v2/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Builds;
-/// let client = Builds::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Builds::builder().build().await?;
+///     let response = client.submit_build()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -233,10 +236,17 @@ impl Builds {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Executions;
-/// let client = Executions::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Executions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_executions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -532,10 +542,17 @@ impl Executions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Instances;
-/// let client = Instances::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Instances::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -897,10 +914,17 @@ impl Instances {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Jobs;
-/// let client = Jobs::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Jobs::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1329,10 +1353,17 @@ impl Jobs {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Revisions;
-/// let client = Revisions::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Revisions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_revisions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1597,10 +1628,17 @@ impl Revisions {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Services;
-/// let client = Services::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Services::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2003,10 +2041,17 @@ impl Services {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::Tasks;
-/// let client = Tasks::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Tasks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tasks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2239,10 +2284,17 @@ impl Tasks {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_run_v2::client::WorkerPools;
-/// let client = WorkerPools::builder().build().await?;
-/// // use `client` to make requests to the Cloud Run Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WorkerPools::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_worker_pools()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_run_v2::client::Executions;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Executions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_executions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/scheduler/v1/src/client.rs
+++ b/src/generated/cloud/scheduler/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_scheduler_v1::client::CloudScheduler;
-/// let client = CloudScheduler::builder().build().await?;
-/// // use `client` to make requests to the Cloud Scheduler API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudScheduler::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/scheduler/v1/src/lib.rs
+++ b/src/generated/cloud/scheduler/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_scheduler_v1::client::CloudScheduler;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudScheduler::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/secretmanager/v1/src/client.rs
+++ b/src/generated/cloud/secretmanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_secretmanager_v1::client::SecretManagerService;
-/// let client = SecretManagerService::builder().build().await?;
-/// // use `client` to make requests to the Secret Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecretManagerService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_secrets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_secretmanager_v1::client::SecretManagerService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecretManagerService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_secrets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/securesourcemanager/v1/src/client.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
-/// let client = SecureSourceManager::builder().build().await?;
-/// // use `client` to make requests to the Secure Source Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecureSourceManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/securesourcemanager/v1/src/lib.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_securesourcemanager_v1::client::SecureSourceManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecureSourceManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instances()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/security/privateca/v1/src/client.rs
+++ b/src/generated/cloud/security/privateca/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
-/// let client = CertificateAuthorityService::builder().build().await?;
-/// // use `client` to make requests to the Certificate Authority API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CertificateAuthorityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_certificates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/security/privateca/v1/src/lib.rs
+++ b/src/generated/cloud/security/privateca/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_security_privateca_v1::client::CertificateAuthorityService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CertificateAuthorityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_certificates()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/security/publicca/v1/src/client.rs
+++ b/src/generated/cloud/security/publicca/v1/src/client.rs
@@ -20,10 +20,18 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_security_publicca_v1::client::PublicCertificateAuthorityService;
-/// let client = PublicCertificateAuthorityService::builder().build().await?;
-/// // use `client` to make requests to the Public Certificate Authority API.
+/// use google_cloud_security_publicca_v1::model::ExternalAccountKey;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PublicCertificateAuthorityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_external_account_key()
+///         .set_parent(parent)
+///         .set_external_account_key(
+///             ExternalAccountKey::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/security/publicca/v1/src/lib.rs
+++ b/src/generated/cloud/security/publicca/v1/src/lib.rs
@@ -51,6 +51,23 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_security_publicca_v1::client::PublicCertificateAuthorityService;
+/// use google_cloud_security_publicca_v1::model::ExternalAccountKey;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PublicCertificateAuthorityService::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_external_account_key()
+///         .set_parent(parent)
+///         .set_external_account_key(
+///             ExternalAccountKey::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/securitycenter/v2/src/client.rs
+++ b/src/generated/cloud/securitycenter/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_securitycenter_v2::client::SecurityCenter;
-/// let client = SecurityCenter::builder().build().await?;
-/// // use `client` to make requests to the Security Command Center API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecurityCenter::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attack_paths()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_securitycenter_v2::client::SecurityCenter;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecurityCenter::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attack_paths()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/securityposture/v1/src/client.rs
+++ b/src/generated/cloud/securityposture/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_securityposture_v1::client::SecurityPosture;
-/// let client = SecurityPosture::builder().build().await?;
-/// // use `client` to make requests to the Security Posture API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecurityPosture::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_postures()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/securityposture/v1/src/lib.rs
+++ b/src/generated/cloud/securityposture/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_securityposture_v1::client::SecurityPosture;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecurityPosture::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_postures()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/servicedirectory/v1/src/client.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_servicedirectory_v1::client::LookupService;
-/// let client = LookupService::builder().build().await?;
-/// // use `client` to make requests to the Service Directory API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LookupService::builder().build().await?;
+///     let response = client.resolve_service()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -190,10 +193,17 @@ impl LookupService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_servicedirectory_v1::client::RegistrationService;
-/// let client = RegistrationService::builder().build().await?;
-/// // use `client` to make requests to the Service Directory API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegistrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_namespaces()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/servicedirectory/v1/src/lib.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_servicedirectory_v1::client::RegistrationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RegistrationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_namespaces()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/servicehealth/v1/src/client.rs
+++ b/src/generated/cloud/servicehealth/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_servicehealth_v1::client::ServiceHealth;
-/// let client = ServiceHealth::builder().build().await?;
-/// // use `client` to make requests to the Service Health API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceHealth::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_events()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/servicehealth/v1/src/lib.rs
+++ b/src/generated/cloud/servicehealth/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_servicehealth_v1::client::ServiceHealth;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceHealth::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_events()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/shell/v1/src/client.rs
+++ b/src/generated/cloud/shell/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_shell_v1::client::CloudShellService;
-/// let client = CloudShellService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Shell API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudShellService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_environment()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/shell/v1/src/lib.rs
+++ b/src/generated/cloud/shell/v1/src/lib.rs
@@ -51,6 +51,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_shell_v1::client::CloudShellService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudShellService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_environment()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/speech/v2/src/client.rs
+++ b/src/generated/cloud/speech/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_speech_v2::client::Speech;
-/// let client = Speech::builder().build().await?;
-/// // use `client` to make requests to the Cloud Speech-to-Text API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Speech::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_recognizers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_speech_v2::client::Speech;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Speech::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_recognizers()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/sql/v1/src/client.rs
+++ b/src/generated/cloud/sql/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlBackupRunsService;
-/// let client = SqlBackupRunsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlBackupRunsService::builder().build().await?;
+///     let response = client.delete()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -209,10 +212,17 @@ impl SqlBackupRunsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlBackupsService;
-/// let client = SqlBackupsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlBackupsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_backups()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -417,10 +427,13 @@ impl SqlBackupsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlConnectService;
-/// let client = SqlConnectService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlConnectService::builder().build().await?;
+///     let response = client.get_connect_settings()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -566,10 +579,13 @@ impl SqlConnectService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlDatabasesService;
-/// let client = SqlDatabasesService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlDatabasesService::builder().build().await?;
+///     let response = client.delete()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -796,10 +812,13 @@ impl SqlDatabasesService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlFlagsService;
-/// let client = SqlFlagsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlFlagsService::builder().build().await?;
+///     let response = client.list()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -919,10 +938,13 @@ impl SqlFlagsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlInstancesService;
-/// let client = SqlInstancesService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlInstancesService::builder().build().await?;
+///     let response = client.add_server_ca()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1966,10 +1988,13 @@ impl SqlInstancesService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlOperationsService;
-/// let client = SqlOperationsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlOperationsService::builder().build().await?;
+///     let response = client.get()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2133,10 +2158,13 @@ impl SqlOperationsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlSslCertsService;
-/// let client = SqlSslCertsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlSslCertsService::builder().build().await?;
+///     let response = client.delete()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2322,10 +2350,13 @@ impl SqlSslCertsService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlTiersService;
-/// let client = SqlTiersService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlTiersService::builder().build().await?;
+///     let response = client.list()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2447,10 +2478,13 @@ impl SqlTiersService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_sql_v1::client::SqlUsersService;
-/// let client = SqlUsersService::builder().build().await?;
-/// // use `client` to make requests to the Cloud SQL Admin API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlUsersService::builder().build().await?;
+///     let response = client.delete()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -62,6 +62,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_sql_v1::client::SqlInstancesService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SqlInstancesService::builder().build().await?;
+///     let response = client.add_server_ca()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/storagebatchoperations/v1/src/client.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
-/// let client = StorageBatchOperations::builder().build().await?;
-/// // use `client` to make requests to the Storage Batch Operations API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageBatchOperations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/storagebatchoperations/v1/src/lib.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_storagebatchoperations_v1::client::StorageBatchOperations;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageBatchOperations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/storageinsights/v1/src/client.rs
+++ b/src/generated/cloud/storageinsights/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_storageinsights_v1::client::StorageInsights;
-/// let client = StorageInsights::builder().build().await?;
-/// // use `client` to make requests to the Storage Insights API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageInsights::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_report_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/storageinsights/v1/src/lib.rs
+++ b/src/generated/cloud/storageinsights/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_storageinsights_v1::client::StorageInsights;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageInsights::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_report_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/support/v2/src/client.rs
+++ b/src/generated/cloud/support/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_support_v2::client::CaseAttachmentService;
-/// let client = CaseAttachmentService::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Support API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CaseAttachmentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attachments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -147,10 +154,17 @@ impl CaseAttachmentService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_support_v2::client::CaseService;
-/// let client = CaseService::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Support API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CaseService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cases()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -454,10 +468,17 @@ impl CaseService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_support_v2::client::CommentService;
-/// let client = CommentService::builder().build().await?;
-/// // use `client` to make requests to the Google Cloud Support API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CommentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_comments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/support/v2/src/lib.rs
+++ b/src/generated/cloud/support/v2/src/lib.rs
@@ -55,6 +55,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_support_v2::client::CaseAttachmentService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CaseAttachmentService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_attachments()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/talent/v4/src/client.rs
+++ b/src/generated/cloud/talent/v4/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_talent_v4::client::CompanyService;
-/// let client = CompanyService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Talent Solution API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CompanyService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_companies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -258,10 +265,13 @@ impl CompanyService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_talent_v4::client::Completion;
-/// let client = Completion::builder().build().await?;
-/// // use `client` to make requests to the Cloud Talent Solution API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Completion::builder().build().await?;
+///     let response = client.complete_query()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -404,10 +414,13 @@ impl Completion {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_talent_v4::client::EventService;
-/// let client = EventService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Talent Solution API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = EventService::builder().build().await?;
+///     let response = client.create_client_event()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -555,10 +568,17 @@ impl EventService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_talent_v4::client::JobService;
-/// let client = JobService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Talent Solution API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = JobService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -958,10 +978,17 @@ impl JobService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_talent_v4::client::TenantService;
-/// let client = TenantService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Talent Solution API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TenantService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tenants()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -57,6 +57,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_talent_v4::client::JobService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = JobService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/tasks/v2/src/client.rs
+++ b/src/generated/cloud/tasks/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_tasks_v2::client::CloudTasks;
-/// let client = CloudTasks::builder().build().await?;
-/// // use `client` to make requests to the Cloud Tasks API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudTasks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_queues()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/tasks/v2/src/lib.rs
+++ b/src/generated/cloud/tasks/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_tasks_v2::client::CloudTasks;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudTasks::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_queues()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/telcoautomation/v1/src/client.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
-/// let client = TelcoAutomation::builder().build().await?;
-/// // use `client` to make requests to the Telco Automation API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TelcoAutomation::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_orchestration_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/telcoautomation/v1/src/lib.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_telcoautomation_v1::client::TelcoAutomation;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TelcoAutomation::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_orchestration_clusters()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/texttospeech/v1/src/client.rs
+++ b/src/generated/cloud/texttospeech/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_texttospeech_v1::client::TextToSpeech;
-/// let client = TextToSpeech::builder().build().await?;
-/// // use `client` to make requests to the Cloud Text-to-Speech API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TextToSpeech::builder().build().await?;
+///     let response = client.list_voices()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -211,10 +214,14 @@ impl TextToSpeech {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_texttospeech_v1::client::TextToSpeechLongAudioSynthesize;
-/// let client = TextToSpeechLongAudioSynthesize::builder().build().await?;
-/// // use `client` to make requests to the Cloud Text-to-Speech API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TextToSpeechLongAudioSynthesize::builder().build().await?;
+///     let response = client.synthesize_long_audio()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -61,6 +61,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_texttospeech_v1::client::TextToSpeech;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TextToSpeech::builder().build().await?;
+///     let response = client.list_voices()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/timeseriesinsights/v1/src/client.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
-/// let client = TimeseriesInsightsController::builder().build().await?;
-/// // use `client` to make requests to the Timeseries Insights API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TimeseriesInsightsController::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_sets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/timeseriesinsights/v1/src/lib.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_timeseriesinsights_v1::client::TimeseriesInsightsController;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TimeseriesInsightsController::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_data_sets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/tpu/v2/src/client.rs
+++ b/src/generated/cloud/tpu/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_tpu_v2::client::Tpu;
-/// let client = Tpu::builder().build().await?;
-/// // use `client` to make requests to the Cloud TPU API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Tpu::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_nodes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/tpu/v2/src/lib.rs
+++ b/src/generated/cloud/tpu/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_tpu_v2::client::Tpu;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Tpu::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_nodes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/translate/v3/src/client.rs
+++ b/src/generated/cloud/translate/v3/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_translation_v3::client::TranslationService;
-/// let client = TranslationService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Translation API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TranslationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_glossaries()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/translate/v3/src/lib.rs
+++ b/src/generated/cloud/translate/v3/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_translation_v3::client::TranslationService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TranslationService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_glossaries()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/video/livestream/v1/src/client.rs
+++ b/src/generated/cloud/video/livestream/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_video_livestream_v1::client::LivestreamService;
-/// let client = LivestreamService::builder().build().await?;
-/// // use `client` to make requests to the Live Stream API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LivestreamService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_channels()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/video/livestream/v1/src/lib.rs
+++ b/src/generated/cloud/video/livestream/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_video_livestream_v1::client::LivestreamService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LivestreamService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_channels()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/video/stitcher/v1/src/client.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
-/// let client = VideoStitcherService::builder().build().await?;
-/// // use `client` to make requests to the Video Stitcher API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VideoStitcherService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cdn_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/video/stitcher/v1/src/lib.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_video_stitcher_v1::client::VideoStitcherService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VideoStitcherService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_cdn_keys()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/video/transcoder/v1/src/client.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_video_transcoder_v1::client::TranscoderService;
-/// let client = TranscoderService::builder().build().await?;
-/// // use `client` to make requests to the Transcoder API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TranscoderService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/video/transcoder/v1/src/lib.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_video_transcoder_v1::client::TranscoderService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TranscoderService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/videointelligence/v1/src/client.rs
+++ b/src/generated/cloud/videointelligence/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
-/// let client = VideoIntelligenceService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Video Intelligence API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VideoIntelligenceService::builder().build().await?;
+///     let response = client.annotate_video()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -53,6 +53,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_videointelligence_v1::client::VideoIntelligenceService;
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VideoIntelligenceService::builder().build().await?;
+///     let response = client.annotate_video()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/vision/v1/src/client.rs
+++ b/src/generated/cloud/vision/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_vision_v1::client::ImageAnnotator;
-/// let client = ImageAnnotator::builder().build().await?;
-/// // use `client` to make requests to the Cloud Vision API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ImageAnnotator::builder().build().await?;
+///     let response = client.batch_annotate_images()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -272,10 +275,17 @@ impl ImageAnnotator {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_vision_v1::client::ProductSearch;
-/// let client = ProductSearch::builder().build().await?;
-/// // use `client` to make requests to the Cloud Vision API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProductSearch::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_product_sets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -54,6 +54,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_vision_v1::client::ProductSearch;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProductSearch::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_product_sets()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/vmmigration/v1/src/client.rs
+++ b/src/generated/cloud/vmmigration/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_vmmigration_v1::client::VmMigration;
-/// let client = VmMigration::builder().build().await?;
-/// // use `client` to make requests to the VM Migration API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VmMigration::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sources()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_vmmigration_v1::client::VmMigration;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VmMigration::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_sources()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/vmwareengine/v1/src/client.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
-/// let client = VmwareEngine::builder().build().await?;
-/// // use `client` to make requests to the VMware Engine API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VmwareEngine::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_vmware_engine_networks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/vmwareengine/v1/src/lib.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_vmwareengine_v1::client::VmwareEngine;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VmwareEngine::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_vmware_engine_networks()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/vpcaccess/v1/src/client.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
-/// let client = VpcAccessService::builder().build().await?;
-/// // use `client` to make requests to the Serverless VPC Access API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VpcAccessService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/vpcaccess/v1/src/lib.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_vpcaccess_v1::client::VpcAccessService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = VpcAccessService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connectors()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/webrisk/v1/src/client.rs
+++ b/src/generated/cloud/webrisk/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_webrisk_v1::client::WebRiskService;
-/// let client = WebRiskService::builder().build().await?;
-/// // use `client` to make requests to the Web Risk API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WebRiskService::builder().build().await?;
+///     let response = client.compute_threat_list_diff()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/webrisk/v1/src/lib.rs
+++ b/src/generated/cloud/webrisk/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_webrisk_v1::client::WebRiskService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WebRiskService::builder().build().await?;
+///     let response = client.compute_threat_list_diff()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/websecurityscanner/v1/src/client.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
-/// let client = WebSecurityScanner::builder().build().await?;
-/// // use `client` to make requests to the Web Security Scanner API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WebSecurityScanner::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_findings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_websecurityscanner_v1::client::WebSecurityScanner;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = WebSecurityScanner::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_findings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/workflows/executions/v1/src/client.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_workflows_executions_v1::client::Executions;
-/// let client = Executions::builder().build().await?;
-/// // use `client` to make requests to the Workflow Executions API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Executions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_executions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/workflows/executions/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_workflows_executions_v1::client::Executions;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Executions::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_executions()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/workflows/v1/src/client.rs
+++ b/src/generated/cloud/workflows/v1/src/client.rs
@@ -22,10 +22,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_workflows_v1::client::Workflows;
-/// let client = Workflows::builder().build().await?;
-/// // use `client` to make requests to the Workflows API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Workflows::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workflows()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/workflows/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_workflows_v1::client::Workflows;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Workflows::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workflows()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/cloud/workstations/v1/src/client.rs
+++ b/src/generated/cloud/workstations/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_workstations_v1::client::Workstations;
-/// let client = Workstations::builder().build().await?;
-/// // use `client` to make requests to the Cloud Workstations API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Workstations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workstations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/cloud/workstations/v1/src/lib.rs
+++ b/src/generated/cloud/workstations/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_workstations_v1::client::Workstations;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Workstations::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_workstations()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/container/v1/src/client.rs
+++ b/src/generated/container/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_container_v1::client::ClusterManager;
-/// let client = ClusterManager::builder().build().await?;
-/// // use `client` to make requests to the Kubernetes Engine API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClusterManager::builder().build().await?;
+///     let response = client.list_clusters()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -53,6 +53,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_container_v1::client::ClusterManager;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ClusterManager::builder().build().await?;
+///     let response = client.list_clusters()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/datastore/admin/v1/src/client.rs
+++ b/src/generated/datastore/admin/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
-/// let client = DatastoreAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Datastore API.
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatastoreAdmin::builder().build().await?;
+///     let response = client.export_entities()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/datastore/admin/v1/src/lib.rs
+++ b/src/generated/datastore/admin/v1/src/lib.rs
@@ -51,6 +51,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_datastore_admin_v1::client::DatastoreAdmin;
+/// use google_cloud_lro::Poller;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatastoreAdmin::builder().build().await?;
+///     let response = client.export_entities()
+///         /* set fields */
+///         .poller().until_done().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/artifactregistry/v1/src/client.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
-/// let client = ArtifactRegistry::builder().build().await?;
-/// // use `client` to make requests to the Artifact Registry API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ArtifactRegistry::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_docker_images()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_artifactregistry_v1::client::ArtifactRegistry;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ArtifactRegistry::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_docker_images()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/cloudbuild/v1/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_build_v1::client::CloudBuild;
-/// let client = CloudBuild::builder().build().await?;
-/// // use `client` to make requests to the Cloud Build API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudBuild::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_builds()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_build_v1::client::CloudBuild;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = CloudBuild::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_builds()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/cloudbuild/v2/src/client.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_build_v2::client::RepositoryManager;
-/// let client = RepositoryManager::builder().build().await?;
-/// // use `client` to make requests to the Cloud Build API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RepositoryManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/cloudbuild/v2/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_build_v2::client::RepositoryManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = RepositoryManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_connections()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/cloudprofiler/v2/src/client.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/client.rs
@@ -20,10 +20,18 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_profiler_v2::client::ProfilerService;
-/// let client = ProfilerService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Profiler API.
+/// use google_cloud_profiler_v2::model::Profile;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProfilerService::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_offline_profile()
+///         .set_parent(parent)
+///         .set_profile(
+///             Profile::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -229,10 +237,17 @@ impl ProfilerService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_profiler_v2::client::ExportService;
-/// let client = ExportService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Profiler API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ExportService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_profiles()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/cloudprofiler/v2/src/lib.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/lib.rs
@@ -52,6 +52,23 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_profiler_v2::client::ProfilerService;
+/// use google_cloud_profiler_v2::model::Profile;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ProfilerService::builder().build().await?;
+///     let parent = "parent_value";
+///     let response = client.create_offline_profile()
+///         .set_parent(parent)
+///         .set_profile(
+///             Profile::new()/* set fields */
+///         )
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/cloudtrace/v1/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v1/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_trace_v1::client::TraceService;
-/// let client = TraceService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Trace API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TraceService::builder().build().await?;
+///     let mut list = client.list_traces()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/cloudtrace/v1/src/lib.rs
+++ b/src/generated/devtools/cloudtrace/v1/src/lib.rs
@@ -51,6 +51,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_trace_v1::client::TraceService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TraceService::builder().build().await?;
+///     let mut list = client.list_traces()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/cloudtrace/v2/src/client.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/client.rs
@@ -20,10 +20,12 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_trace_v2::client::TraceService;
-/// let client = TraceService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Trace API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TraceService::builder().build().await?;
+///     client.batch_write_spans()
+///         /* set fields */
+///         .send().await?;
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/cloudtrace/v2/src/lib.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/lib.rs
@@ -51,6 +51,17 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_trace_v2::client::TraceService;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TraceService::builder().build().await?;
+///     client.batch_write_spans()
+///         /* set fields */
+///         .send().await?;
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/devtools/containeranalysis/v1/src/client.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
-/// let client = ContainerAnalysis::builder().build().await?;
-/// // use `client` to make requests to the Container Analysis API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ContainerAnalysis::builder().build().await?;
+///     let response = client.set_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/devtools/containeranalysis/v1/src/lib.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_containeranalysis_v1::client::ContainerAnalysis;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ContainerAnalysis::builder().build().await?;
+///     let response = client.set_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/firestore/admin/v1/src/client.rs
+++ b/src/generated/firestore/admin/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
-/// let client = FirestoreAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Firestore API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FirestoreAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_indexes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/firestore/admin/v1/src/lib.rs
+++ b/src/generated/firestore/admin/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_firestore_admin_v1::client::FirestoreAdmin;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = FirestoreAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_indexes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/grafeas/v1/src/client.rs
+++ b/src/generated/grafeas/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_grafeas_v1::client::Grafeas;
-/// let client = Grafeas::builder().build().await?;
-/// // use `client` to make requests to the Container Analysis API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Grafeas::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_occurrences()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_grafeas_v1::client::Grafeas;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Grafeas::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_occurrences()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/iam/admin/v1/src/client.rs
+++ b/src/generated/iam/admin/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_admin_v1::client::Iam;
-/// let client = Iam::builder().build().await?;
-/// // use `client` to make requests to the Identity and Access Management (IAM) API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Iam::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_service_account()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -53,6 +53,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iam_admin_v1::client::Iam;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Iam::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_service_account()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/iam/credentials/v1/src/client.rs
+++ b/src/generated/iam/credentials/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
-/// let client = IAMCredentials::builder().build().await?;
-/// // use `client` to make requests to the IAM Service Account Credentials API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IAMCredentials::builder().build().await?;
+///     let response = client.generate_access_token()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/iam/credentials/v1/src/lib.rs
+++ b/src/generated/iam/credentials/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iam_credentials_v1::client::IAMCredentials;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IAMCredentials::builder().build().await?;
+///     let response = client.generate_access_token()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/iam/v1/src/client.rs
+++ b/src/generated/iam/v1/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_v1::client::IAMPolicy;
-/// let client = IAMPolicy::builder().build().await?;
-/// // use `client` to make requests to the IAM Meta API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IAMPolicy::builder().build().await?;
+///     let response = client.set_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -51,6 +51,18 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iam_v1::client::IAMPolicy;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = IAMPolicy::builder().build().await?;
+///     let response = client.set_iam_policy()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/iam/v2/src/client.rs
+++ b/src/generated/iam/v2/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_v2::client::Policies;
-/// let client = Policies::builder().build().await?;
-/// // use `client` to make requests to the Identity and Access Management (IAM) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Policies::builder().build().await?;
+///     let mut list = client.list_policies()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/iam/v2/src/lib.rs
+++ b/src/generated/iam/v2/src/lib.rs
@@ -51,6 +51,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iam_v2::client::Policies;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Policies::builder().build().await?;
+///     let mut list = client.list_policies()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/iam/v3/src/client.rs
+++ b/src/generated/iam/v3/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_v3::client::PolicyBindings;
-/// let client = PolicyBindings::builder().build().await?;
-/// // use `client` to make requests to the Identity and Access Management (IAM) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyBindings::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_policy_bindings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -325,10 +332,17 @@ impl PolicyBindings {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_iam_v3::client::PrincipalAccessBoundaryPolicies;
-/// let client = PrincipalAccessBoundaryPolicies::builder().build().await?;
-/// // use `client` to make requests to the Identity and Access Management (IAM) API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PrincipalAccessBoundaryPolicies::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_principal_access_boundary_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/iam/v3/src/lib.rs
+++ b/src/generated/iam/v3/src/lib.rs
@@ -52,6 +52,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_iam_v3::client::PolicyBindings;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = PolicyBindings::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_policy_bindings()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/identity/accesscontextmanager/v1/src/client.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
-/// let client = AccessContextManager::builder().build().await?;
-/// // use `client` to make requests to the Access Context Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AccessContextManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_access_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/identity/accesscontextmanager/v1/src/lib.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_identity_accesscontextmanager_v1::client::AccessContextManager;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AccessContextManager::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_access_policies()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/logging/v2/src/client.rs
+++ b/src/generated/logging/v2/src/client.rs
@@ -20,10 +20,10 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_logging_v2::client::LoggingServiceV2;
-/// let client = LoggingServiceV2::builder().build().await?;
-/// // use `client` to make requests to the Cloud Logging API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LoggingServiceV2::builder().build().await?;
+///     // use `client` to make requests to the Cloud Logging API.
 /// # Ok(()) }
 /// ```
 ///
@@ -187,10 +187,10 @@ impl LoggingServiceV2 {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_logging_v2::client::ConfigServiceV2;
-/// let client = ConfigServiceV2::builder().build().await?;
-/// // use `client` to make requests to the Cloud Logging API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ConfigServiceV2::builder().build().await?;
+///     // use `client` to make requests to the Cloud Logging API.
 /// # Ok(()) }
 /// ```
 ///
@@ -612,10 +612,10 @@ impl ConfigServiceV2 {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_logging_v2::client::MetricsServiceV2;
-/// let client = MetricsServiceV2::builder().build().await?;
-/// // use `client` to make requests to the Cloud Logging API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetricsServiceV2::builder().build().await?;
+///     // use `client` to make requests to the Cloud Logging API.
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -62,6 +62,15 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_logging_v2::client::LoggingServiceV2;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = LoggingServiceV2::builder().build().await?;
+///     // use `client` to make requests to the Cloud Logging API.
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/longrunning/src/client.rs
+++ b/src/generated/longrunning/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_longrunning::client::Operations;
-/// let client = Operations::builder().build().await?;
-/// // use `client` to make requests to the Long Running Operations API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Operations::builder().build().await?;
+///     let mut list = client.list_operations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/longrunning/src/lib.rs
+++ b/src/generated/longrunning/src/lib.rs
@@ -58,6 +58,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_longrunning::client::Operations;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Operations::builder().build().await?;
+///     let mut list = client.list_operations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/monitoring/dashboard/v1/src/client.rs
+++ b/src/generated/monitoring/dashboard/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
-/// let client = DashboardsService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DashboardsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_dashboards()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_monitoring_dashboard_v1::client::DashboardsService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DashboardsService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_dashboards()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/monitoring/metricsscope/v1/src/client.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
-/// let client = MetricsScopes::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetricsScopes::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_metrics_scope()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/monitoring/metricsscope/v1/src/lib.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/lib.rs
@@ -51,6 +51,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_monitoring_metricsscope_v1::client::MetricsScopes;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetricsScopes::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_metrics_scope()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/monitoring/v3/src/client.rs
+++ b/src/generated/monitoring/v3/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::AlertPolicyService;
-/// let client = AlertPolicyService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = AlertPolicyService::builder().build().await?;
+///     let name = "name_value";
+///     let mut list = client.list_alert_policies()
+///         .set_name(name)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -259,10 +266,17 @@ impl AlertPolicyService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::GroupService;
-/// let client = GroupService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = GroupService::builder().build().await?;
+///     let name = "name_value";
+///     let mut list = client.list_groups()
+///         .set_name(name)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -506,10 +520,16 @@ impl GroupService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::MetricService;
-/// let client = MetricService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = MetricService::builder().build().await?;
+///     let mut list = client.list_metric_descriptors()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -829,10 +849,17 @@ impl MetricService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::NotificationChannelService;
-/// let client = NotificationChannelService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = NotificationChannelService::builder().build().await?;
+///     let name = "name_value";
+///     let mut list = client.list_notification_channel_descriptors()
+///         .set_name(name)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1237,10 +1264,16 @@ impl NotificationChannelService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::QueryService;
-/// let client = QueryService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = QueryService::builder().build().await?;
+///     let mut list = client.query_time_series()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1369,10 +1402,17 @@ impl QueryService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
-/// let client = ServiceMonitoringService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceMonitoringService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1722,10 +1762,17 @@ impl ServiceMonitoringService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::SnoozeService;
-/// let client = SnoozeService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SnoozeService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_snoozes()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -1924,10 +1971,17 @@ impl SnoozeService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_monitoring_v3::client::UptimeCheckService;
-/// let client = UptimeCheckService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Monitoring API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = UptimeCheckService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_uptime_check_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -60,6 +60,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_monitoring_v3::client::ServiceMonitoringService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = ServiceMonitoringService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_services()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/openapi-validation/src/client.rs
+++ b/src/generated/openapi-validation/src/client.rs
@@ -20,10 +20,16 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use secretmanager_openapi_v1::client::SecretManagerService;
-/// let client = SecretManagerService::builder().build().await?;
-/// // use `client` to make requests to the Secret Manager API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecretManagerService::builder().build().await?;
+///     let mut list = client.list_locations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -51,6 +51,21 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use secretmanager_openapi_v1::client::SecretManagerService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SecretManagerService::builder().build().await?;
+///     let mut list = client.list_locations()
+///         /* set fields */
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/privacy/dlp/v2/src/client.rs
+++ b/src/generated/privacy/dlp/v2/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_privacy_dlp_v2::client::DlpService;
-/// let client = DlpService::builder().build().await?;
-/// // use `client` to make requests to the Sensitive Data Protection (DLP).
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DlpService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_dlp_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_privacy_dlp_v2::client::DlpService;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DlpService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_dlp_jobs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -20,10 +20,13 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::Compliance;
-/// let client = Compliance::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Compliance::builder().build().await?;
+///     let response = client.repeat_data_body()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -545,10 +548,13 @@ impl Compliance {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::Echo;
-/// let client = Echo::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Echo::builder().build().await?;
+///     let response = client.echo()
+///         /* set fields */
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1059,10 +1065,14 @@ impl Echo {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::Identity;
-/// let client = Identity::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Identity::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_user()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -1472,10 +1482,17 @@ impl Identity {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::Messaging;
-/// let client = Messaging::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Messaging::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_blurbs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///
@@ -2036,10 +2053,14 @@ impl Messaging {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::SequenceService;
-/// let client = SequenceService::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SequenceService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_sequence_report()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -2447,10 +2468,17 @@ impl SequenceService {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_showcase_v1beta1::client::Testing;
-/// let client = Testing::builder().build().await?;
-/// // use `client` to make requests to the Client Libraries Showcase API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Testing::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_tests()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/showcase/src/lib.rs
+++ b/src/generated/showcase/src/lib.rs
@@ -63,6 +63,19 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_showcase_v1beta1::client::Identity;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = Identity::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.get_user()
+///         .set_name(name)
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/spanner/admin/database/v1/src/client.rs
+++ b/src/generated/spanner/admin/database/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
-/// let client = DatabaseAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Spanner API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatabaseAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_databases()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/spanner/admin/database/v1/src/lib.rs
+++ b/src/generated/spanner/admin/database/v1/src/lib.rs
@@ -51,6 +51,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = DatabaseAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_databases()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/spanner/admin/instance/v1/src/client.rs
+++ b/src/generated/spanner/admin/instance/v1/src/client.rs
@@ -20,10 +20,17 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
-/// let client = InstanceAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Spanner API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instance_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -53,6 +53,22 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_spanner_admin_instance_v1::client::InstanceAdmin;
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = InstanceAdmin::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_instance_configs()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/generated/storagetransfer/v1/src/client.rs
+++ b/src/generated/storagetransfer/v1/src/client.rs
@@ -20,10 +20,20 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
-/// let client = StorageTransferService::builder().build().await?;
-/// // use `client` to make requests to the Storage Transfer API.
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_storagetransfer_v1::model::AgentPool;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageTransferService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_agent_pool()
+///         .set_agent_pool(
+///             AgentPool::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///

--- a/src/generated/storagetransfer/v1/src/lib.rs
+++ b/src/generated/storagetransfer/v1/src/lib.rs
@@ -51,6 +51,25 @@ pub use google_cloud_gax::error::Error;
 #[allow(rustdoc::redundant_explicit_links)]
 pub mod stub;
 
+///
+/// # Example
+/// ```
+/// # use google_cloud_storagetransfer_v1::client::StorageTransferService;
+/// # extern crate wkt as google_cloud_wkt;
+/// use google_cloud_wkt::FieldMask;
+/// use google_cloud_storagetransfer_v1::model::AgentPool;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = StorageTransferService::builder().build().await?;
+///     let name = "name_value";
+///     let response = client.update_agent_pool()
+///         .set_agent_pool(
+///             AgentPool::new().set_name(name)/* set fields */
+///         )
+///         .set_update_mask(FieldMask::default().set_paths(["updated.field.path1", "updated.field.path2"]))
+///         .send().await?;
+///     println!("response {:?}", response);
+/// # Ok(()) }
+/// ```
 /// Concrete implementations of this client library traits.
 pub mod client;
 

--- a/src/pubsub/src/generated/gapic/client.rs
+++ b/src/pubsub/src/generated/gapic/client.rs
@@ -20,10 +20,14 @@
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_pubsub::client::TopicAdmin;
-/// let client = TopicAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Pub/Sub API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = TopicAdmin::builder().build().await?;
+///     let topic = "topic_value";
+///     let response = client.get_topic()
+///         .set_topic(topic)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -307,10 +311,14 @@ impl TopicAdmin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_pubsub::client::SubscriptionAdmin;
-/// let client = SubscriptionAdmin::builder().build().await?;
-/// // use `client` to make requests to the Cloud Pub/Sub API.
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SubscriptionAdmin::builder().build().await?;
+///     let subscription = "subscription_value";
+///     let response = client.get_subscription()
+///         .set_subscription(subscription)
+///         .send().await?;
+///     println!("response {:?}", response);
 /// # Ok(()) }
 /// ```
 ///
@@ -729,10 +737,17 @@ impl SubscriptionAdmin {
 ///
 /// # Example
 /// ```
-/// # async fn sample() -> google_cloud_gax::client_builder::Result<()> {
 /// # use google_cloud_pubsub::client::SchemaService;
-/// let client = SchemaService::builder().build().await?;
-/// // use `client` to make requests to the Cloud Pub/Sub API.
+/// use google_cloud_gax::paginator::ItemPaginator as _;
+/// # async fn sample() -> Result<(), Box<dyn std::error::Error>> {
+///     let client = SchemaService::builder().build().await?;
+///     let parent = "parent_value";
+///     let mut list = client.list_schemas()
+///         .set_parent(parent)
+///         .by_item();
+///     while let Some(item) = list.next().await.transpose()? {
+///         println!("{:?}", item);
+///     }
 /// # Ok(()) }
 /// ```
 ///


### PR DESCRIPTION
Also overrides the package level QuickStart service in cases where the sidekick selected service has been skipped for generation in Rust, or is under a feature flag, etc.