### PR TITLE
fix(o11y): rename `test.client.duration` metric to `gcp.client.request.duration`

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -588,7 +588,7 @@ mod tests {
                 "expected a single metric after flattening scopes and resources, metric={metrics:?}"
             ),
         };
-        assert_eq!(actual.name(), "test.client.duration");
+        assert_eq!(actual.name(), "gcp.client.request.duration");
         assert_eq!(actual.unit(), "s");
         let histo = match actual.data() {
             AggregatedMetrics::F64(MetricData::Histogram(h)) => h,

--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -33,7 +33,7 @@ pub const BOUNDARIES: [f64; 16] = [
     900.0, 3600.0,
 ];
 // TODO(#4772) - use the real name once the attributes are all working.
-const METRIC_NAME: &str = "test.client.duration";
+const METRIC_NAME: &str = "gcp.client.request.duration";
 // This is seconds in SI units.
 const METRIC_UNIT: &str = "s";
 

--- a/tests/o11y/src/e2e/signals.rs
+++ b/tests/o11y/src/e2e/signals.rs
@@ -255,7 +255,7 @@ async fn check_metrics(
             .set_name(format!("projects/{project_id}"))
             .set_interval(TimeInterval::new().set_end_time(end).set_start_time(start))
             .set_filter(
-                format!(r#"metric.type = "workload.googleapis.com/test.client.duration" AND resource.labels.node_id = "{node_id}""#),
+                format!(r#"metric.type = "workload.googleapis.com/gcp.client.request.duration" AND resource.labels.node_id = "{node_id}""#),
             )
             .set_order_by("timestamp desc")
             .send()


### PR DESCRIPTION
Fixes #5196 