### PR TITLE
chore: update `librarian` circa 2026-03-23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1084,7 +1083,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1096,7 +1094,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -1108,7 +1105,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -3725,7 +3721,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio-test",
 ]
 
 [[package]]
@@ -8081,17 +8076,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.8.4-0.20260321192035-dcfe0599f853
+version: v0.8.4-0.20260324004049-755c74ddae0e
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/cloud/aiplatform/schema/predict/instance/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/instance/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/predict/params/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/params/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/predict/prediction/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/predict/prediction/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/cloud/aiplatform/schema/trainingjob/definition/Cargo.toml
+++ b/src/generated/cloud/aiplatform/schema/trainingjob/definition/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true

--- a/src/generated/oslogin/common/Cargo.toml
+++ b/src/generated/oslogin/common/Cargo.toml
@@ -32,6 +32,3 @@ serde.workspace      = true
 serde_json.workspace = true
 serde_with.workspace = true
 wkt.workspace        = true
-
-[dev-dependencies]
-tokio-test.workspace = true


### PR DESCRIPTION
This includes the fixes from https://github.com/googleapis/librarian/pull/4787, which restore generation for the `nosvc` libraries.