### PR TITLE
cleanup(guide): use `anyhow::Result<>` in samples

### DIFF
--- a/guide/samples/src/lib.rs
+++ b/guide/samples/src/lib.rs
@@ -15,8 +15,6 @@
 //! This crate contains a number of guides showing how to use the
 //! Google Cloud Client Libraries for Rust.
 
-pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-
 pub mod authentication;
 pub mod binding_errors;
 pub mod compute;

--- a/guide/samples/src/pagination/pagination_page_token.rs
+++ b/guide/samples/src/pagination/pagination_page_token.rs
@@ -17,7 +17,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = SecretManagerService::builder()
         .with_retry_policy(
             AlwaysRetry

--- a/guide/samples/src/pagination/paginator_iterate_items.rs
+++ b/guide/samples/src/pagination/paginator_iterate_items.rs
@@ -20,7 +20,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = SecretManagerService::builder()
         .with_retry_policy(
             AlwaysRetry

--- a/guide/samples/src/pagination/paginator_iterate_pages.rs
+++ b/guide/samples/src/pagination/paginator_iterate_pages.rs
@@ -20,7 +20,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = SecretManagerService::builder()
         .with_retry_policy(
             AlwaysRetry

--- a/guide/samples/src/pagination/paginator_stream_items.rs
+++ b/guide/samples/src/pagination/paginator_stream_items.rs
@@ -22,7 +22,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = SecretManagerService::builder()
         .with_retry_policy(
             AlwaysRetry

--- a/guide/samples/src/pagination/paginator_stream_pages.rs
+++ b/guide/samples/src/pagination/paginator_stream_pages.rs
@@ -20,7 +20,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = SecretManagerService::builder()
         .with_retry_policy(
             AlwaysRetry

--- a/guide/samples/src/retry_policies/client_retry.rs
+++ b/guide/samples/src/retry_policies/client_retry.rs
@@ -17,7 +17,7 @@ use google_cloud_gax::paginator::ItemPaginator as _;
 use google_cloud_gax::retry_policy::Aip194Strict;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     // [START rust_client_retry_client] ANCHOR: client-retry-client
     let client = SecretManagerService::builder()
         .with_retry_policy(Aip194Strict)

--- a/guide/samples/src/retry_policies/client_retry_full.rs
+++ b/guide/samples/src/retry_policies/client_retry_full.rs
@@ -19,7 +19,7 @@ use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use std::time::Duration;
 
-pub async fn sample(project_id: &str) -> crate::Result<()> {
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     // [START rust_client_retry_full_client] ANCHOR: client-retry-full-client
     let client = SecretManagerService::builder()
         .with_retry_policy(

--- a/guide/samples/src/retry_policies/request_retry.rs
+++ b/guide/samples/src/retry_policies/request_retry.rs
@@ -23,7 +23,7 @@ pub async fn sample(
     client: &SecretManagerService,
     project_id: &str,
     secret_id: &str,
-) -> crate::Result<()> {
+) -> anyhow::Result<()> {
     // [START rust_request_retry_request] ANCHOR: request-retry-request
     client
         .delete_secret()

--- a/guide/samples/tests/driver.rs
+++ b/guide/samples/tests/driver.rs
@@ -115,49 +115,49 @@ mod driver {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn pagination_iterate_pages() -> user_guide_samples::Result<()> {
+    async fn pagination_iterate_pages() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::pagination::paginator_iterate_pages::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn pagination_iterate_items() -> user_guide_samples::Result<()> {
+    async fn pagination_iterate_items() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::pagination::paginator_iterate_items::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn pagination_stream_pages() -> user_guide_samples::Result<()> {
+    async fn pagination_stream_pages() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::pagination::paginator_stream_pages::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn pagination_stream_items() -> user_guide_samples::Result<()> {
+    async fn pagination_stream_items() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::pagination::paginator_stream_items::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn pagination_page_token() -> user_guide_samples::Result<()> {
+    async fn pagination_page_token() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::pagination::pagination_page_token::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn retry_policies_client() -> user_guide_samples::Result<()> {
+    async fn retry_policies_client() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::retry_policies::client_retry::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn retry_policies_client_full() -> user_guide_samples::Result<()> {
+    async fn retry_policies_client_full() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         user_guide_samples::retry_policies::client_retry_full::sample(&project_id).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn retry_policies_request() -> user_guide_samples::Result<()> {
+    async fn retry_policies_request() -> anyhow::Result<()> {
         let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap();
         let secret_id: String = rand::rng()
             .sample_iter(&Alphanumeric)
@@ -180,7 +180,7 @@ mod driver {
     }
 
     #[tokio::test]
-    async fn error_handling_found() -> user_guide_samples::Result<()> {
+    async fn error_handling_found() -> anyhow::Result<()> {
         use google_cloud_gax::retry_policy::AlwaysRetry;
         use google_cloud_gax::retry_policy::RetryPolicyExt;
         use std::time::Duration;
@@ -229,7 +229,7 @@ mod driver {
     }
 
     #[tokio::test]
-    async fn error_handling_not_found() -> user_guide_samples::Result<()> {
+    async fn error_handling_not_found() -> anyhow::Result<()> {
         use google_cloud_gax::retry_policy::AlwaysRetry;
         use google_cloud_gax::retry_policy::RetryPolicyExt;
         use google_cloud_secretmanager_v1 as sm;
@@ -271,19 +271,19 @@ mod driver {
     }
 
     #[tokio::test]
-    async fn examine_error_details() -> user_guide_samples::Result<()> {
+    async fn examine_error_details() -> anyhow::Result<()> {
         user_guide_samples::examine_error_details::sample().await?;
         Ok(())
     }
 
     #[tokio::test]
-    async fn binding_fail() -> user_guide_samples::Result<()> {
+    async fn binding_fail() -> anyhow::Result<()> {
         user_guide_samples::binding_errors::binding_fail::sample().await?;
         Ok(())
     }
 
     #[tokio::test]
-    async fn binding_success() -> user_guide_samples::Result<()> {
+    async fn binding_success() -> anyhow::Result<()> {
         user_guide_samples::binding_errors::binding_success::sample().await?;
         Ok(())
     }


### PR DESCRIPTION
The samples are easier to understand if we use `anyhow::Result<>`. Using `crate::Result<>` forces the customer to open an extra file, which may not even be available in the context of devsite.