### PR TITLE
impl(pubsub): add exactly once processing to MessageStream

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -14,7 +14,7 @@
 
 use super::handler::Action;
 use super::lease_state::{LeaseEvent, LeaseOptions, LeaseState, NewMessage};
-use super::leaser::Leaser;
+use super::leaser::{ConfirmedAcks, Leaser};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::task::JoinHandle;
 
@@ -29,7 +29,11 @@ pub(super) struct LeaseLoop {
 }
 
 impl LeaseLoop {
-    pub(super) fn new<L>(leaser: L, options: LeaseOptions) -> Self
+    pub(super) fn new<L>(
+        leaser: L,
+        mut confirmed_rx: UnboundedReceiver<ConfirmedAcks>,
+        options: LeaseOptions,
+    ) -> Self
     where
         L: Leaser + Clone + Send + 'static,
     {
@@ -58,8 +62,14 @@ impl LeaseLoop {
                             None => break,
                             Some(Action::Ack(ack_id)) => state.process(Action::Ack(ack_id)),
                             Some(Action::Nack(ack_id)) => state.process(Action::Nack(ack_id)),
-                            // TODO(#3964) - process exactly-once acks/nacks in the lease state
-                            _ => unreachable!("we do not return exactly-once handlers yet."),
+                            Some(Action::ExactlyOnceAck(ack_id)) => state.process(Action::ExactlyOnceAck(ack_id)),
+                            Some(Action::ExactlyOnceNack(ack_id)) => state.process(Action::ExactlyOnceNack(ack_id)),
+                        }
+                    },
+                    confirmed_acks = confirmed_rx.recv() => {
+                        match confirmed_acks {
+                            None => break,
+                            Some(results) => state.confirm(results),
                         }
                     },
                 }
