### PR TITLE
chore(spanner): optimize Statement to ExecuteSqlRequest conversion

### DIFF
--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -16,8 +16,7 @@ use crate::database_client::DatabaseClient;
 use crate::google::spanner::v1::result_set_stats::RowCount::RowCountLowerBound;
 use crate::model::transaction_options::PartitionedDml;
 use crate::model::{
-    BeginTransactionRequest, ExecuteSqlRequest, TransactionOptions, TransactionSelector,
-    transaction_selector,
+    BeginTransactionRequest, TransactionOptions, TransactionSelector, transaction_selector,
 };
 use crate::server_streaming::stream::PartialResultSetStream;
 use crate::statement::Statement;
@@ -139,6 +138,7 @@ impl PartitionedDmlTransaction {
             options: Some(transaction_options),
             ..Default::default()
         };
+        let base_request = statement.into_request();
 
         // Execute the statement and retry if the transaction is aborted by Spanner.
         retry_aborted(&*self.retry_policy, || async {
@@ -148,15 +148,13 @@ impl PartitionedDmlTransaction {
                 .begin_transaction(begin_request.clone(), crate::RequestOptions::default())
                 .await?;
 
-            let execute_request = ExecuteSqlRequest::default()
+            let execute_request = base_request
+                .clone()
                 .set_session(self.client.session.name.clone())
                 .set_transaction(TransactionSelector {
                     selector: Some(transaction_selector::Selector::Id(transaction.id.clone())),
                     ..Default::default()
-                })
-                .set_or_clear_params(statement.get_params())
-                .set_param_types(statement.get_param_types())
-                .set_sql(statement.sql.clone());
+                });
 
             let stream_builder = self
                 .client

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -393,13 +393,10 @@ impl ReadContext {
         statement: T,
     ) -> crate::Result<ResultSet> {
         let statement = statement.into();
-
-        let mut request = crate::model::ExecuteSqlRequest::default()
+        let request = statement
+            .into_request()
             .set_session(self.client.session.name.clone())
             .set_transaction(self.transaction_selector.clone());
-        request.params = statement.get_params();
-        request.param_types = statement.get_param_types();
-        request = request.set_sql(statement.sql);
 
         let stream = self
             .client

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -15,7 +15,6 @@
 use crate::database_client::DatabaseClient;
 use crate::model::BeginTransactionRequest;
 use crate::model::CommitRequest;
-use crate::model::ExecuteSqlRequest;
 use crate::model::RollbackRequest;
 use crate::model::TransactionOptions;
 use crate::model::TransactionSelector;
@@ -110,13 +109,11 @@ impl ReadWriteTransaction {
     pub async fn execute_update<T: Into<Statement>>(&self, statement: T) -> crate::Result<i64> {
         let seqno = self.seqno.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let statement = statement.into();
-        let request = ExecuteSqlRequest::default()
+        let request = statement
+            .into_request()
             .set_session(self.context.client.session.name.clone())
             .set_transaction(self.context.transaction_selector.clone())
-            .set_seqno(seqno)
-            .set_or_clear_params(statement.get_params())
-            .set_param_types(statement.get_param_types())
-            .set_sql(statement.sql);
+            .set_seqno(seqno);
 
         let response = self
             .context

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -116,24 +116,27 @@ impl Statement {
         StatementBuilder::new(sql)
     }
 
-    pub(crate) fn get_params(&self) -> Option<wkt::Struct> {
-        if self.params.is_empty() {
+    pub(crate) fn into_request(self) -> crate::model::ExecuteSqlRequest {
+        let params: Option<wkt::Struct> = if self.params.is_empty() {
             None
         } else {
             Some(
                 self.params
-                    .iter()
-                    .map(|(k, v)| (k.clone(), v.clone().into_serde_value()))
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into_serde_value()))
                     .collect(),
             )
-        }
-    }
+        };
+        let param_types: std::collections::HashMap<String, crate::model::Type> = self
+            .param_types
+            .into_iter()
+            .map(|(k, v)| (k, v.0))
+            .collect();
 
-    pub(crate) fn get_param_types(&self) -> std::collections::HashMap<String, crate::model::Type> {
-        self.param_types
-            .iter()
-            .map(|(k, v)| (k.clone(), v.0.clone()))
-            .collect()
+        crate::model::ExecuteSqlRequest::default()
+            .set_sql(self.sql)
+            .set_or_clear_params(params)
+            .set_param_types(param_types)
     }
 }
 
@@ -212,10 +215,10 @@ mod tests {
         let stmt_string: Statement = "SELECT 1".to_string().into();
         assert_eq!(stmt_str.sql, "SELECT 1");
         assert_eq!(stmt_string.sql, "SELECT 1");
-        assert!(stmt_str.get_params().is_none());
-        assert!(stmt_string.get_params().is_none());
-        assert!(stmt_str.get_param_types().is_empty());
-        assert!(stmt_string.get_param_types().is_empty());
+        assert!(stmt_str.params.is_empty());
+        assert!(stmt_string.params.is_empty());
+        assert!(stmt_str.param_types.is_empty());
+        assert!(stmt_string.param_types.is_empty());
     }
 
     #[test]
@@ -235,21 +238,23 @@ mod tests {
     }
 
     #[test]
-    fn test_get_params_and_types() {
+    fn test_into_request() {
         use crate::types;
         let stmt = Statement::builder("SELECT * FROM users WHERE age > @age AND role = @role")
             .add_param("age", &21)
             .add_typed_param("role", &"admin", types::string())
             .build();
 
-        // Test get_params mapped to Option<wkt::Struct>
-        let params = stmt.get_params().unwrap();
+        let req = stmt.into_request();
+
+        let params = req
+            .params
+            .expect("ExecuteSqlRequest parameters should be set after into_request conversion");
         assert_eq!(params.len(), 2);
         assert!(params.contains_key("age"));
         assert!(params.contains_key("role"));
 
-        // Test get_param_types mapped to HashMap<String, model::Type>
-        let param_types = stmt.get_param_types();
+        let param_types = req.param_types;
         assert_eq!(param_types.len(), 1);
         assert!(param_types.contains_key("role"));
     }


### PR DESCRIPTION
Replaced `.get_params()` and `.get_param_types() with `.into_request()` on Statement to consume it and transfer parameters zero-copy.