### PR TITLE
cleanup(pubsub): hide exactly-once sync ack

### DIFF
--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -229,7 +229,7 @@ impl ExactlyOnce {
     ///
     /// Note that the acknowledgement is best effort. The message may still be
     /// redelivered to this client, or another client.
-    pub fn ack(mut self) {
+    pub(crate) fn ack(mut self) {
         if let Some(inner) = self.inner.take() {
             inner.ack();
         }


### PR DESCRIPTION
Part of the work for #4508 

Encourage awaiting acks with exactly-once delivery.

Not breaking as `ExactlyOnce` has never been released: https://docs.rs/google-cloud-pubsub/0.32.3-preview/google_cloud_pubsub/subscriber/handler/index.html