### PR TITLE
test(spanner): provision the Spanner Emulator only once

### DIFF
--- a/tests/spanner/Cargo.toml
+++ b/tests/spanner/Cargo.toml
@@ -34,7 +34,7 @@ google-cloud-spanner  = { workspace = true, features = [] }
 prost-types.workspace = true
 reqwest               = { workspace = true, features = ["json"] }
 serde_json            = { workspace = true }
-tokio.workspace       = true
+tokio                 = { workspace = true, features = ["sync"] }
 tracing.workspace     = true
 
 [lints]

--- a/tests/spanner/src/client.rs
+++ b/tests/spanner/src/client.rs
@@ -37,9 +37,19 @@ pub async fn wait_for_emulator(endpoint: &str) {
     }
 }
 
+static PROVISION_EMULATOR: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
 // Provisions the Spanner Emulator with a test instance and database.
 // ALREADY_EXISTS errors that are returned when creating an instance or database are ignored.
 pub async fn provision_emulator(endpoint: &str) {
+    PROVISION_EMULATOR
+        .get_or_init(|| async {
+            do_provision_emulator(endpoint).await;
+        })
+        .await;
+}
+
+async fn do_provision_emulator(endpoint: &str) {
     // TODO(#4973): Re-write this to use the admin clients once those also support the Emulator.
     let rest_endpoint = endpoint.replace("9010", "9020");
     let rest_endpoint =


### PR DESCRIPTION
The function for provisioning the Spanner Emulator with an instance and database should be executed only once.

The flake would happen if this part of the provisioning code would be executed during the `write_at_least_once` test:

https://github.com/olavloite/google-cloud-rust/blob/3d1daec70cb826dea45438e80f0dd336c28544f4/tests/spanner/src/client.rs#L144-149

```rust
    let write_tx = db_client.write_only_transaction().build();
    let mutation = Mutation::delete("AllTypes", KeySet::all());
    write_tx
        .write_at_least_once(vec![mutation])
        .await
        .expect("Failed to delete all data from AllTypes");
```

Fixes #5096