### PR TITLE
test(integration-tests-o11y): fix flakes

### DIFF
--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -46,7 +46,7 @@ static CREDENTIALS: OnceCell<anyhow::Result<Credentials>> = OnceCell::const_new(
 pub async fn wait_for_trace(
     project_id: &str,
     trace_id: &str,
-    required_spans: usize,
+    required_spans: &std::collections::BTreeSet<&str>,
 ) -> anyhow::Result<Trace> {
     let client = TraceService::builder().build().await?;
 
@@ -66,14 +66,24 @@ pub async fn wait_for_trace(
             .send()
             .await
         {
-            Ok(t) if t.spans.len() >= required_spans => {
-                trace = Some(t);
-                break;
+            Ok(t) => {
+                let span_names = t
+                    .spans
+                    .iter()
+                    .map(|s| s.name.as_str())
+                    .collect::<std::collections::BTreeSet<_>>();
+                let missing = required_spans.difference(&span_names).collect::<Vec<_>>();
+                if missing.is_empty() {
+                    trace = Some(t);
+                    break;
+                } else {
+                    println!(
+                        "Trace found but is missing {} required spans: {:?}",
+                        missing.len(),
+                        missing
+                    );
+                }
             }
-            Ok(t) => println!(
-                "Trace found but only has {} spans, we want at least {required_spans}",
-                t.spans.len()
-            ),
             Err(e) => {
                 if let Some(status) = e.status() {
                     if status.code == Code::NotFound || status.code == Code::Internal {

--- a/tests/o11y/src/e2e/showcase.rs
+++ b/tests/o11y/src/e2e/showcase.rs
@@ -84,7 +84,7 @@ pub async fn run() -> anyhow::Result<()> {
         ROOT_SPAN_NAME,
         "google_cloud_showcase_v1beta1::client::Echo::echo",
     ]);
-    let trace = wait_for_trace(&project_id, &trace_id, required.len()).await?;
+    let trace = wait_for_trace(&project_id, &trace_id, &required).await?;
 
     // Verify the expected spans appear in the trace:
     let span_names = trace

--- a/tests/o11y/src/e2e/storage.rs
+++ b/tests/o11y/src/e2e/storage.rs
@@ -29,7 +29,6 @@ pub async fn run() -> anyhow::Result<()> {
     let trace_id = send_trace(&project_id).await?;
     let required = BTreeSet::from_iter([
         ROOT_SPAN_NAME,
-        "list_buckets",
         "google.storage.v2.Storage/ListBuckets",
         "create_bucket",
         "google.storage.v2.Storage/CreateBucket",
@@ -55,7 +54,7 @@ pub async fn run() -> anyhow::Result<()> {
         "delete_bucket",
         "google.storage.v2.Storage/DeleteBucket",
     ]);
-    let trace = wait_for_trace(&project_id, &trace_id, required.len()).await?;
+    let trace = wait_for_trace(&project_id, &trace_id, &required).await?;
 
     // Verify the expected spans appear in the trace:
     let span_names = trace


### PR DESCRIPTION
#### Using `enter` across `await`s is a problem, because the span is stored in TLS.

See https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code

#### Improve "wait" to wait for specific spans instead of a span count.


#### Remove debug span list_buckets from expectations.

This span is consistently dropped, likely because it is large (~130k of OTLP data).  It (an event attached to it) contains the full response data from the listbuckets request which can be quite large.

A sufficient e2e test for debug level spans (those that include self and ret) would be to enable tracing, set RUSTLOGS=debug and make sure they are visible in console-printed tracing output.

Ideally we update the generated clients with our new Client Request traces.  I think the next best thing is to remove our expectation from tests to tighten them up.