### PR TITLE
test(integration-tests-discovery): missing feature

### DIFF
--- a/tests/discovery/Cargo.toml
+++ b/tests/discovery/Cargo.toml
@@ -42,7 +42,15 @@ tracing.workspace           = true
 
 [dependencies.google-cloud-compute-v1]
 workspace = true
-features  = ["images", "instances", "machine-types", "region-instances", "zone-operations", "zones"]
+features = [
+  "default-rustls-provider",
+  "images",
+  "instances",
+  "machine-types",
+  "region-instances",
+  "zone-operations",
+  "zones",
+]
 
 [lints]
 workspace = true


### PR DESCRIPTION
We need the default TLS provider to use `google-cloud-compute-v1`. Most of the time we run this with other tests, so the bug went unnoticed. When running `cargo test --features run-integration-tests -p integration-tests-discovery` the problem manifests itself.