### PR TITLE
test(gax-internal): deflake some tests

### DIFF
--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -134,9 +134,15 @@ mod tests {
     use crate::options::ClientConfig;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 
+    fn test_config() -> ClientConfig {
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::default().build());
+        config
+    }
+
     #[tokio::test]
     async fn query() -> anyhow::Result<()> {
-        let client = ReqwestClient::new(ClientConfig::default(), "http://example.com").await?;
+        let client = ReqwestClient::new(test_config(), "http://example.com").await?;
         let request = client
             .http_builder(Method::GET, "/some/path")
             .build_for_tests()
@@ -154,10 +160,7 @@ mod tests {
 
     #[tokio::test]
     async fn headers() -> anyhow::Result<()> {
-        let mut config = ClientConfig::default();
-        config.cred = Some(Anonymous::default().build());
-        let client = ReqwestClient::new(config, "http://example.com").await?;
-
+        let client = ReqwestClient::new(test_config(), "http://example.com").await?;
         let request = client
             .http_builder(Method::GET, "/some/path")
             .build_for_tests()
@@ -187,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn body() -> anyhow::Result<()> {
-        let client = ReqwestClient::new(ClientConfig::default(), "http://example.com").await?;
+        let client = ReqwestClient::new(test_config(), "http://example.com").await?;
         let request = client
             .http_builder(Method::POST, "/some/path")
             .build_for_tests()


### PR DESCRIPTION
The tests for `ReqwestClient::http_build()` can and should use anonymous credentials. Otherwise they may be using ADC, which can flake.