### PR TITLE
impl(auth): mark access boundaries unstable

### DIFF
--- a/src/auth/src/access_boundary.rs
+++ b/src/auth/src/access_boundary.rs
@@ -631,14 +631,12 @@ pub(crate) mod tests {
     use super::*;
     use crate::credentials::tests::{get_access_boundary_from_headers, get_token_from_headers};
     use crate::credentials::{AccessToken, EntityTag};
-    use crate::mds::MDS_DEFAULT_URI;
     use http::header::{AUTHORIZATION, HeaderValue};
     use http::{Extensions, HeaderMap};
     use httptest::{Expectation, Server, cycle, matchers::*, responders::*};
     use serde_json::json;
     use serial_test::parallel;
     use test_case::test_case;
-    use tokio::sync::Mutex;
 
     type TestResult = anyhow::Result<()>;
 
@@ -753,6 +751,8 @@ pub(crate) mod tests {
     #[parallel]
     #[cfg(google_cloud_unstable_trusted_boundaries)]
     async fn test_fetch_access_boundary_mds_success() -> TestResult {
+        use crate::mds::MDS_DEFAULT_URI;
+
         let server = Server::run();
         server.expect(
             Expectation::matching(request::method_path(
@@ -1049,6 +1049,7 @@ pub(crate) mod tests {
 
     #[tokio::test(start_paused = true)]
     #[parallel]
+    #[cfg(google_cloud_unstable_trusted_boundaries)]
     async fn test_entity_tag_caching_behavior() -> TestResult {
         let mut mock_creds = MockCredentials::new();
         let latest_token_etag = Arc::new(std::sync::RwLock::new(EntityTag::new()));
@@ -1079,7 +1080,7 @@ pub(crate) mod tests {
         let creds = CredentialsWithAccessBoundary {
             credentials: Arc::new(mock_creds),
             access_boundary: Arc::new(access_boundary),
-            cache: Arc::new(Mutex::new(EntityTagCache::new())),
+            cache: Arc::new(tokio::sync::Mutex::new(EntityTagCache::new())),
         };
 
         // First call - no tag yet

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -706,7 +706,7 @@ impl Builder {
         self
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, google_cloud_unstable_trusted_boundaries))]
     fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
         self.iam_endpoint_override = iam_endpoint_override;
         self
@@ -1441,7 +1441,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
     use crate::constants::{
         ACCESS_TOKEN_TYPE, DEFAULT_SCOPE, JWT_TOKEN_TYPE, TOKEN_EXCHANGE_GRANT_TYPE,
     };
@@ -1449,8 +1448,8 @@ mod tests {
         Builder as SubjectTokenBuilder, SubjectToken, SubjectTokenProvider,
     };
     use crate::credentials::tests::{
-        find_source_error, get_access_boundary_from_headers, get_mock_auth_retry_policy,
-        get_mock_backoff_policy, get_mock_retry_throttler, get_token_from_headers,
+        find_source_error, get_mock_auth_retry_policy, get_mock_backoff_policy,
+        get_mock_retry_throttler, get_token_from_headers,
     };
     use crate::errors::{CredentialsError, SubjectTokenProviderError};
     use httptest::{
@@ -2309,7 +2308,9 @@ mod tests {
     )]
     #[tokio::test]
     #[cfg(google_cloud_unstable_trusted_boundaries)]
-    async fn e2e_access_boundary(audience: &str, iam_path: &str) -> TestResult {
+    async fn e2e_access_boundary(audience: &str, iam_path: &str) -> anyhow::Result<()> {
+        use crate::credentials::tests::get_access_boundary_from_headers;
+
         let audience = audience.to_string();
         let iam_path = iam_path.to_string();
 

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -882,9 +882,7 @@ struct GenerateAccessTokenResponse {
 mod tests {
     use super::*;
     use crate::credentials::service_account::ServiceAccountKey;
-    use crate::credentials::tests::{
-        PKCS8_PK, get_access_boundary_from_headers, get_token_from_headers,
-    };
+    use crate::credentials::tests::PKCS8_PK;
     use crate::credentials::tests::{
         find_source_error, get_mock_auth_retry_policy, get_mock_backoff_policy,
         get_mock_retry_throttler,
@@ -2319,6 +2317,7 @@ mod tests {
     #[parallel]
     #[cfg(google_cloud_unstable_trusted_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
+        use crate::credentials::tests::{get_access_boundary_from_headers, get_token_from_headers};
         let server = Server::run();
         server.expect(
             Expectation::matching(request::method_path("POST", "/token"))

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -474,7 +474,6 @@ mod tests {
     use super::*;
     use crate::credentials::DEFAULT_UNIVERSE_DOMAIN;
     use crate::credentials::QUOTA_PROJECT_KEY;
-    use crate::credentials::tests::get_access_boundary_from_headers;
     use crate::credentials::tests::{
         find_source_error, get_headers_from_cache, get_mock_auth_retry_policy,
         get_mock_backoff_policy, get_mock_retry_throttler, get_token_from_headers,
@@ -1008,6 +1007,7 @@ mod tests {
         let mdsc = Builder::default()
             .with_endpoint(format!("http://{}", server.addr()))
             .with_scopes(scopes)
+            .without_access_boundary()
             .build()?;
         let err = mdsc.headers(Extensions::new()).await.unwrap_err();
         let original_err = find_source_error::<CredentialsError>(&err).unwrap();
@@ -1037,6 +1037,7 @@ mod tests {
         let mdsc = Builder::default()
             .with_endpoint(format!("http://{}", server.addr()))
             .with_scopes(scopes)
+            .without_access_boundary()
             .build()?;
 
         let err = mdsc.headers(Extensions::new()).await.unwrap_err();
@@ -1067,6 +1068,7 @@ mod tests {
         let mdsc = Builder::default()
             .with_endpoint(format!("http://{}", server.addr()))
             .with_scopes(scopes)
+            .without_access_boundary()
             .build()?;
 
         let e = mdsc.headers(Extensions::new()).await.err().unwrap();
@@ -1133,6 +1135,8 @@ mod tests {
     #[parallel]
     #[cfg(google_cloud_unstable_trusted_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
+        use crate::credentials::tests::get_access_boundary_from_headers;
+
         let server = Server::run();
         server.expect(
             Expectation::matching(all_of![request::path(format!("{MDS_DEFAULT_URI}/token")),])

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -266,7 +266,7 @@ impl Builder {
         self
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, google_cloud_unstable_trusted_boundaries))]
     fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
         self.iam_endpoint_override = iam_endpoint_override;
         self
@@ -622,14 +622,11 @@ mod tests {
     use super::*;
     use crate::credentials::QUOTA_PROJECT_KEY;
     use crate::credentials::tests::{
-        PKCS8_PK, b64_decode_to_json, get_access_boundary_from_headers, get_headers_from_cache,
-        get_token_from_headers,
+        PKCS8_PK, b64_decode_to_json, get_headers_from_cache, get_token_from_headers,
     };
     use crate::token::tests::MockTokenProvider;
     use http::HeaderValue;
     use http::header::AUTHORIZATION;
-    use httptest::responders::json_encoded;
-    use httptest::{Expectation, Server, matchers::*};
     use rsa::pkcs1::EncodeRsaPrivateKey;
     use rsa::pkcs8::LineEnding;
     use serde_json::Value;
@@ -1056,6 +1053,11 @@ mod tests {
     #[parallel]
     #[cfg(google_cloud_unstable_trusted_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
+        use crate::credentials::tests::get_access_boundary_from_headers;
+        use httptest::responders::json_encoded;
+        use httptest::{Expectation, Server, matchers::*};
+        use serde_json::Value;
+
         let mut service_account_key = get_mock_service_key();
         service_account_key["private_key"] = Value::from(PKCS8_PK.clone());
         let email = service_account_key["client_email"].as_str().unwrap();

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -567,6 +567,13 @@ mod tests {
             ))
             .respond_with(json_encoded(response)),
         );
+        server.expect(
+            Expectation::matching(request::path(
+                "/computeMetadata/v1/instance/service-accounts/default/email",
+            ))
+            .times(0..)
+            .respond_with(status_code(200).body("some-client-email")),
+        ); // access boundaries might have enough time to fetch email
 
         let test_quota_project = "test-quota-project";
         let mdcs = MdsBuilder::default()


### PR DESCRIPTION
Auth team said that we should not gate the feature under a env var and should be enabled by default when service is available. Service is not available yet without allowlisting, so we are moving to an unstable feature, to avoid it being enabled by default on next release.

Towards #4186 