### PR TITLE
chore: restore `.repo-metadata.json` files

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 language: rust
 version: v0.8.4-0.20260318163223-0ba84a3917a6
+repo: googleapis/google-cloud-rust
 sources:
   conformance:
     commit: b407e8416e3893036aee5af9a12bd9b6a0e2b2e6

--- a/src/generated/api/apikeys/v2/.repo-metadata.json
+++ b/src/generated/api/apikeys/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "apikeys",
     "name_pretty": "API Keys",
     "product_documentation": "https://cloud.google.com/api-keys/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/api/cloudquotas/v1/.repo-metadata.json
+++ b/src/generated/api/cloudquotas/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudquotas",
     "name_pretty": "Cloud Quotas",
     "product_documentation": "https://cloud.google.com/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/api/servicecontrol/v1/.repo-metadata.json
+++ b/src/generated/api/servicecontrol/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "servicecontrol",
     "name_pretty": "Service Control",
     "product_documentation": "https://cloud.google.com/service-infrastructure/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/api/servicecontrol/v2/.repo-metadata.json
+++ b/src/generated/api/servicecontrol/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "servicecontrol",
     "name_pretty": "Service Control",
     "product_documentation": "https://cloud.google.com/service-infrastructure/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/api/servicemanagement/v1/.repo-metadata.json
+++ b/src/generated/api/servicemanagement/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "servicemanagement",
     "name_pretty": "Service Management",
     "product_documentation": "https://cloud.google.com/service-infrastructure/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/api/serviceusage/v1/.repo-metadata.json
+++ b/src/generated/api/serviceusage/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "serviceusage",
     "name_pretty": "Service Usage",
     "product_documentation": "https://cloud.google.com/service-usage",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/appengine/v1/.repo-metadata.json
+++ b/src/generated/appengine/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "appengine",
     "name_pretty": "App Engine Admin",
     "product_documentation": "https://cloud.google.com/appengine/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/bigtable/admin/v2/.repo-metadata.json
+++ b/src/generated/bigtable/admin/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "bigtableadmin",
     "name_pretty": "Cloud Bigtable Admin",
     "product_documentation": "https://cloud.google.com/bigtable/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/accessapproval/v1/.repo-metadata.json
+++ b/src/generated/cloud/accessapproval/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "accessapproval",
     "name_pretty": "Access Approval",
     "product_documentation": "https://cloud.google.com/access-approval/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/advisorynotifications/v1/.repo-metadata.json
+++ b/src/generated/cloud/advisorynotifications/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "advisorynotifications",
     "name_pretty": "Advisory Notifications",
     "product_documentation": "https://cloud.google.com/advisory-notifications/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/aiplatform/v1/.repo-metadata.json
+++ b/src/generated/cloud/aiplatform/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "aiplatform",
     "name_pretty": "Vertex AI",
     "product_documentation": "https://cloud.google.com/ai-platform/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/alloydb/v1/.repo-metadata.json
+++ b/src/generated/cloud/alloydb/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "alloydb",
     "name_pretty": "AlloyDB",
     "product_documentation": "https://cloud.google.com/alloydb/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/apigateway/v1/.repo-metadata.json
+++ b/src/generated/cloud/apigateway/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "apigateway",
     "name_pretty": "API Gateway",
     "product_documentation": "https://cloud.google.com/api-gateway",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/apigeeconnect/v1/.repo-metadata.json
+++ b/src/generated/cloud/apigeeconnect/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "apigeeconnect",
     "name_pretty": "Apigee Connect",
     "product_documentation": "https://cloud.google.com/apigee/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/apihub/v1/.repo-metadata.json
+++ b/src/generated/cloud/apihub/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "apihub",
     "name_pretty": "API hub",
     "product_documentation": "https://cloud.google.com/apigee/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/apiregistry/v1/.repo-metadata.json
+++ b/src/generated/cloud/apiregistry/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "cloudapiregistry",
     "name_pretty": "Cloud API Registry",
     "product_documentation": "https://docs.cloud.google.com/api-registry/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/apphub/v1/.repo-metadata.json
+++ b/src/generated/cloud/apphub/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "apphub",
     "name_pretty": "App Hub",
     "product_documentation": "https://cloud.google.com/app-hub/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/asset/v1/.repo-metadata.json
+++ b/src/generated/cloud/asset/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudasset",
     "name_pretty": "Cloud Asset",
     "product_documentation": "https://cloud.google.com/resource-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/assuredworkloads/v1/.repo-metadata.json
+++ b/src/generated/cloud/assuredworkloads/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "assuredworkloads",
     "name_pretty": "Assured Workloads",
     "product_documentation": "https://cloud.google.com/assured-workloads/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/auditmanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/auditmanager/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "auditmanager",
     "name_pretty": "Audit Manager",
     "product_documentation": "https://cloud.google.com/audit-manager/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/backupdr/v1/.repo-metadata.json
+++ b/src/generated/cloud/backupdr/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "backupdr",
     "name_pretty": "Backup and DR Service",
     "product_documentation": "https://cloud.google.com/backup-disaster-recovery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/baremetalsolution/v2/.repo-metadata.json
