### PR TITLE
fix(pubsub): batch nacks on shutdown to respect service limits

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -34,8 +34,8 @@ use tokio_util::task::TaskTracker;
 // https://docs.cloud.google.com/pubsub/quotas
 const MAX_IDS_PER_RPC: usize = 2500;
 
-// Helper function to chunk ack ids to nack into chunks of MAX_IDS_PER_RPC.
-fn batch_drained(ack_ids: Vec<String>) -> Vec<Vec<String>> {
+// Helper function to chunk ack ids into chunks of MAX_IDS_PER_RPC.
+fn batch(ack_ids: Vec<String>) -> Vec<Vec<String>> {
     ack_ids
         .chunks(MAX_IDS_PER_RPC)
         .map(|c| c.to_vec())

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -104,7 +104,7 @@ impl Leases {
     /// Called during shutdown, if configured to `NackImmediately`.
     pub fn evict_and_drain(mut self) -> (Vec<String>, Vec<Vec<String>>) {
         self.to_nack.extend(self.under_lease.into_keys());
-        (self.to_ack, super::batch_drained(self.to_nack))
+        (self.to_ack, super::batch(self.to_nack))
     }
 }
 
@@ -288,14 +288,11 @@ mod tests {
             leases
         );
 
-        let (mut to_ack, to_nack) = leases.evict_and_drain();
+        let (to_ack, to_nack) = leases.evict_and_drain();
+        assert_eq!(sorted(&to_ack), test_ids(0..10));
 
-        to_ack.sort();
-        assert_eq!(to_ack, test_ids(0..10));
-
-        let mut to_nack = NackBatches::flatten(to_nack).ack_ids;
-        to_nack.sort();
-        assert_eq!(to_nack, test_ids(10..30));
+        let to_nack = NackBatches::flatten(to_nack);
+        assert_eq!(sorted(&to_nack.ack_ids), test_ids(10..30));
     }
 
     #[test]
@@ -319,19 +316,15 @@ mod tests {
             leases
         );
 
-        let (mut to_ack, to_nack) = leases.evict_and_drain();
-
-        to_ack.sort();
-        assert_eq!(to_ack, test_ids(0..10));
+        let (to_ack, to_nack) = leases.evict_and_drain();
+        assert_eq!(sorted(&to_ack), test_ids(0..10));
 
         let to_nack = NackBatches::flatten(to_nack);
         assert_eq!(
             to_nack.counts,
             vec![MAX_IDS_PER_RPC, MAX_IDS_PER_RPC, MAX_IDS_PER_RPC - 10]
         );
-        let mut to_nack_ids = to_nack.ack_ids;
-        to_nack_ids.sort();
-        assert_eq!(to_nack_ids, test_ids(10..MAX_IDS_PER_RPC * 3));
+        assert_eq!(sorted(&to_nack.ack_ids), test_ids(10..MAX_IDS_PER_RPC * 3));
     }
 
     #[test]

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -137,7 +137,7 @@ impl Leases {
                 .send(Err(AckError::Shutdown(NACK_SHUTDOWN_ERROR.into())));
             self.to_nack.push(ack_id);
         }
-        (self.to_ack, super::batch_drained(self.to_nack))
+        (self.to_ack, super::batch(self.to_nack))
     }
 }
 
@@ -165,7 +165,7 @@ impl PartialEq<Leases> for super::tests::TestLeases {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::{NackBatches, TestLeases, test_id, test_ids};
+    use super::super::tests::{NackBatches, TestLeases, sorted, test_id, test_ids};
     use super::*;
     use std::collections::HashSet;
     use tokio::sync::oneshot::channel;
@@ -667,9 +667,8 @@ mod tests {
         let (to_ack, to_nack) = leases.evict_and_drain();
         assert!(to_ack.is_empty(), "{to_ack:?}");
 
-        let mut to_nack = NackBatches::flatten(to_nack).ack_ids;
-        to_nack.sort();
-        assert_eq!(to_nack, test_ids(1..4));
+        let to_nack = NackBatches::flatten(to_nack);
+        assert_eq!(sorted(&to_nack.ack_ids), test_ids(1..4));
 
         let err = result_rx1.await?.expect_err("error should be returned");
         assert!(matches!(err, AckError::Shutdown(_)), "{err:?}");
@@ -695,9 +694,7 @@ mod tests {
 
         let to_nack = NackBatches::flatten(to_nack);
         assert_eq!(to_nack.counts, vec![MAX_IDS_PER_RPC, 20]);
-        let mut to_nack_ids = to_nack.ack_ids;
-        to_nack_ids.sort();
-        assert_eq!(to_nack_ids, test_ids(0..MAX_IDS_PER_RPC + 20));
+        assert_eq!(sorted(&to_nack.ack_ids), test_ids(0..MAX_IDS_PER_RPC + 20));
 
         Ok(())
     }


### PR DESCRIPTION
Ensure that when the Pub/Sub subscriber shuts down, it does not exceed the MAX_IDS_PER_RPC limit (2,500 IDs) when sending negative acknowledgments (nacks) for messages still under lease management. It also refactors the lease eviction logic to reduce code duplication.

Fixes #4847