### PR TITLE
feat(pubsub): configurable max lease

### DIFF
--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -28,6 +28,7 @@ pub struct Subscribe {
     pub(super) client_id: String,
     pub(super) grpc_subchannel_count: usize,
     pub(super) ack_deadline_seconds: i32,
+    pub(super) max_lease: Duration,
     pub(super) max_outstanding_messages: i64,
     pub(super) max_outstanding_bytes: i64,
 }
@@ -45,6 +46,7 @@ impl Subscribe {
             client_id,
             grpc_subchannel_count,
             ack_deadline_seconds: 10,
+            max_lease: Duration::from_secs(600),
             max_outstanding_messages: 1000,
             max_outstanding_bytes: 100 * MIB,
         }
@@ -70,6 +72,30 @@ impl Subscribe {
     /// It is not established until [`MessageStream::next()`] is called.
     pub fn build(self) -> MessageStream {
         MessageStream::new(self)
+    }
+
+    /// Sets the maximum lease deadline for a message.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::Subscriber;
+    /// # use std::time::Duration;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// # let client = Subscriber::builder().build().await?;
+    /// let stream = client.subscribe("projects/my-project/subscriptions/my-subscription")
+    ///     .set_max_lease(Duration::from_secs(3600))
+    ///     .build();
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// The client holds a message for at most this amount. After a message has
+    /// been held for this long, the client will stop extending its lease.
+    ///
+    /// The default value is 10 minutes. If it takes your application longer
+    /// than 10 minutes to process a message, you should increase this value.
+    pub fn set_max_lease<T: Into<Duration>>(mut self, v: T) -> Self {
+        self.max_lease = v.into();
+        self
     }
 
     /// Sets the maximum duration to extend lease deadlines by.
@@ -194,6 +220,11 @@ mod tests {
         assert_eq!(builder.grpc_subchannel_count, 1);
         assert_eq!(builder.ack_deadline_seconds, 10);
         assert!(
+            builder.max_lease >= Duration::from_secs(300),
+            "max_lease={:?}",
+            builder.max_lease
+        );
+        assert!(
             100_000 > builder.max_outstanding_messages && builder.max_outstanding_messages > 100,
             "max_outstanding_messages={}",
             builder.max_outstanding_messages
@@ -215,6 +246,7 @@ mod tests {
             "client-id".to_string(),
             2_usize,
         )
+        .set_max_lease(Duration::from_secs(3600))
         .set_max_lease_extension(Duration::from_secs(20))
         .set_max_outstanding_messages(12345)
         .set_max_outstanding_bytes(6789 * KIB);
@@ -223,6 +255,7 @@ mod tests {
             "projects/my-project/subscriptions/my-subscription"
         );
         assert_eq!(builder.grpc_subchannel_count, 2);
+        assert_eq!(builder.max_lease, Duration::from_secs(3600));
         assert_eq!(builder.ack_deadline_seconds, 20);
         assert_eq!(builder.max_outstanding_messages, 12345);
         assert_eq!(builder.max_outstanding_bytes, 6789 * KIB);

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -41,8 +41,8 @@ pub(super) struct LeaseOptions {
     /// How long we wait for the initial extensions
     pub(super) extend_start: Duration,
     /// How long messages can be kept under lease. A message's lease can be
-    /// extended as long as `max_lease_extension` has not elapsed.
-    pub(super) max_lease_extension: Duration,
+    /// extended as long as `max_lease` has not elapsed.
+    pub(super) max_lease: Duration,
 }
 
 impl Default for LeaseOptions {
@@ -52,7 +52,7 @@ impl Default for LeaseOptions {
             flush_start: Duration::from_millis(100),
             extend_period: Duration::from_secs(3),
             extend_start: Duration::from_millis(500),
-            max_lease_extension: Duration::from_secs(600),
+            max_lease: Duration::from_secs(600),
         }
     }
 }
@@ -109,7 +109,7 @@ where
     // A timer for extending leases
     extend_interval: Interval,
     // How long messages can be kept under lease
-    max_lease_extension: Duration,
+    max_lease: Duration,
 }
 
 /// Actions taken by the `LeaseState` in the lease loop.
@@ -136,7 +136,7 @@ where
             leaser,
             flush_interval,
             extend_interval,
-            max_lease_extension: options.max_lease_extension,
+            max_lease: options.max_lease,
         }
     }
 