+++ b/src/generated/cloud/baremetalsolution/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "baremetalsolution",
     "name_pretty": "Bare Metal Solution",
     "product_documentation": "https://cloud.google.com/bare-metal/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/.repo-metadata.json
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "beyondcorp",
     "name_pretty": "BeyondCorp",
     "product_documentation": "https://cloud.google.com/beyondcorp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/.repo-metadata.json
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "beyondcorp",
     "name_pretty": "BeyondCorp",
     "product_documentation": "https://cloud.google.com/beyondcorp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/.repo-metadata.json
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "beyondcorp",
     "name_pretty": "BeyondCorp",
     "product_documentation": "https://cloud.google.com/beyondcorp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.repo-metadata.json
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "beyondcorp",
     "name_pretty": "BeyondCorp",
     "product_documentation": "https://cloud.google.com/beyondcorp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/.repo-metadata.json
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "beyondcorp",
     "name_pretty": "BeyondCorp",
     "product_documentation": "https://cloud.google.com/beyondcorp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/biglake/v1/.repo-metadata.json
+++ b/src/generated/cloud/biglake/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "biglake",
     "name_pretty": "BigLake",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/analyticshub/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "analyticshub",
     "name_pretty": "Analytics Hub",
     "product_documentation": "https://cloud.google.com/analytics-hub",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/connection/v1/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/connection/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "bigqueryconnection",
     "name_pretty": "BigQuery Connection",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/datapolicies/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "bigquerydatapolicy",
     "name_pretty": "BigQuery Data Policy",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/datapolicies/v2/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/datapolicies/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "bigquerydatapolicy",
     "name_pretty": "BigQuery Data Policy",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/datatransfer/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "bigquerydatatransfer",
     "name_pretty": "BigQuery Data Transfer",
     "product_documentation": "https://cloud.google.com/bigquery/transfer/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/migration/v2/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/migration/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "bigquerymigration",
     "name_pretty": "BigQuery Migration",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/reservation/v1/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/reservation/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "bigqueryreservation",
     "name_pretty": "BigQuery Reservation",
     "product_documentation": "https://cloud.google.com/bigquery/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/bigquery/v2/.repo-metadata.json
+++ b/src/generated/cloud/bigquery/v2/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "bigquery",
     "name_pretty": "BigQuery",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/billing/v1/.repo-metadata.json
+++ b/src/generated/cloud/billing/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "cloudbilling",
     "name_pretty": "Cloud Billing",
     "product_documentation": "https://cloud.google.com/billing",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/binaryauthorization/v1/.repo-metadata.json
+++ b/src/generated/cloud/binaryauthorization/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "binaryauthorization",
     "name_pretty": "Binary Authorization",
     "product_documentation": "https://cloud.google.com/binary-authorization",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/certificatemanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/certificatemanager/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "certificatemanager",
     "name_pretty": "Certificate Manager",
     "product_documentation": "https://cloud.google.com/python/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/chronicle/v1/.repo-metadata.json
+++ b/src/generated/cloud/chronicle/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "chronicle",
     "name_pretty": "Chronicle",
     "product_documentation": "https://cloud.google.com/chronicle/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/.repo-metadata.json
+++ b/src/generated/cloud/cloudcontrolspartner/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudcontrolspartner",
     "name_pretty": "Cloud Controls Partner",
     "product_documentation": "https://cloud.google.com/sovereign-controls-by-partners/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/clouddms/v1/.repo-metadata.json
+++ b/src/generated/cloud/clouddms/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "datamigration",
     "name_pretty": "Database Migration",
     "product_documentation": "https://cloud.google.com/database-migration/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/cloudsecuritycompliance/v1/.repo-metadata.json
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "cloudsecuritycompliance",
     "name_pretty": "Cloud Security Compliance",
     "product_documentation": "https://cloud.google.com/security-command-center/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/.repo-metadata.json
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudcommerceconsumerprocurement",
     "name_pretty": "Cloud Commerce Consumer Procurement",
     "product_documentation": "https://cloud.google.com/marketplace/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/compute/v1/.repo-metadata.json
+++ b/src/generated/cloud/compute/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "compute",
     "name_pretty": "Google Compute Engine",
     "product_documentation": "https://cloud.google.com/compute/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/confidentialcomputing/v1/.repo-metadata.json
+++ b/src/generated/cloud/confidentialcomputing/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "confidentialcomputing",
     "name_pretty": "Confidential Computing",
     "product_documentation": "https://cloud.google.com/confidential-computing",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/config/v1/.repo-metadata.json
+++ b/src/generated/cloud/config/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "infra-manager",
     "name_pretty": "Infrastructure Manager",
     "product_documentation": "https://cloud.google.com/infrastructure-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/configdelivery/v1/.repo-metadata.json
+++ b/src/generated/cloud/configdelivery/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "configdelivery",
     "name_pretty": "Config Delivery",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/config-sync/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/connectors/v1/.repo-metadata.json
+++ b/src/generated/cloud/connectors/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "connectors",
     "name_pretty": "Connectors",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/contactcenterinsights/v1/.repo-metadata.json
+++ b/src/generated/cloud/contactcenterinsights/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "contactcenterinsights",
     "name_pretty": "Contact Center AI Insights",
     "product_documentation": "https://cloud.google.com/contact-center/insights/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/datacatalog/lineage/v1/.repo-metadata.json
