### PR TITLE
cleanup(pubsub): fail sample on error

### DIFF
--- a/src/pubsub/examples/src/publisher/publish_with_ordering_keys.rs
+++ b/src/pubsub/examples/src/publisher/publish_with_ordering_keys.rs
@@ -41,7 +41,7 @@ pub async fn sample(project: &str, topic_id: &str) -> anyhow::Result<()> {
     for publish_future in publish_futures {
         let message_id = publish_future
             .await
-            .inspect_err(|e| println!("error publishing message: {e}"))?;
+            .inspect_err(|e| eprintln!("error publishing message: {e:?}"))?;
         println!("published message with ID: {message_id}");
     }
 


### PR DESCRIPTION
Q: should we prefer `eprintln!` for errors?