### PR TITLE
cleanup(pubsub): not for the reference docs

### DIFF
--- a/src/pubsub/src/subscriber/client.rs
+++ b/src/pubsub/src/subscriber/client.rs
@@ -84,17 +84,8 @@ use std::sync::Arc;
 /// an [Rc](std::rc::Rc) or [Arc] to reuse it, because it already uses an `Arc`
 /// internally.
 ///
-/// # Troubleshooting
-///
-/// At the moment, the `Subscriber` is opaque. It is not possible to locally
-/// examine the performance (e.g. successful acknowledgements per second).
-///
-/// The best view into its performance is via the Cloud Console. There, you can
-/// [monitor subscriptions within Pub/Sub].
-///
 /// [application default credentials]: https://cloud.google.com/docs/authentication#adc
 /// [cloud pub/sub]: https://docs.cloud.google.com/pubsub/docs/overview
-/// [monitor subscriptions within pub/sub]: https://docs.cloud.google.com/pubsub/docs/monitor-subscription
 /// [private google access with vpc service controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
 /// [pull subscription]: https://docs.cloud.google.com/pubsub/docs/pull
 /// [with_endpoint()]: ClientBuilder::with_endpoint

--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -248,15 +248,12 @@ impl ExactlyOnce {
     /// }
     /// ```
     ///
-    /// If the result is `Ok`, the message is guaranteed not to be delivered
-    /// again. You can safely delete any state associated with the message.
+    /// If the result is an `Ok`, the message is guaranteed not to be delivered
+    /// again.
     ///
-    /// Errors may trigger message redelivery. You should refer to the specific
-    /// error type to determine if redelivery is guaranteed.
-    ///
-    /// If no redelivery occurs a sufficient interval after an error, the
-    /// acknowledgement likely succeeded. At this point, you can garbage collect
-    /// any state associated with the message.
+    /// If the result is an `Err`, the message may be redelivered, but this is
+    /// not guaranteed. If no redelivery occurs a sufficient interval after an
+    /// error, the acknowledgement likely succeeded.
     pub async fn confirmed_ack(mut self) -> AckResult {
         let inner = self.inner.take().expect("handler impl is always some");
         inner.confirmed_ack().await


### PR DESCRIPTION
We identified this stuff as "not for the reference docs". I have items in #3636 for them.