### PR TITLE
cleanup(pubsub): future-proof `AckError`

### DIFF
--- a/src/pubsub/src/error.rs
+++ b/src/pubsub/src/error.rs
@@ -62,12 +62,9 @@ pub enum AckError {
     LeaseExpired,
 
     /// The underlying RPC failed.
-    #[error("the acknowledgement failed{}. RPC error: {source}",
-        .details.as_ref().map(|m| format!(", with the server reporting: {m}")).unwrap_or_default())]
+    #[non_exhaustive]
+    #[error("the acknowledgement failed. RPC error: {source}")]
     Rpc {
-        /// Extra details from the server on why the acknowledgement failed.
-        details: Option<String>,
-
         /// The error returned by the service for the acknowledge request.
         #[source]
         source: Arc<Error>,
@@ -97,19 +94,8 @@ mod tests {
     use google_cloud_gax::error::rpc::{Code, Status};
 
     #[test]
-    fn ack_error_rpc_with_details_debug() {
+    fn ack_error_rpc_debug() {
         let e = AckError::Rpc {
-            details: Some("PERMANENT_FAILURE_INVALID_ACK_ID".to_string()),
-            source: Arc::new(Error::service(Status::default().set_code(Code::Unknown))),
-        };
-        let fmt = format!("{e}");
-        assert!(fmt.contains("acknowledgement failed, with the server reporting: PERMANENT_FAILURE_INVALID_ACK_ID."), "{fmt}");
-    }
-
-    #[test]
-    fn ack_error_rpc_without_details_debug() {
-        let e = AckError::Rpc {
-            details: None,
             source: Arc::new(Error::service(
                 Status::default()
                     .set_code(Code::FailedPrecondition)

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -150,11 +150,9 @@ where
             .map(|id| {
                 (
                     id,
-                    shared_result.clone().map_err(|source| AckError::Rpc {
-                        // TODO(#4804): capture error details
-                        details: None,
-                        source,
-                    }),
+                    shared_result
+                        .clone()
+                        .map_err(|source| AckError::Rpc { source }),
                 )
             })
             .collect();


### PR DESCRIPTION
Fixes #4809, related to #4508

We discussed whether the RPC branch should parse the string the server returns into an enum. My official stance on the matter is "why....".

We remove the `details` field for now, and mark the branch as non-exhaustive.

Non breaking, because `AckError` was never released.
