### PR TITLE
impl(gax-internal): use recorder in `ReqwestClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,6 +5684,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-proto",
  "opentelemetry_sdk",
+ "pretty_assertions",
  "rand 0.10.0",
  "reqwest 0.13.2",
  "scoped-env",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.8.5-0.20260325150042-e450f8f7dcab
+version: v0.9.1-0.20260328133821-a87086efbeec
 repo: googleapis/google-cloud-rust
 sources:
   conformance:
@@ -45,7 +45,6 @@ release:
         version: 0.4.0
 default:
   output: src/generated/
-  release_level: stable
   rust:
     package_dependencies:
       - name: async-trait

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -27,7 +27,7 @@ pub mod reqwest;
 use crate::as_inner::as_inner;
 use crate::attempt_info::AttemptInfo;
 #[cfg(google_cloud_unstable_tracing)]
-use crate::observability::create_http_attempt_span;
+use crate::observability::{HttpResultExt, RequestRecorder, create_http_attempt_span};
 use google_cloud_auth::credentials::{
     Builder as CredentialsBuilder, CacheableResource, Credentials,
 };
@@ -261,22 +261,33 @@ impl ReqwestClient {
         options: RequestOptions,
         attempt_info: AttemptInfo,
     ) -> Result<reqwest::Response> {
-        use crate::observability::HttpResultExt;
         let span = create_http_attempt_span(
             &request,
             &options,
             self.instrumentation,
             attempt_info.attempt_count,
         );
-        let (method, url) = (request.method().clone(), request.url().clone());
-        self.execute_http_inner(request)
+        if let Some(recorder) = RequestRecorder::current() {
+            recorder.on_http_request(&request);
+        }
+        let result = self
+            .execute_http_inner(request)
             .instrument(span.clone())
-            .await
-            .record_http(&span, attempt_info.attempt_count, method, url)
+            .await;
+        if let Some(recorder) = RequestRecorder::current() {
+            match &result {
+                Ok(r) => recorder.on_http_response(r),
+                Err(e) => recorder.on_http_error(e),
+            }
+        }
+        result.record_http(&span)
     }
 
     #[cfg_attr(not(google_cloud_unstable_tracing), allow(unused_mut))]
     async fn execute_http_inner(&self, mut request: reqwest::Request) -> Result<reqwest::Response> {
+        // We want to send the tracing propagation headers even if tracing is disabled in the
+        // client. A global trace (say from the incoming HTTP request to Cloud Run) could be
+        // propagated.
         #[cfg(google_cloud_unstable_tracing)]
         crate::observability::propagation::inject_context(
             &tracing::Span::current(),
@@ -410,13 +421,14 @@ impl ReqwestClient {
         options: &RequestOptions,
         attempt_count: u32,
     ) -> Result<reqwest::Response> {
-        use crate::observability::HttpResultExt;
         let span = create_http_attempt_span(&request, options, self.instrumentation, attempt_count);
-        let (method, url) = (request.method().clone(), request.url().clone());
+        if let Some(recorder) = RequestRecorder::current() {
+            recorder.on_http_request(&request);
+        }
         self.request_attempt_inner(request)
             .instrument(span.clone())
             .await
-            .record_http(&span, attempt_count, method, url)
+            .record_http(&span)
     }
 
     #[cfg_attr(not(google_cloud_unstable_tracing), allow(unused_mut))]
@@ -424,12 +436,23 @@ impl ReqwestClient {
         &self,
         mut request: reqwest::Request,
     ) -> Result<reqwest::Response> {
+        // We want to send the tracing propagation headers even if tracing is disabled in the
+        // client. A global trace (say from the incoming HTTP request to Cloud Run) could be
+        // propagated.
         #[cfg(google_cloud_unstable_tracing)]
         crate::observability::propagation::inject_context(
             &tracing::Span::current(),
             request.headers_mut(),
         );
-        let response = self.inner.execute(request).await.map_err(map_send_error)?;
+        let result = self.inner.execute(request).await.map_err(map_send_error);
+        #[cfg(google_cloud_unstable_tracing)]
+        if let Some(recorder) = RequestRecorder::current() {
+            match &result {
+                Ok(r) => recorder.on_http_response(r),
+                Err(e) => recorder.on_http_error(e),
+            }
+        }
+        let response = result?;
         if !response.status().is_success() {
             return self::to_http_error(response).await;
         }
@@ -554,24 +577,14 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(google_cloud_unstable_tracing)]
-    use crate::client_request_span;
     use crate::options::ClientConfig;
     use crate::options::InstrumentationClientInfo;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-    #[cfg(google_cloud_unstable_tracing)]
-    use google_cloud_test_utils::test_layer::TestLayer;
     use http::{HeaderMap, HeaderValue, Method};
-    #[cfg(google_cloud_unstable_tracing)]
-    use opentelemetry_semantic_conventions::trace as otel_trace;
     use test_case::test_case;
-    #[cfg(google_cloud_unstable_tracing)]
-    use tracing::Instrument;
-
-    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[tokio::test]
-    async fn client_http_error_bytes() -> TestResult {
+    async fn client_http_error_bytes() -> anyhow::Result<()> {
         let http_resp = http::Response::builder()
             .header("Content-Type", "application/json")
             .status(400)
@@ -593,7 +606,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn client_error_with_status() -> TestResult {
+    async fn client_error_with_status() -> anyhow::Result<()> {
         use google_cloud_gax::error::rpc::{Code, Status, StatusDetails::LocalizedMessage};
         let body = serde_json::json!({"error": {
             "code": 404,
@@ -634,7 +647,7 @@ mod tests {
     #[test_case(reqwest::StatusCode::OK, "{}"; "200 with empty object")]
     #[test_case(reqwest::StatusCode::NO_CONTENT, "{}"; "204 with empty object")]
     #[test_case(reqwest::StatusCode::NO_CONTENT, ""; "204 with empty content")]
-    async fn client_empty_content(code: reqwest::StatusCode, content: &str) -> TestResult {
+    async fn client_empty_content(code: reqwest::StatusCode, content: &str) -> anyhow::Result<()> {
         let response = resp_from_code_content(code, content)?;
         assert!(response.status().is_success());
 
@@ -649,7 +662,7 @@ mod tests {
     async fn client_error_with_empty_content(
         code: reqwest::StatusCode,
         content: &str,
-    ) -> TestResult {
+    ) -> anyhow::Result<()> {
         let response = resp_from_code_content(code, content)?;
         assert!(response.status().is_success());
 
@@ -779,78 +792,8 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(google_cloud_unstable_tracing)]
-    async fn test_t3_span_enrichment() {
-        let guard = TestLayer::initialize();
-        let t3_span = client_request_span!("Service", "test_method", &TEST_INSTRUMENTATION_INFO);
-
-        // Simulate T4 span scope ending before calling to_http_response
-        let t4_span = tracing::info_span!("t4_span");
-        {
-            let _t4_enter = t4_span.enter();
-            // T4 work happens here
-        } // T4 exit
-
-        let response = resp_from_code_content(reqwest::StatusCode::OK, "{}").unwrap();
-        let url = "https://example.com".parse().unwrap();
-
-        // Manually call the enrichment function, mimicking request_attempt
-        let response = {
-            use crate::observability::HttpResultExt;
-
-            let _enter = t3_span.enter();
-            Ok(response)
-                .record_http(&t4_span, 1, Method::GET, url)
-                .unwrap()
-        };
-
-        let _ = super::to_http_response::<wkt::Empty>(response)
-            .instrument(t3_span.clone())
-            .await;
-
-        let captured = TestLayer::capture(&guard);
-        // We expect t3_span to be captured, and t4_span.
-        // t3_span should have the attributes.
-        let t3_captured = captured
-            .iter()
-            .find(|s| s.name == "client_request")
-            .expect("client_request span not found");
-
-        assert_eq!(
-            t3_captured
-                .attributes
-                .get(crate::observability::attributes::keys::OTEL_NAME),
-            Some(&"google_cloud_gax_internal::Service::test_method".into())
-        );
-
-        assert_eq!(
-            t3_captured
-                .attributes
-                .get(otel_trace::HTTP_RESPONSE_STATUS_CODE),
-            Some(&(200_i64).into())
-        );
-        // Resend count is set because we passed 1
-        assert_eq!(
-            t3_captured
-                .attributes
-                .get(otel_trace::HTTP_REQUEST_RESEND_COUNT),
-            Some(&(1_i64).into())
-        );
-
-        let t4_captured = captured
-            .iter()
-            .find(|s| s.name == "t4_span")
-            .expect("t4_span not found");
-        assert!(
-            !t4_captured
-                .attributes
-                .contains_key(otel_trace::HTTP_RESPONSE_STATUS_CODE)
-        );
-    }
-
-    #[tokio::test]
     #[allow(deprecated)]
-    async fn execute_streaming_success() -> TestResult {
+    async fn execute_streaming_success() -> anyhow::Result<()> {
         let server = httptest::Server::run();
         server.expect(
             httptest::Expectation::matching(httptest::matchers::request::method_path(
@@ -884,7 +827,7 @@ mod tests {
     /// so that the caller can handle the 308 status code appropriately (e.g., to query the upload status).
     #[tokio::test]
     #[allow(deprecated)]
-    async fn execute_streaming_308() -> TestResult {
+    async fn execute_streaming_308() -> anyhow::Result<()> {
         let server = httptest::Server::run();
         server.expect(
             httptest::Expectation::matching(httptest::matchers::request::method_path(

--- a/src/gax-internal/src/observability/client_signals/recorder.rs
+++ b/src/gax-internal/src/observability/client_signals/recorder.rs
@@ -360,6 +360,13 @@ impl ClientSnapshot {
         self.url_template
     }
 
+    /// Returns the resource name (e.g. "//storage.googleapis.com/projects/_/buckets/my-bucket").
+    ///
+    /// Use with the "gcp.resource.destination.id" attribute.
+    pub fn resource_name(&self) -> Option<&str> {
+        self.resource_name.as_deref()
+    }
+
     /// Returns the RPC method (e.g. "cloud.google.secretmanager.v1.SecretManager/GetSecret") used in the request.
     ///
     /// Use with the "rpc.method" attribute.
@@ -437,6 +444,7 @@ mod tests {
 
     const TEST_METHOD_NAME: &str = "google.test.v1.Service/SomeMethod";
     const TEST_PATH_TEMPLATE: &str = "/v42/{parent}";
+    const TEST_RESOURCE_NAME: &str = "//test.googleapis.com/test-only";
     const STORAGE_PATH_TEMPLATE: &str = "/v1/storage/b/{bucket}/o/{object}";
 
     async fn simulate_http_client_gaxi(url: &str) -> Result<String, Error> {
@@ -464,7 +472,7 @@ mod tests {
             ClientRequestAttributes::default()
                 .set_rpc_method(TEST_METHOD_NAME)
                 .set_url_template(TEST_PATH_TEMPLATE)
-                .set_resource_name("//test.googleapis.com/test-only".to_string()),
+                .set_resource_name(TEST_RESOURCE_NAME.to_string()),
         );
         simulate_http_client_gaxi(url).await
     }
@@ -495,6 +503,7 @@ mod tests {
         assert_eq!(snap.start, Instant::now(), "{snap:?}");
         assert_eq!(snap.rpc_method(), Some(TEST_METHOD_NAME), "{snap:?}");
         assert_eq!(snap.url_template(), Some(TEST_PATH_TEMPLATE), "{snap:?}");
+        assert_eq!(snap.resource_name(), Some(TEST_RESOURCE_NAME), "{snap:?}");
         assert_eq!(snap.rpc_system(), Some("http"), "{snap:?}");
         assert_eq!(snap.sanitized_url(), Some(url.as_str()), "{snap:?}");
 

--- a/src/gax-internal/src/observability/client_signals/with_client_logging.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_logging.rs
@@ -116,7 +116,6 @@ where
                     { GCP_CLIENT_REPO } = snapshot.client_repo(),
                     { GCP_CLIENT_ARTIFACT } = snapshot.client_artifact(),
                     { URL_DOMAIN } = snapshot.default_host(),
-                    // TODO(#5152) - sanitize the URL.
                     { URL_FULL } = snapshot.sanitized_url(),
                     { URL_TEMPLATE } = snapshot.url_template(),
                     { RPC_RESPONSE_STATUS_CODE } = rpc_status_code,

--- a/src/gax-internal/src/observability/http_tracing.rs
+++ b/src/gax-internal/src/observability/http_tracing.rs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 use crate::observability::attributes::keys::*;
-use crate::observability::attributes::*;
 use crate::observability::errors::ErrorType;
+use crate::observability::{RequestRecorder, attributes::*};
 use crate::options::InstrumentationClientInfo;
 use google_cloud_gax::Result;
 use google_cloud_gax::options::RequestOptions;
 use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt, ResourceName};
 use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
-use reqwest::{Method, Url};
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use tracing::{Span, field};
@@ -52,10 +51,20 @@ pub(crate) fn create_http_attempt_span(
     let url = sanitize_url(request.url());
     let method = request.method();
 
-    let resource_name = options
-        .get_extension::<ResourceName>()
-        .map(|e| e.0.as_str());
-    let url_template = options.get_extension::<PathTemplate>().map(|e| e.0);
+    let snapshot = RequestRecorder::current().map(|r| r.client_snapshot());
+    let resource_name;
+    let url_template;
+    if let Some(snapshot) = &snapshot {
+        resource_name = snapshot.resource_name();
+        url_template = snapshot.url_template();
+    } else {
+        // TODO(#5177) - remove this code once nothing else uses the extensions.
+        resource_name = options
+            .get_extension::<ResourceName>()
+            .map(|e| e.0.as_str());
+        url_template = options.get_extension::<PathTemplate>().map(|e| e.0);
+    };
+
     let otel_name = url_template
         .map(|template| format!("{method} {template}"))
         .unwrap_or_else(|| method.to_string());
@@ -111,7 +120,7 @@ pub(crate) fn create_http_attempt_span(
 
 /// Records additional attributes to the span based on the `Result`.
 pub trait ResultExt: sealed::ResultExt {
-    fn record_http(self, span: &Span, prior_attempt_count: u32, method: Method, url: Url) -> Self;
+    fn record_http(self, span: &Span) -> Self;
 }
 
 mod sealed {
@@ -120,8 +129,7 @@ mod sealed {
 
 impl sealed::ResultExt for Result<reqwest::Response> {}
 impl ResultExt for Result<reqwest::Response> {
-    fn record_http(self, span: &Span, prior_attempt_count: u32, method: Method, url: Url) -> Self {
-        record_intermediate_client_request(&self, prior_attempt_count, &method, &url);
+    fn record_http(self, span: &Span) -> Self {
         match &self {
             Ok(response) => {
                 span.record(
@@ -153,76 +161,6 @@ impl ResultExt for Result<reqwest::Response> {
     }
 }
 
-/// Records HTTP transport attributes on the current span.
-///
-/// This function is used to enrich the Client Request Span (T3) with attributes
-/// from the transport attempt that are only available before the response is consumed.
-pub fn record_intermediate_client_request(
-    result: &Result<reqwest::Response>,
-    prior_attempt_count: u32,
-    method: &http::Method,
-    request_url: &reqwest::Url,
-) {
-    let span = Span::current();
-    if span.is_disabled() {
-        // Skip disabled traces because this function adds a small amount of
-        // overhead.
-        return;
-    }
-    if span
-        .metadata()
-        .is_none_or(|m| m.fields().field("gax.client.span").is_none())
-    {
-        // Only enrich spans that are explicitly marked as GAX client spans.
-        // This prevents accidental enrichment of user-provided spans that happen to have the same fields.
-        return;
-    }
-
-    span.record(otel_trace::HTTP_REQUEST_METHOD, method.as_str());
-
-    let final_url = match result {
-        Ok(response) => response.url(),
-        Err(_) => request_url,
-    };
-
-    span.record(
-        otel_trace::SERVER_ADDRESS,
-        final_url
-            .host_str()
-            .map(|h| h.trim_start_matches('[').trim_end_matches(']'))
-            .unwrap_or(""),
-    );
-    span.record(
-        otel_trace::SERVER_PORT,
-        final_url
-            .port_or_known_default()
-            .map(|p| p as i64)
-            .unwrap_or(0),
-    );
-    span.record(otel_trace::URL_FULL, final_url.as_str());
-
-    match result {
-        Ok(response) => {
-            span.record(
-                otel_trace::HTTP_RESPONSE_STATUS_CODE,
-                response.status().as_u16() as i64,
-            );
-        }
-        Err(err) => {
-            if let Some(status) = err.http_status_code() {
-                span.record(otel_trace::HTTP_RESPONSE_STATUS_CODE, status as i64);
-            }
-        }
-    }
-
-    if prior_attempt_count > 0 {
-        span.record(
-            otel_trace::HTTP_REQUEST_RESEND_COUNT,
-            prior_attempt_count as i64,
-        );
-    }
-}
-
 pub fn sanitize_url(url: &::reqwest::Url) -> ::reqwest::Url {
     if url.query().is_none() {
         return url.clone();
@@ -249,7 +187,6 @@ pub fn sanitize_url(url: &::reqwest::Url) -> ::reqwest::Url {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client_request_span;
     use crate::options::InstrumentationClientInfo;
     use google_cloud_gax::error::{
         Error,
@@ -260,6 +197,7 @@ mod tests {
     use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer, TestLayerGuard};
     use http::Method;
     use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
+    use pretty_assertions::assert_eq;
     use reqwest::{self, StatusCode};
     use std::collections::{BTreeMap, BTreeSet};
     use test_case::test_case;
@@ -417,7 +355,7 @@ mod tests {
 
         let response = http::Response::builder().status(status_code).body("")?;
         let response: reqwest::Response = response.into();
-        let _ = Ok(response).record_http(&span, 123, Method::GET, request.url().clone());
+        let _ = Ok(response).record_http(&span);
 
         let want: BTreeMap<String, AttributeValue> = [
             (OTEL_NAME, "GET".into()),
@@ -456,7 +394,7 @@ mod tests {
 
         // Simulate a timeout error as a gax::Error
         let error = Error::timeout("test timeout");
-        let _ = Err(error).record_http(&span, 123, Method::GET, request.url().clone());
+        let _ = Err(error).record_http(&span);
 
         let want: BTreeMap<String, AttributeValue> = [
             (OTEL_NAME, "GET".into()),
@@ -509,7 +447,7 @@ mod tests {
             http::HeaderMap::new(),
             bytes::Bytes::new(),
         );
-        let _ = Err(error).record_http(&span, 123, Method::GET, request.url().clone());
+        let _ = Err(error).record_http(&span);
 
         let captured = TestLayer::capture(&guard);
         assert_eq!(captured.len(), 1, "captured spans: {:?}", captured);
@@ -568,7 +506,7 @@ mod tests {
             .set_message("Invalid API Key")
             .set_details(vec![StatusDetails::ErrorInfo(error_info)]);
         let error = Error::service(status);
-        let _ = Err(error).record_http(&span, 123, Method::GET, request.url().clone());
+        let _ = Err(error).record_http(&span);
 
         let captured = TestLayer::capture(&guard);
         assert_eq!(captured.len(), 1, "captured spans: {:?}", captured);
@@ -650,111 +588,52 @@ mod tests {
 
     #[tokio::test]
     async fn test_record_intermediate_client_request() {
-        let guard = TestLayer::initialize();
-        let current = client_request_span!("Service", "test_method", &TEST_INFO);
-        let _enter = current.enter();
-
-        let url = "https://example.com/test".parse::<reqwest::Url>().unwrap();
+        let recorder = RequestRecorder::new(TEST_INFO);
+        let request =
+            reqwest::Request::new(Method::GET, "https://example.com/test".parse().unwrap());
+        recorder.on_http_request(&request);
         let response = http::Response::builder()
             .status(StatusCode::OK)
             .body("")
             .unwrap();
         let response: reqwest::Response = response.into();
+        recorder.on_http_response(&response);
         let t4 = tracing::info_span!("t4");
-        let _ = Ok(response).record_http(&t4, 1, Method::GET, url);
+        let _ = recorder
+            .clone()
+            .scope(async { Ok(response).record_http(&t4) })
+            .await;
 
-        let captured = TestLayer::capture(&guard);
-        let test = captured
-            .iter()
-            .find(|s| s.name == "client_request")
-            .unwrap_or_else(|| panic!("cannot find `client_request` span: {captured:?}"));
-        let attributes = &test.attributes;
-
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_RESPONSE_STATUS_CODE),
-            Some(&(200_i64).into())
-        );
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_REQUEST_RESEND_COUNT),
-            Some(&(1_i64).into())
-        );
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_REQUEST_METHOD),
-            Some(&"GET".into())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_record_intermediate_client_request_no_marker() {
-        let guard = TestLayer::initialize();
-        let current = tracing::info_span!(
-            "test_span",
-            { otel_trace::HTTP_RESPONSE_STATUS_CODE } = field::Empty,
-            { otel_trace::HTTP_REQUEST_RESEND_COUNT } = field::Empty,
-            // Missing "gax.client.span" marker field
-        );
-        let _enter = current.enter();
-
-        let url = "https://example.com/test".parse::<reqwest::Url>().unwrap();
-        let response = http::Response::builder()
-            .status(StatusCode::OK)
-            .body("")
-            .unwrap();
-        let response: reqwest::Response = response.into();
-        let t4 = tracing::info_span!("t4");
-        let _ = Ok(response).record_http(&t4, 1, Method::GET, url);
-
-        let captured = TestLayer::capture(&guard);
-        let test = captured
-            .iter()
-            .find(|s| s.name == "test_span")
-            .unwrap_or_else(|| panic!("cannot find `test_span` span: {captured:?}"));
-        let attributes = &test.attributes;
-
-        // Should NOT be recorded because the span lacks the necessary marker.
-        assert!(!attributes.contains_key(otel_trace::HTTP_RESPONSE_STATUS_CODE));
-        assert!(!attributes.contains_key(otel_trace::HTTP_REQUEST_RESEND_COUNT));
+        let snapshot = recorder.client_snapshot();
+        assert!(snapshot.http_resend_count().is_none(), "{snapshot:?}");
+        assert_eq!(snapshot.http_status_code(), Some(200), "{snapshot:?}");
+        assert_eq!(snapshot.server_address(), "example.com", "{snapshot:?}");
+        assert_eq!(snapshot.server_port(), 443, "{snapshot:?}");
     }
 
     #[tokio::test]
     async fn test_record_intermediate_client_request_error() {
-        let guard = TestLayer::initialize();
-        let span = client_request_span!("Service", "test_method", &TEST_INFO);
-        let _enter = span.enter();
-
-        let url = "https://example.com/test".parse::<reqwest::Url>().unwrap();
+        let recorder = RequestRecorder::new(TEST_INFO);
+        let request =
+            reqwest::Request::new(Method::GET, "https://example.com/test".parse().unwrap());
+        recorder.on_http_request(&request);
         // Simulate a 404 error
-        let error = Error::http(404, http::HeaderMap::new(), bytes::Bytes::new());
+        let response = http::Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body("")
+            .unwrap();
+        let response: reqwest::Response = response.into();
+        recorder.on_http_response(&response);
         let t4 = tracing::info_span!("t4");
-        let _response = Err(error).record_http(&t4, 1, Method::POST, url);
+        let _ = recorder
+            .clone()
+            .scope(async { Ok(response).record_http(&t4) })
+            .await;
 
-        let captured = TestLayer::capture(&guard);
-        let t3 = captured
-            .iter()
-            .find(|s| s.name == "client_request")
-            .unwrap_or_else(|| panic!("cannot find `client_request` span: {captured:?}"));
-        let attributes = &t3.attributes;
-
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_RESPONSE_STATUS_CODE),
-            Some(&(404_i64).into())
-        );
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_REQUEST_RESEND_COUNT),
-            Some(&(1_i64).into())
-        );
-        assert_eq!(
-            attributes.get(otel_trace::HTTP_REQUEST_METHOD),
-            Some(&"POST".into())
-        );
-        // Verify URL attributes from fallback
-        assert_eq!(
-            attributes.get(otel_trace::URL_FULL),
-            Some(&"https://example.com/test".into())
-        );
-        assert_eq!(
-            attributes.get(otel_trace::SERVER_ADDRESS),
-            Some(&"example.com".into())
-        );
+        let snapshot = recorder.client_snapshot();
+        assert!(snapshot.http_resend_count().is_none(), "{snapshot:?}");
+        assert_eq!(snapshot.http_status_code(), Some(404), "{snapshot:?}");
+        assert_eq!(snapshot.server_address(), "example.com", "{snapshot:?}");
+        assert_eq!(snapshot.server_port(), 443, "{snapshot:?}");
     }
 }

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -16,24 +16,31 @@
 mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::Result;
+    use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
     use google_cloud_gax::response::Response;
-    use google_cloud_gax_internal::client_request_span;
+    use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
+    use google_cloud_gax_internal::attempt_info::AttemptInfo;
     use google_cloud_gax_internal::http::{NoBody, ReqwestClient};
-    use google_cloud_gax_internal::observability::ResultExt;
     use google_cloud_gax_internal::observability::attributes::keys::*;
+    use google_cloud_gax_internal::observability::{
+        ClientRequestAttributes, DurationMetric, RequestRecorder,
+    };
     use google_cloud_gax_internal::options::{ClientConfig, InstrumentationClientInfo};
     use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
     use http::{Method, StatusCode};
-    use httptest::matchers::request::{body, headers, method, path};
+    use httptest::matchers::request::{body, headers, method, method_path, path};
     use httptest::{Expectation, Server, all_of, responders::*};
     use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
+    use pretty_assertions::assert_eq;
     use serde::Deserialize;
     use std::collections::BTreeMap;
-    use std::sync::LazyLock;
+    use std::sync::{Arc, LazyLock};
+    use std::time::Duration;
     use test_case::test_case;
     use tracing::{Instrument, field};
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[derive(Debug, Deserialize, Default, PartialEq)]
     struct TestResponse {
@@ -44,6 +51,9 @@ mod tests {
     const TEST_VERSION: &str = "1.2.3";
     const TEST_ARTIFACT: &str = "google-cloud-test";
     const TEST_HOST: &str = "test.googleapis.com";
+    const TEST_RPC_METHOD: &str = "test.Service/method";
+    const TEST_URL_TEMPLATE: &str = "/v42/{parent}:method";
+    const TEST_RESOURCE: &str = "//test.googleapis.com/projects/p/locations/l/widgets/w";
 
     static TEST_INSTRUMENTATION_INFO: LazyLock<InstrumentationClientInfo> = LazyLock::new(|| {
         let mut info = InstrumentationClientInfo::default();
@@ -73,31 +83,28 @@ mod tests {
         let server_addr = server.addr();
         let server_url = format!("http://{}", server_addr);
         server.expect(
-            Expectation::matching(all_of![method("GET"), path("/test"),])
+            Expectation::matching(method_path("GET", "/test"))
                 .respond_with(status_code(200).body("{\"hello\": \"world\"}")),
         );
 
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
-
-        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
-        let request = client.builder(Method::GET, "/test".to_string());
-        let _response: Result<Response<TestResponse>> =
-            client.execute(request, None::<NoBody>, options).await;
+        let _response = generated_tracing_stub(&client).await;
 
         let captured = TestLayer::capture(&guard);
-        assert_eq!(captured.len(), 1, "Should capture one span: {:?}", captured);
+        let span = captured
+            .iter()
+            .find(|s| s.name == "http_request")
+            .unwrap_or_else(|| panic!("cannot find `http_request` span in capture: {captured:#?}"));
 
-        let span = &captured[0];
         let got = BTreeMap::from_iter(span.attributes.clone());
-
         let want: BTreeMap<String, AttributeValue> = [
-            (OTEL_NAME, "GET /test".into()),
+            (OTEL_NAME, format!("GET {TEST_URL_TEMPLATE}").into()),
             (OTEL_KIND, "Client".into()),
             (otel_trace::RPC_SYSTEM, "http".into()),
             (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
             (otel_trace::URL_SCHEME, "http".into()),
-            (otel_attr::URL_TEMPLATE, "/test".into()),
+            (otel_attr::URL_TEMPLATE, TEST_URL_TEMPLATE.into()),
             (otel_attr::URL_DOMAIN, TEST_HOST.into()),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (OTEL_STATUS_CODE, "UNSET".into()),
@@ -106,6 +113,7 @@ mod tests {
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (GCP_RESOURCE_NAME, TEST_RESOURCE.into()),
             (otel_trace::HTTP_RESPONSE_BODY_SIZE, 18_i64.into()), // {"hello": "world"} is 18 bytes
             (
                 otel_trace::SERVER_ADDRESS,
@@ -355,37 +363,24 @@ mod tests {
         let server_addr = server.addr();
         let server_url = format!("http://{}", server_addr);
         server.expect(
-            Expectation::matching(all_of![method("GET"), path("/test"),])
+            Expectation::matching(method_path("GET", "/test"))
                 .respond_with(status_code(200).body("{\"hello\": \"world\"}")),
         );
 
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
-
-        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
-        let request = client.builder(Method::GET, "/test".to_string());
-
-        // Create a parent span (T3) with the marker field
-        let t3_span = tracing::info_span!(
-            "t3_span",
-            { { otel_trace::HTTP_RESPONSE_STATUS_CODE } } = field::Empty,
-            { { otel_trace::HTTP_REQUEST_RESEND_COUNT } } = field::Empty,
-            "gax.client.span" = field::Empty,
-        );
-
-        // Execute the request within the T3 span
-        let _response: Result<Response<TestResponse>> = client
-            .execute(request, None::<NoBody>, options)
-            .instrument(t3_span.clone())
-            .await;
+        let result = generated_tracing_stub(&client).await;
+        assert!(result.is_ok(), "{result:?}");
 
         let captured = TestLayer::capture(&guard);
         // We expect t3_span to be captured, and the internal http_request span (T4).
         // t3_span should have the attributes.
         let t3_captured = captured
             .iter()
-            .find(|s| s.name == "t3_span")
-            .expect("t3_span not found");
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| {
+                panic!("cannot find `client_request` span in capture: {captured:#?}")
+            });
         assert_eq!(
             t3_captured
                 .attributes
@@ -455,57 +450,48 @@ mod tests {
         );
     }
 
+    // Verify the path starting from execute() records the request and responses.
+    //
+    // The verification is indirect, we examine the contents of the T3 span and infer the values were
+    // recorder.
     #[tokio::test]
-    async fn test_t3_span_creation_and_enrichment() {
+    async fn execute_records_request_and_response() {
         let server = Server::run();
         let server_addr = server.addr();
         let server_url = format!("http://{}", server_addr);
         server.expect(
-            Expectation::matching(all_of![method("GET"), path("/test"),])
+            Expectation::matching(method_path("GET", "/test"))
                 .respond_with(status_code(200).body("{\"hello\": \"world\"}")),
         );
 
         let client = create_client(true, server_url.clone()).await;
         let guard = TestLayer::initialize();
 
-        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
-        let request = client.builder(Method::GET, "/test".to_string());
-
-        // 1. Create the T3 span using the helper
-        let t3_span = client_request_span!("Service", "test_method", &TEST_INSTRUMENTATION_INFO);
-
-        // 2. Execute the request within the T3 span
-        let _result: Result<Response<TestResponse>> = client
-            .execute(request, None::<NoBody>, options)
-            .instrument(t3_span.clone())
-            .await
-            // 3. Enrich the span based on the result
-            .record_in_span(&t3_span);
+        let _response = generated_tracing_stub(&client).await;
 
         let captured = TestLayer::capture(&guard);
-
-        // Find the T3 span
         let t3_captured = captured
             .iter()
             .find(|s| s.name == "client_request")
-            .expect("client_request span not found");
+            .unwrap_or_else(|| {
+                panic!("cannot find `client_request` span in capture: {captured:#?}")
+            });
 
         let got = BTreeMap::from_iter(t3_captured.attributes.clone());
 
         let want: BTreeMap<String, AttributeValue> = [
             (
                 OTEL_NAME,
-                format!("{}::Service::test_method", env!("CARGO_CRATE_NAME")).into(),
+                concat!(env!("CARGO_CRATE_NAME"), "::", "generated_tracing_stub").into(),
             ),
             (OTEL_KIND, "Internal".into()),
             (otel_trace::RPC_SYSTEM, "http".into()),
             (otel_trace::RPC_SERVICE, TEST_SERVICE.into()),
-            (otel_trace::RPC_METHOD, "test_method".into()),
+            (otel_trace::RPC_METHOD, TEST_RPC_METHOD.into()),
             (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
             (GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
-            (GCP_CLIENT_LANGUAGE, "rust".into()),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (
                 otel_trace::SERVER_ADDRESS,
@@ -515,7 +501,187 @@ mod tests {
             (otel_trace::URL_FULL, format!("{}/test", server_url).into()),
             (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
             (OTEL_STATUS_CODE, "UNSET".into()),
-            ("gax.client.span", true.into()),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+        assert_eq!(got, want);
+    }
+
+    // Verify the path starting from `execute_http()` records the request and send errors.
+    //
+    // The verification is indirect, we examine the contents of the T3 span and infer the values were
+    // recorder.
+    #[tokio::test]
+    async fn execute_records_send_error() -> anyhow::Result<()> {
+        // All requests will fail with a send error because there is nothing listening on this endpoint.
+        const ENDPOINT: &str = "https://127.0.0.1:1";
+        let mut config = ClientConfig::default();
+        config.tracing = true;
+        config.endpoint = Some(ENDPOINT.to_string());
+        config.cred = Some(Anonymous::new().build());
+        config.retry_policy = Some(Arc::new(
+            Aip194Strict
+                .with_time_limit(Duration::from_secs(5))
+                .with_attempt_limit(5),
+        ));
+        config.backoff_policy = Some(Arc::new(
+            ExponentialBackoffBuilder::default()
+                .with_initial_delay(Duration::from_millis(1))
+                .with_maximum_delay(Duration::from_millis(1))
+                .build()?,
+        ));
+        let client = ReqwestClient::new(config, ENDPOINT)
+            .await?
+            .with_instrumentation(&TEST_INSTRUMENTATION_INFO);
+        let guard = TestLayer::initialize();
+
+        let _response = generated_tracing_stub(&client).await;
+
+        let captured = TestLayer::capture(&guard);
+        let t3_captured = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| {
+                panic!("cannot find `client_request` span in capture: {captured:#?}")
+            });
+
+        let mut got = BTreeMap::from_iter(t3_captured.attributes.clone());
+        // Must exist, but we do not care about its value.
+        assert!(got.remove(OTEL_STATUS_DESCRIPTION).is_some(), "{got:?}");
+        assert!(got.remove(ERROR_TYPE).is_some(), "{got:?}");
+        assert!(got.remove(HTTP_REQUEST_RESEND_COUNT).is_some(), "{got:?}");
+
+        let want: BTreeMap<String, AttributeValue> = [
+            (
+                OTEL_NAME,
+                concat!(env!("CARGO_CRATE_NAME"), "::", "generated_tracing_stub").into(),
+            ),
+            (OTEL_KIND, "Internal".into()),
+            (otel_trace::RPC_SYSTEM, "http".into()),
+            (otel_trace::RPC_SERVICE, TEST_SERVICE.into()),
+            (otel_trace::RPC_METHOD, TEST_RPC_METHOD.into()),
+            (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
+            (GCP_CLIENT_VERSION, TEST_VERSION.into()),
+            (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
+            (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (otel_trace::SERVER_ADDRESS, "127.0.0.1".into()),
+            (otel_trace::SERVER_PORT, (1_i64).into()),
+            (otel_trace::URL_FULL, "https://127.0.0.1:1/test".into()),
+            (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
+            (OTEL_STATUS_CODE, "ERROR".into()),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    // Verify the path starting from `execute_http()` records the request and responses.
+    //
+    // The verification is indirect, we examine the contents of the T3 span and infer the values were
+    // recorder.
+    #[tokio::test]
+    async fn execute_http_records_request_and_response() {
+        let server = Server::run();
+        let server_addr = server.addr();
+        let server_url = format!("http://{}", server_addr);
+        server.expect(
+            Expectation::matching(method_path("GET", "/test"))
+                .respond_with(status_code(200).body("{\"hello\": \"world\"}")),
+        );
+
+        let client = create_client(true, server_url.clone()).await;
+        let guard = TestLayer::initialize();
+
+        let _response = execute_http_tracing_stub(&client).await;
+
+        let captured = TestLayer::capture(&guard);
+        let t3_captured = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| {
+                panic!("cannot find `client_request` span in capture: {captured:#?}")
+            });
+
+        let got = BTreeMap::from_iter(t3_captured.attributes.clone());
+
+        let want: BTreeMap<String, AttributeValue> = [
+            (
+                OTEL_NAME,
+                concat!(env!("CARGO_CRATE_NAME"), "::", "execute_http_tracing_stub").into(),
+            ),
+            (OTEL_KIND, "Internal".into()),
+            (otel_trace::RPC_SYSTEM, "http".into()),
+            (otel_trace::RPC_SERVICE, TEST_SERVICE.into()),
+            (otel_trace::RPC_METHOD, TEST_RPC_METHOD.into()),
+            (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
+            (GCP_CLIENT_VERSION, TEST_VERSION.into()),
+            (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
+            (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
+            (
+                otel_trace::SERVER_ADDRESS,
+                server_addr.ip().to_string().into(),
+            ),
+            (otel_trace::SERVER_PORT, (server_addr.port() as i64).into()),
+            (otel_trace::URL_FULL, format!("{}/test", server_url).into()),
+            (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
+            (OTEL_STATUS_CODE, "UNSET".into()),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+        assert_eq!(got, want);
+    }
+
+    // Verify the path starting from `execute_http()` records the request and send errors.
+    //
+    // The verification is indirect, we examine the contents of the T3 span and infer the values were
+    // recorder.
+    #[tokio::test]
+    async fn execute_http_recorder_send_error() {
+        // All requests will fail with a send error because there is nothing listening on this endpoint.
+        let client = create_client(true, "https://127.0.0.1:1".to_string()).await;
+        let guard = TestLayer::initialize();
+
+        let _response = execute_http_tracing_stub(&client).await;
+
+        let captured = TestLayer::capture(&guard);
+        let t3_captured = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| {
+                panic!("cannot find `client_request` span in capture: {captured:#?}")
+            });
+
+        let mut got = BTreeMap::from_iter(t3_captured.attributes.clone());
+        // Must exist, but we do not care about its value.
+        assert!(got.remove(OTEL_STATUS_DESCRIPTION).is_some(), "{got:?}");
+
+        let want: BTreeMap<String, AttributeValue> = [
+            (
+                OTEL_NAME,
+                concat!(env!("CARGO_CRATE_NAME"), "::", "execute_http_tracing_stub").into(),
+            ),
+            (OTEL_KIND, "Internal".into()),
+            (otel_trace::RPC_SYSTEM, "http".into()),
+            (otel_trace::RPC_SERVICE, TEST_SERVICE.into()),
+            (otel_trace::RPC_METHOD, TEST_RPC_METHOD.into()),
+            (GCP_CLIENT_SERVICE, TEST_SERVICE.into()),
+            (GCP_CLIENT_VERSION, TEST_VERSION.into()),
+            (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
+            (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (otel_trace::SERVER_ADDRESS, "127.0.0.1".into()),
+            (otel_trace::SERVER_PORT, (1_i64).into()),
+            (otel_trace::URL_FULL, "https://127.0.0.1:1/test".into()),
+            (otel_trace::HTTP_REQUEST_METHOD, "GET".into()),
+            (OTEL_STATUS_CODE, "ERROR".into()),
+            (ERROR_TYPE, "CLIENT_CONNECTION_ERROR".into()),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -525,14 +691,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn propagate_trace_context() {
+    async fn generated_propagate_trace_context() {
         let server = Server::run();
         let server_addr = server.addr();
         let server_url = format!("http://{}", server_addr);
         server.expect(
             Expectation::matching(all_of![
-                method("GET"),
-                path("/test"),
+                method_path("GET", "/test"),
                 headers(httptest::matchers::contains((
                     "traceparent",
                     httptest::matchers::any()
@@ -546,19 +711,93 @@ mod tests {
         let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
         let tracer = opentelemetry::trace::TracerProvider::tracer(&tracer_provider, "test");
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-        use tracing_subscriber::layer::SubscriberExt;
         let subscriber = tracing_subscriber::registry().with(telemetry);
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let options = RequestOptions::default().insert_extension(PathTemplate("/test"));
-        let request = client.builder(Method::GET, "/test".to_string());
-
-        let span = tracing::info_span!("parent_span");
-        let result: Result<Response<TestResponse>> = client
-            .execute(request, None::<NoBody>, options)
-            .instrument(span)
-            .await;
-
+        let _ = tracing::info_span!("parent_span").entered();
+        let result = generated_tracing_stub(&client).await;
         assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn execute_http_propagate_trace_context() {
+        let server = Server::run();
+        let server_addr = server.addr();
+        let server_url = format!("http://{}", server_addr);
+        server.expect(
+            Expectation::matching(all_of![
+                method_path("GET", "/test"),
+                headers(httptest::matchers::contains((
+                    "traceparent",
+                    httptest::matchers::any()
+                ))),
+            ])
+            .respond_with(status_code(200).body("{\"hello\": \"world\"}")),
+        );
+
+        let client = create_client(true, server_url.clone()).await;
+
+        let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let tracer = opentelemetry::trace::TracerProvider::tracer(&tracer_provider, "test");
+        let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        let subscriber = tracing_subscriber::registry().with(telemetry);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let _ = tracing::info_span!("parent_span").entered();
+        let result = execute_http_tracing_stub(&client).await;
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    // Simulate a generated client tracing stub.
+    async fn generated_tracing_stub(client: &ReqwestClient) -> Result<Response<TestResponse>> {
+        let metric = DurationMetric::new(&TEST_INSTRUMENTATION_INFO);
+        let (_span, pending) = google_cloud_gax_internal::client_request_signals!(
+            metric: metric,
+            info: *TEST_INSTRUMENTATION_INFO,
+            method: "generated_tracing_stub",
+            generated_transport_stub(client));
+        pending.await
+    }
+
+    // Simulate a generated client transport stub.
+    async fn generated_transport_stub(client: &ReqwestClient) -> Result<Response<TestResponse>> {
+        let options = RequestOptions::default();
+        let request = client.builder(Method::GET, "/test".to_string());
+        if let Some(recorder) = RequestRecorder::current() {
+            recorder.on_client_request(
+                ClientRequestAttributes::default()
+                    .set_rpc_method(TEST_RPC_METHOD)
+                    .set_url_template(TEST_URL_TEMPLATE)
+                    .set_resource_name(TEST_RESOURCE.to_string()),
+            );
+        }
+        client.execute(request, None::<NoBody>, options).await
+    }
+
+    // Simulate a hand-crafted client (Storage at this time) using the `execute_http()` path.
+    async fn execute_http_transport_stub(client: &ReqwestClient) -> Result<reqwest::Response> {
+        let options = RequestOptions::default();
+        if let Some(recorder) = RequestRecorder::current() {
+            recorder.on_client_request(
+                ClientRequestAttributes::default()
+                    .set_rpc_method(TEST_RPC_METHOD)
+                    .set_url_template(TEST_URL_TEMPLATE)
+                    .set_resource_name(TEST_RESOURCE.to_string()),
+            );
+        }
+        let builder = client.http_builder(reqwest::Method::GET, "/test");
+        let attempt_info = AttemptInfo::new(0);
+        builder.send(options, attempt_info).await
+    }
+
+    // Simulate a hand-crafted client (Storage at this time) using the `execute_http()` path.
+    async fn execute_http_tracing_stub(client: &ReqwestClient) -> Result<reqwest::Response> {
+        let metric = DurationMetric::new(&TEST_INSTRUMENTATION_INFO);
+        let (_span, pending) = google_cloud_gax_internal::client_request_signals!(
+            metric: metric,
+            info: *TEST_INSTRUMENTATION_INFO,
+            method: "execute_http_tracing_stub",
+            execute_http_transport_stub(client));
+        pending.await
     }
 }

--- a/src/generated/showcase/src/tracing.rs
+++ b/src/generated/showcase/src/tracing.rs
@@ -51,18 +51,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_body",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataBody")
-            );
-            self.inner
-                .repeat_data_body(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_body",
+                self.inner.repeat_data_body(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_body(req, options).await
@@ -76,18 +70,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_body_info",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataBodyInfo")
-            );
-            self.inner
-                .repeat_data_body_info(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_body_info",
+                self.inner.repeat_data_body_info(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_body_info(req, options).await
@@ -101,18 +89,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_query",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataQuery")
-            );
-            self.inner
-                .repeat_data_query(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_query",
+                self.inner.repeat_data_query(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_query(req, options).await
@@ -126,18 +108,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_simple_path",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataSimplePath")
-            );
-            self.inner
-                .repeat_data_simple_path(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_simple_path",
+                self.inner.repeat_data_simple_path(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_simple_path(req, options).await
@@ -151,18 +127,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_path_resource",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataPathResource")
-            );
-            self.inner
-                .repeat_data_path_resource(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_path_resource",
+                self.inner.repeat_data_path_resource(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_path_resource(req, options).await
@@ -176,18 +146,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_path_trailing_resource",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataPathTrailingResource")
-            );
-            self.inner
-                .repeat_data_path_trailing_resource(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_path_trailing_resource",
+                self.inner.repeat_data_path_trailing_resource(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner
@@ -203,18 +167,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_body_put",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataBodyPut")
-            );
-            self.inner
-                .repeat_data_body_put(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_body_put",
+                self.inner.repeat_data_body_put(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_body_put(req, options).await
@@ -228,18 +186,12 @@ where
     ) -> Result<crate::Response<crate::model::RepeatResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "repeat_data_body_patch",
-                Some("google.showcase.v1beta1.Compliance/RepeatDataBodyPatch")
-            );
-            self.inner
-                .repeat_data_body_patch(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::repeat_data_body_patch",
+                self.inner.repeat_data_body_patch(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.repeat_data_body_patch(req, options).await
@@ -253,18 +205,12 @@ where
     ) -> Result<crate::Response<crate::model::EnumResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "get_enum",
-                Some("google.showcase.v1beta1.Compliance/GetEnum")
-            );
-            self.inner
-                .get_enum(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::get_enum",
+                self.inner.get_enum(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_enum(req, options).await
@@ -278,18 +224,12 @@ where
     ) -> Result<crate::Response<crate::model::EnumResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "verify_enum",
-                Some("google.showcase.v1beta1.Compliance/VerifyEnum")
-            );
-            self.inner
-                .verify_enum(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::verify_enum",
+                self.inner.verify_enum(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.verify_enum(req, options).await
@@ -303,18 +243,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -328,18 +262,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -353,18 +281,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -378,18 +300,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -403,18 +319,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -428,18 +338,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -453,18 +357,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -478,18 +376,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -503,18 +395,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Compliance",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Compliance::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await
@@ -557,18 +443,12 @@ where
     ) -> Result<crate::Response<crate::model::EchoResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "echo",
-                Some("google.showcase.v1beta1.Echo/Echo")
-            );
-            self.inner
-                .echo(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::echo",
+                self.inner.echo(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.echo(req, options).await
@@ -582,18 +462,12 @@ where
     ) -> Result<crate::Response<crate::model::EchoErrorDetailsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "echo_error_details",
-                Some("google.showcase.v1beta1.Echo/EchoErrorDetails")
-            );
-            self.inner
-                .echo_error_details(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::echo_error_details",
+                self.inner.echo_error_details(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.echo_error_details(req, options).await
@@ -607,18 +481,12 @@ where
     ) -> Result<crate::Response<crate::model::FailEchoWithDetailsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "fail_echo_with_details",
-                Some("google.showcase.v1beta1.Echo/FailEchoWithDetails")
-            );
-            self.inner
-                .fail_echo_with_details(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::fail_echo_with_details",
+                self.inner.fail_echo_with_details(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.fail_echo_with_details(req, options).await
@@ -632,18 +500,12 @@ where
     ) -> Result<crate::Response<crate::model::PagedExpandResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "paged_expand",
-                Some("google.showcase.v1beta1.Echo/PagedExpand")
-            );
-            self.inner
-                .paged_expand(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::paged_expand",
+                self.inner.paged_expand(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.paged_expand(req, options).await
@@ -657,18 +519,12 @@ where
     ) -> Result<crate::Response<crate::model::PagedExpandResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "paged_expand_legacy",
-                Some("google.showcase.v1beta1.Echo/PagedExpandLegacy")
-            );
-            self.inner
-                .paged_expand_legacy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::paged_expand_legacy",
+                self.inner.paged_expand_legacy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.paged_expand_legacy(req, options).await
@@ -682,18 +538,12 @@ where
     ) -> Result<crate::Response<crate::model::PagedExpandLegacyMappedResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "paged_expand_legacy_mapped",
-                Some("google.showcase.v1beta1.Echo/PagedExpandLegacyMapped")
-            );
-            self.inner
-                .paged_expand_legacy_mapped(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::paged_expand_legacy_mapped",
+                self.inner.paged_expand_legacy_mapped(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.paged_expand_legacy_mapped(req, options).await
@@ -707,18 +557,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "wait",
-                Some("google.showcase.v1beta1.Echo/Wait")
-            );
-            self.inner
-                .wait(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::wait",
+                self.inner.wait(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.wait(req, options).await
@@ -732,18 +576,12 @@ where
     ) -> Result<crate::Response<crate::model::BlockResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "block",
-                Some("google.showcase.v1beta1.Echo/Block")
-            );
-            self.inner
-                .block(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::block",
+                self.inner.block(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.block(req, options).await
@@ -757,18 +595,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -782,18 +614,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -807,18 +633,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -832,18 +652,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -857,18 +671,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -882,18 +690,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -907,18 +709,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -932,18 +728,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -957,18 +747,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Echo",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Echo::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await
@@ -1025,18 +809,12 @@ where
     ) -> Result<crate::Response<crate::model::User>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "create_user",
-                Some("google.showcase.v1beta1.Identity/CreateUser")
-            );
-            self.inner
-                .create_user(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::create_user",
+                self.inner.create_user(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_user(req, options).await
@@ -1050,18 +828,12 @@ where
     ) -> Result<crate::Response<crate::model::User>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "get_user",
-                Some("google.showcase.v1beta1.Identity/GetUser")
-            );
-            self.inner
-                .get_user(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::get_user",
+                self.inner.get_user(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_user(req, options).await
@@ -1075,18 +847,12 @@ where
     ) -> Result<crate::Response<crate::model::User>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "update_user",
-                Some("google.showcase.v1beta1.Identity/UpdateUser")
-            );
-            self.inner
-                .update_user(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::update_user",
+                self.inner.update_user(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_user(req, options).await
@@ -1100,18 +866,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "delete_user",
-                Some("google.showcase.v1beta1.Identity/DeleteUser")
-            );
-            self.inner
-                .delete_user(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::delete_user",
+                self.inner.delete_user(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_user(req, options).await
@@ -1125,18 +885,12 @@ where
     ) -> Result<crate::Response<crate::model::ListUsersResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "list_users",
-                Some("google.showcase.v1beta1.Identity/ListUsers")
-            );
-            self.inner
-                .list_users(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::list_users",
+                self.inner.list_users(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_users(req, options).await
@@ -1150,18 +904,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -1175,18 +923,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -1200,18 +942,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -1225,18 +961,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -1250,18 +980,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -1275,18 +999,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -1300,18 +1018,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -1325,18 +1037,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -1350,18 +1056,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Identity",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Identity::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await
@@ -1404,18 +1104,12 @@ where
     ) -> Result<crate::Response<crate::model::Room>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "create_room",
-                Some("google.showcase.v1beta1.Messaging/CreateRoom")
-            );
-            self.inner
-                .create_room(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::create_room",
+                self.inner.create_room(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_room(req, options).await
@@ -1429,18 +1123,12 @@ where
     ) -> Result<crate::Response<crate::model::Room>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "get_room",
-                Some("google.showcase.v1beta1.Messaging/GetRoom")
-            );
-            self.inner
-                .get_room(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::get_room",
+                self.inner.get_room(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_room(req, options).await
@@ -1454,18 +1142,12 @@ where
     ) -> Result<crate::Response<crate::model::Room>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "update_room",
-                Some("google.showcase.v1beta1.Messaging/UpdateRoom")
-            );
-            self.inner
-                .update_room(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::update_room",
+                self.inner.update_room(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_room(req, options).await
@@ -1479,18 +1161,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "delete_room",
-                Some("google.showcase.v1beta1.Messaging/DeleteRoom")
-            );
-            self.inner
-                .delete_room(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::delete_room",
+                self.inner.delete_room(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_room(req, options).await
@@ -1504,18 +1180,12 @@ where
     ) -> Result<crate::Response<crate::model::ListRoomsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "list_rooms",
-                Some("google.showcase.v1beta1.Messaging/ListRooms")
-            );
-            self.inner
-                .list_rooms(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::list_rooms",
+                self.inner.list_rooms(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_rooms(req, options).await
@@ -1529,18 +1199,12 @@ where
     ) -> Result<crate::Response<crate::model::Blurb>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "create_blurb",
-                Some("google.showcase.v1beta1.Messaging/CreateBlurb")
-            );
-            self.inner
-                .create_blurb(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::create_blurb",
+                self.inner.create_blurb(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_blurb(req, options).await
@@ -1554,18 +1218,12 @@ where
     ) -> Result<crate::Response<crate::model::Blurb>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "get_blurb",
-                Some("google.showcase.v1beta1.Messaging/GetBlurb")
-            );
-            self.inner
-                .get_blurb(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::get_blurb",
+                self.inner.get_blurb(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_blurb(req, options).await
@@ -1579,18 +1237,12 @@ where
     ) -> Result<crate::Response<crate::model::Blurb>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "update_blurb",
-                Some("google.showcase.v1beta1.Messaging/UpdateBlurb")
-            );
-            self.inner
-                .update_blurb(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::update_blurb",
+                self.inner.update_blurb(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.update_blurb(req, options).await
@@ -1604,18 +1256,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "delete_blurb",
-                Some("google.showcase.v1beta1.Messaging/DeleteBlurb")
-            );
-            self.inner
-                .delete_blurb(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::delete_blurb",
+                self.inner.delete_blurb(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_blurb(req, options).await
@@ -1629,18 +1275,12 @@ where
     ) -> Result<crate::Response<crate::model::ListBlurbsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "list_blurbs",
-                Some("google.showcase.v1beta1.Messaging/ListBlurbs")
-            );
-            self.inner
-                .list_blurbs(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::list_blurbs",
+                self.inner.list_blurbs(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_blurbs(req, options).await
@@ -1654,18 +1294,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "search_blurbs",
-                Some("google.showcase.v1beta1.Messaging/SearchBlurbs")
-            );
-            self.inner
-                .search_blurbs(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::search_blurbs",
+                self.inner.search_blurbs(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.search_blurbs(req, options).await
@@ -1679,18 +1313,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -1704,18 +1332,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -1729,18 +1351,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -1754,18 +1370,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -1779,18 +1389,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -1804,18 +1408,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -1829,18 +1427,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -1854,18 +1446,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -1879,18 +1465,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Messaging",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Messaging::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await
@@ -1947,18 +1527,12 @@ where
     ) -> Result<crate::Response<crate::model::Sequence>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "create_sequence",
-                Some("google.showcase.v1beta1.SequenceService/CreateSequence")
-            );
-            self.inner
-                .create_sequence(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::create_sequence",
+                self.inner.create_sequence(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_sequence(req, options).await
@@ -1972,18 +1546,12 @@ where
     ) -> Result<crate::Response<crate::model::StreamingSequence>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "create_streaming_sequence",
-                Some("google.showcase.v1beta1.SequenceService/CreateStreamingSequence")
-            );
-            self.inner
-                .create_streaming_sequence(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::create_streaming_sequence",
+                self.inner.create_streaming_sequence(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_streaming_sequence(req, options).await
@@ -1997,18 +1565,12 @@ where
     ) -> Result<crate::Response<crate::model::SequenceReport>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "get_sequence_report",
-                Some("google.showcase.v1beta1.SequenceService/GetSequenceReport")
-            );
-            self.inner
-                .get_sequence_report(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::get_sequence_report",
+                self.inner.get_sequence_report(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_sequence_report(req, options).await
@@ -2022,18 +1584,12 @@ where
     ) -> Result<crate::Response<crate::model::StreamingSequenceReport>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "get_streaming_sequence_report",
-                Some("google.showcase.v1beta1.SequenceService/GetStreamingSequenceReport")
-            );
-            self.inner
-                .get_streaming_sequence_report(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::get_streaming_sequence_report",
+                self.inner.get_streaming_sequence_report(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_streaming_sequence_report(req, options).await
@@ -2047,18 +1603,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "attempt_sequence",
-                Some("google.showcase.v1beta1.SequenceService/AttemptSequence")
-            );
-            self.inner
-                .attempt_sequence(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::attempt_sequence",
+                self.inner.attempt_sequence(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.attempt_sequence(req, options).await
@@ -2072,18 +1622,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -2097,18 +1641,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -2122,18 +1660,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -2147,18 +1679,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -2172,18 +1698,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -2197,18 +1717,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -2222,18 +1736,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -2247,18 +1755,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -2272,18 +1774,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::SequenceService",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::SequenceService::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await
@@ -2326,18 +1822,12 @@ where
     ) -> Result<crate::Response<crate::model::Session>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "create_session",
-                Some("google.showcase.v1beta1.Testing/CreateSession")
-            );
-            self.inner
-                .create_session(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::create_session",
+                self.inner.create_session(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.create_session(req, options).await
@@ -2351,18 +1841,12 @@ where
     ) -> Result<crate::Response<crate::model::Session>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "get_session",
-                Some("google.showcase.v1beta1.Testing/GetSession")
-            );
-            self.inner
-                .get_session(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::get_session",
+                self.inner.get_session(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_session(req, options).await
@@ -2376,18 +1860,12 @@ where
     ) -> Result<crate::Response<crate::model::ListSessionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "list_sessions",
-                Some("google.showcase.v1beta1.Testing/ListSessions")
-            );
-            self.inner
-                .list_sessions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::list_sessions",
+                self.inner.list_sessions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_sessions(req, options).await
@@ -2401,18 +1879,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "delete_session",
-                Some("google.showcase.v1beta1.Testing/DeleteSession")
-            );
-            self.inner
-                .delete_session(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::delete_session",
+                self.inner.delete_session(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_session(req, options).await
@@ -2426,18 +1898,12 @@ where
     ) -> Result<crate::Response<crate::model::ReportSessionResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "report_session",
-                Some("google.showcase.v1beta1.Testing/ReportSession")
-            );
-            self.inner
-                .report_session(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::report_session",
+                self.inner.report_session(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.report_session(req, options).await
@@ -2451,18 +1917,12 @@ where
     ) -> Result<crate::Response<crate::model::ListTestsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "list_tests",
-                Some("google.showcase.v1beta1.Testing/ListTests")
-            );
-            self.inner
-                .list_tests(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::list_tests",
+                self.inner.list_tests(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_tests(req, options).await
@@ -2476,18 +1936,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "delete_test",
-                Some("google.showcase.v1beta1.Testing/DeleteTest")
-            );
-            self.inner
-                .delete_test(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::delete_test",
+                self.inner.delete_test(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_test(req, options).await
@@ -2501,18 +1955,12 @@ where
     ) -> Result<crate::Response<crate::model::VerifyTestResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "verify_test",
-                Some("google.showcase.v1beta1.Testing/VerifyTest")
-            );
-            self.inner
-                .verify_test(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::verify_test",
+                self.inner.verify_test(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.verify_test(req, options).await
@@ -2526,18 +1974,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::ListLocationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "list_locations",
-                Some("google.cloud.location.Locations/ListLocations")
-            );
-            self.inner
-                .list_locations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::list_locations",
+                self.inner.list_locations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_locations(req, options).await
@@ -2551,18 +1993,12 @@ where
     ) -> Result<crate::Response<google_cloud_location::model::Location>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "get_location",
-                Some("google.cloud.location.Locations/GetLocation")
-            );
-            self.inner
-                .get_location(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::get_location",
+                self.inner.get_location(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_location(req, options).await
@@ -2576,18 +2012,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "set_iam_policy",
-                Some("google.iam.v1.IAMPolicy/SetIamPolicy")
-            );
-            self.inner
-                .set_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::set_iam_policy",
+                self.inner.set_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.set_iam_policy(req, options).await
@@ -2601,18 +2031,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::Policy>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "get_iam_policy",
-                Some("google.iam.v1.IAMPolicy/GetIamPolicy")
-            );
-            self.inner
-                .get_iam_policy(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::get_iam_policy",
+                self.inner.get_iam_policy(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_iam_policy(req, options).await
@@ -2626,18 +2050,12 @@ where
     ) -> Result<crate::Response<google_cloud_iam_v1::model::TestIamPermissionsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "test_iam_permissions",
-                Some("google.iam.v1.IAMPolicy/TestIamPermissions")
-            );
-            self.inner
-                .test_iam_permissions(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::test_iam_permissions",
+                self.inner.test_iam_permissions(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.test_iam_permissions(req, options).await
@@ -2651,18 +2069,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::ListOperationsResponse>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "list_operations",
-                Some("google.longrunning.Operations/ListOperations")
-            );
-            self.inner
-                .list_operations(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::list_operations",
+                self.inner.list_operations(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.list_operations(req, options).await
@@ -2676,18 +2088,12 @@ where
     ) -> Result<crate::Response<google_cloud_longrunning::model::Operation>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "get_operation",
-                Some("google.longrunning.Operations/GetOperation")
-            );
-            self.inner
-                .get_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::get_operation",
+                self.inner.get_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.get_operation(req, options).await
@@ -2701,18 +2107,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "delete_operation",
-                Some("google.longrunning.Operations/DeleteOperation")
-            );
-            self.inner
-                .delete_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::delete_operation",
+                self.inner.delete_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.delete_operation(req, options).await
@@ -2726,18 +2126,12 @@ where
     ) -> Result<crate::Response<()>> {
         #[cfg(google_cloud_unstable_tracing)]
         {
-            use gaxi::observability::ClientSignalsExt as _;
-            let (start, span) = gaxi::client_request_signals!(
-                &info::INSTRUMENTATION_CLIENT_INFO,
-                &options,
-                "client::Testing",
-                "cancel_operation",
-                Some("google.longrunning.Operations/CancelOperation")
-            );
-            self.inner
-                .cancel_operation(req, options)
-                .instrument_client(self.duration.clone(), start, span)
-                .await
+            let (_span, pending) = gaxi::client_request_signals!(
+                metric: self.duration.clone(),
+                info: *info::INSTRUMENTATION_CLIENT_INFO,
+                method: "client::Testing::cancel_operation",
+                self.inner.cancel_operation(req, options));
+            pending.await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
         self.inner.cancel_operation(req, options).await

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -74,10 +74,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataBody")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -136,10 +139,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataBodyInfo")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -210,10 +216,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataQuery")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -303,10 +312,13 @@ impl super::stub::Compliance for Compliance {
             google_cloud_gax::error::Error::binding(BindingError { paths })
         })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataSimplePath")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -429,10 +441,13 @@ impl super::stub::Compliance for Compliance {
             google_cloud_gax::error::Error::binding(BindingError { paths })
         })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataPathResource")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -543,10 +558,15 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method(
+                        "google.showcase.v1beta1.Compliance/RepeatDataPathTrailingResource",
+                    )
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -585,10 +605,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataBodyPut")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -627,10 +650,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/RepeatDataBodyPatch")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -670,10 +696,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/GetEnum")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -725,10 +754,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Compliance/VerifyEnum")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -782,10 +814,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -846,10 +881,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -872,7 +910,7 @@ impl super::stub::Compliance for Compliance {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -980,16 +1018,14 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1012,7 +1048,7 @@ impl super::stub::Compliance for Compliance {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -1168,16 +1204,14 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1200,7 +1234,7 @@ impl super::stub::Compliance for Compliance {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -1308,16 +1342,14 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1362,10 +1394,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1422,10 +1457,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1482,10 +1520,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1548,10 +1589,13 @@ impl super::stub::Compliance for Compliance {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1626,10 +1670,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/Echo")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1671,10 +1718,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/EchoErrorDetails")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1716,10 +1766,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/FailEchoWithDetails")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1761,10 +1814,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/PagedExpand")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1806,10 +1862,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/PagedExpandLegacy")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1851,10 +1910,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/PagedExpandLegacyMapped")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1896,10 +1958,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/Wait")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -1941,10 +2006,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Echo/Block")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2001,10 +2069,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2065,10 +2136,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2091,7 +2165,7 @@ impl super::stub::Echo for Echo {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -2199,16 +2273,14 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2231,7 +2303,7 @@ impl super::stub::Echo for Echo {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -2387,16 +2459,14 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2419,7 +2489,7 @@ impl super::stub::Echo for Echo {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -2527,16 +2597,14 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2581,10 +2649,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2641,10 +2712,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2701,10 +2775,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2767,10 +2844,13 @@ impl super::stub::Echo for Echo {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2860,10 +2940,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Identity/CreateUser")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2886,7 +2969,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -2915,16 +2998,14 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Identity/GetUser")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -2993,10 +3074,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Identity/UpdateUser")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3019,7 +3103,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -3048,16 +3132,14 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Identity/DeleteUser")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3104,10 +3186,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Identity/ListUsers")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3161,10 +3246,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3225,10 +3313,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3251,7 +3342,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -3359,16 +3450,14 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3391,7 +3480,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -3547,16 +3636,14 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3579,7 +3666,7 @@ impl super::stub::Identity for Identity {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -3687,16 +3774,14 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3741,10 +3826,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3801,10 +3889,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3861,10 +3952,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -3927,10 +4021,13 @@ impl super::stub::Identity for Identity {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4006,10 +4103,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/CreateRoom")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4032,7 +4132,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -4061,16 +4161,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/GetRoom")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4139,10 +4237,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/UpdateRoom")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4165,7 +4266,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -4194,16 +4295,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/DeleteRoom")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4250,10 +4349,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/ListRooms")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4276,7 +4378,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
@@ -4336,16 +4438,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/CreateBlurb")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4368,7 +4468,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -4440,16 +4540,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/GetBlurb")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4578,10 +4676,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/UpdateBlurb")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4604,7 +4705,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -4676,16 +4777,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/DeleteBlurb")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4714,7 +4813,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
@@ -4778,16 +4877,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/ListBlurbs")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4810,7 +4907,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
@@ -4873,16 +4970,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Messaging/SearchBlurbs")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -4936,10 +5031,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5000,10 +5098,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5026,7 +5127,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -5134,16 +5235,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5166,7 +5265,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -5322,16 +5421,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5354,7 +5451,7 @@ impl super::stub::Messaging for Messaging {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -5462,16 +5559,14 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5516,10 +5611,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5576,10 +5674,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5636,10 +5737,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5702,10 +5806,13 @@ impl super::stub::Messaging for Messaging {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5795,10 +5902,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.SequenceService/CreateSequence")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5837,10 +5947,15 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method(
+                        "google.showcase.v1beta1.SequenceService/CreateStreamingSequence",
+                    )
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5863,7 +5978,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -5900,16 +6015,14 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.SequenceService/GetSequenceReport")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -5932,7 +6045,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -5969,16 +6082,16 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method(
+                        "google.showcase.v1beta1.SequenceService/GetStreamingSequenceReport",
+                    )
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6001,7 +6114,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -6030,16 +6143,14 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.SequenceService/AttemptSequence")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6099,10 +6210,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6163,10 +6277,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6189,7 +6306,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -6297,16 +6414,14 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6329,7 +6444,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -6485,16 +6600,14 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6517,7 +6630,7 @@ impl super::stub::SequenceService for SequenceService {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -6625,16 +6738,14 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6679,10 +6790,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6739,10 +6853,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6799,10 +6916,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6865,10 +6985,13 @@ impl super::stub::SequenceService for SequenceService {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6944,10 +7067,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/CreateSession")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -6970,7 +7096,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -6999,16 +7125,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/GetSession")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7049,10 +7173,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/ListSessions")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7075,7 +7202,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -7104,16 +7231,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/DeleteSession")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7142,7 +7267,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -7171,16 +7296,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/ReportSession")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7203,7 +7326,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_parent = try_match(
                     Some(&req).map(|m| &m.parent).map(|s| s.as_str()),
@@ -7234,16 +7357,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/ListTests")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7266,7 +7387,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -7305,16 +7426,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/DeleteTest")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7343,7 +7462,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_name = try_match(
                     Some(&req).map(|m| &m.name).map(|s| s.as_str()),
@@ -7387,16 +7506,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.showcase.v1beta1.Testing/VerifyTest")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7450,10 +7567,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/ListLocations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7514,10 +7634,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.cloud.location.Locations/GetLocation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7540,7 +7663,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -7648,16 +7771,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/SetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7680,7 +7801,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -7836,16 +7957,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/GetIamPolicy")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -7868,7 +7987,7 @@ impl super::stub::Testing for Testing {
         use gaxi::path_parameter::try_match;
         use gaxi::routing_parameter::Segment;
         use google_cloud_gax::error::binding::BindingError;
-        let (builder, method, _path_template, resource_name) = None
+        let (builder, method, _path_template, _resource_name) = None
             .or_else(|| {
                 let var_resource = try_match(
                     Some(&req).map(|m| &m.resource).map(|s| s.as_str()),
@@ -7976,16 +8095,14 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
-        let options = if !resource_name.is_empty() {
-            use google_cloud_gax::options::internal::{RequestOptionsExt, ResourceName};
-            options.insert_extension(ResourceName(resource_name))
-        } else {
-            options
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.iam.v1.IAMPolicy/TestIamPermissions")
+                    .set_url_template(_path_template)
+                    .set_resource_name(_resource_name),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -8030,10 +8147,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/ListOperations")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -8090,10 +8210,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/GetOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -8150,10 +8273,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/DeleteOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),
@@ -8216,10 +8342,13 @@ impl super::stub::Testing for Testing {
                 google_cloud_gax::error::Error::binding(BindingError { paths })
             })??;
         #[cfg(google_cloud_unstable_tracing)]
-        let options = {
-            use google_cloud_gax::options::internal::{PathTemplate, RequestOptionsExt};
-            options.insert_extension(PathTemplate(_path_template))
-        };
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            recorder.on_client_request(
+                gaxi::observability::ClientRequestAttributes::default()
+                    .set_rpc_method("google.longrunning.Operations/CancelOperation")
+                    .set_url_template(_path_template),
+            );
+        }
         let options = google_cloud_gax::options::internal::set_default_idempotency(
             options,
             gaxi::http::default_idempotency(&method),

--- a/tests/o11y/Cargo.toml
+++ b/tests/o11y/Cargo.toml
@@ -45,6 +45,7 @@ http.workspace                = true
 httptest.workspace            = true
 opentelemetry                 = { workspace = true, features = ["logs", "metrics", "trace"] }
 opentelemetry-proto           = { workspace = true, features = ["gen-tonic", "logs", "metrics", "trace"] }
+pretty_assertions.workspace   = true
 thiserror.workspace           = true
 rand.workspace                = true
 reqwest                       = { workspace = true, features = ["json"] }

--- a/tests/o11y/src/e2e/signals.rs
+++ b/tests/o11y/src/e2e/signals.rs
@@ -26,6 +26,7 @@ use httptest::responders::{delay_and_then, status_code};
 use httptest::{Expectation, Server, matchers::*};
 use opentelemetry::TraceId;
 use opentelemetry::trace::TraceContextExt;
+use pretty_assertions::assert_eq;
 use rand::RngExt;
 use std::time::SystemTime;
 use std::{collections::BTreeSet, time::Duration};
@@ -198,31 +199,23 @@ fn check_logs(project_id: &str, buffer: Buffer, trace_id: TraceId) -> anyhow::Re
             .is_some_and(|v| v.as_str().is_some()),
         "{value:?}"
     );
+    assert!(fields.remove("gcp.client.version").is_some(), "{value:?}");
+    assert!(fields.remove("server.address").is_some(), "{value:?}");
+    assert!(fields.remove("server.port").is_some(), "{value:?}");
+    assert!(fields.remove("url.full").is_some(), "{value:?}");
     let want = serde_json::json!({
-        "http.response.status_code": 404,
-        "rpc.method": "google_cloud_showcase_v1beta1::client::Echo::echo",
-        "rpc.response.status_code": "UNKNOWN",
+        "gcp.client.artifact": "google-cloud-showcase-v1beta1",
+        "gcp.client.repo": "googleapis/google-cloud-rust",
+        "gcp.client.service": "showcase",
+        "error.type": "404",
+        "http.request.method": "POST",
+        "rpc.method": "google.showcase.v1beta1.Echo/Echo",
+        "rpc.service": "showcase",
         "rpc.system.name": "http",
         "url.domain": "localhost:7469", // the showcase domain...
-        "url.template": "", // TODO(#...)
-        "exception.type": "404",
+        "url.template": "/v1beta1/echo:echo",
     });
-    for (key, expected) in want.as_object().unwrap() {
-        assert_eq!(
-            fields.get(key),
-            Some(expected),
-            "mismatch for {key:?} in {value:?}"
-        );
-    }
-
-    assert!(
-        fields
-            .get("exception.message")
-            .unwrap()
-            .as_str()
-            .unwrap()
-            .starts_with("the HTTP transport reports a [404] error:")
-    );
+    assert_eq!(Some(&fields), want.as_object(), "{value:?}");
 
     let ts = timestamp
         .as_ref()

--- a/tests/o11y/src/http_tracing.rs
+++ b/tests/o11y/src/http_tracing.rs
@@ -19,6 +19,7 @@ use crate::otlp::trace::Builder as TracerProviderBuilder;
 use google_cloud_showcase_v1beta1::client::Echo;
 use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
 use httptest::{Expectation, Server, matchers::*, responders::status_code};
+use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -237,9 +238,20 @@ pub async fn to_otlp_debug_event() -> anyhow::Result<()> {
         .iter()
         .flat_map(|r| r.get_ref().resource_logs.clone())
         .flat_map(|rl| rl.scope_logs)
+        // Many things emit debug logs, we are only interested in the L4 logs.
+        .filter(|sl| {
+            sl.scope
+                .as_ref()
+                .is_some_and(|i| i.name == "google_cloud_gax_internal::observability::errors")
+        })
         .flat_map(|sl| sl.log_records)
-        .find(|l| l.attributes.iter().any(|kv| kv.key == "error.type"))
-        .expect("Should have logged an ErrorInfo log natively mapped conditionally");
+        .find(|l| l.span_id == attempt_span.span_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "cannot find log matching span {:?} in capture: {logs_requests:#?}",
+                attempt_span.span_id
+            )
+        });
 
     // Ensure the log was correctly correlated back to the original client request trace buffer (attempt span)
     assert_eq!(
@@ -282,7 +294,7 @@ pub async fn to_otlp_debug_event() -> anyhow::Result<()> {
         assert_eq!(
             got.get(key),
             Some(expected),
-            "mismatch for key: {key} in got: {got:?}"
+            "mismatch for key: {key} in got: {got:?}\n\nrequests = {logs_requests:#?}\n"
         );
     }
 
@@ -296,7 +308,6 @@ async fn setup_echo_client() -> (
     google_cloud_test_utils::test_layer::TestLayerGuard,
     httptest::Server,
     Echo,
-    u16,
 ) {
     let guard = TestLayer::initialize();
     let server = Server::run();
@@ -309,13 +320,12 @@ async fn setup_echo_client() -> (
         .build()
         .await
         .expect("failed to build client");
-    let port = server.addr().port();
 
-    (guard, server, client, port)
+    (guard, server, client)
 }
 
 pub async fn success_testlayer() -> anyhow::Result<()> {
-    let (guard, echo_server, client, server_port) = setup_echo_client().await;
+    let (guard, echo_server, client) = setup_echo_client().await;
     let server_addr = echo_server.addr();
 
     echo_server.expect(
@@ -362,13 +372,11 @@ pub async fn success_testlayer() -> anyhow::Result<()> {
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
         ),
-        ("gcp.client.language", "rust".into()),
         ("otel.status_code", "UNSET".into()),
-        ("gax.client.span", true.into()),
         ("http.response.status_code", 200_i64.into()),
         ("http.request.method", "POST".into()),
         ("server.address", server_addr.ip().to_string().into()),
-        ("server.port", (server_port as i64).into()),
+        ("server.port", (server_addr.port() as i64).into()),
         (
             "url.full",
             format!(
@@ -389,7 +397,7 @@ pub async fn success_testlayer() -> anyhow::Result<()> {
 }
 
 pub async fn parse_error() -> anyhow::Result<()> {
-    let (guard, echo_server, client, server_port) = setup_echo_client().await;
+    let (guard, echo_server, client) = setup_echo_client().await;
     let server_addr = echo_server.addr();
 
     // Return invalid JSON (missing closing brace)
@@ -438,9 +446,7 @@ pub async fn parse_error() -> anyhow::Result<()> {
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
         ),
-        ("gcp.client.language", "rust".into()),
         ("otel.status_code", "ERROR".into()),
-        ("gax.client.span", true.into()),
         ("http.response.status_code", 200_i64.into()),
         ("http.request.method", "POST".into()),
         ("error.type", "CLIENT_RESPONSE_DECODE_ERROR".into()),
@@ -450,7 +456,7 @@ pub async fn parse_error() -> anyhow::Result<()> {
                 .into(),
         ),
         ("server.address", server_addr.ip().to_string().into()),
-        ("server.port", (server_port as i64).into()),
+        ("server.port", (server_addr.port() as i64).into()),
         (
             "url.full",
             format!(
@@ -474,7 +480,7 @@ pub async fn api_error() -> anyhow::Result<()> {
     use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
     use httptest::{Expectation, matchers::*, responders::status_code};
 
-    let (guard, echo_server, client, server_port) = setup_echo_client().await;
+    let (guard, echo_server, client) = setup_echo_client().await;
     let server_addr = echo_server.addr();
 
     // 404 Not Found
@@ -523,18 +529,16 @@ pub async fn api_error() -> anyhow::Result<()> {
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
         ),
-        ("gcp.client.language", "rust".into()),
         ("otel.status_code", "ERROR".into()),
-        ("gax.client.span", true.into()),
-        ("http.response.status_code", 404_i64.into()),
         ("http.request.method", "POST".into()),
+        ("http.response.status_code", 404_i64.into()),
         ("error.type", "UNKNOWN".into()),
         (
             "otel.status_description",
             "the service reports an error with code UNKNOWN described as: Not Found".into(),
         ),
         ("server.address", server_addr.ip().to_string().into()),
-        ("server.port", (server_port as i64).into()),
+        ("server.port", (server_addr.port() as i64).into()),
         (
             "url.full",
             format!(


### PR DESCRIPTION
Change the `ReqwestClient` to record interesting events in the `RequestRecorder`.

We need to change the generated code at the same time because the integration tests depend on this generated code and `gax-internal` working together.

Part of the work for #4772 