### PR TITLE
impl(gax-internal): `client_request_signals` macro

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -135,7 +135,6 @@ macro_rules! client_request_signals {
         use ::tracing::instrument::Instrument;
         let recorder = $crate::observability::RequestRecorder::new($info);
         let span = $crate::client_request_span!(info: $info, method: $method);
-        // TODO(#5158) - add the span decorator.
         let pending = recorder.scope(
             $crate::observability::WithClientSpan::new(
                 span.clone(),


### PR DESCRIPTION
This macro will be used by generated code and hand-crafted clients to emit client-request signals.

Part of the work for #4772 