### PR TITLE
docs(pubsub): add into_stream example

### DIFF
--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -205,8 +205,8 @@ impl MessageStream {
     /// ```
     /// # use google_cloud_pubsub::subscriber::MessageStream;
     /// # async fn sample(stream: MessageStream) -> anyhow::Result<()> {
-    /// use futures::Stream::TryStreamExt;
-    /// let stream = stream.into_stream();
+    /// use futures::TryStreamExt;
+    /// let mut stream = stream.into_stream();
     /// while let Some((m, h)) = stream.try_next().await? { /* ... */ }
     /// # Ok(()) }
     /// ```


### PR DESCRIPTION
Part of the work for #4508 

Add an example for `MessageStream::into_stream()`.