### PR TITLE
impl(gax-internal): set the client span error attributes

### DIFF
--- a/src/gax-internal/src/observability/client_signals/with_client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_signals.rs
@@ -19,10 +19,17 @@
 use super::DurationMetric;
 use super::RequestStart;
 use crate::observability::attributes::RPC_SYSTEM_HTTP;
-use crate::observability::attributes::keys::{RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME};
+use crate::observability::attributes::keys::OTEL_STATUS_DESCRIPTION;
+use crate::observability::attributes::keys::{
+    OTEL_STATUS_CODE, RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
+};
+use crate::observability::attributes::otel_status_codes;
+use crate::observability::errors::ErrorType;
 use google_cloud_gax::error::Error;
 use google_cloud_gax::error::rpc::Code;
-use opentelemetry_semantic_conventions::attribute;
+use opentelemetry_semantic_conventions::attribute::{
+    ERROR_TYPE, HTTP_RESPONSE_STATUS_CODE, RPC_METHOD, URL_DOMAIN, URL_TEMPLATE,
+};
 use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
@@ -108,10 +115,20 @@ where
         let this = self.project();
         let output = futures::ready!(this.inner.poll(cx));
         // Record the metric and log the value in the context of the span.
-        let _enter = span.entered();
+        let span = span.entered();
         match &output {
-            Ok(_) => this.metric.record_ok(&this.start),
+            Ok(_) => {
+                span.record(OTEL_STATUS_CODE, otel_status_codes::OK);
+                this.metric.record_ok(&this.start)
+            }
             Err(error) => {
+                let error_type = ErrorType::from_gax_error(error);
+                tracing::record_all!(
+                    span,
+                    { OTEL_STATUS_CODE } = otel_status_codes::ERROR,
+                    { OTEL_STATUS_DESCRIPTION } = error.to_string(),
+                    { ERROR_TYPE } = error_type.as_str()
+                );
                 let rpc_status_code = error
                     .status()
                     .map(|s| s.code.name())
@@ -123,11 +140,11 @@ where
                         target: TARGET,
                         tracing::Level::ERROR,
                         { RPC_SYSTEM_NAME } = RPC_SYSTEM_HTTP,
-                        { attribute::URL_DOMAIN } = this.start.info().default_host,
-                        { attribute::URL_TEMPLATE } = this.start.url_template(),
-                        { attribute::RPC_METHOD } = this.start.method(),
+                        { URL_DOMAIN } = this.start.info().default_host,
+                        { URL_TEMPLATE } = this.start.url_template(),
+                        { RPC_METHOD } = this.start.method(),
                         { RPC_RESPONSE_STATUS_CODE } = rpc_status_code,
-                        { attribute::HTTP_RESPONSE_STATUS_CODE } = http_code,
+                        { HTTP_RESPONSE_STATUS_CODE } = http_code,
                         "{error:?}"
                     );
                 } else {
@@ -136,9 +153,9 @@ where
                         target: TARGET,
                         tracing::Level::ERROR,
                         { RPC_SYSTEM_NAME } = RPC_SYSTEM_HTTP,
-                        { attribute::URL_DOMAIN } = this.start.info().default_host,
-                        { attribute::URL_TEMPLATE } = this.start.url_template(),
-                        { attribute::RPC_METHOD } = this.start.method(),
+                        { URL_DOMAIN } = this.start.info().default_host,
+                        { URL_TEMPLATE } = this.start.url_template(),
+                        { RPC_METHOD } = this.start.method(),
                         { RPC_RESPONSE_STATUS_CODE } = rpc_status_code,
                         "{error:?}"
                     );
