### PR TITLE
test(integration-tests-o11y): deflake span tests

### DIFF
--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -43,7 +43,11 @@ static CREDENTIALS: OnceCell<anyhow::Result<Credentials>> = OnceCell::const_new(
 /// Traces may take a few minutes to propagate from the collector endpoints to
 /// the service. This function retrieves the trace, polling if the trace is
 /// not found.
-pub async fn wait_for_trace(project_id: &str, trace_id: &str) -> anyhow::Result<Trace> {
+pub async fn wait_for_trace(
+    project_id: &str,
+    trace_id: &str,
+    required_spans: usize,
+) -> anyhow::Result<Trace> {
     let client = TraceService::builder().build().await?;
 
     // Because we are limited by quota, start with a backoff.
@@ -62,10 +66,14 @@ pub async fn wait_for_trace(project_id: &str, trace_id: &str) -> anyhow::Result<
             .send()
             .await
         {
-            Ok(t) => {
+            Ok(t) if t.spans.len() >= required_spans => {
                 trace = Some(t);
                 break;
             }
+            Ok(t) => println!(
+                "Trace found but only has {} spans, we want at least {required_spans}",
+                t.spans.len()
+            ),
             Err(e) => {
                 if let Some(status) = e.status() {
                     if status.code == Code::NotFound || status.code == Code::Internal {

--- a/tests/o11y/src/e2e/showcase.rs
+++ b/tests/o11y/src/e2e/showcase.rs
@@ -79,7 +79,11 @@ pub async fn run() -> anyhow::Result<()> {
     }
 
     // 5. Verify (Poll Cloud Trace API)
-    let trace = wait_for_trace(&project_id, &trace_id).await?;
+    let required = BTreeSet::from_iter([
+        ROOT_SPAN_NAME,
+        "google_cloud_showcase_v1beta1::client::Echo::echo",
+    ]);
+    let trace = wait_for_trace(&project_id, &trace_id, required.len()).await?;
 
     // Verify the expected spans appear in the trace:
     let span_names = trace
@@ -87,10 +91,6 @@ pub async fn run() -> anyhow::Result<()> {
         .iter()
         .map(|s| s.name.as_str())
         .collect::<BTreeSet<_>>();
-    let required = BTreeSet::from_iter([
-        ROOT_SPAN_NAME,
-        "google_cloud_showcase_v1beta1::client::Echo::echo",
-    ]);
     let missing = required.difference(&span_names).collect::<Vec<_>>();
     assert!(missing.is_empty(), "missing={missing:?}\n\n{trace:?}",);
 

--- a/tests/o11y/src/e2e/storage.rs
+++ b/tests/o11y/src/e2e/storage.rs
@@ -27,14 +27,6 @@ pub async fn run() -> anyhow::Result<()> {
     // Create a trace with a number of interesting spans from the
     // `google-cloud-storage` client.
     let trace_id = send_trace(&project_id).await?;
-    let trace = wait_for_trace(&project_id, &trace_id).await?;
-
-    // Verify the expected spans appear in the trace:
-    let span_names = trace
-        .spans
-        .iter()
-        .map(|s| s.name.as_str())
-        .collect::<BTreeSet<_>>();
     let required = BTreeSet::from_iter([
         ROOT_SPAN_NAME,
         "list_buckets",
@@ -48,6 +40,14 @@ pub async fn run() -> anyhow::Result<()> {
         "google_cloud_storage::client::Storage::write_object",
         "google_cloud_storage::client::Storage::open_object",
     ]);
+    let trace = wait_for_trace(&project_id, &trace_id, required.len() - 2).await?;
+
+    // Verify the expected spans appear in the trace:
+    let span_names = trace
+        .spans
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect::<BTreeSet<_>>();
     let missing = required.difference(&span_names).collect::<Vec<_>>();
     // Sometimes a few traces are not delivered and are reported as "missing":
     //   https://github.com/user-attachments/assets/7a534f6c-930e-4f97-b840-2ed01de2095e


### PR DESCRIPTION
Make sure enough spans, not just the trace, made it to Cloud Trace before declaring that we found the desired state.