@@ -82,6 +92,9 @@ where
     L: Leaser + Clone + Send + 'static,
 {
     while let Ok(r) = ack_rx.try_recv() {
+        // Do nothing for Action::ExactlyOnceAck, the state returns
+        // NACK_SHUTDOWN_ERROR.
+        // TODO(#4869) - also update shutdown behavior here if needed.
         if let Action::Ack(ack_id) = r {
             state.process(Action::Ack(ack_id));
         }
@@ -91,28 +104,56 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::lease_state::tests::{at_least_once_info, sorted, test_id, test_ids};
+    use super::super::lease_state::tests::{
+        at_least_once_info, exactly_once_info, sorted, test_id, test_ids,
+    };
     use super::super::leaser::tests::MockLeaser;
     use super::*;
     use google_cloud_test_macros::tokio_test_no_panics;
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use test_case::test_case;
     use tokio::sync::Mutex;
     use tokio::time::{Duration, Instant};
 
-    fn test_message(id: i32) -> NewMessage {
+    fn test_at_least_once_message(id: i32) -> NewMessage {
         NewMessage {
             ack_id: test_id(id),
             lease_info: at_least_once_info(),
         }
     }
 
+    fn test_exactly_once_message(id: i32) -> NewMessage {
+        NewMessage {
+            ack_id: test_id(id),
+            lease_info: exactly_once_info(),
+        }
+    }
+
+    fn test_at_least_once_ack(id: i32) -> Action {
+        Action::Ack(test_id(id))
+    }
+
+    fn test_at_least_once_nack(id: i32) -> Action {
+        Action::Nack(test_id(id))
+    }
+
+    fn test_exactly_once_ack(id: i32) -> Action {
+        Action::ExactlyOnceAck(test_id(id))
+    }
+
+    fn test_exactly_once_nack(id: i32) -> Action {
+        Action::ExactlyOnceNack(test_id(id))
+    }
+
     #[tokio_test_no_panics(start_paused = true)]
-    async fn flush_acks_nacks_on_interval() -> anyhow::Result<()> {
+    async fn flush_acks_nacks_on_interval_at_least_once() -> anyhow::Result<()> {
         const FLUSH_PERIOD: Duration = Duration::from_secs(1);
         const FLUSH_START: Duration = Duration::from_millis(200);
 
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
         let options = LeaseOptions {
             flush_period: FLUSH_PERIOD,
             flush_start: FLUSH_START,
@@ -120,18 +161,18 @@ mod tests {
             extend_start: Duration::from_secs(900),
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
         // Seed the lease loop with some messages
         for i in 0..30 {
-            lease_loop.message_tx.send(test_message(i))?;
+            lease_loop.message_tx.send(test_at_least_once_message(i))?;
         }
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_ack(i))?;
         }
 
         // Confirm initial state
@@ -154,7 +195,7 @@ mod tests {
 
         // Nack 10 messages
         for i in 10..20 {
-            lease_loop.ack_tx.send(Action::Nack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_nack(i))?;
         }
 
         // Advance to and validate the second flush
@@ -174,11 +215,11 @@ mod tests {
 
         // Ack 5 messages
         for i in 20..25 {
-            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_ack(i))?;
         }
         // Nack 5 messages
         for i in 25..30 {
-            lease_loop.ack_tx.send(Action::Nack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_nack(i))?;
         }
 
         // Advance to the third flush
@@ -206,12 +247,113 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn deadline_interval() -> anyhow::Result<()> {
+    async fn flush_acks_nacks_on_interval_exactly_once() -> anyhow::Result<()> {
+        const FLUSH_PERIOD: Duration = Duration::from_secs(1);
+        const FLUSH_START: Duration = Duration::from_millis(200);
+
+        let mock = Arc::new(Mutex::new(MockLeaser::new()));
+
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let options = LeaseOptions {
+            flush_period: FLUSH_PERIOD,
+            flush_start: FLUSH_START,
+            // effectively disable extensions to simplify this test.
+            extend_start: Duration::from_secs(900),
+            ..Default::default()
+        };
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+        // Yield execution, so tokio can actually start the lease loop.
+        tokio::task::yield_now().await;
+
+        // Seed the lease loop with some messages
+        for i in 0..30 {
+            lease_loop.message_tx.send(test_exactly_once_message(i))?;
+        }
+
+        // Ack 10 messages
+        for i in 0..10 {
+            lease_loop.ack_tx.send(test_exactly_once_ack(i))?;
+        }
+
+        // Confirm initial state
+        mock.lock().await.checkpoint();
+
+        // Advance to and validate the first flush
+        {
+            mock.lock()
+                .await
+                .expect_confirmed_ack()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(0..10))
+                .returning(move |_| ());
+            tokio::time::advance(FLUSH_START).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        // Nack 10 messages
+        for i in 10..20 {
+            lease_loop.ack_tx.send(test_exactly_once_nack(i))?;
+        }
+
+        // Advance to and validate the second flush
+        {
+            mock.lock()
+                .await
+                .expect_nack()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(10..20))
+                .returning(|_| ());
+            tokio::time::advance(FLUSH_PERIOD).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        // Ack 5 messages
+        for i in 20..25 {
+            lease_loop.ack_tx.send(test_exactly_once_ack(i))?;
+        }
+        // Nack 5 messages
+        for i in 25..30 {
+            lease_loop.ack_tx.send(test_exactly_once_nack(i))?;
+        }
+
+        // Advance to the third flush
+        {
+            mock.lock()
+                .await
+                .expect_confirmed_ack()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(20..25))
+                .returning(move |_| ());
+            mock.lock()
+                .await
+                .expect_nack()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(25..30))
+                .returning(|_| ());
+            tokio::time::advance(FLUSH_PERIOD).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn deadline_interval_at_least_once() -> anyhow::Result<()> {
         const EXTEND_PERIOD: Duration = Duration::from_secs(1);
         const EXTEND_START: Duration = Duration::from_millis(200);
 
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
         let options = LeaseOptions {
             // effectively disable ack/nack flushes to simplify this test.
             flush_start: Duration::from_secs(900),
@@ -219,13 +361,13 @@ mod tests {
             extend_start: EXTEND_START,
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
         // Seed the lease loop with some messages
         for i in 0..30 {
-            lease_loop.message_tx.send(test_message(i))?;
+            lease_loop.message_tx.send(test_at_least_once_message(i))?;
         }
 
         // Confirm initial state
@@ -248,7 +390,7 @@ mod tests {
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_ack(i))?;
         }
 
         // Advance to and validate the second extension
@@ -270,21 +412,113 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn drop_does_not_wait_for_pending_operations() -> anyhow::Result<()> {
-        let start = Instant::now();
-        let mock = MockLeaser::new();
-        let lease_loop = LeaseLoop::new(Arc::new(mock), LeaseOptions::default());
+    async fn deadline_interval_exactly_once() -> anyhow::Result<()> {
+        const EXTEND_PERIOD: Duration = Duration::from_secs(1);
+        const EXTEND_START: Duration = Duration::from_millis(200);
+
+        let mock = Arc::new(Mutex::new(MockLeaser::new()));
+
+        let (confirmed_tx, confirmed_rx) = unbounded_channel();
+        let options = LeaseOptions {
+            // effectively disable ack/nack flushes to simplify this test.
+            flush_start: Duration::from_secs(900),
+            extend_period: EXTEND_PERIOD,
+            extend_start: EXTEND_START,
+            ..Default::default()
+        };
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
         // Seed the lease loop with some messages
         for i in 0..30 {
-            lease_loop.message_tx.send(test_message(i))?;
+            lease_loop.message_tx.send(test_exactly_once_message(i))?;
+        }
+
+        // Confirm initial state
+        mock.lock().await.checkpoint();
+
+        // Advance to and validate the first extension
+        {
+            mock.lock()
+                .await
+                .expect_extend()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(0..30))
+                .returning(move |_| ());
+            tokio::time::advance(EXTEND_START).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        // Ack 10 messages. We should continue to extend these leases
+        // as they are not yet confirmed.
+        for i in 0..10 {
+            lease_loop.ack_tx.send(test_exactly_once_ack(i))?;
+        }
+
+        {
+            mock.lock()
+                .await
+                .expect_extend()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(0..30))
+                .returning(|_| ());
+            tokio::time::advance(EXTEND_PERIOD).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        // Confirm 5 messages. We expect these to not be extended.
+        let mut confirms = HashMap::new();
+        for i in 0..5 {
+            confirms.insert(test_id(i), Ok(()));
+        }
+        confirmed_tx.send(confirms)?;
+
+        {
+            mock.lock()
+                .await
+                .expect_extend()
+                .times(1)
+                .withf(|v| sorted(v) == test_ids(5..30))
+                .returning(|_| ());
+            tokio::time::advance(EXTEND_PERIOD).await;
+
+            // Yield the current task, so tokio can execute the flush().
+            tokio::task::yield_now().await;
+            mock.lock().await.checkpoint();
+        }
+
+        Ok(())
+    }
+
+    #[test_case(super::test_at_least_once_message, super::test_at_least_once_ack)]
+    #[test_case(super::test_exactly_once_message, super::test_exactly_once_ack)]
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn drop_does_not_wait_for_pending_operations(
+        msg_factory: fn(i32) -> NewMessage,
+        action_factory: fn(i32) -> Action,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let mock = MockLeaser::new();
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let lease_loop = LeaseLoop::new(Arc::new(mock), confirmed_rx, LeaseOptions::default());
+        // Yield execution, so tokio can actually start the lease loop.
+        tokio::task::yield_now().await;
+
+        // Seed the lease loop with some messages
+        for i in 0..30 {
+            lease_loop.message_tx.send(msg_factory(i))?;
         }
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(action_factory(i))?;
         }
 
         // Drop the lease_loop.
@@ -297,7 +531,7 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn close_waits_for_flush() -> anyhow::Result<()> {
+    async fn close_at_least_once_waits_for_ack() -> anyhow::Result<()> {
         const EXPECTED_SLEEP: Duration = Duration::from_millis(100);
 
         let start = Instant::now();
@@ -319,16 +553,17 @@ mod tests {
             async fn confirmed_ack(&self, _ack_ids: Vec<String>) {}
         }
 
-        let lease_loop = LeaseLoop::new(FakeLeaser, LeaseOptions::default());
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let lease_loop = LeaseLoop::new(FakeLeaser, confirmed_rx, LeaseOptions::default());
 
         // Seed the lease loop with some messages
         for i in 0..30 {
-            lease_loop.message_tx.send(test_message(i))?;
+            lease_loop.message_tx.send(test_at_least_once_message(i))?;
         }
 
         // Ack 10 messages
         for i in 0..10 {
-            lease_loop.ack_tx.send(Action::Ack(test_id(i)))?;
+            lease_loop.ack_tx.send(test_at_least_once_ack(i))?;
         }
 
         // Shutdown the lease_loop.
@@ -343,7 +578,51 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn no_add_and_ack_race() -> anyhow::Result<()> {
+    async fn close_exactly_once_no_confirmed_ack() -> anyhow::Result<()> {
+        const EXPECTED_SLEEP: Duration = Duration::from_millis(100);
+
+        let start = Instant::now();
+
+        #[derive(Clone)]
+        struct FakeLeaser;
+        #[async_trait::async_trait]
+        impl Leaser for FakeLeaser {
+            async fn ack(&self, mut _ack_ids: Vec<String>) {}
+            async fn nack(&self, mut ack_ids: Vec<String>) {
+                ack_ids.sort();
+                assert_eq!(ack_ids, test_ids(0..30));
+            }
+            async fn extend(&self, _ack_ids: Vec<String>) {}
+            async fn confirmed_ack(&self, _ack_ids: Vec<String>) {
+                tokio::time::sleep(EXPECTED_SLEEP).await;
+            }
+        }
+
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let lease_loop = LeaseLoop::new(FakeLeaser, confirmed_rx, LeaseOptions::default());
+
+        // Seed the lease loop with some messages
+        for i in 0..30 {
+            lease_loop.message_tx.send(test_exactly_once_message(i))?;
+        }
+
+        // Ack 10 messages
+        for i in 0..10 {
+            lease_loop.ack_tx.send(test_exactly_once_ack(i))?;
+        }
+
+        // Shutdown the lease_loop.
+        drop(lease_loop.message_tx);
+        lease_loop.handle.await?;
+
+        // Verify that confirmed ack has not been sent.
+        assert_eq!(start.elapsed(), Duration::ZERO);
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn no_add_and_ack_race_at_least_once() -> anyhow::Result<()> {
         // This test validates the use of `biased` in the select statement.
         //
         // Specifically, we want incoming messages to be processed by the event
@@ -357,19 +636,20 @@ mod tests {
             // Run this test enough times to trigger a race, if one existed.
 
             let mock = Arc::new(Mutex::new(MockLeaser::new()));
+            let (_confirmed_tx, confirmed_rx) = unbounded_channel();
             let options = LeaseOptions {
                 flush_start: Duration::from_millis(100),
                 extend_start: Duration::from_millis(200),
                 ..Default::default()
             };
-            let lease_loop = LeaseLoop::new(mock.clone(), options);
+            let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
             // Yield execution, so tokio can actually start the lease loop.
             tokio::task::yield_now().await;
 
             // Seed the lease loop with a message
-            lease_loop.message_tx.send(test_message(1))?;
+            lease_loop.message_tx.send(test_at_least_once_message(1))?;
             // Immediately ack the message
-            lease_loop.ack_tx.send(Action::Ack(test_id(1)))?;
+            lease_loop.ack_tx.send(test_at_least_once_ack(1))?;
 
             // Advance to and validate the first flush
             {
@@ -387,6 +667,67 @@ mod tests {
             }
 
             // Confirm that no messages are under lease management.
+            {
+                mock.lock().await.expect_extend().times(0);
+                tokio::time::advance(Duration::from_millis(100)).await;
+
+                // Yield the current task, so tokio can execute the flush().
+                tokio::task::yield_now().await;
+                mock.lock().await.checkpoint();
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn no_add_and_ack_race_exactly_once() -> anyhow::Result<()> {
+        // This test validates the use of `biased` in the select statement.
+        //
+        // Specifically, we want incoming messages to be processed by the event
+        // loop before any incoming acks/nacks.
+        //
+        // If these channels can race, we might accept an application's
+        // acknowledgement, and then immediately after, accept that message under
+        // lease management.
+
+        for _ in 0..1000 {
+            // Run this test enough times to trigger a race, if one existed.
+
+            let mock = Arc::new(Mutex::new(MockLeaser::new()));
+            let (confirmed_tx, confirmed_rx) = unbounded_channel();
+            let options = LeaseOptions {
+                flush_start: Duration::from_millis(100),
+                extend_start: Duration::from_millis(200),
+                ..Default::default()
+            };
+            let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+            // Yield execution, so tokio can actually start the lease loop.
+            tokio::task::yield_now().await;
+
+            // Seed the lease loop with a message
+            lease_loop.message_tx.send(test_exactly_once_message(1))?;
+            // Immediately ack the message
+            lease_loop.ack_tx.send(test_exactly_once_ack(1))?;
+            let mut ack_results = HashMap::new();
+            ack_results.insert(test_id(1), Ok(()));
+            confirmed_tx.send(ack_results)?;
+
+            // Advance to and validate the first flush
+            {
+                mock.lock()
+                    .await
+                    .expect_confirmed_ack()
+                    .times(1)
+                    .withf(|v| *v == vec![test_id(1)])
+                    .returning(|_| ());
+                tokio::time::advance(Duration::from_millis(100)).await;
+
+                // Yield the current task, so tokio can execute the flush().
+                tokio::task::yield_now().await;
+                mock.lock().await.checkpoint();
+            }
+
+            // Validate that no messages are under lease management.
             {
                 mock.lock().await.expect_extend().times(0);
                 tokio::time::advance(Duration::from_millis(100)).await;

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -81,6 +81,16 @@ pub(super) struct ExactlyOnceInfo {
     pending: bool,
 }
 
+impl ExactlyOnceInfo {
+    pub(super) fn new(result_tx: Sender<AckResult>) -> Self {
+        ExactlyOnceInfo {
+            receive_time: Instant::now(),
+            result_tx,
+            pending: false,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) struct LeaseState<L>
 where
@@ -257,7 +267,7 @@ pub(super) mod tests {
     use tokio::time::interval;
 
     // Cover the constant, converting it to an integer for convenience.
-    const MAX_IDS_PER_RPC: i32 = super::MAX_IDS_PER_RPC as i32;
+    pub(crate) const MAX_IDS_PER_RPC: i32 = super::MAX_IDS_PER_RPC as i32;
 
     // Any valid `Interval` will do.
     fn test_interval() -> Interval {

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use super::builder::Subscribe;
-use super::handler::{Action, AtLeastOnce, Handler};
+use super::handler::{Action, AtLeastOnce, ExactlyOnce, Handler};
 use super::lease_loop::LeaseLoop;
-use super::lease_state::{LeaseInfo, LeaseOptions, NewMessage};
+use super::lease_state::{ExactlyOnceInfo, LeaseInfo, LeaseOptions, NewMessage};
 use super::leaser::DefaultLeaser;
 use super::retry_policy::StreamRetryPolicy;
 use super::stream::Stream;
@@ -108,7 +108,7 @@ impl MessageStream {
         let inner = builder.inner;
         let subscription = builder.subscription;
 
-        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (confirmed_tx, confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             inner.clone(),
             confirmed_tx,
@@ -120,7 +120,7 @@ impl MessageStream {
             handle: _lease_loop,
             message_tx,
             ack_tx,
-        } = LeaseLoop::new(leaser, LeaseOptions::default());
+        } = LeaseLoop::new(leaser, confirmed_rx, LeaseOptions::default());
 
         let initial_req = StreamingPullRequest {
             subscription,
@@ -270,6 +270,10 @@ impl MessageStream {
             Err(e) => return Some(Err(e)),
         };
 
+        let exactly_once = resp
+            .subscription_properties
+            .is_some_and(|m| m.exactly_once_delivery_enabled);
+
         // Process the received messages in the response.
         for rm in resp.received_messages {
             let Some(message) = rm.message else {
@@ -281,19 +285,33 @@ impl MessageStream {
                 // message.
                 continue;
             };
-            let lease_info = LeaseInfo::AtLeastOnce(Instant::now());
+
+            let (lease_info, handler) = if exactly_once {
+                let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+                (
+                    LeaseInfo::ExactlyOnce(ExactlyOnceInfo::new(result_tx)),
+                    Handler::ExactlyOnce(ExactlyOnce::new(
+                        rm.ack_id.clone(),
+                        self.ack_tx.clone(),
+                        result_rx,
+                    )),
+                )
+            } else {
+                (
+                    LeaseInfo::AtLeastOnce(Instant::now()),
+                    Handler::AtLeastOnce(AtLeastOnce::new(rm.ack_id.clone(), self.ack_tx.clone())),
+                )
+            };
+
             let _ = self.message_tx.send(NewMessage {
-                ack_id: rm.ack_id.clone(),
+                ack_id: rm.ack_id,
                 lease_info,
             });
             let message = match message.cnv().map_err(Error::deser) {
                 Ok(message) => message,
                 Err(e) => return Some(Err(e)),
             };
-            self.pool.push_back((
-                message,
-                Handler::AtLeastOnce(AtLeastOnce::new(rm.ack_id, self.ack_tx.clone())),
-            ));
+            self.pool.push_back((message, handler));
         }
         Some(Ok(()))
     }
@@ -318,6 +336,8 @@ impl MessageStream {
 
 #[cfg(test)]
 mod tests {
+    use crate::subscriber::lease_state::tests::MAX_IDS_PER_RPC;
+
     use super::super::client::Subscriber;
     use super::super::keepalive::KEEPALIVE_PERIOD;
     use super::super::lease_state::tests::{test_id, test_ids};
@@ -328,8 +348,9 @@ mod tests {
     use google_cloud_test_macros::tokio_test_no_panics;
     use pubsub_grpc_mock::google::pubsub::v1;
     use pubsub_grpc_mock::{MockSubscriber, start};
+    use test_case::test_case;
     use tokio::sync::mpsc::{channel, unbounded_channel};
-    use tokio::task::JoinHandle;
+    use tokio::task::{JoinHandle, JoinSet};
     use tokio::time::{Duration, Instant};
 
     fn sorted(mut v: Vec<String>) -> Vec<String> {
@@ -341,8 +362,29 @@ mod tests {
         bytes::Bytes::from(format!("data-{}", test_id(v)))
     }
 
-    fn test_response(range: std::ops::Range<i32>) -> v1::StreamingPullResponse {
+    fn test_at_least_once_response(range: std::ops::Range<i32>) -> v1::StreamingPullResponse {
         v1::StreamingPullResponse {
+            received_messages: range
+                .into_iter()
+                .map(|i| v1::ReceivedMessage {
+                    ack_id: test_id(i),
+                    message: Some(v1::PubsubMessage {
+                        data: test_data(i).to_vec(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    fn test_exactly_once_response(range: std::ops::Range<i32>) -> v1::StreamingPullResponse {
+        v1::StreamingPullResponse {
+            subscription_properties: Some(v1::streaming_pull_response::SubscriptionProperties {
+                exactly_once_delivery_enabled: true,
+                ..Default::default()
+            }),
             received_messages: range
                 .into_iter()
                 .map(|i| v1::ReceivedMessage {
@@ -467,7 +509,7 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn basic_success() -> anyhow::Result<()> {
+    async fn basic_success_at_least_once() -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
         let (ack_tx, mut ack_rx) = unbounded_channel();
 
@@ -484,9 +526,15 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(1..2))).await?;
-        response_tx.send(Ok(test_response(2..4))).await?;
-        response_tx.send(Ok(test_response(4..7))).await?;
+        response_tx
+            .send(Ok(test_at_least_once_response(1..2)))
+            .await?;
+        response_tx
+            .send(Ok(test_at_least_once_response(2..4)))
+            .await?;
+        response_tx
+            .send(Ok(test_at_least_once_response(4..7)))
+            .await?;
         drop(response_tx);
 
         for i in 1..7 {
@@ -512,7 +560,65 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn basic_lease_management() -> anyhow::Result<()> {
+    async fn basic_success_exactly_once() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = channel(10);
+        let (ack_tx, mut ack_rx) = unbounded_channel();
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        mock.expect_acknowledge().returning(move |r| {
+            ack_tx
+                .send(r.into_inner())
+                .expect("sending on channel always succeeds");
+            Ok(TonicResponse::from(()))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+        let mut stream = client.subscribe("projects/p/subscriptions/s").build();
+
+        response_tx
+            .send(Ok(test_exactly_once_response(0..2)))
+            .await?;
+        response_tx
+            .send(Ok(test_exactly_once_response(2..4)))
+            .await?;
+        // We use MAX_IDS_PER_RPC total ids to indirectly force a flush in the subscriber.
+        // This is needed for exactly once because the current shutdown behavior does not
+        // send a final AcknowledgeRequest for application acknowledged ids.
+        response_tx
+            .send(Ok(test_exactly_once_response(4..MAX_IDS_PER_RPC)))
+            .await?;
+
+        let mut ack_join_set = JoinSet::new();
+        for i in 0..MAX_IDS_PER_RPC {
+            let Some((m, Handler::ExactlyOnce(h))) = stream.next().await.transpose()? else {
+                anyhow::bail!("expected message {i}/{MAX_IDS_PER_RPC}")
+            };
+            assert_eq!(m.data, test_data(i));
+            assert_eq!(h.ack_id(), test_id(i));
+            ack_join_set.spawn(h.confirmed_ack());
+        }
+        ack_join_set.join_all().await;
+
+        drop(response_tx);
+        let end = stream.next().await.transpose()?;
+        assert!(end.is_none(), "Received extra message: {end:?}");
+
+        // Wait for the stream to join its background tasks.
+        stream.close().await?;
+
+        // Verify the acks went through.
+        let ack_req = ack_rx.try_recv()?;
+        assert_eq!(ack_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(ack_req.ack_ids.len(), MAX_IDS_PER_RPC as usize);
+        assert_eq!(sorted(ack_req.ack_ids), test_ids(0..MAX_IDS_PER_RPC));
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn basic_lease_management_at_least_once() -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (nack_tx, mut nack_rx) = unbounded_channel();
@@ -542,7 +648,9 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(0..30))).await?;
+        response_tx
+            .send(Ok(test_at_least_once_response(0..30)))
+            .await?;
         drop(response_tx);
 
         // Ack some messages
@@ -604,14 +712,132 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn delayed_responses() -> anyhow::Result<()> {
+    async fn basic_lease_management_exactly_once() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = channel(10);
+        let (ack_tx, mut ack_rx) = unbounded_channel();
+        let (nack_tx, mut nack_rx) = unbounded_channel();
+        let (extend_tx, mut extend_rx) = unbounded_channel();
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        mock.expect_acknowledge().returning(move |r| {
+            ack_tx
+                .send(r.into_inner())
+                .expect("sending on channel always succeeds");
+            Ok(TonicResponse::from(()))
+        });
+        mock.expect_modify_ack_deadline().returning(move |r| {
+            let r = r.into_inner();
+            if r.ack_deadline_seconds == 0 {
+                nack_tx.send(r).expect("sending on channel always succeeds");
+            } else {
+                extend_tx
+                    .send(r)
+                    .expect("sending on channel always succeeds");
+            }
+            Ok(TonicResponse::from(()))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+        let mut stream = client.subscribe("projects/p/subscriptions/s").build();
+
+        // We use MAX_IDS_PER_RPC total ids to indirectly force a flush in the subscriber.
+        // This is needed for exactly once because the current shutdown behavior does not
+        // send a final AcknowledgeRequest for application acknowledged ids.
+        response_tx
+            .send(Ok(test_exactly_once_response(0..MAX_IDS_PER_RPC)))
+            .await?;
+        response_tx
+            .send(Ok(test_exactly_once_response(
+                MAX_IDS_PER_RPC..(MAX_IDS_PER_RPC + 20),
+            )))
+            .await?;
+
+        let mut ack_join_set = JoinSet::new();
+        // Ack some messages
+        for i in 0..MAX_IDS_PER_RPC {
+            let Some((_, Handler::ExactlyOnce(h))) = stream.next().await.transpose()? else {
+                anyhow::bail!("expected message {i}")
+            };
+            ack_join_set.spawn(h.confirmed_ack());
+        }
+        ack_join_set.join_all().await;
+
+        // Nack some messages
+        for i in MAX_IDS_PER_RPC..(MAX_IDS_PER_RPC + 10) {
+            let Some((_, Handler::ExactlyOnce(h))) = stream.next().await.transpose()? else {
+                anyhow::bail!("expected message {i}")
+            };
+            drop(h);
+        }
+        // Take a long time to process some messages
+        let mut hold = Vec::new();
+        for i in (MAX_IDS_PER_RPC + 10)..(MAX_IDS_PER_RPC + 20) {
+            let Some((_, Handler::ExactlyOnce(h))) = stream.next().await.transpose()? else {
+                anyhow::bail!("expected message {i}")
+            };
+            hold.push(h);
+        }
+
+        // Advance the clock 10s, which is the default stream ack deadline. In
+        // this time, we should attempt at least one lease extension RPC.
+        tokio::time::advance(Duration::from_secs(10)).await;
+
+        drop(response_tx);
+        // Close the stream, to make sure pending operations complete.
+        stream.close().await?;
+
+        // Verify the acks went through.
+        let ack_req = ack_rx.try_recv()?;
+        assert_eq!(ack_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(sorted(ack_req.ack_ids), test_ids(0..MAX_IDS_PER_RPC));
+        assert!(ack_rx.is_empty(), "{ack_rx:?}");
+
+        // Verify the initial nacks went through.
+        let nack_req = nack_rx.try_recv()?;
+        assert_eq!(nack_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(nack_req.ack_deadline_seconds, 0);
+        assert_eq!(
+            sorted(nack_req.ack_ids),
+            test_ids(MAX_IDS_PER_RPC..(MAX_IDS_PER_RPC + 10))
+        );
+
+        // Verify that we nack the leftover messages when the stream shuts down.
+        let nack_req = nack_rx.try_recv()?;
+        assert_eq!(nack_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(nack_req.ack_deadline_seconds, 0);
+        assert_eq!(
+            sorted(nack_req.ack_ids),
+            test_ids((MAX_IDS_PER_RPC + 10)..(MAX_IDS_PER_RPC + 20))
+        );
+        assert!(nack_rx.is_empty(), "{nack_rx:?}");
+
+        // Verify at least one lease extension attempt was made.
+        let extend_req = extend_rx.try_recv()?;
+        assert_eq!(extend_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(extend_req.ack_deadline_seconds, 10);
+        assert_eq!(
+            sorted(extend_req.ack_ids),
+            test_ids((MAX_IDS_PER_RPC + 10)..(MAX_IDS_PER_RPC + 20))
+        );
+
+        Ok(())
+    }
+
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn delayed_responses(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         // In this test, we verify the case where an application asks for a
         // message, but a response is not immediately available on the stream.
 
         let (response_tx, response_rx) = channel(10);
         let handle: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(20)).await;
-            response_tx.send(Ok(test_response(1..2))).await?;
+            response_tx.send(Ok(resp_factory(1..2))).await?;
             Ok(())
         });
 
@@ -636,8 +862,12 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
     #[tokio_test_no_panics]
-    async fn serves_messages_immediately() -> anyhow::Result<()> {
+    async fn serves_messages_immediately(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         // This test verifies we do not do something crazy like draining the
         // stream (which would never end) before serving messages to the
         // application.
@@ -654,7 +884,7 @@ mod tests {
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
         for i in 1..7 {
-            response_tx.send(Ok(test_response(i..i + 1))).await?;
+            response_tx.send(Ok(resp_factory(i..i + 1))).await?;
 
             let Some((m, h)) = stream.next().await.transpose()? else {
                 anyhow::bail!("expected message {i}/6")
@@ -669,8 +899,12 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
     #[tokio_test_no_panics]
-    async fn handles_empty_response() -> anyhow::Result<()> {
+    async fn handles_empty_response(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
 
         let mut mock = MockSubscriber::new();
@@ -682,10 +916,10 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(1..2))).await?;
+        response_tx.send(Ok(resp_factory(1..2))).await?;
         // See if we can handle an empty range
-        response_tx.send(Ok(test_response(2..2))).await?;
-        response_tx.send(Ok(test_response(2..3))).await?;
+        response_tx.send(Ok(resp_factory(2..2))).await?;
+        response_tx.send(Ok(resp_factory(2..3))).await?;
         drop(response_tx);
 
         for i in 1..3 {
@@ -701,8 +935,12 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
     #[tokio_test_no_panics(start_paused = true)]
-    async fn handles_missing_message_field() -> anyhow::Result<()> {
+    async fn handles_missing_message_field(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
         let (extend_tx, mut extend_rx) = unbounded_channel();
 
@@ -730,10 +968,10 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(1..4))).await?;
+        response_tx.send(Ok(resp_factory(1..4))).await?;
         // See if we can handle an empty range
         response_tx.send(Ok(bad)).await?;
-        response_tx.send(Ok(test_response(4..7))).await?;
+        response_tx.send(Ok(resp_factory(4..7))).await?;
         drop(response_tx);
 
         let mut handlers = Vec::new();
@@ -765,8 +1003,12 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
     #[tokio_test_no_panics]
-    async fn permanent_error_midstream() -> anyhow::Result<()> {
+    async fn permanent_error_midstream(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
 
         let mut mock = MockSubscriber::new();
@@ -776,7 +1018,7 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(1..4))).await?;
+        response_tx.send(Ok(resp_factory(1..4))).await?;
         response_tx
             .send(Err(TonicStatus::failed_precondition("fail")))
             .await?;
@@ -805,8 +1047,12 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
     #[tokio_test_no_panics(start_paused = true)]
-    async fn keepalives() -> anyhow::Result<()> {
+    async fn keepalives(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         // We use this channel to surface writes (requests) from outside our
         // mock expectation.
         let (recover_writes_tx, mut recover_writes_rx) = channel(1);
@@ -833,7 +1079,7 @@ mod tests {
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
-        response_tx.send(Ok(test_response(1..4))).await?;
+        response_tx.send(Ok(resp_factory(1..4))).await?;
         let _ = stream.next().await;
 
         let initial_req = recover_writes_rx
@@ -1003,7 +1249,7 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn resume_midstream_success() -> anyhow::Result<()> {
+    async fn resume_midstream_success_at_least_once() -> anyhow::Result<()> {
         let (response_tx_1, response_rx_1) = channel(10);
         let (response_tx_2, response_rx_2) = channel(10);
         let (response_tx_3, response_rx_3) = channel(10);
@@ -1033,19 +1279,29 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx_1.send(Ok(test_response(0..10))).await?;
-        response_tx_1.send(Ok(test_response(10..20))).await?;
+        response_tx_1
+            .send(Ok(test_at_least_once_response(0..10)))
+            .await?;
+        response_tx_1
+            .send(Ok(test_at_least_once_response(10..20)))
+            .await?;
         response_tx_1
             .send(Err(TonicStatus::unavailable("GFE disconnect. try again")))
             .await?;
         drop(response_tx_1);
-        response_tx_2.send(Ok(test_response(20..30))).await?;
-        response_tx_2.send(Ok(test_response(30..40))).await?;
+        response_tx_2
+            .send(Ok(test_at_least_once_response(20..30)))
+            .await?;
+        response_tx_2
+            .send(Ok(test_at_least_once_response(30..40)))
+            .await?;
         response_tx_2
             .send(Err(TonicStatus::unavailable("GFE disconnect. try again")))
             .await?;
         drop(response_tx_2);
-        response_tx_3.send(Ok(test_response(40..50))).await?;
+        response_tx_3
+            .send(Ok(test_at_least_once_response(40..50)))
+            .await?;
         drop(response_tx_3);
 
         for i in 0..50 {
@@ -1074,7 +1330,96 @@ mod tests {
     }
 
     #[tokio_test_no_panics(start_paused = true)]
-    async fn resume_midstream_hits_permanent_error() -> anyhow::Result<()> {
+    async fn resume_midstream_success_exactly_once() -> anyhow::Result<()> {
+        let (response_tx_1, response_rx_1) = channel(10);
+        let (response_tx_2, response_rx_2) = channel(10);
+        let (response_tx_3, response_rx_3) = channel(10);
+        let (ack_tx, mut ack_rx) = unbounded_channel();
+
+        let mut seq = mockall::Sequence::new();
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(|_| Ok(TonicResponse::from(response_rx_1)));
+        mock.expect_streaming_pull()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(move |_| Ok(TonicResponse::from(response_rx_2)));
+        mock.expect_streaming_pull()
+            .times(1)
+            .in_sequence(&mut seq)
+            .return_once(|_| Ok(TonicResponse::from(response_rx_3)));
+        mock.expect_acknowledge().times(1..).returning(move |r| {
+            ack_tx
+                .send(r.into_inner())
+                .expect("sending on channel always succeeds");
+            Ok(TonicResponse::from(()))
+        });
+        mock.expect_modify_ack_deadline()
+            .returning(|_| Ok(TonicResponse::from(())));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+        let mut stream = client.subscribe("projects/p/subscriptions/s").build();
+
+        response_tx_1
+            .send(Ok(test_exactly_once_response(0..10)))
+            .await?;
+        response_tx_1
+            .send(Ok(test_exactly_once_response(10..20)))
+            .await?;
+        response_tx_1
+            .send(Err(TonicStatus::unavailable("GFE disconnect. try again")))
+            .await?;
+        drop(response_tx_1);
+        response_tx_2
+            .send(Ok(test_exactly_once_response(20..30)))
+            .await?;
+        response_tx_2
+            .send(Ok(test_exactly_once_response(30..40)))
+            .await?;
+        response_tx_2
+            .send(Err(TonicStatus::unavailable("GFE disconnect. try again")))
+            .await?;
+        drop(response_tx_2);
+        response_tx_3
+            .send(Ok(test_exactly_once_response(40..50)))
+            .await?;
+        drop(response_tx_3);
+
+        for i in 0..50 {
+            let (m, h) = stream
+                .next()
+                .await
+                .unwrap_or_else(|| panic!("expected message {}/50", i + 1))?;
+            assert_eq!(m.data, test_data(i));
+            h.ack();
+        }
+        let end = stream.next().await.transpose()?;
+        assert!(end.is_none(), "Received extra message: {end:?}");
+
+        // Wait for the stream to join its background tasks.
+        stream.close().await?;
+
+        // Verify the acks went through.
+        let mut got = Vec::new();
+        while let Ok(ack_req) = ack_rx.try_recv() {
+            assert_eq!(ack_req.subscription, "projects/p/subscriptions/s");
+            got.extend(ack_req.ack_ids);
+        }
+        // Due to current shutdown behavior for exactly once, the last 10
+        // application acknowledged ids are nacked.
+        assert_eq!(sorted(got), test_ids(0..40));
+
+        Ok(())
+    }
+
+    #[test_case(super::test_at_least_once_response)]
+    #[test_case(super::test_exactly_once_response)]
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn resume_midstream_hits_permanent_error(
+        resp_factory: fn(std::ops::Range<i32>) -> v1::StreamingPullResponse,
+    ) -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
         let (ack_tx, mut ack_rx) = unbounded_channel();
 
@@ -1105,8 +1450,8 @@ mod tests {
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
-        response_tx.send(Ok(test_response(0..10))).await?;
-        response_tx.send(Ok(test_response(10..20))).await?;
+        response_tx.send(Ok(resp_factory(0..10))).await?;
+        response_tx.send(Ok(resp_factory(10..20))).await?;
         response_tx
             .send(Err(TonicStatus::unavailable("GFE disconnect. try again")))
             .await?;
@@ -1176,7 +1521,7 @@ mod tests {
 
     #[cfg(feature = "unstable-stream")]
     #[tokio_test_no_panics(start_paused = true)]
-    async fn into_stream() -> anyhow::Result<()> {
+    async fn into_stream_at_least_once() -> anyhow::Result<()> {
         use futures::TryStreamExt;
         let (response_tx, response_rx) = channel(10);
         let (ack_tx, mut ack_rx) = unbounded_channel();
@@ -1199,7 +1544,9 @@ mod tests {
             .build()
             .into_stream();
 
-        response_tx.send(Ok(test_response(1..3))).await?;
+        response_tx
+            .send(Ok(test_at_least_once_response(1..3)))
+            .await?;
         drop(response_tx);
 
         let got: Vec<_> = stream
@@ -1217,6 +1564,49 @@ mod tests {
             .expect("should receive acknowledgements");
         assert_eq!(ack_req.subscription, "projects/p/subscriptions/s");
         assert_eq!(sorted(ack_req.ack_ids), test_ids(1..3));
+
+        Ok(())
+    }
+
+    #[cfg(feature = "unstable-stream")]
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn into_stream_exactly_once() -> anyhow::Result<()> {
+        use futures::TryStreamExt;
+        let (response_tx, response_rx) = channel(10);
+        let (nack_tx, mut nack_rx) = unbounded_channel();
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        mock.expect_modify_ack_deadline().returning(move |r| {
+            nack_tx
+                .send(r.into_inner())
+                .expect("sending on channel always succeeds");
+            Ok(TonicResponse::from(()))
+        });
+
+        response_tx
+            .send(Ok(test_exactly_once_response(1..3)))
+            .await?;
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+
+        let stream = client
+            .subscribe("projects/p/subscriptions/s")
+            .build()
+            .into_stream();
+        drop(response_tx);
+
+        let got: Vec<_> = stream.map_ok(|(m, _)| m.data).try_collect().await?;
+        assert_eq!(got, vec![test_data(1), test_data(2)]);
+
+        let nack_req = nack_rx
+            .recv()
+            .await
+            .expect("should receive acknowledgements");
+        assert_eq!(nack_req.subscription, "projects/p/subscriptions/s");
+        assert_eq!(sorted(nack_req.ack_ids), test_ids(1..3));
 
         Ok(())
     }


### PR DESCRIPTION
Process exactly once subscription in MessageStream.

A followup PR will update subsriber/client.rs documentation and add integration test.

Towards #3964