### PR TITLE
feat(spanner): add into_stream for ResultSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,6 +4324,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
+ "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
@@ -5790,6 +5791,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64",
+ "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-lro",

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -26,10 +26,14 @@ keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
 
+[features]
+unstable-stream = ["dep:futures"]
+
 [dependencies]
 async-trait.workspace = true
 base64.workspace      = true
 bytes.workspace       = true
+futures               = { workspace = true, optional = true }
 gaxi                  = { workspace = true, features = ["_internal-common", "_internal-grpc-client", "_internal-grpc-server-streaming"] }
 google-cloud-auth     = { workspace = true }
 google-cloud-gax      = { workspace = true }

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -20,6 +20,9 @@ use crate::server_streaming::stream::PartialResultSetStream;
 use gaxi::prost::FromProto;
 use std::collections::VecDeque;
 
+#[cfg(feature = "unstable-stream")]
+use futures::Stream;
+
 /// `ResultSet` contains the rows of a query result.
 ///
 /// # Example
@@ -192,6 +195,36 @@ impl ResultSet {
         }
 
         None
+    }
+
+    /// Converts the [`ResultSet`] into a [`Stream`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_spanner::client::ResultSet;
+    /// # use futures::TryStreamExt;
+    /// # use std::future::ready;
+    /// # async fn example(result_set: ResultSet) -> Result<(), google_cloud_spanner::Error> {
+    /// let rows: Vec<_> = result_set
+    ///     .into_stream()
+    ///     .try_filter(|row| {
+    ///         let id = row.get::<String, _>("Id");
+    ///         ready(id == "id1")
+    ///     })
+    ///     .try_collect()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This consumes the [`ResultSet`] and returns a stream of rows.
+    #[cfg(feature = "unstable-stream")]
+    pub fn into_stream(self) -> impl Stream<Item = crate::Result<Row>> {
+        use futures::stream::unfold;
+        unfold(self, |mut result_set| async move {
+            result_set.next().await.map(|row| (row, result_set))
+        })
     }
 }
 

--- a/tests/spanner/Cargo.toml
+++ b/tests/spanner/Cargo.toml
@@ -27,10 +27,11 @@ run-integration-tests = []
 [dependencies]
 anyhow.workspace        = true
 base64.workspace        = true
+futures.workspace       = true
 google-cloud-auth       = { workspace = true, features = ["default"] }
 google-cloud-gax        = { workspace = true }
 google-cloud-lro        = { workspace = true }
-google-cloud-spanner    = { workspace = true, features = [] }
+google-cloud-spanner    = { workspace = true, features = ["unstable-stream"] }
 google-cloud-test-utils = { workspace = true }
 prost-types.workspace   = true
 reqwest                 = { workspace = true, features = ["json"] }

--- a/tests/spanner/src/read.rs
+++ b/tests/spanner/src/read.rs
@@ -279,3 +279,51 @@ pub async fn read_with_index(db_client: &DatabaseClient) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+pub async fn read_as_stream(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    use futures::TryStreamExt;
+    use std::future::ready;
+
+    let id1 = format!("read-stream-1-{}", LowercaseAlphanumeric.random_string(10));
+    let id2 = format!("read-stream-2-{}", LowercaseAlphanumeric.random_string(10));
+    let mutation_1 = Mutation::new_insert_or_update_builder("AllTypes")
+        .set("Id")
+        .to(&id1)
+        .set("ColString")
+        .to(&"first")
+        .build();
+    let mutation_2 = Mutation::new_insert_or_update_builder("AllTypes")
+        .set("Id")
+        .to(&id2)
+        .set("ColString")
+        .to(&"second")
+        .build();
+    let write_tx = db_client.write_only_transaction().build();
+    write_tx
+        .write_at_least_once(vec![mutation_1, mutation_2])
+        .await
+        .expect("Failed to write to AllTypes");
+
+    let read = ReadRequest::builder("AllTypes", vec!["Id", "ColString"])
+        .with_keys(KeySet::all())
+        .build();
+    let result_set = db_client
+        .single_use()
+        .build()
+        .execute_read(read)
+        .await
+        .expect("Failed to execute read");
+
+    let rows: Vec<_> = result_set
+        .into_stream()
+        .try_filter(|row| {
+            let id = row.get::<String, _>("Id");
+            ready(id == id1)
+        })
+        .try_collect()
+        .await?;
+
+    assert_eq!(rows.len(), 1);
+
+    Ok(())
+}

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -86,6 +86,7 @@ mod spanner {
         integration_tests_spanner::read::read_key_range(&db_client).await?;
         integration_tests_spanner::read::read_with_limit(&db_client).await?;
         integration_tests_spanner::read::read_with_index(&db_client).await?;
+        integration_tests_spanner::read::read_as_stream(&db_client).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Adds an into_stream method for ResultSet.

See also https://github.com/googleapis/google-cloud-rust/pull/5126/changes#r2984156473