### PR TITLE
chore(librarian): remove .sidekick.toml from ignored_changes

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -35,7 +35,6 @@ release:
   branch: main
   ignored_changes:
     - .repo-metadata.json
-    - .sidekick.toml
   remote: upstream
   tools:
     cargo:


### PR DESCRIPTION
The .sidekick.toml file no longer needs to be excluded from release change detection. This removes it from the ignored_changes list in librarian.yaml.