+++ b/src/generated/cloud/datacatalog/lineage/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "datalineage",
     "name_pretty": "Data Lineage",
     "product_documentation": "https://cloud.google.com/data-catalog/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/datacatalog/v1/.repo-metadata.json
+++ b/src/generated/cloud/datacatalog/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "datacatalog",
     "name_pretty": "Google Cloud Data Catalog",
     "product_documentation": "https://cloud.google.com/data-catalog/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dataform/v1/.repo-metadata.json
+++ b/src/generated/cloud/dataform/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "dataform",
     "name_pretty": "Dataform",
     "product_documentation": "https://cloud.google.com/dataform/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/datafusion/v1/.repo-metadata.json
+++ b/src/generated/cloud/datafusion/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "datafusion",
     "name_pretty": "Cloud Data Fusion",
     "product_documentation": "https://cloud.google.com/data-fusion",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dataplex/v1/.repo-metadata.json
+++ b/src/generated/cloud/dataplex/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "dataplex",
     "name_pretty": "Cloud Dataplex",
     "product_documentation": "https://cloud.google.com/dataplex/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dataproc/v1/.repo-metadata.json
+++ b/src/generated/cloud/dataproc/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "dataproc",
     "name_pretty": "Cloud Dataproc",
     "product_documentation": "https://cloud.google.com/dataproc",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/datastream/v1/.repo-metadata.json
+++ b/src/generated/cloud/datastream/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "datastream",
     "name_pretty": "Datastream",
     "product_documentation": "https://cloud.google.com/datastream/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/deploy/v1/.repo-metadata.json
+++ b/src/generated/cloud/deploy/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "clouddeploy",
     "name_pretty": "Cloud Deploy",
     "product_documentation": "https://cloud.google.com/deploy/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/developerconnect/v1/.repo-metadata.json
+++ b/src/generated/cloud/developerconnect/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "developerconnect",
     "name_pretty": "Developer Connect",
     "product_documentation": "https://cloud.google.com/developer-connect/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/devicestreaming/v1/.repo-metadata.json
+++ b/src/generated/cloud/devicestreaming/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "devicestreaming",
     "name_pretty": "Device Streaming",
     "product_documentation": "https://cloud.google.com/device-streaming/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dialogflow/cx/v3/.repo-metadata.json
+++ b/src/generated/cloud/dialogflow/cx/v3/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "dialogflow",
     "name_pretty": "Dialogflow",
     "product_documentation": "https://cloud.google.com/dialogflow/cx/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dialogflow/v2/.repo-metadata.json
+++ b/src/generated/cloud/dialogflow/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "dialogflow",
     "name_pretty": "Dialogflow",
     "product_documentation": "https://docs.cloud.google.com/dialogflow/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/discoveryengine/v1/.repo-metadata.json
+++ b/src/generated/cloud/discoveryengine/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "discoveryengine",
     "name_pretty": "Discovery Engine",
     "product_documentation": "https://cloud.google.com/generative-ai-app-builder/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/dns/v1/.repo-metadata.json
+++ b/src/generated/cloud/dns/v1/.repo-metadata.json
@@ -7,5 +7,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "dns",
     "name_pretty": "Cloud DNS",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/documentai/v1/.repo-metadata.json
+++ b/src/generated/cloud/documentai/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "documentai",
     "name_pretty": "Cloud Document AI",
     "product_documentation": "https://cloud.google.com/document-ai/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/domains/v1/.repo-metadata.json
+++ b/src/generated/cloud/domains/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "domains",
     "name_pretty": "Cloud Domains",
     "product_documentation": "https://cloud.google.com/domains",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/edgecontainer/v1/.repo-metadata.json
+++ b/src/generated/cloud/edgecontainer/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "edgecontainer",
     "name_pretty": "Distributed Cloud Edge Container",
     "product_documentation": "https://cloud.google.com/distributed-cloud/edge",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/edgenetwork/v1/.repo-metadata.json
+++ b/src/generated/cloud/edgenetwork/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "edgenetwork",
     "name_pretty": "Distributed Cloud Edge Network",
     "product_documentation": "https://cloud.google.com/distributed-cloud/edge/latest/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/essentialcontacts/v1/.repo-metadata.json
+++ b/src/generated/cloud/essentialcontacts/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "essentialcontacts",
     "name_pretty": "Essential Contacts",
     "product_documentation": "https://cloud.google.com/resource-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/eventarc/publishing/v1/.repo-metadata.json
+++ b/src/generated/cloud/eventarc/publishing/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "eventarcpublishing",
     "name_pretty": "Eventarc Publishing",
     "product_documentation": "https://cloud.google.com/eventarc/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/eventarc/v1/.repo-metadata.json
+++ b/src/generated/cloud/eventarc/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "eventarc",
     "name_pretty": "Eventarc",
     "product_documentation": "https://cloud.google.com/eventarc/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/filestore/v1/.repo-metadata.json
+++ b/src/generated/cloud/filestore/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "file",
     "name_pretty": "Cloud Filestore",
     "product_documentation": "https://cloud.google.com/filestore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/financialservices/v1/.repo-metadata.json
+++ b/src/generated/cloud/financialservices/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "financialservices",
     "name_pretty": "Financial Services",
     "product_documentation": "https://cloud.google.com/financial-services/anti-money-laundering/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/functions/v2/.repo-metadata.json
