### PR TITLE
test(gax-internal): disable flaky test

### DIFF
--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -162,6 +162,7 @@ mod tests {
     // This is in the middle of the [0.5, 1.0) bucket defined in `boundaries`.
     const DELAY: Duration = Duration::from_millis(750);
 
+    #[ignore = "TODO(#4916) - disabled because it is flaky"]
     #[tokio::test(start_paused = true)]
     async fn global_record_error() -> anyhow::Result<()> {
         let exporter = InMemoryMetricExporter::default();


### PR DESCRIPTION
Related to #4916 . Disabled the test while we find a better solution.
