### PR TITLE
feat(storage): enable transport-level tracing for gRPC

### DIFF
--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -316,11 +316,21 @@ impl StorageInner {
         } else {
             client
         };
-        let inner = StorageInner::new(
-            client,
-            options,
-            gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?,
-        );
+        #[cfg(google_cloud_unstable_tracing)]
+        let grpc = if gaxi::options::tracing_enabled(&config) {
+            gaxi::grpc::Client::new_with_instrumentation(
+                config,
+                super::DEFAULT_HOST,
+                &super::info::INSTRUMENTATION,
+            )
+            .await?
+        } else {
+            gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?
+        };
+        #[cfg(not(google_cloud_unstable_tracing))]
+        let grpc = gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?;
+
+        let inner = StorageInner::new(client, options, grpc);
         Ok(inner)
     }
 }


### PR DESCRIPTION
Update `from_parts` to use `Client::new_with_instrumentation()`.

Before, the http client was instrumented but the gRPC client was not, even when tracing was enabled. This resulted in missing transport-level spans for gRPC operations.