### PR TITLE
impl(pubsub): prepare retry loop for confirmed_ack in Leaser

### DIFF
--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -144,14 +144,13 @@ where
         let leaser = self.clone();
         let mut ack_ids = ack_ids;
 
-        // Returns `Result<()>`.
         let attempt = async move |_| {
             let ids = std::mem::take(&mut ack_ids);
             let ack_ids = leaser.confirmed_ack_attempt(ids).await;
             if ack_ids.is_empty() {
                 Ok(())
             } else {
-                // Return a synthetic error to force retry.
+                // Return a synthetic error to indicate that we should retry.
                 Err(crate::Error::timeout("retry me"))
             }
         };


### PR DESCRIPTION
Update confirmed_ack to prepare for implementing retry_loop. This PR does not change existing behavior as retry_loop is set to NeverRetry.

Towards #4804 
