### PR TITLE
fix(o11y): add schema url and client metric attributes

### DIFF
--- a/src/gax-internal/src/observability/attributes.rs
+++ b/src/gax-internal/src/observability/attributes.rs
@@ -77,6 +77,8 @@ pub mod keys {
     ///
     /// Example: //pubsub.googleapis.com/projects/my-project/topics/my-topic
     pub const GCP_RESOURCE_NAME: &str = "gcp.resource.name";
+    /// The OpenTelemetry Schema URL indicating the schema used for the telemetry.
+    pub const GCP_SCHEMA_URL: &str = "gcp.schema.url";
     /// The number of times this same gRPC request has been resent due to retries.
     ///
     /// 1 for the first retry.
@@ -110,6 +112,8 @@ pub const RPC_SYSTEM_GRPC: &str = "grpc";
 pub const GCP_CLIENT_REPO_GOOGLEAPIS: &str = "googleapis/google-cloud-rust";
 /// Value for [keys::GCP_CLIENT_LANGUAGE].
 pub const GCP_CLIENT_LANGUAGE_RUST: &str = "rust";
+/// The OpenTelemetry Schema URL.
+pub const SCHEMA_URL_VALUE: &str = "https://opentelemetry.io/schemas/1.39.0";
 
 /// Values for the OpenTelemetry `error.type` attribute.
 /// See the semantic conventions around [Error attributes]

--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -70,7 +70,7 @@ macro_rules! client_request_signals {
         use $crate::observability::attributes::keys::*;
         use $crate::observability::attributes::otel_status_codes;
         use $crate::observability::attributes::{
-            GCP_CLIENT_REPO_GOOGLEAPIS, OTEL_KIND_INTERNAL, RPC_SYSTEM_HTTP,
+            GCP_CLIENT_REPO_GOOGLEAPIS, OTEL_KIND_INTERNAL, RPC_SYSTEM_HTTP, SCHEMA_URL_VALUE,
         };
 
         let span = tracing::info_span!(
@@ -83,6 +83,7 @@ macro_rules! client_request_signals {
             { GCP_CLIENT_VERSION } = $info.client_version,
             { GCP_CLIENT_REPO } = GCP_CLIENT_REPO_GOOGLEAPIS,
             { GCP_CLIENT_ARTIFACT } = $info.client_artifact,
+            { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
             // Fields to be recorded later
             { RPC_METHOD } = Empty,
             { OTEL_STATUS_CODE } = otel_status_codes::UNSET,
@@ -243,6 +244,14 @@ mod tests {
                 ("error.type", "404"),
                 ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", server.addr().port().to_string().as_str()),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
 
@@ -297,6 +306,10 @@ mod tests {
                 ("gcp.client.version", "1.2.3"),
                 ("gcp.client.repo", "googleapis/google-cloud-rust"),
                 ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
                 ("gcp.client.service", "test-service"),
                 ("rpc.method", TEST_METHOD),
                 ("rpc.service", "test-service"),

--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -15,7 +15,7 @@
 use crate::observability::RequestRecorder;
 use crate::observability::attributes::GCP_CLIENT_REPO_GOOGLEAPIS;
 use crate::observability::attributes::keys::{
-    GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE, GCP_CLIENT_VERSION,
+    GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE, GCP_CLIENT_VERSION, GCP_SCHEMA_URL,
     HTTP_RESPONSE_STATUS_CODE, RPC_METHOD, RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
 };
 use crate::observability::errors::ErrorType;
@@ -107,7 +107,7 @@ impl DurationMetric {
         let Some(snapshot) = RequestRecorder::current().map(|r| r.client_snapshot()) else {
             return;
         };
-        let attributes: [(&str, Option<Value>); 8] = [
+        let attributes: [(&str, Option<Value>); 13] = [
             (RPC_SYSTEM_NAME, snapshot.rpc_system().map(|v| v.into())),
             (RPC_METHOD, snapshot.rpc_method().map(|v| v.into())),
             (URL_DOMAIN, Some(snapshot.default_host().into())),
@@ -119,6 +119,14 @@ impl DurationMetric {
             ),
             (SERVER_ADDRESS, Some(snapshot.server_address().into())),
             (SERVER_PORT, Some((snapshot.server_port() as i64).into())),
+            (GCP_CLIENT_SERVICE, Some(snapshot.service_name().into())),
+            (GCP_CLIENT_VERSION, Some(snapshot.client_version().into())),
+            (GCP_CLIENT_REPO, Some(GCP_CLIENT_REPO_GOOGLEAPIS.into())),
+            (GCP_CLIENT_ARTIFACT, Some(snapshot.client_artifact().into())),
+            (
+                GCP_SCHEMA_URL,
+                Some(crate::observability::attributes::SCHEMA_URL_VALUE.into()),
+            ),
         ];
         let attributes = attributes
             .into_iter()
@@ -138,7 +146,7 @@ impl DurationMetric {
             return;
         };
         let error_type = ErrorType::from_gax_error(error);
-        let attributes: [(&str, Option<Value>); 9] = [
+        let attributes: [(&str, Option<Value>); 14] = [
             (RPC_SYSTEM_NAME, snapshot.rpc_system().map(|v| v.into())),
             (RPC_METHOD, snapshot.rpc_method().map(|v| v.into())),
             (URL_DOMAIN, Some(snapshot.default_host().into())),
@@ -154,6 +162,14 @@ impl DurationMetric {
             ),
             (SERVER_ADDRESS, Some(snapshot.server_address().into())),
             (SERVER_PORT, Some((snapshot.server_port() as i64).into())),
+            (GCP_CLIENT_SERVICE, Some(snapshot.service_name().into())),
+            (GCP_CLIENT_VERSION, Some(snapshot.client_version().into())),
+            (GCP_CLIENT_REPO, Some(GCP_CLIENT_REPO_GOOGLEAPIS.into())),
+            (GCP_CLIENT_ARTIFACT, Some(snapshot.client_artifact().into())),
+            (
+                GCP_SCHEMA_URL,
+                Some(crate::observability::attributes::SCHEMA_URL_VALUE.into()),
+            ),
         ];
         let attributes = attributes
             .into_iter()
@@ -231,6 +247,14 @@ mod tests {
                 ("url.template", TEST_URL_TEMPLATE),
                 ("rpc.method", TEST_METHOD),
                 ("rpc.response.status_code", "OK"),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
         Ok(())
@@ -281,6 +305,14 @@ mod tests {
                 ("rpc.method", TEST_METHOD),
                 ("error.type", "NOT_FOUND"),
                 ("rpc.response.status_code", "NOT_FOUND"),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
         Ok(())
@@ -326,6 +358,14 @@ mod tests {
                 ("url.template", TEST_URL_TEMPLATE),
                 ("rpc.method", TEST_METHOD),
                 ("error.type", "429"),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
         Ok(())

--- a/src/gax-internal/src/observability/client_signals/with_client_logging.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_logging.rs
@@ -18,10 +18,12 @@
 
 use super::RequestRecorder;
 
+use crate::observability::attributes::SCHEMA_URL_VALUE;
 use crate::observability::attributes::keys::{
     ERROR_TYPE, GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE, GCP_CLIENT_VERSION,
-    GCP_ERRORS_DOMAIN, GCP_ERRORS_METADATA, HTTP_REQUEST_METHOD, HTTP_REQUEST_RESEND_COUNT,
-    RPC_RESPONSE_STATUS_CODE, RPC_SERVICE, RPC_SYSTEM_NAME, SERVER_ADDRESS, SERVER_PORT, URL_FULL,
+    GCP_ERRORS_DOMAIN, GCP_ERRORS_METADATA, GCP_SCHEMA_URL, HTTP_REQUEST_METHOD,
+    HTTP_REQUEST_RESEND_COUNT, RPC_RESPONSE_STATUS_CODE, RPC_SERVICE, RPC_SYSTEM_NAME,
+    SERVER_ADDRESS, SERVER_PORT, URL_FULL,
 };
 use crate::observability::errors::ErrorType;
 use google_cloud_gax::error::Error;
@@ -115,6 +117,7 @@ where
                     { GCP_CLIENT_VERSION } = snapshot.client_version(),
                     { GCP_CLIENT_REPO } = snapshot.client_repo(),
                     { GCP_CLIENT_ARTIFACT } = snapshot.client_artifact(),
+                    { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
                     { URL_DOMAIN } = snapshot.default_host(),
                     { URL_FULL } = snapshot.sanitized_url(),
                     { URL_TEMPLATE } = snapshot.url_template(),
@@ -220,6 +223,7 @@ mod tests {
             "url.domain": "example.com",
             "url.template": TEST_URL_TEMPLATE,
             "gcp.client.artifact": "test-artifact",
+            "gcp.schema.url": crate::observability::attributes::SCHEMA_URL_VALUE,
             "gcp.client.repo": "googleapis/google-cloud-rust",
             "gcp.client.version": "1.2.3",
             "gcp.client.service": "test-service",
@@ -282,6 +286,7 @@ mod tests {
             "url.template": TEST_URL_TEMPLATE,
             "error.type": "404",
             "gcp.client.artifact": "test-artifact",
+            "gcp.schema.url": crate::observability::attributes::SCHEMA_URL_VALUE,
             "gcp.client.repo": "googleapis/google-cloud-rust",
             "gcp.client.version": "1.2.3",
             "gcp.client.service": "test-service",

--- a/src/gax-internal/src/observability/client_signals/with_client_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_metric.rs
@@ -158,6 +158,14 @@ mod tests {
                 ("url.domain", "example.com"),
                 ("server.address", "example.com"),
                 ("server.port", "443"),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
         Ok(())
@@ -203,6 +211,14 @@ mod tests {
                 ("error.type", "404"),
                 ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", format!("{}", server.addr().port()).as_str()),
+                ("gcp.client.service", "test-service"),
+                ("gcp.client.version", "1.2.3"),
+                ("gcp.client.repo", "googleapis/google-cloud-rust"),
+                ("gcp.client.artifact", "test-artifact"),
+                (
+                    "gcp.schema.url",
+                    crate::observability::attributes::SCHEMA_URL_VALUE,
+                ),
             ],
         );
         Ok(())

--- a/src/gax-internal/src/observability/client_signals/with_client_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_span.rs
@@ -17,10 +17,11 @@
 //! This is a private module, it is not exposed in the public API.
 
 use super::RequestRecorder;
+use crate::observability::attributes::SCHEMA_URL_VALUE;
 use crate::observability::attributes::keys::{
-    ERROR_TYPE, GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_VERSION, HTTP_REQUEST_METHOD,
-    HTTP_REQUEST_RESEND_COUNT, OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION, RPC_RESPONSE_STATUS_CODE,
-    RPC_SERVICE,
+    ERROR_TYPE, GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_VERSION, GCP_SCHEMA_URL,
+    HTTP_REQUEST_METHOD, HTTP_REQUEST_RESEND_COUNT, OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION,
+    RPC_RESPONSE_STATUS_CODE, RPC_SERVICE,
 };
 use crate::observability::attributes::otel_status_codes;
 use crate::observability::errors::ErrorType;
@@ -76,6 +77,7 @@ where
                     { GCP_CLIENT_VERSION } = snapshot.client_version(),
                     { GCP_CLIENT_REPO } = snapshot.client_repo(),
                     { GCP_CLIENT_ARTIFACT } = snapshot.client_artifact(),
+                    { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
                     { URL_FULL } = snapshot.sanitized_url(),
                     { SERVER_ADDRESS } = snapshot.server_address(),
                     { SERVER_PORT } = snapshot.server_port() as i64,
@@ -97,6 +99,7 @@ where
                     { GCP_CLIENT_VERSION } = snapshot.client_version(),
                     { GCP_CLIENT_REPO } = snapshot.client_repo(),
                     { GCP_CLIENT_ARTIFACT } = snapshot.client_artifact(),
+                    { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
                     { URL_FULL } = snapshot.sanitized_url(),
                     { RPC_RESPONSE_STATUS_CODE } = rpc_status_code,
                     { ERROR_TYPE } = error_type.as_str(),
@@ -141,6 +144,7 @@ mod tests {
             { GCP_CLIENT_VERSION } = ::tracing::field::Empty,
             { GCP_CLIENT_REPO } = ::tracing::field::Empty,
             { GCP_CLIENT_ARTIFACT } = ::tracing::field::Empty,
+            { GCP_SCHEMA_URL } = ::tracing::field::Empty,
             { URL_FULL } = ::tracing::field::Empty,
             { SERVER_ADDRESS } = ::tracing::field::Empty,
             { SERVER_PORT } = ::tracing::field::Empty,
@@ -209,6 +213,7 @@ mod tests {
             { GCP_CLIENT_VERSION } = ::tracing::field::Empty,
             { GCP_CLIENT_REPO } = ::tracing::field::Empty,
             { GCP_CLIENT_ARTIFACT } = ::tracing::field::Empty,
+            { GCP_SCHEMA_URL } = ::tracing::field::Empty,
             { URL_FULL } = ::tracing::field::Empty,
             { SERVER_ADDRESS } = ::tracing::field::Empty,
             { SERVER_PORT } = ::tracing::field::Empty,

--- a/src/gax-internal/src/observability/http_tracing.rs
+++ b/src/gax-internal/src/observability/http_tracing.rs
@@ -104,6 +104,7 @@ pub(crate) fn create_http_attempt_span(
         { GCP_CLIENT_VERSION } = gcp_client_version,
         { GCP_CLIENT_REPO } = GCP_CLIENT_REPO_GOOGLEAPIS,
         { GCP_CLIENT_ARTIFACT } = gcp_client_artifact,
+        { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
         { GCP_CLIENT_LANGUAGE } = GCP_CLIENT_LANGUAGE_RUST,
         { GCP_RESOURCE_NAME } = resource_name,
         { otel_trace::HTTP_REQUEST_RESEND_COUNT } = http_request_resend_count,
@@ -247,6 +248,7 @@ mod tests {
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, "google-cloud-test".into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (GCP_SCHEMA_URL, SCHEMA_URL_VALUE.into()),
             (
                 GCP_RESOURCE_NAME,
                 "//example.com/projects/p/resources/r".into(),
@@ -282,6 +284,7 @@ mod tests {
             (otel_trace::URL_SCHEME, "http".into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (GCP_SCHEMA_URL, SCHEMA_URL_VALUE.into()),
             (OTEL_STATUS_CODE, "UNSET".into()),
         ]
         .into_iter()
@@ -368,6 +371,7 @@ mod tests {
             (otel_trace::URL_SCHEME, "https".into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (GCP_SCHEMA_URL, SCHEMA_URL_VALUE.into()),
             (OTEL_STATUS_CODE, "UNSET".into()),
             (
                 otel_trace::HTTP_RESPONSE_STATUS_CODE,
@@ -407,6 +411,7 @@ mod tests {
             (otel_trace::URL_SCHEME, "https".into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (GCP_SCHEMA_URL, SCHEMA_URL_VALUE.into()),
             (OTEL_STATUS_CODE, "ERROR".into()),
             (otel_trace::ERROR_TYPE, "CLIENT_TIMEOUT".into()),
             (

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -113,6 +113,10 @@ mod tests {
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (GCP_RESOURCE_NAME, TEST_RESOURCE.into()),
             (otel_trace::HTTP_RESPONSE_BODY_SIZE, 18_i64.into()), // {"hello": "world"} is 18 bytes
             (
@@ -257,6 +261,10 @@ mod tests {
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
             (GCP_CLIENT_LANGUAGE, "rust".into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (otel_trace::HTTP_RESPONSE_BODY_SIZE, 21_i64.into()), // {"status": "created"} is 21 bytes
             (
                 otel_trace::SERVER_ADDRESS,
@@ -492,6 +500,10 @@ mod tests {
             (GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (
                 otel_trace::SERVER_ADDRESS,
@@ -566,6 +578,10 @@ mod tests {
             (GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (otel_trace::SERVER_ADDRESS, "127.0.0.1".into()),
             (otel_trace::SERVER_PORT, (1_i64).into()),
             (otel_trace::URL_FULL, "https://127.0.0.1:1/test".into()),
@@ -622,6 +638,10 @@ mod tests {
             (GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (
                 otel_trace::SERVER_ADDRESS,
@@ -676,6 +696,10 @@ mod tests {
             (GCP_CLIENT_VERSION, TEST_VERSION.into()),
             (GCP_CLIENT_REPO, "googleapis/google-cloud-rust".into()),
             (GCP_CLIENT_ARTIFACT, TEST_ARTIFACT.into()),
+            (
+                GCP_SCHEMA_URL,
+                google_cloud_gax_internal::observability::attributes::SCHEMA_URL_VALUE.into(),
+            ),
             (otel_trace::SERVER_ADDRESS, "127.0.0.1".into()),
             (otel_trace::SERVER_PORT, (1_i64).into()),
             (otel_trace::URL_FULL, "https://127.0.0.1:1/test".into()),

--- a/src/storage/src/storage/tracing.rs
+++ b/src/storage/src/storage/tracing.rs
@@ -20,11 +20,11 @@ use crate::storage::bidi::stub::dynamic::ObjectDescriptor as DynamicObjectDescri
 use crate::storage::info::INSTRUMENTATION;
 use crate::storage::stub::ObjectDescriptor as ObjectDescriptorStub;
 use gaxi::observability::attributes::keys::{
-    GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE, GCP_CLIENT_VERSION, OTEL_KIND,
-    RPC_SERVICE, RPC_SYSTEM_NAME,
+    GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_SERVICE, GCP_CLIENT_VERSION, GCP_SCHEMA_URL,
+    OTEL_KIND, RPC_SERVICE, RPC_SYSTEM_NAME,
 };
 use gaxi::observability::attributes::{
-    GCP_CLIENT_REPO_GOOGLEAPIS, OTEL_KIND_INTERNAL, RPC_SYSTEM_GRPC,
+    GCP_CLIENT_REPO_GOOGLEAPIS, OTEL_KIND_INTERNAL, RPC_SYSTEM_GRPC, SCHEMA_URL_VALUE,
 };
 use std::sync::Arc;
 
@@ -98,6 +98,7 @@ impl ObjectDescriptorStub for TracingObjectDescriptor<Arc<dyn DynamicObjectDescr
             { GCP_CLIENT_VERSION } = INSTRUMENTATION.client_version,
             { GCP_CLIENT_REPO } = GCP_CLIENT_REPO_GOOGLEAPIS,
             { GCP_CLIENT_ARTIFACT } = INSTRUMENTATION.client_artifact,
+            { GCP_SCHEMA_URL } = SCHEMA_URL_VALUE,
             { "read_range.start" } = start,
             { "read_range.limit" } = limit,
         );

--- a/tests/o11y/src/e2e/signals.rs
+++ b/tests/o11y/src/e2e/signals.rs
@@ -205,6 +205,7 @@ fn check_logs(project_id: &str, buffer: Buffer, trace_id: TraceId) -> anyhow::Re
     assert!(fields.remove("url.full").is_some(), "{value:?}");
     let want = serde_json::json!({
         "gcp.client.artifact": "google-cloud-showcase-v1beta1",
+        "gcp.schema.url": "https://opentelemetry.io/schemas/1.39.0",
         "gcp.client.repo": "googleapis/google-cloud-rust",
         "gcp.client.service": "showcase",
         "error.type": "404",

--- a/tests/o11y/src/http_tracing.rs
+++ b/tests/o11y/src/http_tracing.rs
@@ -372,6 +372,10 @@ pub async fn success_testlayer() -> anyhow::Result<()> {
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
         ),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
+        ),
         ("otel.status_code", "UNSET".into()),
         ("http.response.status_code", 200_i64.into()),
         ("http.request.method", "POST".into()),
@@ -445,6 +449,10 @@ pub async fn parse_error() -> anyhow::Result<()> {
         (
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
+        ),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
         ),
         ("otel.status_code", "ERROR".into()),
         ("http.response.status_code", 200_i64.into()),
@@ -528,6 +536,10 @@ pub async fn api_error() -> anyhow::Result<()> {
         (
             "gcp.client.artifact",
             "google-cloud-showcase-v1beta1".into(),
+        ),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
         ),
         ("otel.status_code", "ERROR".into()),
         ("http.request.method", "POST".into()),

--- a/tests/o11y/src/otlp/metrics.rs
+++ b/tests/o11y/src/otlp/metrics.rs
@@ -258,6 +258,7 @@ mod tests {
             ("gcp.client.version", "1.2.3"),
             ("gcp.client.repo", "googleapis/google-cloud-rust"),
             ("gcp.client.artifact", "google-cloud-storage"),
+            ("gcp.schema.url", "https://opentelemetry.io/schemas/1.39.0"),
             ("rpc.system.name", "GRPC"),
             (
                 "gcp.method",

--- a/tests/o11y/src/storage_tracing.rs
+++ b/tests/o11y/src/storage_tracing.rs
@@ -96,6 +96,10 @@ async fn read_object(
         ("gcp.client.version", version.clone()),
         ("gcp.client.repo", "googleapis/google-cloud-rust".into()),
         ("gcp.client.artifact", "google-cloud-storage".into()),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
+        ),
         ("gcp.client.language", "rust".into()),
         ("otel.name", "GET /storage/v1/b/{bucket}/o/{object}".into()),
         ("otel.kind", "Client".into()),
@@ -201,6 +205,10 @@ async fn write_object_single_shot(
         ("gcp.client.version", version.clone()),
         ("gcp.client.repo", "googleapis/google-cloud-rust".into()),
         ("gcp.client.artifact", "google-cloud-storage".into()),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
+        ),
         ("gcp.client.language", "rust".into()),
         ("otel.name", "POST /upload/storage/v1/b/{bucket}/o".into()),
         ("otel.kind", "Client".into()),
@@ -321,6 +329,10 @@ async fn write_object_resumable(
         ("gcp.client.version", version.clone()),
         ("gcp.client.repo", "googleapis/google-cloud-rust".into()),
         ("gcp.client.artifact", "google-cloud-storage".into()),
+        (
+            "gcp.schema.url",
+            "https://opentelemetry.io/schemas/1.39.0".into(),
+        ),
         ("gcp.client.language", "rust".into()),
         ("otel.kind", "Client".into()),
         ("otel.status_code", "UNSET".into()),


### PR DESCRIPTION
Introduce the `gcp.schema.url` attribute and standardize metadata dimensions.

For #4924