### PR TITLE
fix(pubsub): default shutdown behavior

### DIFF
--- a/src/pubsub/src/subscriber/builder.rs
+++ b/src/pubsub/src/subscriber/builder.rs
@@ -51,8 +51,7 @@ impl Subscribe {
             max_lease: Duration::from_secs(60 * 60),
             max_outstanding_messages: 1000,
             max_outstanding_bytes: 100 * MIB,
-            // TODO(#4869) - switch the default.
-            shutdown_behavior: ShutdownBehavior::NackImmediately,
+            shutdown_behavior: ShutdownBehavior::WaitForProcessing,
         }
     }
 
@@ -260,8 +259,10 @@ mod tests {
             "max_outstanding_bytes={}",
             builder.max_outstanding_bytes
         );
-        // TODO(#4869) - switch the default.
-        //assert_eq!(builder.shutdown_behavior, ShutdownBehavior::WaitForProcessing);
+        assert_eq!(
+            builder.shutdown_behavior,
+            ShutdownBehavior::WaitForProcessing
+        );
 
         Ok(())
     }

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -56,8 +56,7 @@ impl Default for LeaseOptions {
             extend_period: Duration::from_secs(3),
             extend_start: Duration::from_millis(500),
             max_lease: Duration::from_secs(600),
-            // TODO(#4869) - switch to `WaitForProcessing`
-            shutdown_behavior: ShutdownBehavior::NackImmediately,
+            shutdown_behavior: ShutdownBehavior::WaitForProcessing,
         }
     }
 }
@@ -247,8 +246,8 @@ where
             self.leaser.nack(to_nack).await;
         }
 
+        // TODO(#5109) - evicting exactly-once leases is ok, but not ideal.
         self.eo_leases.evict();
-        // TODO(#4869) - default shutdown behavior needs to be more clearly defined.
         // Currently, evict returns NACK_SHUTDOWN_ERROR for all exactly once
         // leases. This includes the to_ack leases. Specifically,
         // the leases that have been acknowledged by the application but not yet
@@ -714,7 +713,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn shutdown() {
-        // TODO(#4869) - update test when shutdown behavior for exactly once is defined.
         let mut mock = MockLeaser::new();
         // For exactly once, the current behavior is to Nack everything that has not yet
         // been confirmed.

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -648,6 +648,7 @@ mod tests {
         let mut stream = client
             .subscribe("projects/p/subscriptions/s")
             .set_max_lease_extension(Duration::from_secs(10))
+            .set_shutdown_behavior(ShutdownBehavior::NackImmediately)
             .build();
 
         response_tx.send(Ok(test_response(0..30))).await?;
@@ -826,8 +827,6 @@ mod tests {
         let mut mock = MockSubscriber::new();
         mock.expect_streaming_pull()
             .return_once(|_| Ok(TonicResponse::from(response_rx)));
-        mock.expect_acknowledge()
-            .returning(|_| Ok(TonicResponse::from(())));
         mock.expect_modify_ack_deadline().returning(move |r| {
             extend_tx
                 .send(r.into_inner())
@@ -839,6 +838,7 @@ mod tests {
         let mut stream = client
             .subscribe("projects/p/subscriptions/s")
             .set_max_lease_extension(Duration::from_secs(10))
+            .set_shutdown_behavior(ShutdownBehavior::NackImmediately)
             .build();
 
         response_tx.send(Ok(test_response(1..4))).await?;
@@ -1359,6 +1359,7 @@ mod tests {
             .subscribe("projects/p/subscriptions/s")
             .set_max_lease(MAX_LEASE)
             .set_max_lease_extension(MAX_LEASE_EXTENSION)
+            .set_shutdown_behavior(ShutdownBehavior::NackImmediately)
             .build();
 
         response_tx.send(Ok(test_response(0..1))).await?;


### PR DESCRIPTION
Fixes #4869 

Change the default shutdown behavior to wait until the application has consumed all of its ack handlers.