### PR TITLE
test(pubsub): mixed stream

### DIFF
--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -1484,7 +1484,7 @@ mod tests {
         assert!(end.is_none(), "Received extra message: {end:?}");
 
         // Wait for the stream to join its background tasks.
-        stream.close().await?;
+        stream.close().await;
 
         Ok(())
     }


### PR DESCRIPTION
Follow up to #3964 

Verify we handle a stream switching delivery type mid-stream.