### PR TITLE
fix(gax-internal): add `gcp.client.version` metric attribute

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -828,9 +828,26 @@ mod tests {
                 KeyValue::new("gcp.client.artifact", "test-artifact"),
                 KeyValue::new("gcp.client.service", "test-service"),
                 KeyValue::new("gcp.client.repo", "googleapis/google-cloud-rust"),
+                KeyValue::new("gcp.client.version", "1.2.3"),
             ])
             .build();
-        assert_eq!(scope, &want, "{got:?}");
+        let got_attrs = std::collections::BTreeSet::from_iter(
+            scope
+                .attributes()
+                .map(|kv| (kv.key.as_str(), kv.value.to_string())),
+        );
+        let want_attrs = std::collections::BTreeSet::from_iter(
+            want.attributes()
+                .map(|kv| (kv.key.as_str(), kv.value.to_string())),
+        );
+        assert_eq!(got_attrs, want_attrs, "scope attributes mismatch");
+        assert_eq!(scope.name(), want.name(), "scope name mismatch");
+        assert_eq!(scope.version(), want.version(), "scope version mismatch");
+        assert_eq!(
+            scope.schema_url(),
+            want.schema_url(),
+            "scope schema_url mismatch"
+        );
     }
 
     #[track_caller]

--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -90,6 +90,7 @@ impl DurationMetric {
                 KeyValue::new(GCP_CLIENT_ARTIFACT, info.client_artifact),
                 KeyValue::new(GCP_CLIENT_SERVICE, info.service_name),
                 KeyValue::new(GCP_CLIENT_REPO, GCP_CLIENT_REPO_GOOGLEAPIS),
+                KeyValue::new(GCP_CLIENT_VERSION, info.client_version),
             ])
             .build();
         let meter = provider.meter_with_scope(scope);

--- a/src/gax-internal/src/observability/client_signals/transport_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/transport_metric.rs
@@ -65,6 +65,7 @@ impl TransportMetric {
                 KeyValue::new(GCP_CLIENT_ARTIFACT, info.client_artifact),
                 KeyValue::new(GCP_CLIENT_SERVICE, info.service_name),
                 KeyValue::new(GCP_CLIENT_REPO, GCP_CLIENT_REPO_GOOGLEAPIS),
+                KeyValue::new(GCP_CLIENT_VERSION, info.client_version),
             ])
             .build();
         let meter = provider.meter_with_scope(scope);


### PR DESCRIPTION
Fix the missing `gcp.client.version` attribute in the `InstrumentationScope` of client metrics.