### PR TITLE
chore: force `h2` version to avoid minimal-versions deadlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ dependencies = [
  "google-cloud-test-utils",
  "google-cloud-wkt",
  "grpc-server",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,6 +370,7 @@ crates_io_api         = { default-features = false, version = "0.12" }
 clap                  = { default-features = false, version = "4" }
 crc32c                = { default-features = false, version = "0.6.8" }
 futures               = { default-features = false, version = "0.3" }
+h2                    = { default-features = false, version = "0.4.13" }
 hex                   = { default-features = false, version = "0.4.3" }
 http                  = { default-features = false, version = "1.1", features = ["std"] }
 http-body             = { default-features = false, version = "1" }

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -47,6 +47,7 @@ _internal-http-client = ["_internal-common", "dep:hyper", "dep:reqwest", "dep:se
 # features of reqwest that `google-cloud-auth` does.
 _internal-grpc-client = [
   "_internal-common",
+  "dep:h2",
   "dep:http-body",
   "dep:prost",
   "dep:prost-types",
@@ -95,6 +96,7 @@ _default-rustls-provider = ["google-cloud-auth?/default-rustls-provider", "tonic
 _internal-grpc-server-streaming = []
 
 [dependencies]
+h2                                 = { workspace = true, optional = true }
 bytes                              = { workspace = true, optional = true, features = ["serde"] }
 futures                            = { workspace = true, optional = true }
 lazy_static                        = { workspace = true, optional = true }


### PR DESCRIPTION
Fix a `gcb-pr-minimal-versions` build failure in `google-cloud-gax-internal` tests caused by `h2` version `0.4.2`, which surfaces after `google_cloud_unstable_tracing` guards are removed in #5292.

The Problem
During minimal-versions checks, `h2` resolves to `0.4.2`, which somehow leads to deadlocks or missing tracing spans in our gRPC tests.

Previous Attempts
I tried switching tests to `multi_thread` (PR #5308), which masked the issue but was not a good solution.
I tried forcing the version in the root `[workspace.dependencies]`, but `Cargo` ignored it during the isolated package build for `gax-internal`.

The Fix
Add `h2 = "0.4.13"` as a direct dependency in `src/gax-internal/Cargo.toml`. `0.4.13` is the version resolved in our normal Cargo.lock.