### PR TITLE
fix(o11y): use correct Tokio `task_local` API in `RequestRecorder`

### DIFF
--- a/src/gax-internal/src/observability/client_signals/recorder.rs
+++ b/src/gax-internal/src/observability/client_signals/recorder.rs
@@ -120,7 +120,7 @@ impl RequestRecorder {
     /// }
     /// ```
     pub fn current() -> Option<Self> {
-        RECORDER.try_get().ok()
+        RECORDER.try_with(|r| r.clone()).ok()
     }
 
     /// Returns the data captured for the client layer.


### PR DESCRIPTION
`RequestRecorder::current()` was using `RECORDER.try_get()`, which is not a valid method on `tokio::task::LocalKey`, causing a compilation error. 

Surfaced in #5292 when `google_cloud_unstable_tracing` is removed.