### PR TITLE
fix(storage-w1r3): make `download()` correctly return `transfer_size`

### DIFF
--- a/src/storage/benchmarks/w1r3/src/main.rs
+++ b/src/storage/benchmarks/w1r3/src/main.rs
@@ -333,8 +333,9 @@ async fn download(
         }
     };
     read_done();
+
     let mut transfer_size = 0;
-    let mut read_data = async move || {
+    let read_data = async {
         while let Some(result) = read.next().await {
             match result {
                 Ok(b) => transfer_size += b.len(),
@@ -346,8 +347,7 @@ async fn download(
         }
         Ok(())
     };
-
-    match tokio::time::timeout(timeout, Instrumented::new(read_data())).await {
+    match tokio::time::timeout(timeout, Instrumented::new(read_data)).await {
         Err(e) => (transfer_size, Err(google_cloud_storage::Error::timeout(e))),
         Ok(r) => (transfer_size, r),
     }


### PR DESCRIPTION
Previously `read_data` was created using `move`. Since `transfer_size` is a `usize` which is `Copy`, `read_data` received its own copy of `transfer_size`.

As the original `transfer_size` was never updated, `download()` always returned `0`.