### PR TITLE
chore: update MSRV to 1.86

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We need to support 1.85. Stop clippy from issuing newer warnings.
-msrv = "1.85.0"
+# We need to support 1.86. Stop clippy from issuing newer warnings.
+msrv = "1.86.0"

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -139,7 +139,7 @@ locals {
       config       = "complex.yaml"
       flags        = local.unstable_flags
       script       = "test"
-      rust_version = "1.85"
+      rust_version = "1.86"
     }
     test-unstable-cfg = {
       config = "complex.yaml"

--- a/.gcb/referenceupload.yaml
+++ b/.gcb/referenceupload.yaml
@@ -31,7 +31,7 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
-  - name: 'rust:1.85-bookworm'
+  - name: 'rust:1.86-bookworm'
     script: |
       #!/usr/bin/env bash
       set -e

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -345,7 +345,7 @@ license      = "Apache-2.0"
 repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
 keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
 categories   = ["network-programming"]
-rust-version = "1.85.0"
+rust-version = "1.86.0"
 
 # Define a custom profile for builds on GHA. The standard profiles exhaust the
 # available disk space on the free GHA runners. The GHA builds cannot take

--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ client libraries for Rust.
 
 ## Minimum Supported Rust Version (MSRV)
 
-We require Rust >= 1.85. We will compile the development branch with this
-version until at least 2026-03-01. Once we update our MSRV beyond 1.85, we plan
-to update the MSRV periodically. However, the development branch will always
-compile with the `rustc` versions released within the previous year[^1].
+We require Rust >= 1.86. We plan to update the MSRV periodically. However, the
+development branch will always compile with the `rustc` versions released within
+the previous year.
 
 ## Semantic versioning
 
@@ -79,9 +78,6 @@ the [Set Up Development Environment] and the [Architecture] guides useful.
 ## License
 
 Apache 2.0 - See [LICENSE] for more information.
-
-[^1]: That is, once 1.85 is at least a year old we will bump to 1.86 or higher,
-    and we will bump from 1.86 to 1.87 once 1.86 is at least a year old.
 
 [architecture]: ARCHITECTURE.md
 [contributing]: CONTRIBUTING.md

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -94,7 +94,7 @@ impl Leases {
 
         // We want to extract some values from `HashMap`, leaving the rest
         // unchanged.
-        // - `extract_if()` is not available as our MSRV is 1.85 and that appears
+        // - `extract_if()` is not available as our MSRV is 1.86 and that appears
         //   in 1.88.
         // - `retain` does not work because we need a *value* of `info` to
         //   change `tx` and that only gives us a `&mut ExactlyOnceInfo`.


### PR DESCRIPTION
1.85.1 was released on 2025-03-18, we can start requiring 1.86.0. No major new features.