### PR TITLE
refactor(pubsub): prepare message stream for cancel

### DIFF
--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -64,7 +64,6 @@ pub struct MessageStream {
     #[allow(dead_code)] // TODO(#5024) - implementation in progress...
     /// This future is ready when the lease loop shutdown completes.
     lease_loop: Shared<BoxFuture<'static, ()>>,
-
     // TODO(#5024) - cancel message stream
     //shutdown: CancellationToken,
 }


### PR DESCRIPTION
Part of the work for #5024. A pure refactor.

Separate the parts of `MessageStream` that are mutable on read, from the parts of `MessageStream` that cancel a stream,(which is coming soon).

If that is not clear, here is the difference in the code:

Before the refactor: https://github.com/dbolduc/google-cloud-rust/blob/e97637b8700fb3d9127b0c7c5b697aba646713d1/src/pubsub/src/subscriber/message_stream.rs#L196-L207

After the refactor: https://github.com/dbolduc/google-cloud-rust/blob/6b4575213af75e5bf1347349c6681d74155cfea0/src/pubsub/src/subscriber/message_stream.rs#L193-L197