### PR TITLE
fix(gax-internal): fix missing argument in `check_metric_data` in test

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -678,6 +678,7 @@ mod tests {
         check_metric_scope(&metrics);
         check_metric_data(
             &metrics,
+            "gcp.client.request.duration",
             1_u64..=1_u64,
             &[
                 ("rpc.system.name", "grpc"),


### PR DESCRIPTION
Fixes #5305