### PR TITLE
chore(deps): update protoc in GCB scripts to v31.0

### DIFF
--- a/.gcb/scripts/coverage.sh
+++ b/.gcb/scripts/coverage.sh
@@ -20,8 +20,8 @@ rustup show active-toolchain -v
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
 echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
-sha256sum -c <(echo 0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f  /tmp/protoc.zip)
+curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
+sha256sum -c <(echo 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42 /tmp/protoc.zip)
 env -C /usr/local unzip -x /tmp/protoc.zip
 protoc --version
 

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -16,8 +16,8 @@
 set -ev
 
 echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
-sha256sum -c <(echo 0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f  /tmp/protoc.zip)
+curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
+sha256sum -c <(echo 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42 /tmp/protoc.zip)
 env -C /usr/local unzip -x /tmp/protoc.zip
 protoc --version
 

--- a/.gcb/scripts/test-ignored-samples.sh
+++ b/.gcb/scripts/test-ignored-samples.sh
@@ -17,8 +17,8 @@ set -ev
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
 echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip
-sha256sum -c <(echo 0ad949f04a6a174da83cdcbdb36dee0a4925272a5b6d83f79a6bf9852076d53f  /tmp/protoc.zip)
+curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
+sha256sum -c <(echo 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42 /tmp/protoc.zip)
 env -C /usr/local unzip -x /tmp/protoc.zip
 protoc --version
 


### PR DESCRIPTION
Updates the protoc zip file downloaded in three GCB scripts to v31.0, which we're hoping to align on for all languages using Librarian.
