### PR TITLE
chore(storage): fix benchmark builds and README

### DIFF
--- a/src/storage/benchmarks/random/Cargo.toml
+++ b/src/storage/benchmarks/random/Cargo.toml
@@ -27,23 +27,23 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-anyhow.workspace               = true
-bytes.workspace                = true
-clap                           = { workspace = true, features = ["derive", "help", "std", "usage"] }
-futures.workspace              = true
-google-cloud-auth.workspace    = true
-google-cloud-gax.workspace     = true
-google-cloud-storage.workspace = true
-humantime.workspace            = true
-parse-size.workspace           = true
-pin-project.workspace          = true
-rand.workspace                 = true
-regex.workspace                = true
-tokio                          = { workspace = true, features = ["macros"] }
-tokio-metrics                  = { workspace = true, features = ["rt"] }
-tracing.workspace              = true
-tracing-log                    = { workspace = true, features = ["log-tracer", "std"] }
-tracing-subscriber             = { workspace = true, features = ["fmt", "std"] }
+anyhow.workspace            = true
+bytes.workspace             = true
+clap                        = { workspace = true, features = ["derive", "help", "std", "usage"] }
+futures.workspace           = true
+google-cloud-auth.workspace = true
+google-cloud-gax.workspace  = true
+google-cloud-storage        = { workspace = true, features = ["default-rustls-provider"] }
+humantime.workspace         = true
+parse-size.workspace        = true
+pin-project.workspace       = true
+rand.workspace              = true
+regex.workspace             = true
+tokio                       = { workspace = true, features = ["macros"] }
+tokio-metrics               = { workspace = true, features = ["rt"] }
+tracing.workspace           = true
+tracing-log                 = { workspace = true, features = ["log-tracer", "std"] }
+tracing-subscriber          = { workspace = true, features = ["fmt", "std"] }
 
 [dev-dependencies]
 test-case.workspace = true

--- a/src/storage/benchmarks/random/README.md
+++ b/src/storage/benchmarks/random/README.md
@@ -38,10 +38,9 @@ Start the program and use different files for `stdout` vs. `stderr`:
 ```shell
 TS=$(date +%s); cargo run --release --package storage-random -- \
     --bucket-name ${BUCKET_NAME} \
-    --min-range-size 8KiB --max-range-size 8KiB \
-    --min-batch-size 16 --max-batch-size 16 \
+    --range-size 8KiB \
     --task-count=4 \
-    --min-sample-count=1000 bidi  >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
+    bidi  >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
 ```
 
 Wait for the program to finish.

--- a/src/storage/benchmarks/w1r3/Cargo.toml
+++ b/src/storage/benchmarks/w1r3/Cargo.toml
@@ -24,20 +24,20 @@ keywords.workspace   = true
 categories.workspace = true
 
 [dependencies]
-anyhow.workspace               = true
-bytes.workspace                = true
-clap                           = { workspace = true, features = ["derive", "help", "std", "usage"] }
-futures.workspace              = true
-google-cloud-auth.workspace    = true
-google-cloud-gax.workspace     = true
-google-cloud-storage.workspace = true
-humantime.workspace            = true
-parse-size.workspace           = true
-pin-project.workspace          = true
-rand.workspace                 = true
-regex.workspace                = true
-tokio                          = { workspace = true, features = ["macros"] }
-tokio-metrics                  = { workspace = true, features = ["rt"] }
-tracing.workspace              = true
-tracing-log                    = { workspace = true, features = ["log-tracer", "std"] }
-tracing-subscriber             = { workspace = true, features = ["fmt", "std"] }
+anyhow.workspace            = true
+bytes.workspace             = true
+clap                        = { workspace = true, features = ["derive", "help", "std", "usage"] }
+futures.workspace           = true
+google-cloud-auth.workspace = true
+google-cloud-gax.workspace  = true
+google-cloud-storage        = { workspace = true, features = ["default-rustls-provider"] }
+humantime.workspace         = true
+parse-size.workspace        = true
+pin-project.workspace       = true
+rand.workspace              = true
+regex.workspace             = true
+tokio                       = { workspace = true, features = ["macros"] }
+tokio-metrics               = { workspace = true, features = ["rt"] }
+tracing.workspace           = true
+tracing-log                 = { workspace = true, features = ["log-tracer", "std"] }
+tracing-subscriber          = { workspace = true, features = ["fmt", "std"] }

--- a/src/storage/benchmarks/w1r3/README.md
+++ b/src/storage/benchmarks/w1r3/README.md
@@ -37,7 +37,7 @@ Start the program and use different files for `stdout` vs. `stderr`:
 ```shell
 TS=$(date +%s); cargo run --release --package storage-w1r3 -- \
     --bucket-name ${BUCKET_NAME} --max-object-size 128KiB --task-count=4 \
-    --min-sample-count=1000  >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
+    >bm-${TS}.txt 2>bm-${TS}.log </dev/null &
 ```
 
 Wait for the program to finish.


### PR DESCRIPTION
Enable the 'default-rustls-provider' feature for the 'google-cloud-storage' dependency in the `random` and `w1r3` benchmarks.
Also update the README documentation to remove obsolete parameters like '--min-sample-count' and '--min-batch-size'.