### PR TITLE
test(storage-w1r3): add OpenTelemetry tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7915,6 +7915,9 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-storage",
  "humantime",
+ "integration-tests-o11y",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "parse-size",
  "pin-project",
  "rand 0.10.0",
@@ -7923,6 +7926,7 @@ dependencies = [
  "tokio-metrics",
  "tracing",
  "tracing-log",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -519,8 +519,9 @@ secretmanager-openapi-v1             = { default-features = false, path = "src/g
 google-cloud-test-macros = { path = "src/test-macros" }
 google-cloud-test-utils  = { default-features = false, path = "src/test-utils" }
 integration-tests        = { path = "tests/integration" }
-pubsub-samples           = { path = "src/pubsub/examples" }
-storage-samples          = { path = "src/storage/examples" }
+integration-tests-o11y = { default-features = false, path = "tests/o11y" }
+pubsub-samples         = { path = "src/pubsub/examples" }
+storage-samples        = { path = "src/storage/examples" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [

--- a/src/storage/benchmarks/w1r3/Cargo.toml
+++ b/src/storage/benchmarks/w1r3/Cargo.toml
@@ -32,12 +32,19 @@ google-cloud-auth.workspace = true
 google-cloud-gax.workspace  = true
 google-cloud-storage        = { workspace = true, features = ["default-rustls-provider"] }
 humantime.workspace         = true
-parse-size.workspace        = true
-pin-project.workspace       = true
-rand.workspace              = true
-regex.workspace             = true
-tokio                       = { workspace = true, features = ["macros"] }
-tokio-metrics               = { workspace = true, features = ["rt"] }
-tracing.workspace           = true
-tracing-log                 = { workspace = true, features = ["log-tracer", "std"] }
-tracing-subscriber          = { workspace = true, features = ["fmt", "std"] }
+integration-tests-o11y.workspace = true
+opentelemetry = { workspace = true, features = ["trace"] }
+opentelemetry_sdk     = { workspace = true, features = ["rt-tokio", "trace"] }
+parse-size.workspace  = true
+pin-project.workspace = true
+rand.workspace        = true
+regex.workspace       = true
+tokio                 = { workspace = true, features = ["macros"] }
+tokio-metrics         = { workspace = true, features = ["rt"] }
+tracing.workspace     = true
+tracing-log           = { workspace = true, features = ["log-tracer", "std"] }
+tracing-opentelemetry.workspace = true
+tracing-subscriber              = { workspace = true, features = ["fmt", "std"] }
+
+[lints]
+workspace = true

--- a/src/storage/benchmarks/w1r3/src/main.rs
+++ b/src/storage/benchmarks/w1r3/src/main.rs
@@ -47,6 +47,11 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Sender;
+use tracing::Instrument;
+
+#[cfg(google_cloud_unstable_tracing)]
+static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::SdkTracerProvider> =
+    std::sync::OnceLock::new();
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(900);
 
@@ -62,7 +67,8 @@ async fn main() -> anyhow::Result<()> {
     if args.reqwest_logs {
         tracing_log::LogTracer::init()?;
     }
-    enable_tracing(&args);
+    let credentials = CredentialsBuilder::default().build()?;
+    enable_tracing(&args, &credentials).await?;
     tracing::info!("{args:?}");
 
     let handle = tokio::runtime::Handle::current();
@@ -75,10 +81,9 @@ async fn main() -> anyhow::Result<()> {
             tokio::time::sleep(frequency).await;
         }
     });
-
-    let credentials = CredentialsBuilder::default().build()?;
     let client = Storage::builder()
         .with_credentials(credentials.clone())
+        .with_tracing()
         .build()
         .await?;
 
@@ -96,15 +101,19 @@ async fn main() -> anyhow::Result<()> {
     let test_start = Instant::now();
     let tasks = (0..args.task_count)
         .map(|task| {
-            tokio::spawn(runner(
-                task,
-                test_start,
-                client.clone(),
-                credentials.clone(),
-                buffer.clone(),
-                tx.clone(),
-                args.clone(),
-            ))
+            let span = tracing::info_span!("w1r3.task", task_id = task);
+            tokio::spawn(
+                runner(
+                    task,
+                    test_start,
+                    client.clone(),
+                    credentials.clone(),
+                    buffer.clone(),
+                    tx.clone(),
+                    args.clone(),
+                )
+                .instrument(span),
+            )
         })
         .collect::<Vec<_>>();
     drop(tx);
@@ -125,6 +134,7 @@ async fn main() -> anyhow::Result<()> {
         }
     }
     tracing::info!("DONE");
+    flush_tracing();
     Ok(())
 }
 
@@ -171,6 +181,7 @@ async fn runner(
             (Operation::SingleShot, size + 1)
         };
 
+        let upload_span = tracing::info_span!("w1r3.upload", op = %write_op.name(), size);
         let builder = SampleBuilder::new(&task, iteration, write_op, size, name.clone());
         let upload = match upload(
             &client,
@@ -180,6 +191,7 @@ async fn runner(
             buffer.slice(0..size),
             threshold,
         )
+        .instrument(upload_span)
         .await
         {
             Ok(u) => {
@@ -197,7 +209,11 @@ async fn runner(
         for i in 0..(args.read_count) {
             let op = Operation::Read(i);
             let builder = SampleBuilder::new(&task, iteration, op, size, upload.name.clone());
-            let sample = match download(&client, &args, &upload).await {
+            let download_span = tracing::info_span!("w1r3.download", read_index = i, size);
+            let sample = match download(&client, &args, &upload)
+                .instrument(download_span)
+                .await
+            {
                 (_, Ok(_)) => builder.success(),
                 (0, Err(e)) => builder.error(&e),
                 (partial, Err(e)) => builder.interrupted(partial, &e),
@@ -209,6 +225,7 @@ async fn runner(
         }
         if deletes.len() >= batch_size {
             batch_size = rand::rng().sample(batch_size_gen);
+            let delete_span = tracing::info_span!("w1r3.delete_batch", batch_size = deletes.len());
             batch_delete(
                 &task,
                 iteration,
@@ -216,9 +233,11 @@ async fn runner(
                 deletes.drain(..),
                 name.as_str(),
             )
+            .instrument(delete_span)
             .await;
         }
     }
+    let delete_span = tracing::info_span!("w1r3.delete_batch", batch_size = deletes.len());
     batch_delete(
         &task,
         args.iterations,
@@ -226,6 +245,7 @@ async fn runner(
         deletes.into_iter(),
         "N/A",
     )
+    .instrument(delete_span)
     .await;
     Ok(())
 }
@@ -610,7 +630,7 @@ fn counters() -> impl Iterator<Item = (&'static str, u64)> {
     .into_iter()
 }
 
-fn enable_tracing(args: &Args) {
+async fn enable_tracing(args: &Args, _credentials: &Credentials) -> anyhow::Result<()> {
     use tracing_subscriber::fmt::format::{self, FmtSpan};
     use tracing_subscriber::prelude::*;
 
@@ -643,21 +663,48 @@ fn enable_tracing(args: &Args) {
     // formatter so that a delimiter is added between fields.
     .delimited("; ");
 
-    let subscriber = tracing_subscriber::fmt()
+    let level_filter = if args.reqwest_logs {
+        tracing_subscriber::filter::LevelFilter::TRACE
+    } else {
+        tracing_subscriber::filter::LevelFilter::INFO
+    };
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
         .with_level(true)
         .with_thread_ids(true)
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
         .with_writer(std::io::stderr)
-        .fmt_fields(formatter);
-    let subscriber = if !args.reqwest_logs {
-        subscriber.with_max_level(tracing::Level::INFO)
-    } else {
-        subscriber.with_max_level(tracing::Level::TRACE)
-    };
-    let subscriber = subscriber.finish();
+        .fmt_fields(formatter)
+        .with_filter(level_filter);
 
-    tracing::subscriber::set_global_default(subscriber)
-        .expect("setting global subscriber succeeds");
+    let registry = tracing_subscriber::Registry::default().with(fmt_layer);
+
+    #[cfg(google_cloud_unstable_tracing)]
+    if let Some(project_id) = &args.project_id {
+        let tracer_provider =
+            integration_tests_o11y::otlp::trace::Builder::new(project_id, "storage-w1r3")
+                .with_credentials(_credentials.clone())
+                .build()
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to create tracer provider: {e}"))?;
+        let otel_layer = integration_tests_o11y::tracing::layer(tracer_provider.clone());
+        TRACER_PROVIDER.set(tracer_provider).ok();
+        tracing::subscriber::set_global_default(registry.with(otel_layer))
+            .expect("setting global subscriber succeeds");
+        return Ok(());
+    }
+
+    tracing::subscriber::set_global_default(registry).expect("setting global subscriber succeeds");
+    Ok(())
+}
+
+fn flush_tracing() {
+    #[cfg(google_cloud_unstable_tracing)]
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(e) = provider.force_flush() {
+            eprintln!("error flushing trace provider: {e}");
+        }
+    }
 }
 
 /// Runs the W1R3 benchmark for the Rust client library.
@@ -728,6 +775,14 @@ struct Args {
     /// Enable logs for the retry policies.
     #[arg(long)]
     debug_retry: bool,
+
+    /// The Google Cloud project ID.
+    ///
+    /// When set, enables OpenTelemetry export to Cloud Trace via
+    /// telemetry.googleapis.com.
+    #[cfg(google_cloud_unstable_tracing)]
+    #[arg(long)]
+    project_id: Option<String>,
 }
 
 fn parse_size_arg(arg: &str) -> anyhow::Result<u64> {


### PR DESCRIPTION
Integrates OpenTelemetry tracing into the w1r3 storage benchmark using the `integration-tests-o11y` crate. When built with `--cfg google_cloud_unstable_tracing` and run with the `--project-id` flag, traces will be exported to Google Cloud Trace.

The eventual goal is to move this to `storage-shared-benchmarking-prelaunch`. As a start, the plan is to bring the existing benchmark to parity with the other language benchmarks, before migrating it over to `storage-shared-benchmarking-prelaunch`.