### PR TITLE
chore: upgrade librarian to v0.8.4-0.20260312155511-6e855470a751 and run generate --all

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.8.4-0.20260311134127-181b74e0c0d8
+version: v0.8.4-0.20260312155511-6e855470a751
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -4285,7 +4285,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4302,7 +4302,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4723,7 +4723,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::GET, path);
                 let builder = builder.query(&[("pageSize", &req.page_size)]);
                 let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -4742,7 +4742,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::GET, path);
                 let builder = builder.query(&[("pageSize", &req.page_size)]);
                 let builder = builder.query(&[("pageToken", &req.page_token)]);
@@ -4819,7 +4819,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs:search", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs:search";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = Ok(builder);
                 Some(builder.map(|b| (b, Method::POST, path_template, resource_name)))
@@ -4836,7 +4836,7 @@ impl super::stub::Messaging for Messaging {
                 let path = format!("/v1beta1/{}/blurbs:search", var_parent,);
                 let path_template = "/v1beta1/{parent}/blurbs:search";
 
-                let resource_name = format!("//localhost:7469/{}/blurbs", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::POST, path);
                 let builder = builder.query(&[("query", &req.query)]);
                 let builder = builder.query(&[("pageSize", &req.page_size)]);
@@ -7212,7 +7212,7 @@ impl super::stub::Testing for Testing {
                 let path = format!("/v1beta1/{}/tests", var_parent,);
                 let path_template = "/v1beta1/{parent}/tests";
 
-                let resource_name = format!("//localhost:7469/{}/tests", var_parent,);
+                let resource_name = format!("//localhost:7469/{}", var_parent,);
                 let builder = self.inner.builder(Method::GET, path);
                 let builder = builder.query(&[("pageSize", &req.page_size)]);
                 let builder = builder.query(&[("pageToken", &req.page_token)]);


### PR DESCRIPTION
This PR upgrades librarian to version v0.8.4-0.20260312155511-6e855470a751 and runs `librarian generate --all`.