### PR TITLE
impl(storage): use `RequestRecorder` for o11y

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1445,6 +1445,7 @@ libraries:
     copyright_year: "2025"
     output: src/storage
     rust:
+      detailed_tracing_attributes: true
       modules:
         - module_path: crate::generated::gapic_control::model
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf

--- a/src/storage/src/generated/gapic/tracing.rs
+++ b/src/storage/src/generated/gapic/tracing.rs
@@ -22,6 +22,8 @@ where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
     inner: T,
+    #[cfg(google_cloud_unstable_tracing)]
+    duration: gaxi::observability::DurationMetric,
 }
 
 impl<T> StorageControl<T>
@@ -29,7 +31,11 @@ where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
     pub fn new(inner: T) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            #[cfg(google_cloud_unstable_tracing)]
+            duration: gaxi::observability::DurationMetric::new(&info::INSTRUMENTATION_CLIENT_INFO),
+        }
     }
 }
 
@@ -37,129 +43,285 @@ impl<T> super::stub::StorageControl for StorageControl<T>
 where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn delete_bucket(
         &self,
         req: crate::model::DeleteBucketRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<()>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::delete_bucket",
+                self.inner.delete_bucket(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_bucket(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_bucket(
         &self,
         req: crate::model::GetBucketRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Bucket>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_bucket",
+                self.inner.get_bucket(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_bucket(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn create_bucket(
         &self,
         req: crate::model::CreateBucketRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Bucket>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::create_bucket",
+                self.inner.create_bucket(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_bucket(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn list_buckets(
         &self,
         req: crate::model::ListBucketsRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ListBucketsResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::list_buckets",
+                self.inner.list_buckets(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_buckets(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn lock_bucket_retention_policy(
         &self,
         req: crate::model::LockBucketRetentionPolicyRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Bucket>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::lock_bucket_retention_policy",
+                self.inner.lock_bucket_retention_policy(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.lock_bucket_retention_policy(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_bucket(
         &self,
         req: crate::model::UpdateBucketRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Bucket>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_bucket",
+                self.inner.update_bucket(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_bucket(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn compose_object(
         &self,
         req: crate::model::ComposeObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Object>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::compose_object",
+                self.inner.compose_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.compose_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn delete_object(
         &self,
         req: crate::model::DeleteObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<()>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::delete_object",
+                self.inner.delete_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn restore_object(
         &self,
         req: crate::model::RestoreObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Object>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::restore_object",
+                self.inner.restore_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.restore_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_object(
         &self,
         req: crate::model::GetObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Object>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_object",
+                self.inner.get_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_object(
         &self,
         req: crate::model::UpdateObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Object>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_object",
+                self.inner.update_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn list_objects(
         &self,
         req: crate::model::ListObjectsRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ListObjectsResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::list_objects",
+                self.inner.list_objects(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_objects(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn rewrite_object(
         &self,
         req: crate::model::RewriteObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::RewriteResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::rewrite_object",
+                self.inner.rewrite_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.rewrite_object(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn move_object(
         &self,
         req: crate::model::MoveObjectRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Object>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::move_object",
+                self.inner.move_object(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.move_object(req, options).await
     }
+}
+
+#[cfg(google_cloud_unstable_tracing)]
+pub(crate) mod info {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    pub(crate) static INSTRUMENTATION_CLIENT_INFO: std::sync::LazyLock<
+        gaxi::options::InstrumentationClientInfo,
+    > = std::sync::LazyLock::new(|| {
+        let mut info = gaxi::options::InstrumentationClientInfo::default();
+        info.service_name = "storage";
+        info.client_version = VERSION;
+        info.client_artifact = NAME;
+        info.default_host = "storage";
+        info
+    });
 }

--- a/src/storage/src/generated/gapic/transport.rs
+++ b/src/storage/src/generated/gapic/transport.rs
@@ -50,6 +50,18 @@ impl std::fmt::Debug for StorageControl {
 
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
+        #[cfg(google_cloud_unstable_tracing)]
+        let inner = if gaxi::options::tracing_enabled(&config) {
+            gaxi::grpc::Client::new_with_instrumentation(
+                config,
+                DEFAULT_HOST,
+                &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
+            )
+            .await?
+        } else {
+            gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
+        };
+        #[cfg(not(google_cloud_unstable_tracing))]
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -106,6 +118,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = ();
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/DeleteBucket");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -169,6 +187,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Bucket;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/GetBucket");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -256,6 +280,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Bucket;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/CreateBucket");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -319,6 +349,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::ListBucketsResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/ListBuckets");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -387,6 +423,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Bucket;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/LockBucketRetentionPolicy");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -456,6 +498,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Bucket;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/UpdateBucket");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -528,6 +576,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Object;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/ComposeObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -591,6 +645,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = ();
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/DeleteObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -657,6 +717,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Object;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/RestoreObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -720,6 +786,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Object;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/GetObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -789,6 +861,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Object;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/UpdateObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -852,6 +930,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::ListObjectsResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/ListObjects");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -938,6 +1022,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::RewriteResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/RewriteObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1001,6 +1091,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::v2::Object;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/MoveObject");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,

--- a/src/storage/src/generated/gapic_control/tracing.rs
+++ b/src/storage/src/generated/gapic_control/tracing.rs
@@ -22,6 +22,8 @@ where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
     inner: T,
+    #[cfg(google_cloud_unstable_tracing)]
+    duration: gaxi::observability::DurationMetric,
 }
 
 impl<T> StorageControl<T>
@@ -29,7 +31,11 @@ where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
     pub fn new(inner: T) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            #[cfg(google_cloud_unstable_tracing)]
+            duration: gaxi::observability::DurationMetric::new(&info::INSTRUMENTATION_CLIENT_INFO),
+        }
     }
 }
 
@@ -37,267 +43,547 @@ impl<T> super::stub::StorageControl for StorageControl<T>
 where
     T: super::stub::StorageControl + std::fmt::Debug + Send + Sync,
 {
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn create_folder(
         &self,
         req: crate::model::CreateFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Folder>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::create_folder",
+                self.inner.create_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn delete_folder(
         &self,
         req: crate::model::DeleteFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<()>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::delete_folder",
+                self.inner.delete_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_folder(
         &self,
         req: crate::model::GetFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::Folder>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_folder",
+                self.inner.get_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn list_folders(
         &self,
         req: crate::model::ListFoldersRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ListFoldersResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::list_folders",
+                self.inner.list_folders(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_folders(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn rename_folder(
         &self,
         req: crate::model::RenameFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::rename_folder",
+                self.inner.rename_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.rename_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn delete_folder_recursive(
         &self,
         req: crate::model::DeleteFolderRecursiveRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::delete_folder_recursive",
+                self.inner.delete_folder_recursive(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_folder_recursive(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_storage_layout(
         &self,
         req: crate::model::GetStorageLayoutRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::StorageLayout>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_storage_layout",
+                self.inner.get_storage_layout(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_storage_layout(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn create_managed_folder(
         &self,
         req: crate::model::CreateManagedFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ManagedFolder>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::create_managed_folder",
+                self.inner.create_managed_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_managed_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn delete_managed_folder(
         &self,
         req: crate::model::DeleteManagedFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<()>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::delete_managed_folder",
+                self.inner.delete_managed_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_managed_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_managed_folder(
         &self,
         req: crate::model::GetManagedFolderRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ManagedFolder>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_managed_folder",
+                self.inner.get_managed_folder(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_managed_folder(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn list_managed_folders(
         &self,
         req: crate::model::ListManagedFoldersRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ListManagedFoldersResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::list_managed_folders",
+                self.inner.list_managed_folders(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_managed_folders(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn create_anywhere_cache(
         &self,
         req: crate::model::CreateAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::create_anywhere_cache",
+                self.inner.create_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_anywhere_cache(
         &self,
         req: crate::model::UpdateAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_anywhere_cache",
+                self.inner.update_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn disable_anywhere_cache(
         &self,
         req: crate::model::DisableAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::AnywhereCache>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::disable_anywhere_cache",
+                self.inner.disable_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.disable_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn pause_anywhere_cache(
         &self,
         req: crate::model::PauseAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::AnywhereCache>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::pause_anywhere_cache",
+                self.inner.pause_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.pause_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn resume_anywhere_cache(
         &self,
         req: crate::model::ResumeAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::AnywhereCache>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::resume_anywhere_cache",
+                self.inner.resume_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.resume_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_anywhere_cache(
         &self,
         req: crate::model::GetAnywhereCacheRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::AnywhereCache>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_anywhere_cache",
+                self.inner.get_anywhere_cache(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_anywhere_cache(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn list_anywhere_caches(
         &self,
         req: crate::model::ListAnywhereCachesRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::ListAnywhereCachesResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::list_anywhere_caches",
+                self.inner.list_anywhere_caches(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_anywhere_caches(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_project_intelligence_config(
         &self,
         req: crate::model::GetProjectIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_project_intelligence_config",
+                self.inner.get_project_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .get_project_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_project_intelligence_config(
         &self,
         req: crate::model::UpdateProjectIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_project_intelligence_config",
+                self.inner.update_project_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .update_project_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_folder_intelligence_config(
         &self,
         req: crate::model::GetFolderIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_folder_intelligence_config",
+                self.inner.get_folder_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .get_folder_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_folder_intelligence_config(
         &self,
         req: crate::model::UpdateFolderIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_folder_intelligence_config",
+                self.inner.update_folder_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .update_folder_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_organization_intelligence_config(
         &self,
         req: crate::model::GetOrganizationIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_organization_intelligence_config",
+                self.inner.get_organization_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .get_organization_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn update_organization_intelligence_config(
         &self,
         req: crate::model::UpdateOrganizationIntelligenceConfigRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<crate::model::IntelligenceConfig>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::update_organization_intelligence_config",
+                self.inner.update_organization_intelligence_config(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
             .update_organization_intelligence_config(req, options)
             .await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_iam_policy(
         &self,
         req: google_cloud_iam_v1::model::GetIamPolicyRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn set_iam_policy(
         &self,
         req: google_cloud_iam_v1::model::SetIamPolicyRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn test_iam_permissions(
         &self,
         req: google_cloud_iam_v1::model::TestIamPermissionsRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
     }
 
-    #[tracing::instrument(ret)]
+    #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
     async fn get_operation(
         &self,
         req: google_cloud_longrunning::model::GetOperationRequest,
         options: crate::RequestOptions,
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::StorageControl::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
+        }
+        #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
     }
 
@@ -314,4 +600,20 @@ where
     ) -> std::sync::Arc<dyn google_cloud_gax::polling_backoff_policy::PollingBackoffPolicy> {
         self.inner.get_polling_backoff_policy(options)
     }
+}
+
+#[cfg(google_cloud_unstable_tracing)]
+pub(crate) mod info {
+    const NAME: &str = env!("CARGO_PKG_NAME");
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    pub(crate) static INSTRUMENTATION_CLIENT_INFO: std::sync::LazyLock<
+        gaxi::options::InstrumentationClientInfo,
+    > = std::sync::LazyLock::new(|| {
+        let mut info = gaxi::options::InstrumentationClientInfo::default();
+        info.service_name = "storage";
+        info.client_version = VERSION;
+        info.client_artifact = NAME;
+        info.default_host = "storage";
+        info
+    });
 }

--- a/src/storage/src/generated/gapic_control/transport.rs
+++ b/src/storage/src/generated/gapic_control/transport.rs
@@ -50,6 +50,18 @@ impl std::fmt::Debug for StorageControl {
 
 impl StorageControl {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
+        #[cfg(google_cloud_unstable_tracing)]
+        let inner = if gaxi::options::tracing_enabled(&config) {
+            gaxi::grpc::Client::new_with_instrumentation(
+                config,
+                DEFAULT_HOST,
+                &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
+            )
+            .await?
+        } else {
+            gaxi::grpc::Client::new(config, DEFAULT_HOST).await?
+        };
+        #[cfg(not(google_cloud_unstable_tracing))]
         let inner = gaxi::grpc::Client::new(config, DEFAULT_HOST).await?;
         Ok(Self { inner })
     }
@@ -111,6 +123,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::Folder;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/CreateFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -190,6 +208,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = ();
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/DeleteFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -269,6 +293,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::Folder;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/GetFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -337,6 +367,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::ListFoldersResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/ListFolders");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -416,6 +452,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::longrunning::Operation;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/RenameFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -495,6 +537,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::longrunning::Operation;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/DeleteFolderRecursive");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -574,6 +622,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::StorageLayout;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/GetStorageLayout");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -642,6 +696,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::ManagedFolder;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/CreateManagedFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -721,6 +781,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = ();
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/DeleteManagedFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -800,6 +866,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::ManagedFolder;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/GetManagedFolder");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -868,6 +940,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::ListManagedFoldersResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/ListManagedFolders");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -936,6 +1014,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::longrunning::Operation;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/CreateAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1021,6 +1105,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::longrunning::Operation;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/UpdateAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1100,6 +1190,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/DisableAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1179,6 +1275,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/PauseAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1258,6 +1360,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/ResumeAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1337,6 +1445,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::AnywhereCache;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/GetAnywhereCache");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1405,6 +1519,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::storage::control::v2::ListAnywhereCachesResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/ListAnywhereCaches");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1448,6 +1568,25 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/GetProjectIntelligenceConfig",
+                );
+            let resource_name = (|| {
+                Some(format!(
+                    "//storage.googleapis.com/{}",
+                    Some(&req).map(|m| &m.name).map(|s| s.as_str())?,
+                ))
+            })();
+            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn)
+            } else {
+                attributes
+            };
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1492,6 +1631,14 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/UpdateProjectIntelligenceConfig",
+                );
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1535,6 +1682,25 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/GetFolderIntelligenceConfig",
+                );
+            let resource_name = (|| {
+                Some(format!(
+                    "//storage.googleapis.com/{}",
+                    Some(&req).map(|m| &m.name).map(|s| s.as_str())?,
+                ))
+            })();
+            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn)
+            } else {
+                attributes
+            };
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1579,6 +1745,14 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/UpdateFolderIntelligenceConfig",
+                );
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1622,6 +1796,25 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/GetOrganizationIntelligenceConfig",
+                );
+            let resource_name = (|| {
+                Some(format!(
+                    "//storage.googleapis.com/{}",
+                    Some(&req).map(|m| &m.name).map(|s| s.as_str())?,
+                ))
+            })();
+            let attributes = if let Some(rn) = resource_name.filter(|s| !s.is_empty()) {
+                attributes.set_resource_name(rn)
+            } else {
+                attributes
+            };
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1666,6 +1859,14 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::storage::control::v2::IntelligenceConfig;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method(
+                    "google.storage.control.v2.StorageControl/UpdateOrganizationIntelligenceConfig",
+                );
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1763,6 +1964,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::iam::v1::Policy;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/GetIamPolicy");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1860,6 +2067,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::iam::v1::Policy;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/SetIamPolicy");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -1991,6 +2204,12 @@ impl super::stub::StorageControl for StorageControl {
         }
 
         type TR = crate::google::iam::v1::TestIamPermissionsResponse;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.control.v2.StorageControl/TestIamPermissions");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,
@@ -2038,6 +2257,12 @@ impl super::stub::StorageControl for StorageControl {
         .fold(String::new(), |b, p| b + "&" + &p);
 
         type TR = crate::google::longrunning::Operation;
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.longrunning.Operations/GetOperation");
+            recorder.on_client_request(attributes);
+        }
         self.inner
             .execute(
                 extensions,

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -30,10 +30,8 @@ use crate::{
     storage::bidi::connector::Connector, storage::bidi::transport::ObjectDescriptorTransport,
 };
 #[cfg(google_cloud_unstable_tracing)]
-use gaxi::observability::ResultExt;
+use gaxi::observability::{ClientRequestAttributes, DurationMetric, RequestRecorder};
 use std::sync::Arc;
-#[cfg(google_cloud_unstable_tracing)]
-use tracing::Instrument;
 
 /// An implementation of [`stub::Storage`][crate::storage::stub::Storage] that
 /// interacts with the Cloud Storage service.
@@ -54,6 +52,8 @@ use tracing::Instrument;
 pub struct Storage {
     inner: Arc<StorageInner>,
     tracing: bool,
+    #[cfg(google_cloud_unstable_tracing)]
+    metric: DurationMetric,
 }
 
 impl Storage {
@@ -62,6 +62,17 @@ impl Storage {
         Self::new(inner, false)
     }
 
+    #[cfg(google_cloud_unstable_tracing)]
+    pub(crate) fn new(inner: Arc<StorageInner>, tracing: bool) -> Arc<Self> {
+        let metric = DurationMetric::new(&INSTRUMENTATION);
+        Arc::new(Self {
+            inner,
+            tracing,
+            metric,
+        })
+    }
+
+    #[cfg(not(google_cloud_unstable_tracing))]
     pub(crate) fn new(inner: Arc<StorageInner>, tracing: bool) -> Arc<Self> {
         Arc::new(Self { inner, tracing })
     }
@@ -87,16 +98,25 @@ impl Storage {
     ) -> Result<ReadObjectResponse> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            let span =
-                gaxi::client_request_span!("client::Storage", "read_object", &INSTRUMENTATION);
-            let response = self
-                .read_object_plain(request, options)
-                .instrument(span.clone())
-                .await
-                .record_in_span(&span)?;
+            let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
+            let (span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::read_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_url_template("/storage/v1/b/{bucket}/o/{object}")
+                            .set_resource_name(resource_name),
+                    );
+                }
+                self.read_object_plain(request, options).await
+            });
+
+            let response = pending.await?;
             let inner = TracingResponse::new(response.into_parts(), span);
-            let response = ReadObjectResponse::new(Box::new(inner));
-            Ok(response)
+            Ok(ReadObjectResponse::new(Box::new(inner)))
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.read_object_plain(request, options).await
@@ -134,12 +154,31 @@ impl Storage {
     {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            let span =
-                gaxi::client_request_span!("client::Storage", "write_object", &INSTRUMENTATION);
-            self.write_object_buffered_plain(payload, request, options)
-                .instrument(span.clone())
-                .await
-                .record_in_span(&span)
+            let resource_name = format!(
+                "//storage.googleapis.com/{}",
+                request
+                    .spec
+                    .resource
+                    .as_ref()
+                    .map(|r| r.bucket.as_str())
+                    .unwrap_or_default()
+            );
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.metric.clone(),
+                info: *INSTRUMENTATION,
+                method: "client::Storage::write_object",
+                async {
+                    if let Some(recorder) = RequestRecorder::current() {
+                        recorder.on_client_request(
+                            ClientRequestAttributes::default()
+                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                                .set_resource_name(resource_name),
+                        );
+                    }
+                    self.write_object_buffered_plain(payload, request, options).await
+                }
+            );
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.write_object_buffered_plain(payload, request, options)
@@ -178,12 +217,31 @@ impl Storage {
     {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            let span =
-                gaxi::client_request_span!("client::Storage", "write_object", &INSTRUMENTATION);
-            self.write_object_unbuffered_plain(payload, request, options)
-                .instrument(span.clone())
-                .await
-                .record_in_span(&span)
+            let resource_name = format!(
+                "//storage.googleapis.com/{}",
+                request
+                    .spec
+                    .resource
+                    .as_ref()
+                    .map(|r| r.bucket.as_str())
+                    .unwrap_or_default()
+            );
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.metric.clone(),
+                info: *INSTRUMENTATION,
+                method: "client::Storage::write_object",
+                async {
+                    if let Some(recorder) = RequestRecorder::current() {
+                        recorder.on_client_request(
+                            ClientRequestAttributes::default()
+                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                                .set_resource_name(resource_name),
+                        );
+                    }
+                    self.write_object_unbuffered_plain(payload, request, options).await
+                }
+            );
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.write_object_unbuffered_plain(payload, request, options)
@@ -209,13 +267,25 @@ impl Storage {
     ) -> Result<(ObjectDescriptor, Vec<ReadObjectResponse>)> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            let span =
-                gaxi::client_request_span!("client::Storage", "open_object", &INSTRUMENTATION);
+            let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.metric.clone(),
+                info: *INSTRUMENTATION,
+                method: "client::Storage::open_object",
+                async {
+                    if let Some(recorder) = RequestRecorder::current() {
+                        recorder.on_client_request(
+                            ClientRequestAttributes::default()
+                                .set_rpc_method("google.storage.v2.Storage/BidiStreamingRead")
+                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                                .set_resource_name(resource_name),
+                        );
+                    }
+                    self.open_object_plain(request, options).await
+                }
+            );
             // TODO(#3178) - wrap descriptor and responses with tracing decorators.
-            self.open_object_plain(request, options)
-                .instrument(span.clone())
-                .await
-                .record_in_span(&span)
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.open_object_plain(request, options).await
@@ -288,14 +358,14 @@ impl super::stub::Storage for Storage {
 #[cfg(test)]
 mod tests {
     #[cfg(google_cloud_unstable_tracing)]
-    use gaxi::observability::attributes::{
-        GCP_CLIENT_LANGUAGE_RUST, OTEL_KIND_INTERNAL, RPC_SYSTEM_HTTP, keys::*,
-    };
+    use gaxi::observability::attributes::{OTEL_KIND_INTERNAL, RPC_SYSTEM_HTTP, keys::*};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     #[cfg(google_cloud_unstable_tracing)]
     use google_cloud_test_utils::test_layer::AttributeValue;
     use google_cloud_test_utils::test_layer::{CapturedSpan, TestLayer};
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
+    #[cfg(google_cloud_unstable_tracing)]
+    use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
 
     #[tokio::test]
@@ -522,7 +592,7 @@ mod tests {
         method: &'static str,
         error_type: &'static str,
     ) {
-        const EXPECTED_ATTRIBUTES: [(&str, &str); 8] = [
+        const EXPECTED_ATTRIBUTES: [(&str, &str); 7] = [
             (OTEL_KIND, OTEL_KIND_INTERNAL),
             (RPC_SYSTEM, RPC_SYSTEM_HTTP),
             (RPC_SERVICE, "storage"),
@@ -530,7 +600,6 @@ mod tests {
             (GCP_CLIENT_SERVICE, "storage"),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust"),
             (GCP_CLIENT_ARTIFACT, "google-cloud-storage"),
-            (GCP_CLIENT_LANGUAGE, GCP_CLIENT_LANGUAGE_RUST),
         ];
         let span = captured
             .iter()
@@ -545,12 +614,10 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), AttributeValue::from(*v)))
                 .chain(
                     [
-                        ("gax.client.span", true.into()),
                         (
                             OTEL_NAME,
                             format!("google_cloud_storage::client::Storage::{method}").into(),
                         ),
-                        (RPC_METHOD, method.into()),
                         (ERROR_TYPE, error_type.into()),
                     ]
                     .map(|(k, v)| (k.to_string(), v)),


### PR DESCRIPTION
Probably won't compile, it is intended to show how the recorder is used in generated code.