### PR TITLE
impl(integration-tests-o11y): always enable some modules

### DIFF
--- a/tests/o11y/src/lib.rs
+++ b/tests/o11y/src/lib.rs
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(google_cloud_unstable_tracing)]
-use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-
 pub mod auth;
 pub mod detector;
+pub mod mock_collector;
+pub mod otlp;
+pub mod tracing;
+
+#[cfg(google_cloud_unstable_tracing)]
+use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 #[cfg(google_cloud_unstable_tracing)]
 pub mod e2e;
 #[cfg(google_cloud_unstable_tracing)]
 pub mod http_tracing;
-pub mod mock_collector;
-pub mod otlp;
 #[cfg(google_cloud_unstable_tracing)]
 pub mod storage_tracing;
-#[cfg(google_cloud_unstable_tracing)]
-pub mod tracing;


### PR DESCRIPTION
I want to use these modules in a demo. These changes are safe because (1) the crate is not published, and (2) the modules do not depend on the `google_cloud_unstable_tracing` features enabled by the libraries.

This may help with #5065 