### PR TITLE
chore(netapp): major version for breaking change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-netapp-v1"
-version = "1.9.0"
+version = "2.0.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1067,7 +1067,7 @@ libraries:
       - path: google/monitoring/v3
     copyright_year: "2025"
   - name: google-cloud-netapp-v1
-    version: 1.9.0
+    version: 2.0.0
     copyright_year: "2025"
   - name: google-cloud-networkconnectivity-v1
     version: 1.9.0

--- a/src/generated/cloud/netapp/v1/Cargo.toml
+++ b/src/generated/cloud/netapp/v1/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-netapp-v1"
-version                = "1.9.0"
+version                = "2.0.0"
 description            = "Google Cloud Client Libraries for Rust - NetApp API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/cloud/netapp/v1/README.md
+++ b/src/generated/cloud/netapp/v1/README.md
@@ -28,8 +28,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-netapp-v1/1.9.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-netapp-v1/2.0.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[NetApp]: https://docs.rs/google-cloud-netapp-v1/1.9.0/google_cloud_netapp_v1/client/struct.NetApp.html
+[NetApp]: https://docs.rs/google-cloud-netapp-v1/2.0.0/google_cloud_netapp_v1/client/struct.NetApp.html


### PR DESCRIPTION
Bumping `google-cloud-netapp-v1` to `2.0.0` due to breaking change: https://github.com/googleapis/googleapis/commit/a90dc55a699b916cbff59aa8112e067f6bab5bd4#diff-e27f128d5351ddda01fecd51c61074507a21a98bbb9c774f213dd6ea32392f8a.