### PR TITLE
feat(o11y): align L3 client request logs with payload schema

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -327,6 +327,11 @@ mod tests {
                     "exception.message",
                     "the service reports an error with code NOT_FOUND described as: NOT FOUND",
                 ),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.artifact", "test-artifact"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.language", "rust"),
             ],
         );
         Ok(())

--- a/src/gax-internal/src/observability/client_signals/with_client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_signals.rs
@@ -21,9 +21,12 @@ use super::RequestStart;
 use crate::observability::attributes::RPC_SYSTEM_HTTP;
 use crate::observability::attributes::keys::OTEL_STATUS_DESCRIPTION;
 use crate::observability::attributes::keys::{
-    OTEL_STATUS_CODE, RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
+    GCP_CLIENT_ARTIFACT, GCP_CLIENT_LANGUAGE, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE,
+    GCP_CLIENT_VERSION, GCP_ERRORS_DOMAIN, GCP_ERRORS_METADATA, OTEL_STATUS_CODE,
+    RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
 };
 use crate::observability::attributes::otel_status_codes;
+use crate::observability::attributes::{GCP_CLIENT_LANGUAGE_RUST, GCP_CLIENT_REPO_GOOGLEAPIS};
 use crate::observability::errors::ErrorType;
 use google_cloud_gax::error::Error;
 use google_cloud_gax::error::rpc::Code;
@@ -134,6 +137,19 @@ where
                 let error_str = error_type.as_str();
                 let err_msg = error.to_string();
 
+                let (domain, metadata) = match &error_type {
+                    ErrorType::HttpError {
+                        domain, metadata, ..
+                    }
+                    | ErrorType::RpcError {
+                        domain, metadata, ..
+                    } => (domain.as_deref(), metadata.as_ref()),
+                    _ => (None, None),
+                };
+
+                let metadata_json =
+                    metadata.map(|m| serde_json::to_string(m).unwrap_or_else(|_| "{}".to_string()));
+
                 // TODO(#4795) - use the correct name and target
                 if !this.start.disable_actionable_error_logging() {
                     tracing::event!(
@@ -148,6 +164,13 @@ where
                         { HTTP_RESPONSE_STATUS_CODE } = error.http_status_code(),
                         { EXCEPTION_TYPE } = error_str,
                         { EXCEPTION_MESSAGE } = err_msg,
+                        { GCP_CLIENT_SERVICE } = this.start.info().service_name,
+                        { GCP_CLIENT_VERSION } = this.start.info().client_version,
+                        { GCP_CLIENT_ARTIFACT } = this.start.info().client_artifact,
+                        { GCP_CLIENT_REPO } = GCP_CLIENT_REPO_GOOGLEAPIS,
+                        { GCP_CLIENT_LANGUAGE } = GCP_CLIENT_LANGUAGE_RUST,
+                        { GCP_ERRORS_DOMAIN } = domain,
+                        { GCP_ERRORS_METADATA } = metadata_json,
                         "{error:?}"
                     );
                 }
@@ -303,6 +326,11 @@ mod tests {
                     "exception.message",
                     "the service reports an error with code NOT_FOUND described as: NOT FOUND",
                 ),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.artifact", "test-artifact"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.language", "rust"),
             ],
         );
 
@@ -369,6 +397,11 @@ mod tests {
                     "exception.message",
                     "the HTTP transport reports a [429] error: ",
                 ),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.artifact", "test-artifact"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.language", "rust"),
             ],
         );
 


### PR DESCRIPTION
Add fields to Client Request logs so that they comply with the standard OTel log payload schema.

Note: this establishes the correct schema mapping so impending refactors can inherit the formatting for Client logs.