### PR TITLE
docs: minor docs fixes

### DIFF
--- a/guide/src/working_with_enums.md
+++ b/guide/src/working_with_enums.md
@@ -65,7 +65,7 @@ everything else works as normal:
 The same principle applies to unknown integer values:
 
 ```rust,ignore
-{{#include ../samples/tests/enums.rs:unknown_string}}
+{{#include ../samples/tests/enums.rs:unknown_integer}}
 ```
 
 ## Preparing for upgrades

--- a/src/gax/src/error/binding.rs
+++ b/src/gax/src/error/binding.rs
@@ -26,7 +26,7 @@
 /// Also see the [Handling binding errors] section in the user guide to learn
 /// how to resolve these errors.
 ///
-/// [Handling binding errors]: https://google-cloud-rust.github.io/binding_errors.html
+/// [Handling binding errors]: https://googleapis.github.io/google-cloud-rust/binding_errors.html
 /// [aip-127]: https://google.aip.dev/127
 /// [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
 #[derive(thiserror::Error, Debug, PartialEq)]


### PR DESCRIPTION
1. User guide moved from https://google-cloud-rust.github.io/ to https://googleapis.github.io/google-cloud-rust. Just fixing broken links
2. Docs include directive points to wrong sample