### PR TITLE
fix(o11y): use `multi_thread` for grpc test

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -646,9 +646,10 @@ mod tests {
     }
 
     #[cfg(feature = "_internal-grpc-client")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn grpc_client_request_success() -> anyhow::Result<()> {
         let (endpoint, _server) = grpc_server::start_echo_server().await?;
+        tokio::time::pause();
         let signals = SignalProviders::new();
 
         let metric = DurationMetric::new_with_provider(


### PR DESCRIPTION
Use `current_thread` with delayed `tokio::time::pause()` for `grpc_client_request_success` to avoid flakiness and deadlocks.

I made a mistake previously when applying `#[tokio::test(flavor = "current_thread", start_paused = true)]` to this test. That caused a deadlock because the background gRPC server was started in a paused runtime and could not make progress before the client blocked.

The test originally used `flavor = "multi_thread"`, which avoided the deadlock but left the test vulnerable to timing-sensitive flakiness (as noted by @coryan).

To fix both issues, I have:
1. Kept the default `current_thread` runtime.
2. Started the background gRPC server before pausing time.
3. Called `tokio::time::pause();` after the server is ready and before the client request.

This ensures the test executes deterministically and fast without flakiness or deadlocks. We verified this by running 1,000 iterations without failure.

This surfaces in #5292 when the `unstable_tracing` guards are removed.