@@ -158,9 +175,11 @@ mod tests {
     use google_cloud_gax::error::rpc::Status;
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-    use opentelemetry::TraceId;
-    use opentelemetry::trace::TraceContextExt;
+    use opentelemetry::trace::{Status as TraceStatus, TraceContextExt};
+    use opentelemetry::{TraceId, Value};
     use opentelemetry_sdk::logs::{InMemoryLogExporter, SdkLoggerProvider};
+    use opentelemetry_sdk::trace::SpanData;
+    use std::collections::BTreeSet;
     use std::future::ready;
     use tracing::subscriber::DefaultGuard;
     use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -168,9 +187,15 @@ mod tests {
     // The tests run serially because the tracing subscriber is global, yuck.
     #[tokio::test(start_paused = true)]
     async fn poll_ok() -> anyhow::Result<()> {
-        let (exporter, provider, _guard) = init_logger();
+        let providers = SignalProviders::new();
 
-        let span = tracing::info_span!("test-span");
+        let span = tracing::info_span!(
+            "client_request",
+            // Fields to be recorded later
+            { OTEL_STATUS_CODE } = ::tracing::field::Empty,
+            { ERROR_TYPE } = ::tracing::field::Empty,
+            { OTEL_STATUS_DESCRIPTION } = ::tracing::field::Empty
+        );
         let metric = DurationMetric::new(&TEST_INFO);
         let options = RequestOptions::default().insert_extension(PathTemplate(URL_TEMPLATE));
         let start = RequestStart::new(&TEST_INFO, &options, METHOD);
@@ -181,13 +206,31 @@ mod tests {
             matches!(result, Ok(ref s) if s == "hello world"),
             "{result:?}"
         );
+        let trace_id = trace_id(&span);
 
-        provider.force_flush()?;
-        let logs = exporter.get_emitted_logs()?;
+        drop(span);
+        providers.force_flush()?;
+        let logs = providers.logs_exporter.get_emitted_logs()?;
         let record = logs
             .iter()
             .find(|r| r.record.target().is_some_and(|v| v == TARGET));
         assert!(record.is_none(), "{record:?}\nlogs={logs:#?}");
+
+        let captured = providers.trace_exporter.get_finished_spans()?;
+        let span = match &captured[..] {
+            [s] => s,
+            _ => panic!("expected exactly one span, got={captured:?}"),
+        };
+        // The tracing-opentelemetry subscriber converts `otel.status_code` and
+        // `otel.status_description` into `span.status`.
+        assert_eq!(span.status, TraceStatus::Ok);
+        check_span(span, trace_id, &[]);
+        let found = span
+            .attributes
+            .iter()
+            .find(|kv| kv.key.as_str() == ERROR_TYPE);
+        assert!(found.is_none(), "{found:?}");
+
         Ok(())
     }
 
@@ -222,10 +265,16 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn poll_err() -> anyhow::Result<()> {
-        let (exporter, provider, _guard) = init_logger();
+        let providers = SignalProviders::new();
 
-        let span = crate::client_request_span!("TestClient", "test_method", &TEST_INFO);
-        let _enter = span.enter();
+        let span = tracing::info_span!(
+            "client_request",
+            // Fields to be recorded later
+            { OTEL_STATUS_CODE } = ::tracing::field::Empty,
+            { ERROR_TYPE } = ::tracing::field::Empty,
+            { OTEL_STATUS_DESCRIPTION } = ::tracing::field::Empty
+        );
+        let trace_id = trace_id(&span);
         let metric = DurationMetric::new(&TEST_INFO);
         let options = RequestOptions::default().insert_extension(PathTemplate(URL_TEMPLATE));
         let start = RequestStart::new(&TEST_INFO, &options, METHOD);
@@ -237,49 +286,73 @@ mod tests {
             "{result:?}"
         );
 
-        provider.force_flush()?;
-        let captured = exporter.get_emitted_logs()?;
+        drop(span);
+        providers.force_flush()?;
+        let captured = providers.logs_exporter.get_emitted_logs()?;
         let record = captured
             .iter()
             .find(|r| r.record.target().is_some_and(|v| v == TARGET))
             .unwrap_or_else(|| panic!("missing log for target {TARGET} in {captured:#?}"));
         check_log_record(
             &record.record,
-            trace_id(&span),
+            trace_id,
             &[
                 ("rpc.method", METHOD),
                 ("rpc.response.status_code", "NOT_FOUND"),
             ],
         );
 
+        let captured = providers.trace_exporter.get_finished_spans()?;
+        let span = match &captured[..] {
+            [s] => s,
+            _ => panic!("expected exactly one span, got={captured:?}"),
+        };
+        // The tracing-opentelemetry subscriber converts `otel.status_code` and
+        // `otel.status_description` into `span.status`.
+        assert_eq!(
+            span.status,
+            TraceStatus::Error {
+                description: not_found().to_string().into()
+            }
+        );
+        check_span(span, trace_id, &[("error.type", "NOT_FOUND")]);
+
         Ok(())
     }
 
     #[tokio::test(start_paused = true)]
     async fn poll_err_http() -> anyhow::Result<()> {
-        let (exporter, provider, _guard) = init_logger();
+        let providers = SignalProviders::new();
 
-        let span = tracing::info_span!("test-span");
+        let span = tracing::info_span!(
+            "client_request",
+            // Fields to be recorded later
+            { OTEL_STATUS_CODE } = ::tracing::field::Empty,
+            { ERROR_TYPE } = ::tracing::field::Empty,
+            { OTEL_STATUS_DESCRIPTION } = ::tracing::field::Empty
+        );
+        let trace_id = trace_id(&span);
         let metric = DurationMetric::new(&TEST_INFO);
         let options = RequestOptions::default().insert_extension(PathTemplate(URL_TEMPLATE));
         let start = RequestStart::new(&TEST_INFO, &options, METHOD);
         let future = ready(Err::<String, Error>(http_too_many_requests()));
-        let future = WithClientSignals::new(future, metric.clone(), start, span.clone());
+        let future = WithClientSignals::new(future, metric.clone(), start, span);
         let result = future.await;
         assert!(
             matches!(result, Err(ref e) if e.http_status_code() == http_too_many_requests().http_status_code()),
             "{result:?}"
         );
 
-        provider.force_flush()?;
-        let captured = exporter.get_emitted_logs()?;
+        providers.force_flush()?;
+
+        let captured = providers.logs_exporter.get_emitted_logs()?;
         let record = captured
             .iter()
             .find(|r| r.record.target().is_some_and(|v| v == TARGET))
             .unwrap_or_else(|| panic!("missing log for target {TARGET} in {captured:#?}"));
         check_log_record(
             &record.record,
-            trace_id(&span),
+            trace_id,
             &[
                 ("rpc.method", METHOD),
                 ("rpc.response.status_code", "UNKNOWN"),
@@ -287,7 +360,56 @@ mod tests {
             ],
         );
 
+        let captured = providers.trace_exporter.get_finished_spans()?;
+        let span = match &captured[..] {
+            [s] => s,
+            _ => panic!("expected exactly one span, got={captured:?}"),
+        };
+        // The tracing-opentelemetry subscriber converts `otel.status_code` and
+        // `otel.status_description` into `span.status`.
+        assert_eq!(
+            span.status,
+            TraceStatus::Error {
+                description: http_too_many_requests().to_string().into()
+            }
+        );
+        check_span(span, trace_id, &[("error.type", "429")]);
+
         Ok(())
+    }
+
+    #[track_caller]
+    pub fn check_span(
+        data: &SpanData,
+        trace_id: TraceId,
+        attributes: &[(&'static str, &'static str)],
+    ) {
+        fn format_value(value: &Value) -> String {
+            match value {
+                Value::Bool(v) => v.to_string(),
+                Value::I64(v) => v.to_string(),
+                Value::F64(v) => v.to_string(),
+                Value::String(v) => v.to_string(),
+                _ => "unexpected Value variant".to_string(),
+            }
+        }
+        assert_eq!(data.span_context.trace_id(), trace_id, "{data:?}");
+        let unsorted = data
+            .attributes
+            .iter()
+            .map(|kv| (kv.key.as_str(), format_value(&kv.value)))
+            .collect::<Vec<_>>();
+        let got = BTreeSet::from_iter(
+            data.attributes
+                .iter()
+                .map(|kv| (kv.key.as_str(), format_value(&kv.value))),
+        );
+        let want = BTreeSet::from_iter(attributes.iter().map(|(k, v)| (*k, v.to_string())));
+        let missing = want.difference(&got).collect::<Vec<_>>();
+        assert!(
+            missing.is_empty(),
+            "missing = {missing:?}\nwant = {want:?}\ngot  = {got:?}\nunsorted = {unsorted:?}\nspan = {data:?}"
+        );
     }
 
     fn trace_id(span: &Span) -> TraceId {


### PR DESCRIPTION
Part of the work for #4924 adds some missing fields to the client request spans.
