### PR TITLE
impl(gax-internal): `server_address()` with IPv6

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -244,7 +244,7 @@ mod tests {
                 ("rpc.method", TEST_METHOD),
                 ("http.response.status_code", "404"),
                 ("error.type", "404"),
-                ("server.address", "127.0.0.1"),
+                ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", server.addr().port().to_string().as_str()),
                 ("gcp.client.service", "test-service"),
                 ("gcp.client.version", "1.2.3"),
@@ -282,9 +282,12 @@ mod tests {
                 ("error.type", "404"),
                 ("http.request.method", "GET"),
                 ("http.response.status_code", "404"),
-                ("server.address", "127.0.0.1"),
+                ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", server.addr().port().to_string().as_str()),
-                ("network.peer.address", "127.0.0.1"),
+                (
+                    "network.peer.address",
+                    server.addr().ip().to_string().as_str(),
+                ),
                 (
                     "network.peer.port",
                     server.addr().port().to_string().as_str(),
@@ -322,9 +325,12 @@ mod tests {
                 ("rpc.service", "test-service"),
                 ("error.type", "404"),
                 ("http.request.method", "GET"),
-                ("server.address", "127.0.0.1"),
+                ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", server.addr().port().to_string().as_str()),
-                ("network.peer.address", "127.0.0.1"),
+                (
+                    "network.peer.address",
+                    server.addr().ip().to_string().as_str(),
+                ),
                 (
                     "network.peer.port",
                     server.addr().port().to_string().as_str(),

--- a/src/gax-internal/src/observability/client_signals/recorder.rs
+++ b/src/gax-internal/src/observability/client_signals/recorder.rs
@@ -316,8 +316,11 @@ impl ClientSnapshot {
     /// Use with the "server.address" attribute.
     pub fn server_address(&self) -> String {
         if let Some(uri) = self.sanitized_url().and_then(|u| u.parse::<Uri>().ok()) {
-            if let Some(host) = uri.authority().map(|a| a.host().to_string()) {
-                return host;
+            if let Some(host) = uri.host() {
+                return host
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .to_string();
             }
         }
         self.info.default_host.to_string()

--- a/src/gax-internal/src/observability/client_signals/with_client_logging.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_logging.rs
@@ -293,9 +293,9 @@ mod tests {
             "gcp.client.version": "1.2.3",
             "gcp.client.service": "test-service",
             "url.full": url,
-            "server.address": "127.0.0.1",
+            "server.address": server.addr().ip().to_string(),
             "server.port": server.addr().port(),
-            "network.peer.address": "127.0.0.1",
+            "network.peer.address": server.addr().ip().to_string(),
             "network.peer.port": server.addr().port(),
             "http.request.method": "GET",
         });

--- a/src/gax-internal/src/observability/client_signals/with_client_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_metric.rs
@@ -209,7 +209,7 @@ mod tests {
                 ("url.template", TEST_URL_TEMPLATE),
                 ("http.response.status_code", "404"),
                 ("error.type", "404"),
-                ("server.address", "127.0.0.1"),
+                ("server.address", server.addr().ip().to_string().as_str()),
                 ("server.port", server.addr().port().to_string().as_str()),
                 ("gcp.client.service", "test-service"),
                 ("gcp.client.version", "1.2.3"),

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -28,7 +28,7 @@ mod tests {
         ClientRequestAttributes, DurationMetric, RequestRecorder,
     };
     use google_cloud_gax_internal::options::{ClientConfig, InstrumentationClientInfo};
-    use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer, format_server_address};
+    use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
     use http::{Method, StatusCode};
     use httptest::matchers::request::{body, headers, method, method_path, path};
     use httptest::{Expectation, Server, all_of, responders::*};
@@ -507,7 +507,7 @@ mod tests {
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (
                 otel_trace::SERVER_ADDRESS,
-                format_server_address(server_addr).into(),
+                server_addr.ip().to_string().into(),
             ),
             (otel_trace::SERVER_PORT, (server_addr.port() as i64).into()),
             (NETWORK_PEER_ADDRESS, server_addr.ip().to_string().into()),
@@ -647,7 +647,7 @@ mod tests {
             (otel_trace::HTTP_RESPONSE_STATUS_CODE, 200_i64.into()),
             (
                 otel_trace::SERVER_ADDRESS,
-                format_server_address(server_addr).into(),
+                server_addr.ip().to_string().into(),
             ),
             (otel_trace::SERVER_PORT, (server_addr.port() as i64).into()),
             (NETWORK_PEER_ADDRESS, server_addr.ip().to_string().into()),

--- a/src/test-utils/src/test_layer.rs
+++ b/src/test-utils/src/test_layer.rs
@@ -356,15 +356,6 @@ where
     }
 }
 
-/// Handles IPv6 bracket formatting for server addresses.
-pub fn format_server_address(addr: std::net::SocketAddr) -> String {
-    if addr.is_ipv6() {
-        format!("[{}]", addr.ip())
-    } else {
-        addr.ip().to_string()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/o11y/src/http_tracing.rs
+++ b/tests/o11y/src/http_tracing.rs
@@ -17,7 +17,7 @@ use crate::mock_collector::MockCollector;
 use crate::otlp::logs::Builder as LoggerProviderBuilder;
 use crate::otlp::trace::Builder as TracerProviderBuilder;
 use google_cloud_showcase_v1beta1::client::Echo;
-use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer, format_server_address};
+use google_cloud_test_utils::test_layer::{AttributeValue, TestLayer};
 use httptest::{Expectation, Server, matchers::*, responders::status_code};
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
@@ -379,7 +379,7 @@ pub async fn success_testlayer() -> anyhow::Result<()> {
         ("otel.status_code", "UNSET".into()),
         ("http.response.status_code", 200_i64.into()),
         ("http.request.method", "POST".into()),
-        ("server.address", format_server_address(server_addr).into()),
+        ("server.address", server_addr.ip().to_string().into()),
         ("server.port", (server_addr.port() as i64).into()),
         ("network.peer.address", server_addr.ip().to_string().into()),
         ("network.peer.port", (server_addr.port() as i64).into()),
@@ -465,7 +465,7 @@ pub async fn parse_error() -> anyhow::Result<()> {
             "cannot deserialize the response EOF while parsing an object at line 1 column 18"
                 .into(),
         ),
-        ("server.address", format_server_address(server_addr).into()),
+        ("server.address", server_addr.ip().to_string().into()),
         ("server.port", (server_addr.port() as i64).into()),
         ("network.peer.address", server_addr.ip().to_string().into()),
         ("network.peer.port", (server_addr.port() as i64).into()),
@@ -553,7 +553,7 @@ pub async fn api_error() -> anyhow::Result<()> {
             "otel.status_description",
             "the service reports an error with code UNKNOWN described as: Not Found".into(),
         ),
-        ("server.address", format_server_address(server_addr).into()),
+        ("server.address", server_addr.ip().to_string().into()),
         ("server.port", (server_addr.port() as i64).into()),
         ("network.peer.address", server_addr.ip().to_string().into()),
         ("network.peer.port", (server_addr.port() as i64).into()),


### PR DESCRIPTION
The code was leaving the brackets for IPv6 `server_address()`, as they are extracted from the Uri. Fixing that just requires some trimming of the extra characters.

The tests did not pass because they hard-coded 127.0.0.1.

TIL: my laptop has an IPv6 enabled. Or maybe I knew and Today I Remembered.