### PR TITLE
feat(spanner): batch read-only transactions

### DIFF
--- a/src/spanner/src/batch_read_only_transaction.rs
+++ b/src/spanner/src/batch_read_only_transaction.rs
@@ -1,0 +1,439 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::database_client::DatabaseClient;
+use crate::model::PartitionOptions;
+use crate::read_only_transaction::{
+    MultiUseReadOnlyTransaction, MultiUseReadOnlyTransactionBuilder,
+};
+use crate::result_set::ResultSet;
+use crate::statement::Statement;
+use crate::timestamp_bound::TimestampBound;
+
+/// A builder for [BatchReadOnlyTransaction].
+///
+/// # Example
+/// ```
+/// # use google_cloud_spanner::client::Spanner;
+/// # use google_cloud_spanner::client::TimestampBound;
+/// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+/// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+/// let read_only_transaction = db_client.batch_read_only_transaction()
+///     .with_timestamp_bound(TimestampBound::strong())
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct BatchReadOnlyTransactionBuilder {
+    inner: MultiUseReadOnlyTransactionBuilder,
+}
+
+impl BatchReadOnlyTransactionBuilder {
+    pub(crate) fn new(client: DatabaseClient) -> Self {
+        Self {
+            inner: MultiUseReadOnlyTransactionBuilder::new(client),
+        }
+    }
+
+    /// Sets the timestamp bound for the read-only transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_spanner::client::TimestampBound;
+    /// # async fn set_bound(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let builder = db_client.batch_read_only_transaction().with_timestamp_bound(TimestampBound::strong());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_timestamp_bound(self, bound: TimestampBound) -> Self {
+        Self {
+            inner: self.inner.with_timestamp_bound(bound),
+        }
+    }
+
+    /// Builds the [BatchReadOnlyTransaction] and starts the transaction
+    /// by calling the `BeginTransaction` RPC.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.batch_read_only_transaction().build().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn build(self) -> crate::Result<BatchReadOnlyTransaction> {
+        let inner = self.inner.build().await?;
+        Ok(BatchReadOnlyTransaction { inner })
+    }
+}
+
+/// A read-only transaction that can be used to partition reads and queries
+/// and execute these in parallel across multiple workers.
+///
+/// # Example
+/// ```
+/// # use google_cloud_spanner::client::Spanner;
+/// # use google_cloud_spanner::client::Statement;
+/// # use google_cloud_spanner::PartitionOptions;
+///
+/// # async fn run(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+/// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+/// let transaction = db_client.batch_read_only_transaction().build().await?;
+/// let stmt = Statement::builder("SELECT * FROM users WHERE id = @id")
+///     .add_param("id", &42)
+///     .build();
+/// let options = PartitionOptions::default()
+///     .set_max_partitions(10);
+/// let partitions = transaction.partition_query(stmt, options).await?;
+///
+/// // partitions can be sent to other workers for parallel execution
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct BatchReadOnlyTransaction {
+    inner: MultiUseReadOnlyTransaction,
+}
+
+impl BatchReadOnlyTransaction {
+    /// Returns the read timestamp chosen for the transaction.
+    pub fn read_timestamp(&self) -> Option<wkt::Timestamp> {
+        self.inner.read_timestamp()
+    }
+
+    /// Creates a set of partitions that can be used to execute a query in parallel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_spanner::client::Statement;
+    /// # use google_cloud_spanner::PartitionOptions;
+    /// # async fn run(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db.batch_read_only_transaction().build().await?;
+    ///
+    /// let stmt = Statement::builder("SELECT * FROM users WHERE id = @id")
+    ///     .add_param("id", &42)
+    ///     .build();
+    /// let options = PartitionOptions::default()
+    ///     .set_max_partitions(10);
+    /// let partitions = transaction.partition_query(stmt, options).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn partition_query<T: Into<Statement>>(
+        &self,
+        statement: T,
+        options: PartitionOptions,
+    ) -> crate::Result<Vec<Partition>> {
+        let statement = statement.into();
+        let request = statement
+            .clone()
+            .into_partition_query_request()
+            .set_session(self.inner.context.client.session.name.clone())
+            .set_transaction(self.inner.context.transaction_selector.clone())
+            .set_partition_options(options);
+
+        let response = self
+            .inner
+            .context
+            .client
+            .spanner
+            .partition_query(request, crate::RequestOptions::default())
+            .await?;
+
+        Ok(response
+            .partitions
+            .into_iter()
+            .map(|p| Partition {
+                inner: PartitionedOperation::Query {
+                    partition_token: p.partition_token,
+                    transaction_selector: self.inner.context.transaction_selector.clone(),
+                    session_name: self.inner.context.client.session.name.clone(),
+                    statement: statement.clone(),
+                },
+            })
+            .collect())
+    }
+
+    /// Creates a set of partitions that can be used to execute a read in parallel.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::{KeySet, Spanner};
+    /// # use google_cloud_spanner::client::ReadRequest;
+    /// # use google_cloud_spanner::PartitionOptions;
+    /// # async fn run(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db.batch_read_only_transaction().build().await?;
+    ///
+    /// let read = ReadRequest::builder("users", vec!["id".to_string(), "name".to_string()])
+    ///     .with_keys(KeySet::all())
+    ///     .build();
+    /// let options = PartitionOptions::default()
+    ///     .set_max_partitions(10);
+    /// let partitions = transaction.partition_read(read, options).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn partition_read<T: Into<crate::read::ReadRequest>>(
+        &self,
+        read: T,
+        options: PartitionOptions,
+    ) -> crate::Result<Vec<Partition>> {
+        let read = read.into();
+        let request = read
+            .clone()
+            .into_partition_read_request()
+            .set_session(self.inner.context.client.session.name.clone())
+            .set_transaction(self.inner.context.transaction_selector.clone())
+            .set_partition_options(options);
+
+        let response = self
+            .inner
+            .context
+            .client
+            .spanner
+            .partition_read(request, crate::RequestOptions::default())
+            .await?;
+
+        Ok(response
+            .partitions
+            .into_iter()
+            .map(|p| Partition {
+                inner: PartitionedOperation::Read {
+                    partition_token: p.partition_token,
+                    transaction_selector: self.inner.context.transaction_selector.clone(),
+                    session_name: self.inner.context.client.session.name.clone(),
+                    read_request: read.clone(),
+                },
+            })
+            .collect())
+    }
+}
+
+/// Defines the segments of data to be read in a partitioned read or query.
+/// These partitions can be serialized and processed across several
+/// different machines or processes.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct Partition {
+    pub(crate) inner: PartitionedOperation,
+}
+
+impl Partition {
+    /// Executes this partition and returns a [ResultSet] that
+    /// contains the rows that belong to this partition.
+    ///
+    /// # Panics
+    ///
+    /// This method is currently a placeholder and will panic via `unimplemented!()`.
+    /// Full execution support will be added in a future release.
+    pub async fn execute(&self) -> crate::Result<ResultSet> {
+        unimplemented!("Partition execution will be added in a follow-up PR")
+    }
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) enum PartitionedOperation {
+    Query {
+        partition_token: prost::bytes::Bytes,
+        transaction_selector: crate::model::TransactionSelector,
+        session_name: String,
+        statement: Statement,
+    },
+    Read {
+        partition_token: prost::bytes::Bytes,
+        transaction_selector: crate::model::TransactionSelector,
+        session_name: String,
+        read_request: crate::read::ReadRequest,
+    },
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::client::Statement;
+    use crate::client::{KeySet, ReadRequest as SpannerReadRequest, TimestampBound};
+    use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
+    use gaxi::grpc::tonic::Response;
+    use prost_types::Timestamp;
+    use spanner_grpc_mock::google::spanner::v1::{
+        Partition as MockPartition, PartitionResponse, Transaction,
+    };
+
+    #[test]
+    fn auto_traits() {
+        static_assertions::assert_impl_all!(BatchReadOnlyTransactionBuilder: Send, Sync);
+        static_assertions::assert_impl_all!(BatchReadOnlyTransaction: Send, Sync, std::fmt::Debug);
+        static_assertions::assert_impl_all!(Partition: Send, Sync, std::fmt::Debug);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "Partition execution will be added in a follow-up PR")]
+    async fn execute_panics() {
+        let partition = Partition {
+            inner: PartitionedOperation::Query {
+                partition_token: "token".into(),
+                transaction_selector: Default::default(),
+                session_name: "session".into(),
+                statement: Statement::builder("SELECT 1").build(),
+            },
+        };
+        let _ = partition.execute().await;
+    }
+
+    #[tokio::test]
+    async fn partition_query() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.session,
+                "projects/p/instances/i/databases/d/sessions/123"
+            );
+            Ok(Response::new(Transaction {
+                id: vec![1, 2, 3],
+                read_timestamp: Some(Timestamp {
+                    seconds: 123456789,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_partition_query().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.session,
+                "projects/p/instances/i/databases/d/sessions/123"
+            );
+            assert_eq!(req.sql, "SELECT 1");
+            Ok(Response::new(PartitionResponse {
+                partitions: vec![
+                    MockPartition {
+                        partition_token: vec![10],
+                    },
+                    MockPartition {
+                        partition_token: vec![20],
+                    },
+                ],
+                transaction: None,
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let tx = db_client
+            .batch_read_only_transaction()
+            .with_timestamp_bound(TimestampBound::strong())
+            .build()
+            .await?;
+
+        let ts = tx.read_timestamp().expect("Missing read timestamp");
+        assert_eq!(ts.seconds(), 123456789);
+        assert_eq!(ts.nanos(), 0);
+
+        let partitions = tx
+            .partition_query(
+                Statement::builder("SELECT 1").build(),
+                PartitionOptions::default(),
+            )
+            .await?;
+
+        assert_eq!(partitions.len(), 2);
+
+        match &partitions[0].inner {
+            PartitionedOperation::Query {
+                partition_token,
+                statement,
+                ..
+            } => {
+                assert_eq!(partition_token.as_ref(), &[10]);
+                assert_eq!(statement.sql, "SELECT 1");
+            }
+            _ => panic!("Expected Query partition"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn partition_read() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.session,
+                "projects/p/instances/i/databases/d/sessions/123"
+            );
+            Ok(Response::new(Transaction {
+                id: vec![1, 2, 3],
+                read_timestamp: Some(Timestamp {
+                    seconds: 123456789,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_partition_read().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.session,
+                "projects/p/instances/i/databases/d/sessions/123"
+            );
+            assert_eq!(req.table, "Users");
+            Ok(Response::new(PartitionResponse {
+                partitions: vec![MockPartition {
+                    partition_token: vec![30],
+                }],
+                transaction: None,
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = db_client.batch_read_only_transaction().build().await?;
+
+        let read = SpannerReadRequest::builder("Users", vec!["Id", "Name"])
+            .with_keys(KeySet::all())
+            .build();
+        let partitions = transaction
+            .partition_read(read, PartitionOptions::default())
+            .await?;
+
+        assert_eq!(partitions.len(), 1);
+
+        match &partitions[0].inner {
+            PartitionedOperation::Read {
+                partition_token,
+                read_request,
+                ..
+            } => {
+                assert_eq!(partition_token.as_ref(), &[30]);
+                assert_eq!(read_request.table, "Users");
+            }
+            _ => panic!("Expected Read partition"),
+        }
+        Ok(())
+    }
+}

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -244,6 +244,32 @@ impl Spanner {
             .await
     }
 
+    pub(crate) async fn partition_query(
+        &self,
+        request: crate::model::PartitionQueryRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<crate::model::PartitionResponse> {
+        self.inner
+            .partition_query()
+            .with_request(request)
+            .with_options(options)
+            .send()
+            .await
+    }
+
+    pub(crate) async fn partition_read(
+        &self,
+        request: crate::model::PartitionReadRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<crate::model::PartitionResponse> {
+        self.inner
+            .partition_read()
+            .with_request(request)
+            .with_options(options)
+            .send()
+            .await
+    }
+
     /// Executes an SQL statement, returning a stream of results.
     ///
     /// This is a custom streaming implementation over the underlying Spanner gRPC

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::batch_read_only_transaction::BatchReadOnlyTransactionBuilder;
 use crate::client::Spanner;
 use crate::model::Session;
 use crate::partitioned_dml_transaction::PartitionedDmlTransactionBuilder;
@@ -97,6 +98,24 @@ impl DatabaseClient {
     /// but don't permit data modifications. Read-only transactions do not take locks.
     pub fn read_only_transaction(&self) -> MultiUseReadOnlyTransactionBuilder {
         MultiUseReadOnlyTransactionBuilder::new(self.clone())
+    }
+
+    /// Returns a builder for a batch read-only transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::{Spanner, Statement};
+    /// # async fn build(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.batch_read_only_transaction().build().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// A batch read-only transaction is similar to a read-only transaction, but it allows for partitioning
+    /// a read or query request. Run tasks in parallel over the partitions to execute a large read or query.
+    pub fn batch_read_only_transaction(&self) -> BatchReadOnlyTransactionBuilder {
+        BatchReadOnlyTransactionBuilder::new(self.clone())
     }
 
     /// Returns a builder for a partitioned DML transaction.

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -20,8 +20,12 @@
 //! about the APIs, documentation, missing features, bugs, etc.
 //!
 
+pub use crate::model::PartitionOptions;
 pub use batch_dml::BatchDml;
 pub use batch_dml::BatchDmlBuilder;
+pub use batch_read_only_transaction::{
+    BatchReadOnlyTransaction, BatchReadOnlyTransactionBuilder, Partition,
+};
 pub use error::BatchUpdateError;
 pub use google_cloud_gax::Result;
 pub use google_cloud_gax::error::Error;
@@ -38,6 +42,7 @@ pub(crate) mod server_streaming;
 pub mod builder {
     pub use crate::database_client::DatabaseClientBuilder;
 }
+pub mod batch_read_only_transaction;
 pub(crate) mod database_client;
 pub(crate) mod model {
     pub use crate::generated::gapic_dataplane::model::*;

--- a/src/spanner/src/read.rs
+++ b/src/spanner/src/read.rs
@@ -161,6 +161,43 @@ impl ReadRequest {
             columns: columns.into_iter().map(|s| s.into()).collect(),
         }
     }
+
+    fn into_parts(
+        self,
+    ) -> (
+        String,
+        Option<String>,
+        crate::model::KeySet,
+        Vec<String>,
+        Option<i64>,
+    ) {
+        (
+            self.table,
+            self.index,
+            self.keys.into_proto(),
+            self.columns,
+            self.limit,
+        )
+    }
+
+    pub(crate) fn into_request(self) -> crate::model::ReadRequest {
+        let (table, index, keys, columns, limit) = self.into_parts();
+        crate::model::ReadRequest::default()
+            .set_table(table)
+            .set_columns(columns)
+            .set_key_set(keys)
+            .set_index(index.unwrap_or_default())
+            .set_limit(limit.unwrap_or_default())
+    }
+
+    pub(crate) fn into_partition_read_request(self) -> crate::model::PartitionReadRequest {
+        let (table, index, keys, columns, _limit) = self.into_parts();
+        crate::model::PartitionReadRequest::default()
+            .set_table(table)
+            .set_columns(columns)
+            .set_key_set(keys)
+            .set_index(index.unwrap_or_default())
+    }
 }
 
 #[cfg(test)]

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -294,7 +294,7 @@ impl MultiUseReadOnlyTransactionBuilder {
 /// ```
 #[derive(Debug)]
 pub struct MultiUseReadOnlyTransaction {
-    context: ReadContext,
+    pub(crate) context: ReadContext,
     pub(crate) read_timestamp: Option<wkt::Timestamp>,
 }
 
@@ -415,20 +415,10 @@ impl ReadContext {
     ) -> crate::Result<ResultSet> {
         let read = read.into();
 
-        let mut request = crate::model::ReadRequest::default()
+        let request = read
+            .into_request()
             .set_session(self.client.session.name.clone())
-            .set_transaction(self.transaction_selector.clone())
-            .set_table(read.table)
-            .set_columns(read.columns)
-            .set_key_set(read.keys.into_proto());
-
-        if let Some(index) = read.index {
-            request = request.set_index(index);
-        }
-
-        if let Some(limit) = read.limit {
-            request = request.set_limit(limit);
-        }
+            .set_transaction(self.transaction_selector.clone());
 
         let stream = self
             .client

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -156,6 +156,14 @@ impl Statement {
             .set_or_clear_params(params)
             .set_param_types(param_types)
     }
+
+    pub(crate) fn into_partition_query_request(self) -> crate::model::PartitionQueryRequest {
+        let (sql, params, param_types) = self.into_parts();
+        crate::model::PartitionQueryRequest::default()
+            .set_sql(sql)
+            .set_or_clear_params(params)
+            .set_param_types(param_types)
+    }
 }
 
 impl From<StatementBuilder> for Statement {


### PR DESCRIPTION
This is step 1 in adding support for batch read-only transactions to the Spanner client. Batch read-only transactions are a specialized sort of multi-use read-only transactions that allow you to partition queries or reads, and then execute each partition separately. The partitions can be distributed to multiple processes (including processes on a separate machine) and executed in parallel. This can reduce the time that is needed to for example bulk-extract a large amount of data.

This change adds support for creating a BatchReadOnlyTransaction and partitioning queries and read operations. Follow-up pull requests will add support for executing partitions and distributing partitions to other hosts.