### PR TITLE
ci(pubsub): re-enable exactly-once test

### DIFF
--- a/tests/pubsub/tests/driver.rs
+++ b/tests/pubsub/tests/driver.rs
@@ -86,7 +86,6 @@ mod pubsub {
         result
     }
 
-    #[ignore = "TODO(#5063) - disabled because it was flaky"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn run_exactly_once_roundtrip() -> anyhow::Result<()> {
         let _guard = enable_tracing();


### PR DESCRIPTION
Related to #5063 

It looks like #3975 was the root problem for these acks failing. That is fixed, so re-enable the test, and see if we catch any other sort of error.

From longrunning benchmarks, I have only seen transient errors, which should be fixed by implementing the exactly once retry loop (#4804).