### PR TITLE
chore: bump tokio to 1.48.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -394,7 +394,7 @@ serde_with            = { default-features = false, version = "3", features = ["
 sha2                  = { default-features = false, version = "0.11.0" }
 thiserror             = { default-features = false, version = "2.0.12" }
 time                  = { default-features = false, version = "0.3.45" }
-tokio                 = { default-features = false, version = "1.47.0" }
+tokio                 = { default-features = false, version = "1.48.0" }
 tokio-metrics         = { default-features = false, version = "0.4.9" }
 tokio-util            = { default-features = false, version = "0.7.18" }
 toml_edit             = { default-features = false, version = "0.25" }


### PR DESCRIPTION
Bump Tokio to 1.48.0 to make use of `try_get()`, which is not available in 1.47.0.