@@ -212,12 +212,12 @@ where
     /// Drops messages whose lease deadline cannot be extended any further.
     pub(super) async fn extend(&mut self) {
         // TODO(#3975) - send RPCs concurrently.
-        let batches = self.leases.retain(self.max_lease_extension);
+        let batches = self.leases.retain(self.max_lease);
         for ack_ids in batches {
             self.leaser.extend(ack_ids).await;
         }
 
-        let batches = self.eo_leases.retain(self.max_lease_extension);
+        let batches = self.eo_leases.retain(self.max_lease);
         for ack_ids in batches {
             self.leaser.extend(ack_ids).await;
         }
@@ -1061,7 +1061,7 @@ pub(super) mod tests {
     #[test_case(super::exactly_once_info)]
     #[tokio::test(start_paused = true)]
     async fn message_expiration(lease_info_factory: fn() -> LeaseInfo) -> anyhow::Result<()> {
-        const MAX_LEASE_EXTENSION: Duration = Duration::from_secs(300);
+        const MAX_LEASE: Duration = Duration::from_secs(300);
         const DELTA: Duration = Duration::from_secs(1);
 
         let mut seq = mockall::Sequence::new();
@@ -1078,7 +1078,7 @@ pub(super) mod tests {
             .returning(|_| ());
 
         let options = LeaseOptions {
-            max_lease_extension: MAX_LEASE_EXTENSION,
+            max_lease: MAX_LEASE,
             ..Default::default()
         };
         let mut state = LeaseState::new(Arc::new(mock), options);
@@ -1096,7 +1096,7 @@ pub(super) mod tests {
         state.extend().await;
 
         // Advance the time past the expiration of the original 10 messages.
-        tokio::time::advance(MAX_LEASE_EXTENSION - DELTA).await;
+        tokio::time::advance(MAX_LEASE - DELTA).await;
         state.extend().await;
 
         // Advance the time past the expiration of the subsequent 10 messages.

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -116,11 +116,15 @@ impl MessageStream {
             builder.ack_deadline_seconds,
             builder.grpc_subchannel_count,
         );
+        let options = LeaseOptions {
+            max_lease: builder.max_lease,
+            ..Default::default()
+        };
         let LeaseLoop {
             handle: _lease_loop,
             message_tx,
             ack_tx,
-        } = LeaseLoop::new(leaser, confirmed_rx, LeaseOptions::default());
+        } = LeaseLoop::new(leaser, confirmed_rx, options);
 
         let initial_req = StreamingPullRequest {
             subscription,
@@ -1217,6 +1221,68 @@ mod tests {
             .expect("should receive acknowledgements");
         assert_eq!(ack_req.subscription, "projects/p/subscriptions/s");
         assert_eq!(sorted(ack_req.ack_ids), test_ids(1..3));
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn basic_lease_expiration() -> anyhow::Result<()> {
+        const MAX_LEASE_EXTENSION: Duration = Duration::from_secs(10);
+        const MAX_LEASE: Duration = Duration::from_secs(30);
+        // We configure a max lease for this test (30s) that differs from the
+        // default (600s) to verify that an application's configuration
+        // overrides the default.
+
+        let start_time = Instant::now();
+        let (response_tx, response_rx) = channel(10);
+        let (extend_tx, mut extend_rx) = unbounded_channel();
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        mock.expect_modify_ack_deadline().returning(move |r| {
+            extend_tx
+                .send(r.into_inner())
+                .expect("sending on channel always succeeds");
+            Ok(TonicResponse::from(()))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+        let mut stream = client
+            .subscribe("projects/p/subscriptions/s")
+            .set_max_lease(MAX_LEASE)
+            .set_max_lease_extension(MAX_LEASE_EXTENSION)
+            .build();
+
+        response_tx.send(Ok(test_response(0..1))).await?;
+        drop(response_tx);
+
+        let (_m, _h) = stream
+            .next()
+            .await
+            .expect("stream should yield a message")?;
+
+        // Advance the clock well past the expected message expiration,
+        // recording the time at which we sent the last lease extension.
+        let mut latest = None;
+        for _ in 0..MAX_LEASE.as_secs() * 2 {
+            while let Ok(r) = extend_rx.try_recv() {
+                assert_ne!(r.ack_deadline_seconds, 0, "unexpectedly received a nack");
+                latest = Some(start_time.elapsed());
+            }
+            tokio::time::advance(Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
+        }
+
+        // Verify when we stop sending lease extensions.
+        let expected_range = (MAX_LEASE - MAX_LEASE_EXTENSION)..=MAX_LEASE;
+        assert!(
+            latest.is_some_and(|t| expected_range.contains(&t)),
+            "{latest:?}"
+        );
+
+        // Close the stream, to make sure pending operations complete.
+        stream.close().await?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #4947

Let applications configure the max lease time - how long the client extends a message lease for before giving up.

nit: I am not overly concerned, about the hold time falling in the range of `[max_lease, max_lease + max_lease_extension]`.