### PR TITLE
test(pubsub): speed up testing on macOS

### DIFF
--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -555,7 +555,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics(start_paused = true)]
+    #[tokio_test_no_panics]
     async fn basic_success_exactly_once() -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
         let (ack_tx, mut ack_rx) = unbounded_channel();


### PR DESCRIPTION
Without this change the test takes over 2 minutes on macOS. At least one attempt takes over 10 minutes. It is possible it is even deadlocked or at least not making progress.

With this change the test passes in less than 100ms.