### PR TITLE
ci: ignore `src/test-utils` coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,6 +24,7 @@ ignore:
   # Ignore tools and test helpers.
   - "src/gax-internal/echo-server"
   - "src/gax-internal/grpc-server"
+  - "src/test-utils"
   - "src/w1r3"
   - "tools/check-copyright"
   - "tools/golints"


### PR DESCRIPTION
We ignore the coverage for all testing-support code.