### PR TITLE
cleanup(pubsub): rename ClientBuilder to BasePublisherBuilder

### DIFF
--- a/src/pubsub/src/publisher/base_publisher.rs
+++ b/src/pubsub/src/publisher/base_publisher.rs
@@ -45,20 +45,7 @@ pub struct BasePublisher {
     pub(crate) inner: crate::generated::gapic_dataplane::client::Publisher,
 }
 
-/// A builder for [BasePublisher].
-///
-/// ```
-/// # async fn sample() -> anyhow::Result<()> {
-/// # use google_cloud_pubsub::*;
-/// # use builder::publisher::BasePublisherBuilder;
-/// # use google_cloud_pubsub::client::BasePublisher;
-/// let builder: BasePublisherBuilder = BasePublisher::builder();
-/// let client = builder
-///     .with_endpoint("https://pubsub.googleapis.com")
-///     .build().await?;
-/// # Ok(()) }
-/// ```
-pub use super::client_builder::ClientBuilder as BasePublisherBuilder;
+pub use super::client_builder::BasePublisherBuilder;
 
 impl BasePublisher {
     /// Returns a builder for [BasePublisher].

--- a/src/pubsub/src/publisher/client_builder.rs
+++ b/src/pubsub/src/publisher/client_builder.rs
@@ -19,7 +19,7 @@ use google_cloud_gax::client_builder::Result as BuilderResult;
 use google_cloud_gax::retry_policy::RetryPolicyArg;
 use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 
-/// A builder for [BasePublisher].
+/// A builder for [`BasePublisher`].
 ///
 /// # Example
 /// ```
@@ -33,11 +33,11 @@ use google_cloud_gax::retry_throttler::RetryThrottlerArg;
 /// # Ok(()) }
 /// ```
 #[derive(Clone, Debug)]
-pub struct ClientBuilder {
+pub struct BasePublisherBuilder {
     pub(super) config: ClientConfig,
 }
 
-impl ClientBuilder {
+impl BasePublisherBuilder {
     pub(super) fn new() -> Self {
         let mut config = ClientConfig::default();
         config.backoff_policy = Some(std::sync::Arc::new(
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn defaults() -> anyhow::Result<()> {
-        let builder = ClientBuilder::new();
+        let builder = BasePublisherBuilder::new();
         assert!(builder.config.endpoint.is_none(), "{builder:?}");
         assert!(builder.config.cred.is_none(), "{builder:?}");
         assert!(!builder.config.tracing);
@@ -266,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn setters() -> anyhow::Result<()> {
         use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
-        let builder = ClientBuilder::new()
+        let builder = BasePublisherBuilder::new()
             .with_endpoint("test-endpoint.com")
             .with_credentials(Anonymous::new().build())
             .with_tracing()


### PR DESCRIPTION
Re-exporting the BasePublisherBuilder under a different name led to some slight confusion in the docs where the impl block used the original name. Update the naming to clean this up.