### PR TITLE
impl(spanner): stream from `ResultSet` is `Unpin`

### DIFF
--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -220,11 +220,11 @@ impl ResultSet {
     ///
     /// This consumes the [`ResultSet`] and returns a stream of rows.
     #[cfg(feature = "unstable-stream")]
-    pub fn into_stream(self) -> impl Stream<Item = crate::Result<Row>> {
+    pub fn into_stream(self) -> impl Stream<Item = crate::Result<Row>> + Unpin {
         use futures::stream::unfold;
-        unfold(self, |mut result_set| async move {
+        Box::pin(unfold(self, |mut result_set| async move {
             result_set.next().await.map(|row| (row, result_set))
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
Follow up to #5166 

We decided it is simpler if we just always pin the stream so callers don't have to. (#2701, #2702)