### PR TITLE
test(guide): deflake `id_token` driver

### DIFF
--- a/guide/samples/src/authentication.rs
+++ b/guide/samples/src/authentication.rs
@@ -21,6 +21,8 @@ pub mod impersonation;
 pub mod request_id_token;
 pub mod verify_id_token;
 
+use std::time::Duration;
+
 use google_cloud_auth::credentials::idtoken::Builder as IdTokenBuilder;
 use google_cloud_gax::error::rpc::{Code, StatusDetails};
 use httptest::{Expectation, Server, matchers::*, responders::*};
@@ -77,6 +79,13 @@ pub async fn drive_id_token() -> anyhow::Result<()> {
     );
 
     let target_url = server.url("/").to_string();
-    request_id_token::api_call_with_id_token(&target_url, &credentials).await?;
-    Ok(())
+    let mut last_error = Ok(());
+    for delay in [0, 100, 200, 400] {
+        tokio::time::sleep(Duration::from_millis(delay)).await;
+        match request_id_token::api_call_with_id_token(&target_url, &credentials).await {
+            Ok(_) => break,
+            Err(e) => last_error = Err(e),
+        }
+    }
+    last_error
 }

--- a/guide/samples/src/authentication/request_id_token.rs
+++ b/guide/samples/src/authentication/request_id_token.rs
@@ -28,7 +28,8 @@ pub async fn sample(audience: &str) -> anyhow::Result<String> {
 
     // [START rust_auth_request_id_token_call] ANCHOR: request_id_token_call
     let id_token = credentials.id_token().await?;
-    println!("ID Token: {id_token:?}");
+    let censored = &id_token[0..32];
+    println!("ID Token starts with: {censored:?}");
     // [END rust_auth_request_id_token_call] ANCHOR_END: request_id_token_call
     Ok(id_token)
 }


### PR DESCRIPTION
The driver creates an http server to verify the code can correctly contact it. The server may not be ready on the first attempt. Use a little retry loop to avoid flakes.

I noticed this in:

https://pantheon.corp.google.com/cloud-build/builds;region=us-central1/1c77aaae-a447-404f-a895-3a0bfefbac36?project=rust-sdk-testing&e=SqlStudioMysqlLaunch::SqlStudioMysqlEnabled&mods=allow_workbench_image_override