+++ b/src/generated/cloud/functions/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudfunctions",
     "name_pretty": "Cloud Functions",
     "product_documentation": "https://cloud.google.com/functions/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gkebackup/v1/.repo-metadata.json
+++ b/src/generated/cloud/gkebackup/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "gkebackup",
     "name_pretty": "Backup for GKE",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/.repo-metadata.json
+++ b/src/generated/cloud/gkeconnect/gateway/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "connectgateway",
     "name_pretty": "Connect Gateway",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gkehub/v1/.repo-metadata.json
+++ b/src/generated/cloud/gkehub/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "gkehub",
     "name_pretty": "GKE Hub",
     "product_documentation": "https://cloud.google.com/anthos/gke/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gkemulticloud/v1/.repo-metadata.json
+++ b/src/generated/cloud/gkemulticloud/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "gkemulticloud",
     "name_pretty": "GKE Multi-Cloud",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/multi-cloud/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gkerecommender/v1/.repo-metadata.json
+++ b/src/generated/cloud/gkerecommender/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "gkerecommender",
     "name_pretty": "GKE Recommender",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/gsuiteaddons/v1/.repo-metadata.json
+++ b/src/generated/cloud/gsuiteaddons/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "gsuiteaddons",
     "name_pretty": "Google Workspace add-ons",
     "product_documentation": "https://developers.google.com/workspace/add-ons/overview",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/hypercomputecluster/v1/.repo-metadata.json
+++ b/src/generated/cloud/hypercomputecluster/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "hypercomputecluster",
     "name_pretty": "Cluster Director",
     "product_documentation": "https://cloud.google.com/cluster-director/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/iap/v1/.repo-metadata.json
+++ b/src/generated/cloud/iap/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "iap",
     "name_pretty": "Cloud Identity-Aware Proxy",
     "product_documentation": "https://cloud.google.com/iap",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/ids/v1/.repo-metadata.json
+++ b/src/generated/cloud/ids/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "ids",
     "name_pretty": "Cloud IDS",
     "product_documentation": "https://cloud.google.com/intrusion-detection-system/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/kms/inventory/v1/.repo-metadata.json
+++ b/src/generated/cloud/kms/inventory/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "kmsinventory",
     "name_pretty": "KMS Inventory",
     "product_documentation": "https://cloud.google.com/kms/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/kms/v1/.repo-metadata.json
+++ b/src/generated/cloud/kms/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudkms",
     "name_pretty": "Cloud Key Management Service (KMS)",
     "product_documentation": "https://cloud.google.com/kms",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/language/v2/.repo-metadata.json
+++ b/src/generated/cloud/language/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "language",
     "name_pretty": "Cloud Natural Language",
     "product_documentation": "https://cloud.google.com/natural-language/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/licensemanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/licensemanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "licensemanager",
     "name_pretty": "License Manager",
     "product_documentation": "https://cloud.google.com/compute/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/location/.repo-metadata.json
+++ b/src/generated/cloud/location/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloud",
     "name_pretty": "Cloud Metadata",
     "product_documentation": "https://github.com/googleapis/googleapis/tree/master/google",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/locationfinder/v1/.repo-metadata.json
+++ b/src/generated/cloud/locationfinder/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "locationfinder",
     "name_pretty": "Cloud Location Finder",
     "product_documentation": "https://cloud.google.com/location-finder/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/lustre/v1/.repo-metadata.json
+++ b/src/generated/cloud/lustre/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "lustre",
     "name_pretty": "Google Cloud Managed Lustre",
     "product_documentation": "https://cloud.google.com/managed-lustre/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/maintenance/api/v1/.repo-metadata.json
+++ b/src/generated/cloud/maintenance/api/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "maintenance",
     "name_pretty": "Maintenance",
     "product_documentation": "https://cloud.google.com/unified-maintenance/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/managedidentities/v1/.repo-metadata.json
+++ b/src/generated/cloud/managedidentities/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "managedidentities",
     "name_pretty": "Managed Service for Microsoft Active Directory",
     "product_documentation": "https://cloud.google.com/managed-microsoft-ad/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/.repo-metadata.json
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "managedkafka",
     "name_pretty": "Managed Service for Apache Kafka",
     "product_documentation": "https://cloud.google.com/managed-service-for-apache-kafka/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/managedkafka/v1/.repo-metadata.json
+++ b/src/generated/cloud/managedkafka/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "managedkafka",
     "name_pretty": "Managed Service for Apache Kafka",
     "product_documentation": "https://cloud.google.com/managed-service-for-apache-kafka/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/memcache/v1/.repo-metadata.json
+++ b/src/generated/cloud/memcache/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "memcache",
     "name_pretty": "Cloud Memorystore for Memcached",
     "product_documentation": "https://cloud.google.com/memorystore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/memorystore/v1/.repo-metadata.json
+++ b/src/generated/cloud/memorystore/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "memorystore",
     "name_pretty": "Memorystore",
     "product_documentation": "https://cloud.google.com/memorystore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/metastore/v1/.repo-metadata.json
+++ b/src/generated/cloud/metastore/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "metastore",
     "name_pretty": "Dataproc Metastore",
     "product_documentation": "https://cloud.google.com/dataproc-metastore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/migrationcenter/v1/.repo-metadata.json
