### PR TITLE
chore: fix versions for recent libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,7 +1307,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-apiregistry-v1"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-auditmanager-v1"
-version = "0.1.1"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-hypercomputecluster-v1"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4209,7 +4209,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-securitycentermanagement-v1"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-vectorsearch-v1"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -326,7 +326,7 @@ libraries:
     rust:
       package_name_override: google-cloud-apikeys-v2
   - name: google-cloud-apiregistry-v1
-    version: 0.1.2
+    version: 1.0.0
     copyright_year: "2026"
   - name: google-cloud-appengine-v1
     version: 1.8.0
@@ -436,7 +436,7 @@ libraries:
     version: 1.8.0
     copyright_year: "2025"
   - name: google-cloud-auditmanager-v1
-    version: 0.1.1
+    version: 1.0.0
     copyright_year: "2026"
   - name: google-cloud-auth
     version: 1.8.0
@@ -916,7 +916,7 @@ libraries:
           package: google-cloud-apps-script-type-slides
           source: google.apps.script.type.slides
   - name: google-cloud-hypercomputecluster-v1
-    version: 0.1.0
+    version: 1.0.0
     copyright_year: "2026"
     rust: {}
   - name: google-cloud-iam-admin-v1
@@ -1339,7 +1339,7 @@ libraries:
     version: 1.8.0
     copyright_year: "2025"
   - name: google-cloud-securitycentermanagement-v1
-    version: 0.1.0
+    version: 1.0.0
     copyright_year: "2026"
     rust: {}
   - name: google-cloud-securityposture-v1
@@ -1628,7 +1628,7 @@ libraries:
     rust:
       package_name_override: google-cloud-type
   - name: google-cloud-vectorsearch-v1
-    version: 0.1.0
+    version: 1.0.0
     copyright_year: "2026"
     rust: {}
   - name: google-cloud-video-livestream-v1

--- a/src/generated/cloud/apiregistry/v1/Cargo.toml
+++ b/src/generated/cloud/apiregistry/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-apiregistry-v1"
-version                = "0.1.2"
+version                = "1.0.0"
 description            = "Google Cloud Client Libraries for Rust - Cloud API Registry API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/apiregistry/v1/README.md
+++ b/src/generated/cloud/apiregistry/v1/README.md
@@ -24,8 +24,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-apiregistry-v1/0.1.2)
+- Read the [crate's documentation](https://docs.rs/google-cloud-apiregistry-v1/1.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[CloudApiRegistry]: https://docs.rs/google-cloud-apiregistry-v1/0.1.2/google_cloud_apiregistry_v1/client/struct.CloudApiRegistry.html
+[CloudApiRegistry]: https://docs.rs/google-cloud-apiregistry-v1/1.0.0/google_cloud_apiregistry_v1/client/struct.CloudApiRegistry.html

--- a/src/generated/cloud/auditmanager/v1/Cargo.toml
+++ b/src/generated/cloud/auditmanager/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-auditmanager-v1"
-version                = "0.1.1"
+version                = "1.0.0"
 description            = "Google Cloud Client Libraries for Rust - Audit Manager API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/auditmanager/v1/README.md
+++ b/src/generated/cloud/auditmanager/v1/README.md
@@ -24,8 +24,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-auditmanager-v1/0.1.1)
+- Read the [crate's documentation](https://docs.rs/google-cloud-auditmanager-v1/1.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[AuditManager]: https://docs.rs/google-cloud-auditmanager-v1/0.1.1/google_cloud_auditmanager_v1/client/struct.AuditManager.html
+[AuditManager]: https://docs.rs/google-cloud-auditmanager-v1/1.0.0/google_cloud_auditmanager_v1/client/struct.AuditManager.html

--- a/src/generated/cloud/hypercomputecluster/v1/Cargo.toml
+++ b/src/generated/cloud/hypercomputecluster/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-hypercomputecluster-v1"
-version                = "0.1.0"
+version                = "1.0.0"
 description            = "Google Cloud Client Libraries for Rust - Cluster Director API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/hypercomputecluster/v1/README.md
+++ b/src/generated/cloud/hypercomputecluster/v1/README.md
@@ -27,8 +27,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-hypercomputecluster-v1/0.1.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-hypercomputecluster-v1/1.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[HypercomputeCluster]: https://docs.rs/google-cloud-hypercomputecluster-v1/0.1.0/google_cloud_hypercomputecluster_v1/client/struct.HypercomputeCluster.html
+[HypercomputeCluster]: https://docs.rs/google-cloud-hypercomputecluster-v1/1.0.0/google_cloud_hypercomputecluster_v1/client/struct.HypercomputeCluster.html

--- a/src/generated/cloud/securitycentermanagement/v1/Cargo.toml
+++ b/src/generated/cloud/securitycentermanagement/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-securitycentermanagement-v1"
-version                = "0.1.0"
+version                = "1.0.0"
 description            = "Google Cloud Client Libraries for Rust - Security Command Center Management API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/securitycentermanagement/v1/README.md
+++ b/src/generated/cloud/securitycentermanagement/v1/README.md
@@ -28,8 +28,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-securitycentermanagement-v1/0.1.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-securitycentermanagement-v1/1.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[SecurityCenterManagement]: https://docs.rs/google-cloud-securitycentermanagement-v1/0.1.0/google_cloud_securitycentermanagement_v1/client/struct.SecurityCenterManagement.html
+[SecurityCenterManagement]: https://docs.rs/google-cloud-securitycentermanagement-v1/1.0.0/google_cloud_securitycentermanagement_v1/client/struct.SecurityCenterManagement.html

--- a/src/generated/cloud/vectorsearch/v1/Cargo.toml
+++ b/src/generated/cloud/vectorsearch/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-vectorsearch-v1"
-version                = "0.1.0"
+version                = "1.0.0"
 description            = "Google Cloud Client Libraries for Rust - Vector Search API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/vectorsearch/v1/README.md
+++ b/src/generated/cloud/vectorsearch/v1/README.md
@@ -36,10 +36,10 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-vectorsearch-v1/0.1.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-vectorsearch-v1/1.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[DataObjectSearchService]: https://docs.rs/google-cloud-vectorsearch-v1/0.1.0/google_cloud_vectorsearch_v1/client/struct.DataObjectSearchService.html
-[DataObjectService]: https://docs.rs/google-cloud-vectorsearch-v1/0.1.0/google_cloud_vectorsearch_v1/client/struct.DataObjectService.html
-[VectorSearchService]: https://docs.rs/google-cloud-vectorsearch-v1/0.1.0/google_cloud_vectorsearch_v1/client/struct.VectorSearchService.html
+[DataObjectSearchService]: https://docs.rs/google-cloud-vectorsearch-v1/1.0.0/google_cloud_vectorsearch_v1/client/struct.DataObjectSearchService.html
+[DataObjectService]: https://docs.rs/google-cloud-vectorsearch-v1/1.0.0/google_cloud_vectorsearch_v1/client/struct.DataObjectService.html
+[VectorSearchService]: https://docs.rs/google-cloud-vectorsearch-v1/1.0.0/google_cloud_vectorsearch_v1/client/struct.VectorSearchService.html


### PR DESCRIPTION
A few recent libraries had the wrong initial version and the wrong initial version bump. This bumps all those libraries to 1.0.0 where librarian can start maintaining the numbers correctly.

See https://github.com/googleapis/librarian/issues/4881 for details of why this happens and how we are going to prevent the problem in the future.
