### PR TITLE
fix: restore generation for `nosvc` libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1084,7 +1083,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1096,7 +1094,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1108,7 +1105,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -3725,7 +3721,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -8081,17 +8076,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -185,18 +185,26 @@ libraries:
       quickstart_service_override: PredictionService
   - name: google-cloud-aiplatform-v1-schema-predict-instance
     version: 1.0.0
+    apis:
+      - path: google/cloud/aiplatform/v1/schema/predict/instance
     copyright_year: "2025"
     output: src/generated/cloud/aiplatform/schema/predict/instance
   - name: google-cloud-aiplatform-v1-schema-predict-params
     version: 1.0.0
+    apis:
+      - path: google/cloud/aiplatform/v1/schema/predict/params
     copyright_year: "2025"
     output: src/generated/cloud/aiplatform/schema/predict/params
   - name: google-cloud-aiplatform-v1-schema-predict-prediction
     version: 1.0.0
+    apis:
+      - path: google/cloud/aiplatform/v1/schema/predict/prediction
     copyright_year: "2025"
     output: src/generated/cloud/aiplatform/schema/predict/prediction
   - name: google-cloud-aiplatform-v1-schema-trainingjob-definition
     version: 1.0.0
+    apis:
+      - path: google/cloud/aiplatform/v1/schema/trainingjob/definition
     copyright_year: "2025"
     output: src/generated/cloud/aiplatform/schema/trainingjob/definition
   - name: google-cloud-alloydb-connectors-v1
@@ -1141,6 +1149,8 @@ libraries:
         - invalid_html_tags
   - name: google-cloud-oslogin-common
     version: 1.2.0
+    apis:
+      - path: google/cloud/oslogin/common
     copyright_year: "2025"
     output: src/generated/oslogin/common
   - name: google-cloud-oslogin-v1

--- a/src/generated/cloud/aiplatform/schema/predict/instance/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/instance/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/predict/params/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/params/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/predict/prediction/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/prediction/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/trainingjob/definition/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/trainingjob/definition/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true


### PR DESCRIPTION
Gemini explained the problem to me:

Inside the librarian codebase (`internal/librarian/rust/generate.go`), the function `IsVeneer()` checks whether a library is a handwritten "veneer" library wrapping generated code:

```go
func IsVeneer(lib *config.Library) bool {
    if lib.Rust != nil && len(lib.Rust.Modules) > 0 {
        return true
    }
    return len(lib.APIs) == 0 && lib.Output != ""
}
```

Because `google-cloud-oslogin-common` has an explicit `output` set but its `apis` array is empty (implicitly `0` length), `IsVeneer()` returns `true`.

When `librarian` attempts to generate a veneer library, it looks for the `rust.modules` configuration to know what exact manual steps to execute (`generateVeneer()` in `generate.go`). Since
`google-cloud-oslogin-common` has no `rust:` configuration blocks, the generator simply iterates over an empty list of modules, quietly exiting without generating any code or throwing an error.