+++ b/src/generated/cloud/migrationcenter/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "migrationcenter",
     "name_pretty": "Migration Center",
     "product_documentation": "https://cloud.google.com/migration-center/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/modelarmor/v1/.repo-metadata.json
+++ b/src/generated/cloud/modelarmor/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "modelarmor",
     "name_pretty": "Model Armor",
     "product_documentation": "https://cloud.google.com/security-command-center/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/netapp/v1/.repo-metadata.json
+++ b/src/generated/cloud/netapp/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "netapp",
     "name_pretty": "NetApp",
     "product_documentation": "https://cloud.google.com/netapp/volumes/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/networkconnectivity/v1/.repo-metadata.json
+++ b/src/generated/cloud/networkconnectivity/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "networkconnectivity",
     "name_pretty": "Network Connectivity",
     "product_documentation": "https://cloud.google.com/network-connectivity/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/networkmanagement/v1/.repo-metadata.json
+++ b/src/generated/cloud/networkmanagement/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "networkmanagement",
     "name_pretty": "Network Management",
     "product_documentation": "https://cloud.google.com/network-management",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/networksecurity/v1/.repo-metadata.json
+++ b/src/generated/cloud/networksecurity/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "networksecurity",
     "name_pretty": "Network Security",
     "product_documentation": "https://cloud.google.com/traffic-director/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/networkservices/v1/.repo-metadata.json
+++ b/src/generated/cloud/networkservices/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "networkservices",
     "name_pretty": "Network Services",
     "product_documentation": "https://cloud.google.com/products/networking",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/notebooks/v2/.repo-metadata.json
+++ b/src/generated/cloud/notebooks/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "notebooks",
     "name_pretty": "Notebooks",
     "product_documentation": "https://cloud.google.com/vertex-ai/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/optimization/v1/.repo-metadata.json
+++ b/src/generated/cloud/optimization/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "cloudoptimization",
     "name_pretty": "Cloud Optimization",
     "product_documentation": "https://cloud.google.com/optimization/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/oracledatabase/v1/.repo-metadata.json
+++ b/src/generated/cloud/oracledatabase/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "oracledatabase",
     "name_pretty": "Oracle Database@Google Cloud",
     "product_documentation": "https://cloud.google.com/oracle/database/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/.repo-metadata.json
+++ b/src/generated/cloud/orchestration/airflow/service/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "composer",
     "name_pretty": "Cloud Composer",
     "product_documentation": "https://cloud.google.com/composer/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/orgpolicy/v2/.repo-metadata.json
+++ b/src/generated/cloud/orgpolicy/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "orgpolicy",
     "name_pretty": "Organization Policy",
     "product_documentation": "https://cloud.google.com/resource-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/osconfig/v1/.repo-metadata.json
+++ b/src/generated/cloud/osconfig/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "osconfig",
     "name_pretty": "OS Config",
     "product_documentation": "https://cloud.google.com/compute/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/oslogin/v1/.repo-metadata.json
+++ b/src/generated/cloud/oslogin/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "oslogin",
     "name_pretty": "Cloud OS Login",
     "product_documentation": "https://cloud.google.com/compute/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/parallelstore/v1/.repo-metadata.json
+++ b/src/generated/cloud/parallelstore/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "parallelstore",
     "name_pretty": "Parallelstore",
     "product_documentation": "https://cloud.google.com/parallelstore?hl=en",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/parametermanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/parametermanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "parametermanager",
     "name_pretty": "Parameter Manager",
     "product_documentation": "https://cloud.google.com/secret-manager/parameter-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/policysimulator/v1/.repo-metadata.json
+++ b/src/generated/cloud/policysimulator/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "policysimulator",
     "name_pretty": "Policy Simulator",
     "product_documentation": "https://cloud.google.com/policy-intelligence/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/.repo-metadata.json
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "policytroubleshooter",
     "name_pretty": "Policy Troubleshooter",
     "product_documentation": "https://cloud.google.com/policy-intelligence/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/policytroubleshooter/v1/.repo-metadata.json
+++ b/src/generated/cloud/policytroubleshooter/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "policytroubleshooter",
     "name_pretty": "Policy Troubleshooter",
     "product_documentation": "https://cloud.google.com/policy-intelligence/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/privilegedaccessmanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "privilegedaccessmanager",
     "name_pretty": "Privileged Access Manager",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/.repo-metadata.json
+++ b/src/generated/cloud/rapidmigrationassessment/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "rapidmigrationassessment",
     "name_pretty": "Rapid Migration Assessment",
     "product_documentation": "https://cloud.google.com/migration-center/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/.repo-metadata.json
+++ b/src/generated/cloud/recaptchaenterprise/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "recaptchaenterprise",
     "name_pretty": "reCAPTCHA Enterprise",
     "product_documentation": "https://cloud.google.com/recaptcha-enterprise",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/recommender/v1/.repo-metadata.json
+++ b/src/generated/cloud/recommender/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "recommender",
     "name_pretty": "Recommender",
     "product_documentation": "https://cloud.google.com/recommender",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/redis/cluster/v1/.repo-metadata.json
