### PR TITLE
chore: share ownership with GCS team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,6 @@
 
 *           @googleapis/cloud-sdk-rust-team
 /src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-auth-team
+
+/src/storage/ @googleapis/gcs-team @googleapis/cloud-sdk-rust-team
+/tests/storage/ @googleapis/gcs-team @googleapis/cloud-sdk-rust-team


### PR DESCRIPTION
The GCS team owns the GCS crate. They should be able to approve their own PRs, instead of waiting on `cloud-sdk-rust-team`.

cc: @joshuatants 