### PR TITLE
fix(o11y): omit invalid spans and traces from logs

### DIFF
--- a/tests/o11y/src/otlp/logs/event_formatter.rs
+++ b/tests/o11y/src/otlp/logs/event_formatter.rs
@@ -231,7 +231,7 @@ mod tests {
 
         let output = String::from_utf8(writer.data.lock().unwrap().clone())
             .expect("Output should be valid UTF-8");
-        
+
         let entry: LogEntry = serde_json::from_str(&output).expect("Failed to parse JSON");
 
         let expected = LogEntry {
@@ -240,7 +240,10 @@ mod tests {
             trace_sampled: None,
         };
 
-        assert_eq!(entry, expected, "All trace fields should be omitted: {output}");
+        assert_eq!(
+            entry, expected,
+            "All trace fields should be omitted: {output}"
+        );
     }
 
     #[test]
@@ -268,7 +271,7 @@ mod tests {
 
         let output = String::from_utf8(writer.data.lock().unwrap().clone())
             .expect("Output should be valid UTF-8");
-        
+
         let lines: Vec<&str> = output.trim().split('\n').collect();
         let last_line = lines.last().expect("output should not be empty");
 
@@ -285,7 +288,13 @@ mod tests {
             "trace should not be the invalid trace ID"
         );
 
-        assert!(entry.span_id.is_some(), "spanId should be included: {output}");
-        assert!(entry.trace_sampled.is_some(), "trace_sampled should be included: {output}");
+        assert!(
+            entry.span_id.is_some(),
+            "spanId should be included: {output}"
+        );
+        assert!(
+            entry.trace_sampled.is_some(),
+            "trace_sampled should be included: {output}"
+        );
     }
 }


### PR DESCRIPTION
Previously, `EventFormatter` formatted and serialized invalid (zeroed) trace and span configurations straight to the JSON log payload when logging occurred outside of an active telemetry context. 

This PR fixes the formatting logic to ensure that `trace`, `spanId`, and `trace_sampled` are omitted from the log unless they are validated as active by OpenTelemetry. 

Fixes #4976