### PR TITLE
test(storage): not propagate errors during stale bucket cleanup

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -767,13 +767,10 @@ pub async fn cleanup_stale_buckets(
 
     println!("cleaning up {} buckets", pending.len());
     let results = futures::future::join_all(pending).await;
-    let errors = results
-        .into_iter()
-        .zip(names)
-        .filter(|(r, _)| r.is_err());
-   for (r, name) in errors {
+    let errors = results.into_iter().zip(names).filter(|(r, _)| r.is_err());
+    for (r, name) in errors {
         println!("error deleting bucket {name}: {r:?}");
-   }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Fixes #5212
