### PR TITLE
impl(pubsub): fewer at-least-once lease extensions

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -351,6 +351,8 @@ mod tests {
             flush_start: Duration::from_secs(900),
             extend_period: EXTEND_PERIOD,
             extend_start: EXTEND_START,
+            // extend leases for all messages on the timer
+            max_lease_extension: Duration::ZERO,
             ..Default::default()
         };
         let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -34,6 +34,9 @@ use tokio_util::task::TaskTracker;
 // https://docs.cloud.google.com/pubsub/quotas
 const MAX_IDS_PER_RPC: usize = 1000;
 
+// How often we extend deadlines for messages under lease
+const EXTEND_PERIOD: Duration = Duration::from_secs(3);
+
 // Helper function to chunk ack ids into chunks of MAX_IDS_PER_RPC.
 fn batch(ack_ids: Vec<String>) -> Vec<Vec<String>> {
     ack_ids
@@ -54,6 +57,8 @@ pub(super) struct LeaseOptions {
     /// How long messages can be kept under lease. A message's lease can be
     /// extended as long as `max_lease` has not elapsed.
     pub(super) max_lease: Duration,
+    /// How long a message's lease can be extended by.
+    pub(super) max_lease_extension: Duration,
     /// The shutdown behavior of the lease loop
     pub(super) shutdown_behavior: ShutdownBehavior,
 }
@@ -63,9 +68,10 @@ impl Default for LeaseOptions {
         LeaseOptions {
             flush_period: Duration::from_millis(100),
             flush_start: Duration::from_millis(100),
-            extend_period: Duration::from_secs(3),
+            extend_period: EXTEND_PERIOD,
             extend_start: Duration::from_millis(500),
             max_lease: Duration::from_secs(600),
+            max_lease_extension: Duration::from_secs(60),
             shutdown_behavior: ShutdownBehavior::WaitForProcessing,
         }
     }
@@ -79,8 +85,23 @@ pub(super) struct NewMessage {
 
 #[derive(Debug)]
 pub(super) enum LeaseInfo {
-    AtLeastOnce(Instant),
+    AtLeastOnce(AtLeastOnceInfo),
     ExactlyOnce(ExactlyOnceInfo),
+}
+
+#[derive(Debug)]
+pub(super) struct AtLeastOnceInfo {
+    receive_time: Instant,
+    last_extension: Option<Instant>,
+}
+
+impl AtLeastOnceInfo {
+    pub(super) fn new() -> Self {
+        AtLeastOnceInfo {
+            receive_time: Instant::now(),
+            last_extension: None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -125,6 +146,8 @@ where
     extend_interval: Interval,
     // How long messages can be kept under lease
     max_lease: Duration,
+    // How long a message's lease can be extended by
+    max_lease_extension: Duration,
 
     // In flight acks and nacks.
     pending_acks_nacks: TaskTracker,
@@ -161,6 +184,7 @@ where
             flush_interval,
             extend_interval,
             max_lease: options.max_lease,
+            max_lease_extension: options.max_lease_extension,
             pending_acks_nacks: TaskTracker::new(),
             pending_extends: JoinSet::new(),
         }
@@ -244,7 +268,7 @@ where
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
     pub(super) fn extend(&mut self) {
-        let batches = self.leases.retain(self.max_lease);
+        let batches = self.leases.retain(self.max_lease, self.max_lease_extension);
         for ack_ids in batches {
             let leaser = self.leaser.clone();
             self.pending_extends
@@ -327,12 +351,12 @@ pub(super) mod tests {
     }
 
     #[derive(Debug)]
-    pub(super) struct NackBatches {
+    pub(super) struct Batches {
         pub(super) counts: Vec<i32>,
         pub(super) ack_ids: Vec<String>,
     }
 
-    impl NackBatches {
+    impl Batches {
         pub(super) fn flatten(to_nack: Vec<Vec<String>>) -> Self {
             let counts = to_nack.iter().map(|v| v.len() as i32).collect();
             let ack_ids = to_nack.into_iter().flatten().collect();
@@ -355,7 +379,7 @@ pub(super) mod tests {
     }
 
     pub(in super::super) fn at_least_once_info() -> LeaseInfo {
-        LeaseInfo::AtLeastOnce(Instant::now())
+        LeaseInfo::AtLeastOnce(AtLeastOnceInfo::new())
     }
 
     pub(in super::super) fn exactly_once_info() -> LeaseInfo {
@@ -731,7 +755,11 @@ pub(super) mod tests {
             .withf(|v| sorted(v) == test_ids(10..20))
             .returning(|_| ());
 
-        let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
+        let options = LeaseOptions {
+            max_lease_extension: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut state = LeaseState::new(Arc::new(mock), options);
 
         // Add 10 messages. These are now under lease management.
         for i in 0..10 {
@@ -833,7 +861,11 @@ pub(super) mod tests {
             .withf(|v| *v == vec![test_id(1)])
             .returning(|_| ());
 
-        let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
+        let options = LeaseOptions {
+            max_lease_extension: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut state = LeaseState::new(Arc::new(mock), options);
 
         state.add(test_id(1), at_least_once_info());
         state.extend();

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -12,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::MAX_IDS_PER_RPC;
+use super::{AtLeastOnceInfo, EXTEND_PERIOD, MAX_IDS_PER_RPC};
 use std::collections::HashMap;
 // Use a `tokio::time::Instant` to facilitate time-based unit testing.
 use tokio::time::{Duration, Instant};
+
+/// The buffer applied to the lease extension period to account for network
+/// latency and processing time.
+const EXTEND_BUFFER: Duration = Duration::from_secs(2);
 
 /// Leases for messages with at-least-once delivery semantics.
 #[derive(Debug, Default)]
 pub struct Leases {
     /// Ack IDs that are under lease management. The `Instant` denotes the time
     /// they were received.
-    under_lease: HashMap<String, Instant>,
+    under_lease: HashMap<String, AtLeastOnceInfo>,
     /// Ack IDs we need to acknowledge.
     to_ack: Vec<String>,
     /// Ack IDs we need to nack.
@@ -31,8 +35,8 @@ pub struct Leases {
 
 impl Leases {
     /// Accept a new ack ID under lease management
-    pub fn add(&mut self, ack_id: String, receive_time: Instant) {
-        self.under_lease.insert(ack_id, receive_time);
+    pub fn add(&mut self, ack_id: String, info: AtLeastOnceInfo) {
+        self.under_lease.insert(ack_id, info);
     }
 
     /// Process an ack from the application
@@ -71,17 +75,28 @@ impl Leases {
     /// Returns batches of ack IDs to extend.
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
-    pub fn retain(&mut self, max_lease_extension: Duration) -> Vec<Vec<String>> {
+    pub fn retain(
+        &mut self,
+        max_lease: Duration,
+        max_lease_extension: Duration,
+    ) -> Vec<Vec<String>> {
         let now = Instant::now();
         let mut batches = Vec::new();
         let mut batch = Vec::new();
-        self.under_lease.retain(|ack_id, receive_time| {
+        self.under_lease.retain(|ack_id, info| {
             // Note that using `HashMap::retain` allows us to iterate over the
             // map and conditionally drop elements in one pass.
 
-            if *receive_time + max_lease_extension < now {
+            if info.receive_time + max_lease < now {
                 // Drop messages that have been held for too long.
                 false
+            } else if info
+                .last_extension
+                .is_some_and(|i| i + max_lease_extension > now + EXTEND_PERIOD + EXTEND_BUFFER)
+            {
+                // The current lease is valid for a while. Retain the message,
+                // but do not extend its leases.
+                true
             } else {
                 // Extend leases for all other messages.
                 batch.push(ack_id.clone());
@@ -89,6 +104,7 @@ impl Leases {
                     // Flush the batch when it is full.
                     batches.push(std::mem::take(&mut batch));
                 }
+                info.last_extension = Some(now);
                 true
             }
         });
@@ -132,7 +148,7 @@ impl PartialEq<Leases> for super::tests::TestLeases {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::{NackBatches, TestLeases, sorted, test_id, test_ids};
+    use super::super::tests::{Batches, TestLeases, sorted, test_id, test_ids};
     use super::*;
     use std::collections::HashSet;
 
@@ -151,7 +167,7 @@ mod tests {
             leases
         );
 
-        leases.add(test_id(1), Instant::now());
+        leases.add(test_id(1), AtLeastOnceInfo::new());
         assert_eq!(
             TestLeases {
                 under_lease: vec![test_id(1)],
@@ -161,7 +177,7 @@ mod tests {
             leases
         );
 
-        leases.add(test_id(2), Instant::now());
+        leases.add(test_id(2), AtLeastOnceInfo::new());
         assert_eq!(
             TestLeases {
                 under_lease: vec![test_id(1), test_id(2)],
@@ -171,7 +187,7 @@ mod tests {
             leases
         );
 
-        leases.add(test_id(3), Instant::now());
+        leases.add(test_id(3), AtLeastOnceInfo::new());
         assert_eq!(
             TestLeases {
                 under_lease: vec![test_id(1), test_id(2), test_id(3)],
@@ -201,7 +217,7 @@ mod tests {
             leases
         );
 
-        leases.add(test_id(4), Instant::now());
+        leases.add(test_id(4), AtLeastOnceInfo::new());
         assert_eq!(
             TestLeases {
                 under_lease: vec![test_id(3), test_id(4)],
@@ -236,7 +252,7 @@ mod tests {
     fn drain() {
         let mut leases = Leases::default();
         for i in 0..100 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
         }
         for i in 0..10 {
             leases.ack(test_id(i));
@@ -271,7 +287,7 @@ mod tests {
     fn evict() {
         let mut leases = Leases::default();
         for i in 0..30 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
         }
         for i in 0..10 {
             leases.ack(test_id(i));
@@ -291,7 +307,7 @@ mod tests {
         let (to_ack, to_nack) = leases.evict_and_drain();
         assert_eq!(sorted(&to_ack), test_ids(0..10));
 
-        let to_nack = NackBatches::flatten(to_nack);
+        let to_nack = Batches::flatten(to_nack);
         assert_eq!(sorted(&to_nack.ack_ids), test_ids(10..30));
     }
 
@@ -299,7 +315,7 @@ mod tests {
     fn evict_overflow_batches() {
         let mut leases = Leases::default();
         for i in 0..MAX_IDS_PER_RPC * 3 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
         }
         for i in 0..10 {
             leases.ack(test_id(i));
@@ -319,7 +335,7 @@ mod tests {
         let (to_ack, to_nack) = leases.evict_and_drain();
         assert_eq!(sorted(&to_ack), test_ids(0..10));
 
-        let to_nack = NackBatches::flatten(to_nack);
+        let to_nack = Batches::flatten(to_nack);
         assert_eq!(
             to_nack.counts,
             vec![MAX_IDS_PER_RPC, MAX_IDS_PER_RPC, MAX_IDS_PER_RPC - 10]
@@ -378,14 +394,14 @@ mod tests {
         let mut leases = Leases::default();
 
         for i in 0..100 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             leases.ack(test_id(i));
         }
         // With 100 pending acks, the batch is not full.
         assert!(!leases.needs_flush());
 
         for i in 100..MAX_IDS_PER_RPC {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             leases.ack(test_id(i));
         }
         // With `MAX_IDS_PER_RPC` pending acks, the batch is full. We should
@@ -398,14 +414,14 @@ mod tests {
         let mut leases = Leases::default();
 
         for i in 0..100 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             leases.nack(test_id(i));
         }
         // With 100 pending nacks, the batch is not full.
         assert!(!leases.needs_flush());
 
         for i in 100..MAX_IDS_PER_RPC {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             leases.nack(test_id(i));
         }
         // With `MAX_IDS_PER_RPC` pending nacks, the batch is full. We should
@@ -419,10 +435,10 @@ mod tests {
 
         let over_half_full = MAX_IDS_PER_RPC / 2 + 100;
         for i in 0..over_half_full {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             leases.ack(test_id(i));
 
-            leases.add(test_id(over_half_full + i), Instant::now());
+            leases.add(test_id(over_half_full + i), AtLeastOnceInfo::new());
             leases.nack(test_id(over_half_full + i));
         }
 
@@ -439,11 +455,11 @@ mod tests {
 
         let mut want = HashSet::new();
         for i in 0..NUM_BATCHES * MAX_IDS_PER_RPC {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
             want.insert(test_id(i));
         }
 
-        let batches = leases.retain(Duration::from_secs(1));
+        let batches = leases.retain(Duration::from_secs(1), Duration::ZERO);
         assert_eq!(batches.len(), NUM_BATCHES as usize);
 
         let mut got = HashSet::new();
@@ -459,22 +475,22 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn message_expiration() -> anyhow::Result<()> {
-        const MAX_LEASE_EXTENSION: Duration = Duration::from_secs(300);
+        const MAX_LEASE: Duration = Duration::from_secs(300);
         const DELTA: Duration = Duration::from_secs(1);
 
         let mut leases = Leases::default();
 
         // Add 10 messages under lease management
         for i in 0..10 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
         }
 
         // Add 10 more messages under lease management, a little later.
         tokio::time::advance(DELTA * 2).await;
         for i in 10..20 {
-            leases.add(test_id(i), Instant::now());
+            leases.add(test_id(i), AtLeastOnceInfo::new());
         }
-        let batches = leases.retain(MAX_LEASE_EXTENSION);
+        let batches = leases.retain(MAX_LEASE, Duration::ZERO);
         assert_eq!(batches.len(), 1);
         assert_eq!(sorted(&batches[0]), test_ids(0..20));
         assert_eq!(
@@ -487,8 +503,8 @@ mod tests {
         );
 
         // Advance the time past the expiration of the original 10 messages.
-        tokio::time::advance(MAX_LEASE_EXTENSION - DELTA).await;
-        let batches = leases.retain(MAX_LEASE_EXTENSION);
+        tokio::time::advance(MAX_LEASE - DELTA).await;
+        let batches = leases.retain(MAX_LEASE, Duration::ZERO);
         assert_eq!(batches.len(), 1);
         assert_eq!(sorted(&batches[0]), test_ids(10..20));
         assert_eq!(
@@ -502,11 +518,63 @@ mod tests {
 
         // Advance the time past the expiration of the subsequent 10 messages.
         tokio::time::advance(DELTA * 2).await;
-        let batches = leases.retain(MAX_LEASE_EXTENSION);
+        let batches = leases.retain(MAX_LEASE, Duration::ZERO);
         assert!(batches.is_empty(), "{}", batches.len());
         assert_eq!(
             TestLeases {
                 under_lease: Vec::new(),
+                to_ack: Vec::new(),
+                to_nack: Vec::new(),
+            },
+            leases
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn necessary_extensions() -> anyhow::Result<()> {
+        const MAX_LEASE: Duration = Duration::from_secs(900);
+        const MAX_LEASE_EXTENSION: Duration = Duration::from_secs(10);
+
+        let mut leases = Leases::default();
+        leases.add(test_id(0), AtLeastOnceInfo::new());
+
+        // We should always send a receipt lease extension upon receiving a
+        // message.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        assert_eq!(batches, vec![vec![test_id(0)]]);
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..1),
+                to_ack: Vec::new(),
+                to_nack: Vec::new(),
+            },
+            leases
+        );
+
+        // The clock has not advanced, and we just sent out an extension. We
+        // should not send another extension.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        assert!(batches.is_empty(), "{batches:?}");
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..1),
+                to_ack: Vec::new(),
+                to_nack: Vec::new(),
+            },
+            leases
+        );
+
+        // Advance the time close to the expiration of the initial lease.
+        tokio::time::advance(MAX_LEASE_EXTENSION - Duration::from_secs(1)).await;
+
+        // We need to extend the lease again.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        assert_eq!(batches, vec![vec![test_id(0)]]);
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..1),
                 to_ack: Vec::new(),
                 to_nack: Vec::new(),
             },

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -87,7 +87,7 @@ impl Leases {
     /// Returns batches of ack IDs to extend.
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
-    pub fn retain(&mut self, max_lease_extension: Duration) -> Vec<Vec<String>> {
+    pub fn retain(&mut self, max_lease: Duration) -> Vec<Vec<String>> {
         let now = Instant::now();
 
         // We want to extract some values from `HashMap`, leaving the rest
@@ -105,7 +105,7 @@ impl Leases {
             .under_lease
             .iter()
             .filter_map(|(id, info)| {
-                if !info.pending && info.receive_time + max_lease_extension < now {
+                if !info.pending && info.receive_time + max_lease < now {
                     expired.push(id.clone());
                     None
                 } else {
@@ -165,7 +165,7 @@ impl PartialEq<Leases> for super::tests::TestLeases {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::{NackBatches, TestLeases, sorted, test_id, test_ids};
+    use super::super::tests::{Batches, TestLeases, sorted, test_id, test_ids};
     use super::*;
     use std::collections::HashSet;
     use tokio::sync::oneshot::channel;
@@ -669,7 +669,7 @@ mod tests {
         let (to_ack, to_nack) = leases.evict_and_drain();
         assert!(to_ack.is_empty(), "{to_ack:?}");
 
-        let to_nack = NackBatches::flatten(to_nack);
+        let to_nack = Batches::flatten(to_nack);
         assert_eq!(sorted(&to_nack.ack_ids), test_ids(1..4));
 
         let err = result_rx1.await?.expect_err("error should be returned");
@@ -694,7 +694,7 @@ mod tests {
         let (to_ack, to_nack) = leases.evict_and_drain();
         assert!(to_ack.is_empty(), "{to_ack:?}");
 
-        let to_nack = NackBatches::flatten(to_nack);
+        let to_nack = Batches::flatten(to_nack);
         assert_eq!(to_nack.counts, vec![MAX_IDS_PER_RPC, 20]);
         assert_eq!(sorted(&to_nack.ack_ids), test_ids(0..MAX_IDS_PER_RPC + 20));
 

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -15,7 +15,7 @@
 use super::builder::Subscribe;
 use super::handler::{Action, AtLeastOnce, ExactlyOnce, Handler};
 use super::lease_loop::LeaseLoop;
-use super::lease_state::{ExactlyOnceInfo, LeaseInfo, LeaseOptions, NewMessage};
+use super::lease_state::{AtLeastOnceInfo, ExactlyOnceInfo, LeaseInfo, LeaseOptions, NewMessage};
 use super::leaser::DefaultLeaser;
 use super::retry_policy::StreamRetryPolicy;
 use super::stream::Stream;
@@ -32,7 +32,7 @@ use google_cloud_gax::retry_result::RetryResult;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
-use tokio::time::Instant;
+use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 /// Represents an open subscribe stream.
@@ -133,6 +133,7 @@ impl MessageStream {
         );
         let options = LeaseOptions {
             max_lease: builder.max_lease,
+            max_lease_extension: Duration::from_secs(builder.ack_deadline_seconds as u64),
             shutdown_behavior: builder.shutdown_behavior,
             ..Default::default()
         };
@@ -351,7 +352,7 @@ impl MessageStreamImpl {
                 )
             } else {
                 (
-                    LeaseInfo::AtLeastOnce(Instant::now()),
+                    LeaseInfo::AtLeastOnce(AtLeastOnceInfo::new()),
                     Handler::AtLeastOnce(AtLeastOnce::new(rm.ack_id.clone(), self.ack_tx.clone())),
                 )
             };


### PR DESCRIPTION
Part of the work for #5048 

Only extend at-least-once leases if they are within 5 seconds of expiring. @suzmue was also thinking along these lines.

We are trading off fewer RPCs or at least fewer bytes being sent out to extend leases for less retries of the lease extensions. But note that with the default retry settings, we would be retrying a lease extension operation 60s / 3s = 20 times. That is way too many times.

We should do the same thing for exactly-once, but that's too much for one PR.

If the reviewer wants me to break this down into smaller PRs, I will gladly do so. Just let me know.