### PR TITLE
test(gax-internal): deflake metrics test

### DIFF
--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -185,10 +185,9 @@ mod tests {
         check_scope(&metrics);
         check_data(
             &metrics,
-            // We cannot predict the exact value as other tests in the crate may
-            // be using the same same global meter provider. The remaining
-            // tests in this module take care of the counts, we can relax the
-            // conditions here.
+            // We cannot predict the exact value as other tests in the crate may be using the same
+            // global meter provider. The remaining tests in this module take care of the counts, we
+            // can relax the conditions here.
             1_u64..,
             &[
                 ("rpc.response.status_code", "UNKNOWN"),


### PR DESCRIPTION
Relax one of the test conditions to make the test not fail. Other tests cover the "value must be strictly 1" case, we can relax this test to be "value must be at least 1".

Fixes #4916 