### PR TITLE
fix(integration-tests-o11y): sensitive headers and gRPC

### DIFF
--- a/tests/o11y/src/auth.rs
+++ b/tests/o11y/src/auth.rs
@@ -103,10 +103,11 @@ async fn refresh_task(credentials: Credentials, tx: watch::Sender<Option<Metadat
             Ok(CacheableResource::New { entity_tag, data }) => {
                 let mut metadata = MetadataMap::new();
                 for (name, value) in data.iter() {
-                    if let (Ok(key), Ok(val)) = (
+                    if let (Ok(key), Ok(mut val)) = (
                         tonic::metadata::MetadataKey::from_bytes(name.as_str().as_bytes()),
                         tonic::metadata::MetadataValue::try_from(value.as_bytes()),
                     ) {
+                        val.set_sensitive(value.is_sensitive());
                         metadata.insert(key, val);
                     } else {
                         // Skip invalid headers. This can happen if the header name or value


### PR DESCRIPTION
When converting the auth headers to gRPC metadata we need to preserve any `is_sensitive()` properties in the header. That makes them safer in debug logs.