+++ b/src/generated/cloud/redis/cluster/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "redis",
     "name_pretty": "Google Cloud Memorystore for Redis",
     "product_documentation": "https://cloud.google.com/memorystore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/redis/v1/.repo-metadata.json
+++ b/src/generated/cloud/redis/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "redis",
     "name_pretty": "Google Cloud Memorystore for Redis",
     "product_documentation": "https://cloud.google.com/memorystore/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/resourcemanager/v3/.repo-metadata.json
+++ b/src/generated/cloud/resourcemanager/v3/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudresourcemanager",
     "name_pretty": "Cloud Resource Manager",
     "product_documentation": "https://cloud.google.com/resource-manager",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/retail/v2/.repo-metadata.json
+++ b/src/generated/cloud/retail/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "retail",
     "name_pretty": "Vertex AI Search for commerce",
     "product_documentation": "https://cloud.google.com/retail/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/run/v2/.repo-metadata.json
+++ b/src/generated/cloud/run/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "run",
     "name_pretty": "Cloud Run Admin",
     "product_documentation": "https://cloud.google.com/run/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/scheduler/v1/.repo-metadata.json
+++ b/src/generated/cloud/scheduler/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudscheduler",
     "name_pretty": "Cloud Scheduler",
     "product_documentation": "https://cloud.google.com/scheduler/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/secretmanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/secretmanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "secretmanager",
     "name_pretty": "Secret Manager",
     "product_documentation": "https://cloud.google.com/secret-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/securesourcemanager/v1/.repo-metadata.json
+++ b/src/generated/cloud/securesourcemanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "securesourcemanager",
     "name_pretty": "Secure Source Manager",
     "product_documentation": "https://cloud.google.com/secure-source-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/security/privateca/v1/.repo-metadata.json
+++ b/src/generated/cloud/security/privateca/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "privateca",
     "name_pretty": "Certificate Authority",
     "product_documentation": "https://cloud.google.com/certificate-authority-service",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/security/publicca/v1/.repo-metadata.json
+++ b/src/generated/cloud/security/publicca/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "publicca",
     "name_pretty": "Public Certificate Authority",
     "product_documentation": "https://cloud.google.com/certificate-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/securitycenter/v2/.repo-metadata.json
+++ b/src/generated/cloud/securitycenter/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "securitycenter",
     "name_pretty": "Security Command Center",
     "product_documentation": "https://cloud.google.com/security-command-center/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/securitycentermanagement/v1/.repo-metadata.json
+++ b/src/generated/cloud/securitycentermanagement/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "securitycentermanagement",
     "name_pretty": "Security Command Center Management",
     "product_documentation": "https://cloud.google.com/security-command-center/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/securityposture/v1/.repo-metadata.json
+++ b/src/generated/cloud/securityposture/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "securityposture",
     "name_pretty": "Security Posture",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/servicedirectory/v1/.repo-metadata.json
+++ b/src/generated/cloud/servicedirectory/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "servicedirectory",
     "name_pretty": "Service Directory",
     "product_documentation": "https://cloud.google.com/service-directory/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/servicehealth/v1/.repo-metadata.json
+++ b/src/generated/cloud/servicehealth/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "servicehealth",
     "name_pretty": "Service Health",
     "product_documentation": "https://cloud.google.com/service-health/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/shell/v1/.repo-metadata.json
+++ b/src/generated/cloud/shell/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "cloudshell",
     "name_pretty": "Cloud Shell",
     "product_documentation": "https://cloud.google.com/shell/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/speech/v2/.repo-metadata.json
+++ b/src/generated/cloud/speech/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "speech",
     "name_pretty": "Cloud Speech-to-Text",
     "product_documentation": "https://cloud.google.com/speech-to-text/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/sql/v1/.repo-metadata.json
+++ b/src/generated/cloud/sql/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "sqladmin",
     "name_pretty": "Cloud SQL Admin",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/storagebatchoperations/v1/.repo-metadata.json
+++ b/src/generated/cloud/storagebatchoperations/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "storagebatchoperations",
     "name_pretty": "Storage Batch Operations",
     "product_documentation": "https://cloud.google.com/storage/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/storageinsights/v1/.repo-metadata.json
+++ b/src/generated/cloud/storageinsights/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "storageinsights",
     "name_pretty": "Storage Insights",
     "product_documentation": "https://cloud.google.com/storage/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/support/v2/.repo-metadata.json
+++ b/src/generated/cloud/support/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudsupport",
     "name_pretty": "Google Cloud Support",
     "product_documentation": "https://cloud.google.com/support/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/talent/v4/.repo-metadata.json
+++ b/src/generated/cloud/talent/v4/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "jobs",
     "name_pretty": "Cloud Talent Solution",
     "product_documentation": "https://cloud.google.com/solutions/talent-solution/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/tasks/v2/.repo-metadata.json
+++ b/src/generated/cloud/tasks/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudtasks",
     "name_pretty": "Cloud Tasks",
     "product_documentation": "https://cloud.google.com/tasks/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/telcoautomation/v1/.repo-metadata.json
+++ b/src/generated/cloud/telcoautomation/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "telcoautomation",
     "name_pretty": "Telco Automation",
     "product_documentation": "https://cloud.google.com/telecom-network-automation",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/texttospeech/v1/.repo-metadata.json
