### PR TITLE
cleanup(gax-internal): shrink o11y public API

### DIFF
--- a/src/gax-internal/src/observability.rs
+++ b/src/gax-internal/src/observability.rs
@@ -36,7 +36,7 @@ pub(crate) mod http_tracing;
 pub(crate) use http_tracing::{ResultExt as HttpResultExt, create_http_attempt_span};
 
 #[cfg(all(google_cloud_unstable_tracing, feature = "_internal-grpc-client"))]
-pub mod grpc_tracing;
+pub(crate) mod grpc_tracing;
 
 #[cfg(google_cloud_unstable_tracing)]
 mod client_signals;


### PR DESCRIPTION
This is a very small change to reduce the public API once o11y becomes the default.

Part of the work for #4772 