### PR TITLE
chore: update librarian to v0.10.1-0.20260408162740-399e2ccbf6bb

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.10.1-0.20260407232632-befad4aa0ce6
+version: v0.10.1-0.20260408162740-399e2ccbf6bb
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/cloud/datacatalog/lineage/v1/.repo-metadata.json
+++ b/src/generated/cloud/datacatalog/lineage/v1/.repo-metadata.json
@@ -3,7 +3,6 @@
     "api_shortname": "datalineage",
     "client_documentation": "https://docs.rs/google-cloud-datacatalog-lineage-v1/latest",
     "distribution_name": "google-cloud-datacatalog-lineage-v1",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "rust",
     "library_type": "GAPIC_AUTO",
     "name": "datalineage",

--- a/src/generated/cloud/location/.repo-metadata.json
+++ b/src/generated/cloud/location/.repo-metadata.json
@@ -4,12 +4,10 @@
     "api_shortname": "cloud",
     "client_documentation": "https://docs.rs/google-cloud-location/latest",
     "distribution_name": "google-cloud-location",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "rust",
     "library_type": "GAPIC_AUTO",
     "name": "cloud",
     "name_pretty": "Cloud Metadata",
-    "product_documentation": "https://github.com/googleapis/googleapis/tree/master/google",
     "release_level": "stable",
     "repo": "googleapis/google-cloud-rust"
 }

--- a/src/generated/cloud/vmwareengine/v1/.repo-metadata.json
+++ b/src/generated/cloud/vmwareengine/v1/.repo-metadata.json
@@ -4,7 +4,6 @@
     "api_shortname": "vmwareengine",
     "client_documentation": "https://docs.rs/google-cloud-vmwareengine-v1/latest",
     "distribution_name": "google-cloud-vmwareengine-v1",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "rust",
     "library_type": "GAPIC_AUTO",
     "name": "vmwareengine",

--- a/src/generated/identity/accesscontextmanager/v1/.repo-metadata.json
+++ b/src/generated/identity/accesscontextmanager/v1/.repo-metadata.json
@@ -4,7 +4,6 @@
     "api_shortname": "accesscontextmanager",
     "client_documentation": "https://docs.rs/google-cloud-identity-accesscontextmanager-v1/latest",
     "distribution_name": "google-cloud-identity-accesscontextmanager-v1",
-    "issue_tracker": "https://github.com/googleapis/google-cloud-python/issues",
     "language": "rust",
     "library_type": "GAPIC_AUTO",
     "name": "accesscontextmanager",


### PR DESCRIPTION
Update `librarian` version to latest.

Includes regeneration diffs - just some repo metadata changes removing erroneous `issue_tracker` links.

Notably, includes bq storage rust allowlisting https://github.com/googleapis/librarian/commit/997c933270a8d3ababd449a216b305115a11d32e.