+++ b/src/generated/cloud/texttospeech/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "texttospeech",
     "name_pretty": "Cloud Text-to-Speech",
     "product_documentation": "https://cloud.google.com/text-to-speech",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/timeseriesinsights/v1/.repo-metadata.json
+++ b/src/generated/cloud/timeseriesinsights/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "timeseriesinsights",
     "name_pretty": "Timeseries Insights",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/tpu/v2/.repo-metadata.json
+++ b/src/generated/cloud/tpu/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "tpu",
     "name_pretty": "Cloud TPU",
     "product_documentation": "https://cloud.google.com/tpu/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/translate/v3/.repo-metadata.json
+++ b/src/generated/cloud/translate/v3/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "translate",
     "name_pretty": "Cloud Translation",
     "product_documentation": "https://cloud.google.com/translate/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vectorsearch/v1/.repo-metadata.json
+++ b/src/generated/cloud/vectorsearch/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "vectorsearch",
     "name_pretty": "Vector Search",
     "product_documentation": "https://docs.cloud.google.com/vertex-ai/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/video/livestream/v1/.repo-metadata.json
+++ b/src/generated/cloud/video/livestream/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "livestream",
     "name_pretty": "Live Stream",
     "product_documentation": "https://cloud.google.com/livestream/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/video/stitcher/v1/.repo-metadata.json
+++ b/src/generated/cloud/video/stitcher/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "videostitcher",
     "name_pretty": "Video Stitcher",
     "product_documentation": "https://cloud.google.com/video-stitcher",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/video/transcoder/v1/.repo-metadata.json
+++ b/src/generated/cloud/video/transcoder/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "transcoder",
     "name_pretty": "Transcoder",
     "product_documentation": "https://cloud.google.com/transcoder",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/videointelligence/v1/.repo-metadata.json
+++ b/src/generated/cloud/videointelligence/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "videointelligence",
     "name_pretty": "Cloud Video Intelligence",
     "product_documentation": "https://cloud.google.com/video-intelligence/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vision/v1/.repo-metadata.json
+++ b/src/generated/cloud/vision/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "vision",
     "name_pretty": "Cloud Vision",
     "product_documentation": "https://cloud.google.com/vision/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vmmigration/v1/.repo-metadata.json
+++ b/src/generated/cloud/vmmigration/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "vmmigration",
     "name_pretty": "VM Migration",
     "product_documentation": "https://cloud.google.com/migrate/compute-engine/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vmwareengine/v1/.repo-metadata.json
+++ b/src/generated/cloud/vmwareengine/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "vmwareengine",
     "name_pretty": "VMware Engine",
     "product_documentation": "https://cloud.google.com/vmware-engine/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vpcaccess/v1/.repo-metadata.json
+++ b/src/generated/cloud/vpcaccess/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "vpcaccess",
     "name_pretty": "Serverless VPC Access",
     "product_documentation": "https://cloud.google.com/vpc/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/webrisk/v1/.repo-metadata.json
+++ b/src/generated/cloud/webrisk/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "name": "webrisk",
     "name_pretty": "Web Risk",
     "product_documentation": "https://cloud.google.com/web-risk/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/websecurityscanner/v1/.repo-metadata.json
+++ b/src/generated/cloud/websecurityscanner/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "websecurityscanner",
     "name_pretty": "Web Security Scanner",
     "product_documentation": "https://cloud.google.com/security-scanner/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/workflows/executions/v1/.repo-metadata.json
+++ b/src/generated/cloud/workflows/executions/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "workflowexecutions",
     "name_pretty": "Workflow Executions",
     "product_documentation": "https://cloud.google.com/workflows/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/workflows/v1/.repo-metadata.json
+++ b/src/generated/cloud/workflows/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "workflows",
     "name_pretty": "Workflows",
     "product_documentation": "https://cloud.google.com/workflows/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/workstations/v1/.repo-metadata.json
+++ b/src/generated/cloud/workstations/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "workstations",
     "name_pretty": "Cloud Workstations",
     "product_documentation": "https://cloud.google.com/workstations/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/container/v1/.repo-metadata.json
+++ b/src/generated/container/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "container",
     "name_pretty": "Kubernetes Engine",
     "product_documentation": "https://cloud.google.com/kubernetes-engine/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/datastore/admin/v1/.repo-metadata.json
+++ b/src/generated/datastore/admin/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "datastore",
     "name_pretty": "Cloud Datastore",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/artifactregistry/v1/.repo-metadata.json
+++ b/src/generated/devtools/artifactregistry/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "artifactregistry",
     "name_pretty": "Artifact Registry",
     "product_documentation": "https://cloud.google.com/artifact-registry",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/cloudbuild/v1/.repo-metadata.json
+++ b/src/generated/devtools/cloudbuild/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudbuild",
     "name_pretty": "Cloud Build",
     "product_documentation": "https://cloud.google.com/cloud-build/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/cloudbuild/v2/.repo-metadata.json
+++ b/src/generated/devtools/cloudbuild/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudbuild",
     "name_pretty": "Cloud Build",
     "product_documentation": "https://cloud.google.com/cloud-build/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/cloudprofiler/v2/.repo-metadata.json
+++ b/src/generated/devtools/cloudprofiler/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudprofiler",
     "name_pretty": "Cloud Profiler",
     "product_documentation": "https://cloud.google.com/profiler/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/cloudtrace/v1/.repo-metadata.json
