### PR TITLE
cleanup(o11y): remove temporary rpc_system override logic

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -345,7 +345,6 @@ mod tests {
             ClientRequestAttributes::default()
                 .set_rpc_method(TEST_METHOD)
                 .set_url_template(TEST_URL_TEMPLATE)
-                .set_rpc_system("grpc")
                 .set_resource_name("//test.googleapis.com/test-only".to_string()),
         );
 

--- a/src/gax-internal/src/observability/client_signals/recorder.rs
+++ b/src/gax-internal/src/observability/client_signals/recorder.rs
@@ -156,7 +156,6 @@ impl RequestRecorder {
         guard.rpc_method = attributes.rpc_method;
         guard.url_template = attributes.url_template;
         guard.resource_name = attributes.resource_name;
-        guard.rpc_system = attributes.rpc_system;
     }
 
     /// Call before issuing a HTTP request to capture its data.
@@ -244,7 +243,6 @@ pub struct ClientRequestAttributes {
     pub rpc_method: Option<&'static str>,
     pub url_template: Option<&'static str>,
     pub resource_name: Option<String>,
-    pub rpc_system: Option<&'static str>,
 }
 
 impl ClientRequestAttributes {
@@ -262,11 +260,6 @@ impl ClientRequestAttributes {
         self.resource_name = Some(v);
         self
     }
-
-    pub fn set_rpc_system(mut self, v: &'static str) -> Self {
-        self.rpc_system = Some(v);
-        self
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -278,7 +271,6 @@ pub struct ClientSnapshot {
     url_template: Option<&'static str>,
     resource_name: Option<String>,
     attempt_count: u32,
-    rpc_system: Option<&'static str>,
     transport_snapshot: Option<TransportSnapshot>,
 }
 
@@ -292,7 +284,6 @@ impl ClientSnapshot {
             url_template: None,
             resource_name: None,
             attempt_count: 0_u32,
-            rpc_system: None,
             transport_snapshot: None,
         }
     }
@@ -345,8 +336,7 @@ impl ClientSnapshot {
     ///
     /// Use with the "rpc.system.name" attribute.
     pub fn rpc_system(&self) -> Option<&'static str> {
-        self.rpc_system
-            .or_else(|| self.transport_snapshot.as_ref().and_then(|s| s.rpc_system))
+        self.transport_snapshot.as_ref().and_then(|s| s.rpc_system)
     }
 
     /// Returns the server address used in the last low-level request.


### PR DESCRIPTION
Now that the transport layer natively populates `rpc_system` via `on_grpc_request` (https://github.com/googleapis/google-cloud-rust/pull/5237), the manual struct injection at the `ClientRequestAttributes` level is redundant.