### PR TITLE
feat(o11y): add actionable log suppression option

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -22,6 +22,13 @@ pub use duration_metric::DurationMetric;
 pub use request_start::RequestStart;
 pub use with_client_signals::WithClientSignals;
 
+/// An extension to disable terminal actionable error logging.
+///
+/// If this extension is present in the `RequestOptions` supplied to a GAX call,
+/// the terminal application logs will be suppressed.
+#[derive(Clone, Copy, Debug)]
+pub struct SuppressActionableErrorLog;
+
 /// Creates a [Span] and [RequestStart] for a client request.
 ///
 /// # Parameters

--- a/src/gax-internal/src/observability/client_signals/request_start.rs
+++ b/src/gax-internal/src/observability/client_signals/request_start.rs
@@ -49,6 +49,7 @@ pub struct RequestStart {
     info: InstrumentationClientInfo,
     url_template: &'static str,
     method: &'static str,
+    disable_actionable_error_logging: bool,
 }
 
 impl RequestStart {
@@ -64,11 +65,15 @@ impl RequestStart {
             .get_extension::<PathTemplate>()
             .map(|p| p.0)
             .unwrap_or_default();
+        let disable_actionable_error_logging = options
+            .get_extension::<super::SuppressActionableErrorLog>()
+            .is_some();
         Self {
             start,
             info: *info,
             method,
             url_template,
+            disable_actionable_error_logging,
         }
     }
 
@@ -87,6 +92,10 @@ impl RequestStart {
 
     pub(crate) fn method(&self) -> &'static str {
         self.method
+    }
+
+    pub(crate) fn disable_actionable_error_logging(&self) -> bool {
+        self.disable_actionable_error_logging
     }
 }
 

--- a/src/gax-internal/src/observability/client_signals/with_client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_signals.rs
@@ -135,7 +135,7 @@ where
                 let err_msg = error.to_string();
 
                 // TODO(#4795) - use the correct name and target
-                if !this.start.info().disable_actionable_error_logging {
+                if !this.start.disable_actionable_error_logging() {
                     tracing::event!(
                         name: NAME,
                         target: TARGET,
@@ -451,15 +451,15 @@ mod tests {
             { OTEL_STATUS_DESCRIPTION } = ::tracing::field::Empty
         );
 
-        let mut disabled_info = TEST_INFO;
-        disabled_info.disable_actionable_error_logging = true;
-
         let metric = DurationMetric::new_with_provider(
-            &disabled_info,
+            &TEST_INFO,
             Arc::new(providers.metric_provider.clone()),
         );
-        let options = RequestOptions::default().insert_extension(PathTemplate(URL_TEMPLATE));
-        let start = RequestStart::new(&disabled_info, &options, METHOD);
+        use google_cloud_gax::options::internal::RequestOptionsExt;
+        let options = RequestOptions::default()
+            .insert_extension(PathTemplate(URL_TEMPLATE))
+            .insert_extension(crate::observability::client_signals::SuppressActionableErrorLog);
+        let start = RequestStart::new(&TEST_INFO, &options, METHOD);
 
         let future = ready(Err::<String, Error>(not_found()));
         let future = WithClientSignals::new(future, metric.clone(), start, span.clone());


### PR DESCRIPTION
Set up the `disable_actionable_error_logging` to prevent actionable error logs from polluting the pipeline.

Depends on #5113
Must be merged after #5113 and keep the `log_layer` logic.