+++ b/src/generated/devtools/cloudtrace/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudtrace",
     "name_pretty": "Cloud Trace",
     "product_documentation": "https://cloud.google.com/trace/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/cloudtrace/v2/.repo-metadata.json
+++ b/src/generated/devtools/cloudtrace/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "cloudtrace",
     "name_pretty": "Cloud Trace",
     "product_documentation": "https://cloud.google.com/trace/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/devtools/containeranalysis/v1/.repo-metadata.json
+++ b/src/generated/devtools/containeranalysis/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "containeranalysis",
     "name_pretty": "Container Analysis",
     "product_documentation": "https://cloud.google.com/container-registry/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/firestore/admin/v1/.repo-metadata.json
+++ b/src/generated/firestore/admin/v1/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "firestore",
     "name_pretty": "Cloud Firestore",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/grafeas/v1/.repo-metadata.json
+++ b/src/generated/grafeas/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "containeranalysis",
     "name_pretty": "Container Analysis",
     "product_documentation": "https://grafeas.io",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/iam/admin/v1/.repo-metadata.json
+++ b/src/generated/iam/admin/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "iam",
     "name_pretty": "Identity and Access Management (IAM)",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/iam/credentials/v1/.repo-metadata.json
+++ b/src/generated/iam/credentials/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "iamcredentials",
     "name_pretty": "IAM Service Account Credentials",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/iam/v1/.repo-metadata.json
+++ b/src/generated/iam/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "iam-meta-api",
     "name_pretty": "IAM Meta",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/iam/v2/.repo-metadata.json
+++ b/src/generated/iam/v2/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "iam",
     "name_pretty": "Identity and Access Management (IAM)",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/iam/v3/.repo-metadata.json
+++ b/src/generated/iam/v3/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "iam",
     "name_pretty": "Identity and Access Management (IAM)",
     "product_documentation": "https://cloud.google.com/iam/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/identity/accesscontextmanager/v1/.repo-metadata.json
+++ b/src/generated/identity/accesscontextmanager/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "accesscontextmanager",
     "name_pretty": "Access Context Manager",
     "product_documentation": "https://cloud.google.com/access-context-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/logging/v2/.repo-metadata.json
+++ b/src/generated/logging/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "logging",
     "name_pretty": "Cloud Logging",
     "product_documentation": "https://cloud.google.com/logging/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/longrunning/.repo-metadata.json
+++ b/src/generated/longrunning/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "longrunning",
     "name_pretty": "Long Running Operations",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/monitoring/dashboard/v1/.repo-metadata.json
+++ b/src/generated/monitoring/dashboard/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "monitoring",
     "name_pretty": "Cloud Monitoring",
     "product_documentation": "https://cloud.google.com/monitoring/dashboards/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/monitoring/metricsscope/v1/.repo-metadata.json
+++ b/src/generated/monitoring/metricsscope/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "monitoring",
     "name_pretty": "Cloud Monitoring",
     "product_documentation": "https://cloud.google.com/monitoring/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/monitoring/v3/.repo-metadata.json
+++ b/src/generated/monitoring/v3/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "monitoring",
     "name_pretty": "Cloud Monitoring",
     "product_documentation": "https://cloud.google.com/monitoring/docs",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/openapi-validation/.repo-metadata.json
+++ b/src/generated/openapi-validation/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "secretmanager",
     "name_pretty": "Secret Manager",
     "product_documentation": "https://cloud.google.com/secret-manager/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/privacy/dlp/v2/.repo-metadata.json
+++ b/src/generated/privacy/dlp/v2/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "dlp",
     "name_pretty": "Sensitive Data Protection (DLP)",
     "product_documentation": "https://cloud.google.com/dlp/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/showcase/.repo-metadata.json
+++ b/src/generated/showcase/.repo-metadata.json
@@ -8,5 +8,6 @@
     "library_type": "GAPIC_AUTO",
     "name": "showcase",
     "name_pretty": "Client Libraries Showcase",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/spanner/admin/database/v1/.repo-metadata.json
+++ b/src/generated/spanner/admin/database/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "spanner",
     "name_pretty": "Cloud Spanner",
     "product_documentation": "https://cloud.google.com/spanner/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/spanner/admin/instance/v1/.repo-metadata.json
+++ b/src/generated/spanner/admin/instance/v1/.repo-metadata.json
@@ -10,5 +10,6 @@
     "name": "spanner",
     "name_pretty": "Cloud Spanner",
     "product_documentation": "https://cloud.google.com/spanner/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/storagetransfer/v1/.repo-metadata.json
+++ b/src/generated/storagetransfer/v1/.repo-metadata.json
@@ -9,5 +9,6 @@
     "name": "storagetransfer",
     "name_pretty": "Storage Transfer",
     "product_documentation": "https://cloud.google.com/storage-transfer/",
-    "release_level": "stable"
+    "release_level": "stable",
+    "repo": "googleapis/google-cloud-rust"
 }


### PR DESCRIPTION
Evidently librarian now requires the `repo` field to produce compute `.repo-metadata.json` files.

Fixes some of my changes from #5055.  Evidently librarian now requires the `repo` field after https://github.com/googleapis/librarian/pull/4627
