### PR TITLE
feat(o11y): remove `google-cloud-unstable-tracing guards`

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -35,7 +35,6 @@ locals {
   gcb_secret_name = "projects/${var.project}/secrets/github-github-oauthtoken-319d75/versions/latest"
 
   unstable_flags = join(" ", [
-    "--cfg google_cloud_unstable_tracing",
     "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
     "--cfg google_cloud_unstable_grpc_server_streaming"

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.94" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_tracing --cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming'
 
 jobs:
   build:

--- a/demos/cloud-run-o11y/Dockerfile
+++ b/demos/cloud-run-o11y/Dockerfile
@@ -16,7 +16,7 @@ FROM rust:1.93-slim-bookworm AS builder
 
 WORKDIR /usr/src/workspace
 COPY . .
-RUN env RUSTFLAGS="--cfg google_cloud_unstable_tracing" cargo build -p demo-cloud-run-o11y --release
+RUN cargo build -p demo-cloud-run-o11y --release
 
 # Use a lightweight Debian image for the runtime
 FROM debian:bookworm-slim

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -18,12 +18,9 @@ pub mod from_status;
 pub mod status;
 pub mod tonic;
 
-#[cfg(google_cloud_unstable_tracing)]
-use crate::observability::attributes::{self, keys::*, otel_status_codes};
 use ::tonic::client::Grpc;
 use ::tonic::transport::Channel;
 use from_status::to_gax_error;
-use futures::TryFutureExt;
 use google_cloud_auth::credentials::{
     Builder as CredentialsBuilder, CacheableResource, Credentials,
 };
@@ -45,35 +42,23 @@ use google_cloud_gax::retry_policy::{
 };
 use google_cloud_gax::retry_throttler::SharedRetryThrottler;
 use http::HeaderMap;
-#[cfg(google_cloud_unstable_tracing)]
-use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
 use std::sync::Arc;
 use std::time::Duration;
 
 // A tonic::transport::Channel always has a Buffer layer.
 const DEFAULT_REQUEST_BUFFER_CAPACITY: usize = 1024;
 
-pub type GrpcService = Channel;
+pub type GrpcService = tower::util::Either<
+    crate::observability::grpc_tracing::TracingTowerService<Channel>,
+    crate::observability::grpc_tracing::NoTracingTowerService<Channel>,
+>;
 
 /// The inner gRPC client type.
 pub type InnerClient = Grpc<GrpcService>;
 
-#[cfg(google_cloud_unstable_tracing)]
-#[derive(Clone, Debug)]
-pub struct TracingAttributes {
-    pub server_address: String,
-    pub server_port: Option<i64>,
-    pub url_domain: String,
-    pub instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
-}
-
 #[derive(Clone, Debug)]
 pub struct Client {
     inner: InnerClient,
-    #[cfg(google_cloud_unstable_tracing)]
-    metric: crate::observability::TransportMetric,
-    #[cfg(google_cloud_unstable_tracing)]
-    tracing_attributes: Option<TracingAttributes>,
     credentials: Credentials,
     retry_policy: Arc<dyn RetryPolicy>,
     backoff_policy: Arc<dyn BackoffPolicy>,
@@ -88,17 +73,10 @@ impl Client {
         config: crate::options::ClientConfig,
         default_endpoint: &str,
     ) -> ClientBuilderResult<Self> {
-        Self::build(
-            config,
-            default_endpoint,
-            #[cfg(google_cloud_unstable_tracing)]
-            None,
-        )
-        .await
+        Self::build(config, default_endpoint, None).await
     }
 
     /// Create a new client with instrumentation info.
-    #[cfg(google_cloud_unstable_tracing)]
     pub async fn new_with_instrumentation(
         config: crate::options::ClientConfig,
         default_endpoint: &str,
@@ -110,26 +88,16 @@ impl Client {
     async fn build(
         config: crate::options::ClientConfig,
         default_endpoint: &str,
-        #[cfg(google_cloud_unstable_tracing)] instrumentation: Option<
-            &'static crate::options::InstrumentationClientInfo,
-        >,
+        instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
     ) -> ClientBuilderResult<Self> {
         let credentials = Self::make_credentials(&config).await?;
         let tracing_enabled = crate::options::tracing_enabled(&config);
 
-        #[cfg(not(google_cloud_unstable_tracing))]
-        let inner = Self::make_inner(&config, default_endpoint, tracing_enabled).await?;
-
-        #[cfg(google_cloud_unstable_tracing)]
-        let (inner, tracing_attributes) =
+        let inner =
             Self::make_inner(&config, default_endpoint, tracing_enabled, instrumentation).await?;
 
         Ok(Self {
             inner,
-            #[cfg(google_cloud_unstable_tracing)]
-            metric: crate::observability::TransportMetric::new(instrumentation),
-            #[cfg(google_cloud_unstable_tracing)]
-            tracing_attributes,
             credentials,
             retry_policy: config.retry_policy.clone().unwrap_or_else(|| {
                 Arc::new(
@@ -223,14 +191,12 @@ impl Client {
         let codec = tonic_prost::ProstCodec::<Request, Response>::default();
         let mut inner = self.inner.clone();
         inner.ready().await.map_err(Error::io)?;
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = crate::observability::RequestRecorder::current() {
             recorder.on_grpc_request(&path);
         }
         let result = inner
             .streaming(request.into_streaming_request(), path, codec)
             .await;
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = crate::observability::RequestRecorder::current() {
             match &result {
                 Ok(_) => recorder.on_grpc_response(),
@@ -293,14 +259,12 @@ impl Client {
         let codec = tonic_prost::ProstCodec::<Request, Response>::default();
         let mut inner = self.inner.clone();
         inner.ready().await.map_err(Error::io)?;
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = crate::observability::RequestRecorder::current() {
             recorder.on_grpc_request(&path);
         }
         let result = inner
             .server_streaming(request.into_request(), path, codec)
             .await;
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = crate::observability::RequestRecorder::current() {
             match &result {
                 Ok(_) => recorder.on_grpc_response(),
@@ -366,62 +330,31 @@ impl Client {
         options: &RequestOptions,
         remaining_time: Option<std::time::Duration>,
         headers: HeaderMap,
-        _prior_attempt_count: i64,
+        prior_attempt_count: i64,
     ) -> Result<tonic::Response<Response>>
     where
         Request: prost::Message + 'static,
         Response: prost::Message + std::default::Default + 'static,
     {
-        #[cfg(google_cloud_unstable_tracing)]
-        let span = if let Some(attrs) = &self.tracing_attributes {
-            let rpc_method = path.path().trim_start_matches('/');
-            let (service, version, repo, artifact) = if let Some(info) = attrs.instrumentation {
-                (
-                    Some(info.service_name),
-                    Some(info.client_version),
-                    Some("googleapis/google-cloud-rust"),
-                    Some(info.client_artifact),
-                )
-            } else {
-                (None, None, None, None)
-            };
-            let resend_count = if _prior_attempt_count > 0 {
-                Some(_prior_attempt_count)
-            } else {
-                None
-            };
-
-            tracing::info_span!(
-                "grpc.request",
-                { OTEL_NAME } = rpc_method,
-                { RPC_SYSTEM_NAME } = attributes::RPC_SYSTEM_GRPC,
-                { OTEL_KIND } = attributes::OTEL_KIND_CLIENT,
-                { otel_trace::RPC_METHOD } = rpc_method,
-                { otel_trace::SERVER_ADDRESS } = attrs.server_address,
-                { otel_trace::SERVER_PORT } = attrs.server_port,
-                { otel_attr::URL_DOMAIN } = attrs.url_domain,
-                { RPC_RESPONSE_STATUS_CODE } = tracing::field::Empty,
-                { OTEL_STATUS_CODE } = otel_status_codes::UNSET,
-                { otel_trace::ERROR_TYPE } = tracing::field::Empty,
-                { GCP_CLIENT_SERVICE } = service,
-                { GCP_CLIENT_VERSION } = version,
-                { GCP_CLIENT_REPO } = repo,
-                { GCP_CLIENT_ARTIFACT } = artifact,
-                { GCP_GRPC_RESEND_COUNT } = resend_count,
-                { GCP_RESOURCE_DESTINATION_ID } = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::none()
-        };
-
         #[allow(unused_mut)]
         let mut headers = self.add_auth_headers(headers).await?;
 
-        #[cfg(google_cloud_unstable_tracing)]
-        crate::observability::propagation::inject_context(&span, &mut headers);
-
         let metadata = tonic::MetadataMap::from_headers(headers);
         let mut request = ::tonic::Request::from_parts(metadata, extensions, request);
+        {
+            use crate::observability::grpc_tracing::{AttemptCount, ResourceName};
+            use google_cloud_gax::options::internal::{
+                RequestOptionsExt, ResourceName as GaxResourceName,
+            };
+            request
+                .extensions_mut()
+                .insert(AttemptCount::new(prior_attempt_count));
+            if let Some(n) = options.get_extension::<GaxResourceName>() {
+                request
+                    .extensions_mut()
+                    .insert(ResourceName::new(n.0.to_string()));
+            }
+        }
 
         if let Some(timeout) = effective_timeout(options, remaining_time) {
             request.set_timeout(timeout);
@@ -429,42 +362,28 @@ impl Client {
         let codec = tonic_prost::ProstCodec::<Request, Response>::default();
         let mut inner = self.inner.clone();
         inner.ready().await.map_err(Error::io)?;
-
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = crate::observability::RequestRecorder::current() {
             recorder.on_grpc_request(&path);
         }
-
-        let pending = inner.unary(request, path, codec).map_err(to_gax_error);
-
-        #[cfg(not(google_cloud_unstable_tracing))]
-        let result = pending.await;
-        #[cfg(google_cloud_unstable_tracing)]
-        let result = {
-            use crate::observability::{
-                WithTransportLogging, WithTransportMetric, WithTransportSpan,
-            };
-
-            let pending =
-                WithTransportMetric::new(self.metric.clone(), pending, _prior_attempt_count as u32);
-            let pending = WithTransportLogging::new(pending);
-            let pending = WithTransportSpan::new(span, pending);
-
-            if let Some(recorder) = crate::observability::RequestRecorder::current() {
-                recorder.scope(pending).await
-            } else {
-                pending.await
+        let result = inner
+            .unary(request, path, codec)
+            .await
+            .map_err(to_gax_error);
+        if let Some(recorder) = crate::observability::RequestRecorder::current() {
+            match &result {
+                Ok(_) => recorder.on_grpc_response(),
+                Err(e) => recorder.on_grpc_error(e),
             }
         };
 
         result
     }
 
-    #[cfg(not(google_cloud_unstable_tracing))]
     async fn make_inner(
         config: &crate::options::ClientConfig,
         default_endpoint: &str,
         tracing_enabled: bool,
+        instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
     ) -> ClientBuilderResult<InnerClient> {
         use ::tonic::transport::{Channel, channel::Change};
         let endpoint = Self::make_endpoint(
@@ -483,60 +402,22 @@ impl Client {
             let _ = tx.send(Change::Insert(i, endpoint.clone())).await;
         }
 
-        let _ = tracing_enabled;
-        Ok(InnerClient::new(channel))
-    }
+        let uri = endpoint.uri().clone();
 
-    #[cfg(google_cloud_unstable_tracing)]
-    async fn make_inner(
-        config: &crate::options::ClientConfig,
-        default_endpoint: &str,
-        tracing_enabled: bool,
-        instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
-    ) -> ClientBuilderResult<(InnerClient, Option<TracingAttributes>)> {
-        use ::tonic::transport::{Channel, channel::Change};
-        let endpoint = Self::make_endpoint(
-            config.endpoint.clone(),
-            default_endpoint,
-            config.grpc_max_header_list_size,
-        )
-        .await?;
-        let (channel, tx) = Channel::balance_channel(
-            config
-                .grpc_request_buffer_capacity
-                .unwrap_or(DEFAULT_REQUEST_BUFFER_CAPACITY),
-        );
-        let count = std::cmp::max(1, config.grpc_subchannel_count.unwrap_or_default());
-        for i in 0..count {
-            let _ = tx.send(Change::Insert(i, endpoint.clone())).await;
-        }
-
-        let default_uri = default_endpoint
-            .parse::<::tonic::transport::Uri>()
-            .map_err(BuilderError::transport)?;
-        let default_host = default_uri.host().unwrap_or("").to_string();
-
-        let uri = endpoint.uri();
-        let host = uri.host().unwrap_or("").to_string();
-        let port = uri.port_u16().or_else(|| match uri.scheme_str() {
-            Some("https") => Some(443),
-            Some("http") => Some(80),
-            _ => None,
-        });
-
-        let attrs = TracingAttributes {
-            server_address: host,
-            server_port: port.map(|p| p as i64),
-            url_domain: default_host.clone(),
-            instrumentation,
+        let service = if tracing_enabled {
+            let layer = crate::observability::grpc_tracing::TracingTowerLayer::new(
+                &uri,
+                default_endpoint.to_string(),
+                instrumentation,
+            );
+            tower::util::Either::Left(tower::Layer::layer(&layer, channel))
+        } else {
+            let layer = crate::observability::grpc_tracing::NoTracingTowerLayer;
+            tower::util::Either::Right(tower::Layer::layer(&layer, channel))
         };
 
-        let inner_client = InnerClient::new(channel);
-        if tracing_enabled {
-            Ok((inner_client, Some(attrs)))
-        } else {
-            Ok((inner_client, None))
-        }
+        let inner_client = InnerClient::new(service);
+        Ok(inner_client)
     }
 
     async fn make_endpoint(
@@ -682,7 +563,6 @@ where
 }
 
 #[cfg(test)]
-#[cfg(google_cloud_unstable_tracing)]
 mod tests {
     use super::Client;
     use crate::options::InstrumentationClientInfo;

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -26,7 +26,6 @@ pub mod reqwest;
 
 use crate::as_inner::as_inner;
 use crate::attempt_info::AttemptInfo;
-#[cfg(google_cloud_unstable_tracing)]
 use crate::observability::{HttpResultExt, RequestRecorder, create_http_attempt_span};
 use google_cloud_auth::credentials::{
     Builder as CredentialsBuilder, CacheableResource, Credentials,
@@ -53,7 +52,6 @@ pub use http_request_builder::HttpRequestBuilder;
 use reqwest::Method;
 use std::sync::Arc;
 use std::time::Duration;
-#[cfg(google_cloud_unstable_tracing)]
 use tracing::Instrument;
 
 #[derive(Clone, Debug)]
@@ -69,7 +67,6 @@ pub struct ReqwestClient {
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
     instrumentation: Option<&'static crate::options::InstrumentationClientInfo>,
     _tracing_enabled: bool,
-    #[cfg(google_cloud_unstable_tracing)]
     transport_metric: Option<crate::observability::TransportMetric>,
 }
 
@@ -120,7 +117,6 @@ impl ReqwestClient {
                 .unwrap_or_else(|| Arc::new(ExponentialBackoff::default())),
             instrumentation: None,
             _tracing_enabled: tracing_enabled,
-            #[cfg(google_cloud_unstable_tracing)]
             transport_metric: None,
         })
     }
@@ -130,7 +126,6 @@ impl ReqwestClient {
         instrumentation: &'static crate::options::InstrumentationClientInfo,
     ) -> Self {
         self.instrumentation = Some(instrumentation);
-        #[cfg(google_cloud_unstable_tracing)]
         if self._tracing_enabled {
             self.transport_metric = Some(crate::observability::TransportMetric::new(Some(
                 instrumentation,
@@ -255,7 +250,6 @@ impl ReqwestClient {
         let request = self
             .request(builder, &options, attempt_info.remaining_time)
             .await?;
-        #[cfg(google_cloud_unstable_tracing)]
         if self._tracing_enabled {
             return self
                 .execute_http_traced(request, options, attempt_info)
@@ -264,7 +258,6 @@ impl ReqwestClient {
         self.execute_http_inner(request).await
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     async fn execute_http_traced(
         &self,
         request: reqwest::Request,
@@ -293,12 +286,10 @@ impl ReqwestClient {
         result.record_http(&span)
     }
 
-    #[cfg_attr(not(google_cloud_unstable_tracing), allow(unused_mut))]
     async fn execute_http_inner(&self, mut request: reqwest::Request) -> Result<reqwest::Response> {
         // We want to send the tracing propagation headers even if tracing is disabled in the
         // client. A global trace (say from the incoming HTTP request to Cloud Run) could be
         // propagated.
-        #[cfg(google_cloud_unstable_tracing)]
         crate::observability::propagation::inject_context(
             &tracing::Span::current(),
             request.headers_mut(),
@@ -415,7 +406,6 @@ impl ReqwestClient {
         _attempt_count: u32,
     ) -> Result<reqwest::Response> {
         let request = self.request(builder, options, remaining_time).await?;
-        #[cfg(google_cloud_unstable_tracing)]
         if self._tracing_enabled {
             return self
                 .request_attempt_traced(request, options, _attempt_count)
@@ -424,7 +414,6 @@ impl ReqwestClient {
         self.request_attempt_inner(request).await
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     async fn request_attempt_traced(
         &self,
         request: reqwest::Request,
@@ -446,7 +435,6 @@ impl ReqwestClient {
         crate::observability::WithTransportSpan::new(span, pending).await
     }
 
-    #[cfg_attr(not(google_cloud_unstable_tracing), allow(unused_mut))]
     async fn request_attempt_inner(
         &self,
         mut request: reqwest::Request,
@@ -454,13 +442,11 @@ impl ReqwestClient {
         // We want to send the tracing propagation headers even if tracing is disabled in the
         // client. A global trace (say from the incoming HTTP request to Cloud Run) could be
         // propagated.
-        #[cfg(google_cloud_unstable_tracing)]
         crate::observability::propagation::inject_context(
             &tracing::Span::current(),
             request.headers_mut(),
         );
         let result = self.inner.execute(request).await.map_err(map_send_error);
-        #[cfg(google_cloud_unstable_tracing)]
         if let Some(recorder) = RequestRecorder::current() {
             match &result {
                 Ok(r) => recorder.on_http_response(r),

--- a/src/gax-internal/src/observability.rs
+++ b/src/gax-internal/src/observability.rs
@@ -17,42 +17,31 @@
 //! This module and its sub-modules contain types and functions for emitting
 //! tracing spans and metrics.
 
-#[cfg(google_cloud_unstable_tracing)]
 pub(crate) mod propagation;
 
-#[cfg(google_cloud_unstable_tracing)]
 pub(crate) mod attributes;
 
-#[cfg(all(
-    google_cloud_unstable_tracing,
-    any(feature = "_internal-http-client", feature = "_internal-grpc-client")
-))]
+#[cfg(any(feature = "_internal-http-client", feature = "_internal-grpc-client"))]
 mod errors;
 
-#[cfg(all(google_cloud_unstable_tracing, feature = "_internal-http-client"))]
+#[cfg(feature = "_internal-http-client")]
 pub(crate) mod http_tracing;
 
-#[cfg(all(google_cloud_unstable_tracing, feature = "_internal-http-client"))]
+#[cfg(feature = "_internal-http-client")]
 pub(crate) use http_tracing::{ResultExt as HttpResultExt, create_http_attempt_span};
 
-#[cfg(all(google_cloud_unstable_tracing, feature = "_internal-grpc-client"))]
+#[cfg(feature = "_internal-grpc-client")]
 pub(crate) mod grpc_tracing;
 
-#[cfg(google_cloud_unstable_tracing)]
 mod client_signals;
 
-#[cfg(google_cloud_unstable_tracing)]
 pub use client_signals::{
     ClientRequestAttributes, DurationMetric, RequestRecorder, TransportMetric, WithClientLogging,
     WithClientMetric, WithClientSpan, WithTransportMetric,
 };
 
-#[cfg(all(
-    google_cloud_unstable_tracing,
-    any(feature = "_internal-http-client", feature = "_internal-grpc-client")
-))]
+#[cfg(feature = "_internal-http-client")]
 pub use client_signals::{WithTransportLogging, WithTransportSpan};
 
 #[doc(hidden)]
-#[cfg(google_cloud_unstable_tracing)]
 pub use attributes::{GCP_CLIENT_REPO_GOOGLEAPIS, SCHEMA_URL_VALUE};

--- a/src/gax-internal/src/observability/errors.rs
+++ b/src/gax-internal/src/observability/errors.rs
@@ -104,7 +104,6 @@ pub(crate) fn emit_error_log(span: &tracing::Span, err: &Error) {
     let rpc_status_code = err.status().map(|s| s.code.name());
     let http_status_code = err.http_status_code();
 
-    #[cfg(google_cloud_unstable_tracing)]
     {
         let (domain, metadata) = match &error_type {
             ErrorType::HttpError {
@@ -246,7 +245,6 @@ pub(crate) mod tests {
 
     #[test]
     fn test_emit_error_log() {
-        #[cfg(google_cloud_unstable_tracing)]
         {
             use std::sync::{Arc, Mutex};
             use tracing_subscriber::fmt::MakeWriter;

--- a/src/gax-internal/src/observability/grpc_tracing.rs
+++ b/src/gax-internal/src/observability/grpc_tracing.rs
@@ -37,6 +37,21 @@ impl AttemptCount {
     }
 }
 
+/// A wrapper for the resource name to be stored in request extensions.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct ResourceName(String);
+
+#[allow(dead_code)]
+impl ResourceName {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A type alias for the response body that can be either an instrumented body or a raw body.
 ///
 /// This allows us to return a single type from both the tracing and non-tracing paths
@@ -126,11 +141,16 @@ impl TracingTowerLayer {
             Some("http") => Some(80),
             _ => None,
         });
+        let extracted_domain = default_domain
+            .parse::<http::Uri>()
+            .ok()
+            .and_then(|u| u.host().map(|h| h.to_string()))
+            .unwrap_or(default_domain);
         Self {
             inner: Arc::new(TracingTowerLayerInner {
                 server_address: host,
                 server_port: port.map(|p| p as i64),
-                url_domain: default_domain,
+                url_domain: extracted_domain,
                 instrumentation,
             }),
         }
@@ -179,9 +199,15 @@ where
 
     fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
         let attempt_count = req.extensions().get::<AttemptCount>().map(|a| a.as_i64());
-        let resource_name = RequestRecorder::current()
-            .map(|r| r.client_snapshot())
-            .and_then(|s| s.resource_name().map(|n| n.to_string()));
+        let resource_name = req
+            .extensions()
+            .get::<ResourceName>()
+            .map(|r| r.as_str().to_string())
+            .or_else(|| {
+                RequestRecorder::current()
+                    .map(|r| r.client_snapshot())
+                    .and_then(|s| s.resource_name().map(|n| n.to_string()))
+            });
         let span = create_grpc_span(
             req.uri(),
             &self.layer.inner,

--- a/src/gax-internal/tests/grpc_observability.rs
+++ b/src/gax-internal/tests/grpc_observability.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "_internal-grpc-client", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
     use google_cloud_auth::credentials::Credentials;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -77,7 +77,7 @@ mod tests {
 
         Ok(())
     }
-    #[cfg(all(test, google_cloud_unstable_tracing, feature = "_internal-http-client"))]
+    #[cfg(all(test, feature = "_internal-http-client"))]
     mod tracing_tests {
         use super::*;
         use google_cloud_test_utils::test_layer::TestLayer;

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "_internal-http-client", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "_internal-http-client"))]
 mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::Result;

--- a/src/gax-internal/tests/http_retry_loop.rs
+++ b/src/gax-internal/tests/http_retry_loop.rs
@@ -31,7 +31,6 @@ mod tests {
     use google_cloud_gax_internal::options::ClientConfig;
     use http::StatusCode;
     use httptest::{Expectation, Server, matchers::*, responders::*};
-    #[cfg(google_cloud_unstable_tracing)]
     use opentelemetry_semantic_conventions::attribute::{
         HTTP_REQUEST_RESEND_COUNT, HTTP_RESPONSE_STATUS_CODE, OTEL_STATUS_CODE,
         OTEL_STATUS_DESCRIPTION,
@@ -39,7 +38,6 @@ mod tests {
     use serde_json::json;
     use std::time::Duration;
 
-    #[cfg(google_cloud_unstable_tracing)]
     use google_cloud_test_utils::test_layer::TestLayer;
 
     type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
@@ -114,7 +112,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn retry_loop_retry_success_with_tracing_on() -> Result<()> {
         let guard = TestLayer::initialize();

--- a/src/gax-internal/tests/http_timeout.rs
+++ b/src/gax-internal/tests/http_timeout.rs
@@ -226,7 +226,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(all(test, google_cloud_unstable_tracing, feature = "_internal-http-client"))]
+    #[cfg(all(test, feature = "_internal-http-client"))]
     mod tracing_tests {
         use super::*;
         use google_cloud_test_utils::test_layer::TestLayer;

--- a/src/storage/benchmarks/w1r3/src/main.rs
+++ b/src/storage/benchmarks/w1r3/src/main.rs
@@ -684,7 +684,6 @@ async fn enable_tracing(
 
     let registry = tracing_subscriber::Registry::default().with(fmt_layer);
 
-    #[cfg(google_cloud_unstable_tracing)]
     if let Some(project_id) = &_args.project_id {
         let tracer_provider =
             integration_tests_o11y::otlp::trace::Builder::new(project_id, "storage-w1r3")
@@ -772,7 +771,6 @@ struct Args {
     ///
     /// When set, enables OpenTelemetry export to Cloud Trace via
     /// telemetry.googleapis.com.
-    #[cfg(google_cloud_unstable_tracing)]
     #[arg(long)]
     project_id: Option<String>,
 }

--- a/src/storage/src/object_descriptor.rs
+++ b/src/storage/src/object_descriptor.rs
@@ -147,7 +147,6 @@ impl ObjectDescriptor {
         }
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     pub(crate) fn into_parts(self) -> Arc<dyn ObjectDescriptorStub> {
         self.inner
     }

--- a/src/storage/src/read_object.rs
+++ b/src/storage/src/read_object.rs
@@ -37,7 +37,6 @@ impl ReadObjectResponse {
         Self { inner }
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     pub(crate) fn into_parts(self) -> Box<dyn dynamic::ReadObjectResponse + Send + 'static> {
         self.inner
     }

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -23,7 +23,6 @@ pub mod request_options;
 pub(crate) mod signed_url;
 pub mod streaming_source;
 pub mod stub;
-#[cfg(google_cloud_unstable_tracing)]
 pub(crate) mod tracing;
 pub(crate) mod transport;
 pub(crate) mod v1;
@@ -50,7 +49,6 @@ pub(crate) mod info {
         ac.grpc_header_value()
     });
 
-    #[cfg(google_cloud_unstable_tracing)]
     pub(crate) static INSTRUMENTATION: LazyLock<gaxi::options::InstrumentationClientInfo> =
         LazyLock::new(|| {
             let mut info = gaxi::options::InstrumentationClientInfo::default();

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -310,13 +310,11 @@ impl StorageInner {
         config.disable_follow_redirects = true;
 
         let client = gaxi::http::ReqwestClient::new(config.clone(), super::DEFAULT_HOST).await?;
-        #[cfg(google_cloud_unstable_tracing)]
         let client = if gaxi::options::tracing_enabled(&config) {
             client.with_instrumentation(&super::info::INSTRUMENTATION)
         } else {
             client
         };
-        #[cfg(google_cloud_unstable_tracing)]
         let grpc = if gaxi::options::tracing_enabled(&config) {
             gaxi::grpc::Client::new_with_instrumentation(
                 config,
@@ -327,8 +325,6 @@ impl StorageInner {
         } else {
             gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?
         };
-        #[cfg(not(google_cloud_unstable_tracing))]
-        let grpc = gaxi::grpc::Client::new(config, super::DEFAULT_HOST).await?;
 
         let inner = StorageInner::new(client, options, grpc);
         Ok(inner)

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(google_cloud_unstable_tracing)]
 use super::tracing::{TracingObjectDescriptor, TracingResponse};
 use crate::Result;
 use crate::model::{Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
-#[cfg(google_cloud_unstable_tracing)]
 use crate::storage::info::INSTRUMENTATION;
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;
@@ -29,7 +27,6 @@ use crate::{
     model_ext::OpenObjectRequest, object_descriptor::ObjectDescriptor,
     storage::bidi::connector::Connector, storage::bidi::transport::ObjectDescriptorTransport,
 };
-#[cfg(google_cloud_unstable_tracing)]
 use gaxi::observability::{ClientRequestAttributes, DurationMetric, RequestRecorder};
 use std::sync::Arc;
 
@@ -52,7 +49,6 @@ use std::sync::Arc;
 pub struct Storage {
     inner: Arc<StorageInner>,
     tracing: bool,
-    #[cfg(google_cloud_unstable_tracing)]
     metric: DurationMetric,
 }
 
@@ -62,7 +58,6 @@ impl Storage {
         Self::new(inner, false)
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     pub(crate) fn new(inner: Arc<StorageInner>, tracing: bool) -> Arc<Self> {
         let metric = DurationMetric::new(&INSTRUMENTATION);
         Arc::new(Self {
@@ -70,11 +65,6 @@ impl Storage {
             tracing,
             metric,
         })
-    }
-
-    #[cfg(not(google_cloud_unstable_tracing))]
-    pub(crate) fn new(inner: Arc<StorageInner>, tracing: bool) -> Arc<Self> {
-        Arc::new(Self { inner, tracing })
     }
 
     async fn read_object_plain(
@@ -96,31 +86,26 @@ impl Storage {
         request: ReadObjectRequest,
         options: RequestOptions,
     ) -> Result<ReadObjectResponse> {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
-            let (span, pending) = gaxi::client_request_signals!(
-            metric: self.metric.clone(),
-            info: *INSTRUMENTATION,
-            method: "client::Storage::read_object",
-            async {
-                if let Some(recorder) = RequestRecorder::current() {
-                    recorder.on_client_request(
-                        ClientRequestAttributes::default()
-                            .set_rpc_method("google.storage.v2.Storage/ReadObject")
-                            .set_url_template("/storage/v1/b/{bucket}/o/{object}")
-                            .set_resource_name(resource_name),
-                    );
-                }
-                self.read_object_plain(request, options).await
-            });
+        let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
+        let (span, pending) = gaxi::client_request_signals!(
+        metric: self.metric.clone(),
+        info: *INSTRUMENTATION,
+        method: "client::Storage::read_object",
+        async {
+            if let Some(recorder) = RequestRecorder::current() {
+                recorder.on_client_request(
+                    ClientRequestAttributes::default()
+                        .set_rpc_method("google.storage.v2.Storage/ReadObject")
+                        .set_url_template("/storage/v1/b/{bucket}/o/{object}")
+                        .set_resource_name(resource_name),
+                );
+            }
+            self.read_object_plain(request, options).await
+        });
 
-            let response = pending.await?;
-            let inner = TracingResponse::new(response.into_parts(), span);
-            Ok(ReadObjectResponse::new(Box::new(inner)))
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        self.read_object_plain(request, options).await
+        let response = pending.await?;
+        let inner = TracingResponse::new(response.into_parts(), span);
+        Ok(ReadObjectResponse::new(Box::new(inner)))
     }
 
     async fn write_object_buffered_plain<P>(
@@ -153,38 +138,32 @@ impl Storage {
     where
         P: StreamingSource + Send + Sync + 'static,
     {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let resource_name = format!(
-                "//storage.googleapis.com/{}",
-                request
-                    .spec
-                    .resource
-                    .as_ref()
-                    .map(|r| r.bucket.as_str())
-                    .unwrap_or_default()
-            );
-            let (_span, pending) = gaxi::client_request_signals!(
-                metric: self.metric.clone(),
-                info: *INSTRUMENTATION,
-                method: "client::Storage::write_object",
-                async {
-                    if let Some(recorder) = RequestRecorder::current() {
-                        recorder.on_client_request(
-                            ClientRequestAttributes::default()
-                                .set_rpc_method("google.storage.v2.Storage/WriteObject")
-                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
-                                .set_resource_name(resource_name),
-                        );
-                    }
-                    self.write_object_buffered_plain(payload, request, options).await
+        let resource_name = format!(
+            "//storage.googleapis.com/{}",
+            request
+                .spec
+                .resource
+                .as_ref()
+                .map(|r| r.bucket.as_str())
+                .unwrap_or_default()
+        );
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::write_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_rpc_method("google.storage.v2.Storage/WriteObject")
+                            .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                            .set_resource_name(resource_name),
+                    );
                 }
-            );
-            pending.await
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        self.write_object_buffered_plain(payload, request, options)
-            .await
+                self.write_object_buffered_plain(payload, request, options).await
+            }
+        );
+        pending.await
     }
 
     async fn write_object_unbuffered_plain<P>(
@@ -217,38 +196,32 @@ impl Storage {
     where
         P: StreamingSource + Seek + Send + Sync + 'static,
     {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let resource_name = format!(
-                "//storage.googleapis.com/{}",
-                request
-                    .spec
-                    .resource
-                    .as_ref()
-                    .map(|r| r.bucket.as_str())
-                    .unwrap_or_default()
-            );
-            let (_span, pending) = gaxi::client_request_signals!(
-                metric: self.metric.clone(),
-                info: *INSTRUMENTATION,
-                method: "client::Storage::write_object",
-                async {
-                    if let Some(recorder) = RequestRecorder::current() {
-                        recorder.on_client_request(
-                            ClientRequestAttributes::default()
-                                .set_rpc_method("google.storage.v2.Storage/WriteObject")
-                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
-                                .set_resource_name(resource_name),
-                        );
-                    }
-                    self.write_object_unbuffered_plain(payload, request, options).await
+        let resource_name = format!(
+            "//storage.googleapis.com/{}",
+            request
+                .spec
+                .resource
+                .as_ref()
+                .map(|r| r.bucket.as_str())
+                .unwrap_or_default()
+        );
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::write_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_rpc_method("google.storage.v2.Storage/WriteObject")
+                            .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                            .set_resource_name(resource_name),
+                    );
                 }
-            );
-            pending.await
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        self.write_object_unbuffered_plain(payload, request, options)
-            .await
+                self.write_object_unbuffered_plain(payload, request, options).await
+            }
+        );
+        pending.await
     }
 
     async fn open_object_plain(
@@ -268,39 +241,34 @@ impl Storage {
         request: OpenObjectRequest,
         options: RequestOptions,
     ) -> Result<(ObjectDescriptor, Vec<ReadObjectResponse>)> {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
-            let (span, pending) = gaxi::client_request_signals!(
-                metric: self.metric.clone(),
-                info: *INSTRUMENTATION,
-                method: "client::Storage::open_object",
-                async {
-                    if let Some(recorder) = RequestRecorder::current() {
-                        recorder.on_client_request(
-                            ClientRequestAttributes::default()
-                                .set_rpc_method("google.storage.v2.Storage/BidiStreamingRead")
-                                .set_url_template("/upload/storage/v1/b/{bucket}/o")
-                                .set_resource_name(resource_name),
-                        );
-                    }
-                    self.open_object_plain(request, options).await
+        let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
+        let (span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::open_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_rpc_method("google.storage.v2.Storage/BidiStreamingRead")
+                            .set_url_template("/upload/storage/v1/b/{bucket}/o")
+                            .set_resource_name(resource_name),
+                    );
                 }
-            );
-            let (descriptor, readers) = pending.await?;
-            let descriptor =
-                ObjectDescriptor::new(TracingObjectDescriptor::new(descriptor.into_parts()));
-            let readers = readers
-                .into_iter()
-                .map(|r| {
-                    let inner = r.into_parts();
-                    ReadObjectResponse::new(Box::new(TracingResponse::new(inner, span.clone())))
-                })
-                .collect::<Vec<_>>();
-            Ok((descriptor, readers))
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        self.open_object_plain(request, options).await
+                self.open_object_plain(request, options).await
+            }
+        );
+        let (descriptor, readers) = pending.await?;
+        let descriptor =
+            ObjectDescriptor::new(TracingObjectDescriptor::new(descriptor.into_parts()));
+        let readers = readers
+            .into_iter()
+            .map(|r| {
+                let inner = r.into_parts();
+                ReadObjectResponse::new(Box::new(TracingResponse::new(inner, span.clone())))
+            })
+            .collect::<Vec<_>>();
+        Ok((descriptor, readers))
     }
 }
 
@@ -370,11 +338,9 @@ impl super::stub::Storage for Storage {
 #[cfg(test)]
 mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-    #[cfg(google_cloud_unstable_tracing)]
     use google_cloud_test_utils::test_layer::AttributeValue;
     use google_cloud_test_utils::test_layer::{CapturedSpan, TestLayer};
     use httptest::{Expectation, Server, matchers::*, responders::status_code};
-    #[cfg(google_cloud_unstable_tracing)]
     use pretty_assertions::assert_eq;
     use std::collections::BTreeMap;
 
@@ -409,13 +375,11 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         check_debug_log(&captured, "read_object");
 
-        #[cfg(google_cloud_unstable_tracing)]
         client_request_span(&captured, "read_object", "404", "http");
 
         Ok(())
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test]
     async fn read_object_success() -> anyhow::Result<()> {
         let guard = TestLayer::initialize();
@@ -496,7 +460,6 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         check_debug_log(&captured, "write_object_buffered");
 
-        #[cfg(google_cloud_unstable_tracing)]
         client_request_span(&captured, "write_object", "404", "http");
 
         Ok(())
@@ -533,7 +496,6 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         check_debug_log(&captured, "write_object_unbuffered");
 
-        #[cfg(google_cloud_unstable_tracing)]
         client_request_span(&captured, "write_object", "404", "http");
 
         Ok(())
@@ -570,12 +532,10 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         check_debug_log(&captured, "open_object");
 
-        #[cfg(google_cloud_unstable_tracing)]
         client_request_span(&captured, "open_object", "NOT_FOUND", "grpc");
         Ok(())
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test]
     #[ignore = "flaky test, see #5290"]
     async fn open_object_success() -> anyhow::Result<()> {
@@ -717,7 +677,6 @@ mod tests {
         );
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[track_caller]
     fn client_request_span(
         captured: &Vec<CapturedSpan>,

--- a/tests/o11y/src/lib.rs
+++ b/tests/o11y/src/lib.rs
@@ -18,11 +18,7 @@ pub mod mock_collector;
 pub mod otlp;
 pub mod tracing;
 
-#[cfg(google_cloud_unstable_tracing)]
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-#[cfg(google_cloud_unstable_tracing)]
 pub mod e2e;
-#[cfg(google_cloud_unstable_tracing)]
 pub mod http_tracing;
-#[cfg(google_cloud_unstable_tracing)]
 pub mod storage_tracing;

--- a/tests/o11y/tests/http_tracing.rs
+++ b/tests/o11y/tests/http_tracing.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(google_cloud_unstable_tracing)]
 mod http_tracing {
     use google_cloud_test_utils::errors::anydump;
     use serial_test::serial;

--- a/tests/o11y/tests/metrics.rs
+++ b/tests/o11y/tests/metrics.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "run-integration-tests", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "run-integration-tests"))]
 mod metrics {
     use google_cloud_test_utils::errors::anydump;
 

--- a/tests/o11y/tests/signals.rs
+++ b/tests/o11y/tests/signals.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "run-integration-tests", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "run-integration-tests"))]
 mod signals {
     #[tokio::test(flavor = "multi_thread")]
     async fn run() -> anyhow::Result<()> {

--- a/tests/o11y/tests/storage.rs
+++ b/tests/o11y/tests/storage.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "run-integration-tests", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "run-integration-tests"))]
 mod storage {
     use google_cloud_test_utils::errors::anydump;
 

--- a/tests/o11y/tests/storage_grpc_tracing.rs
+++ b/tests/o11y/tests/storage_grpc_tracing.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![cfg(google_cloud_unstable_tracing)]
-
 use gaxi::observability::RequestRecorder;
 use gaxi::options::InstrumentationClientInfo;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;

--- a/tests/o11y/tests/storage_tracing.rs
+++ b/tests/o11y/tests/storage_tracing.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(google_cloud_unstable_tracing)]
 mod storage_tracing {
     use google_cloud_test_utils::errors::anydump;
 

--- a/tests/o11y/tests/telemetry.rs
+++ b/tests/o11y/tests/telemetry.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(test, feature = "run-integration-tests", google_cloud_unstable_tracing))]
+#[cfg(all(test, feature = "run-integration-tests"))]
 mod telemetry {
     use google_cloud_test_utils::errors::anydump;
 


### PR DESCRIPTION
Remove `google_cloud_unstable_tracing` feature guards from handwritten code (`src/gax-internal/`, `src/storage/`, and `tests`), making observability features unconditionally available.

This PR is the first step in resolving a cross-repository dependency involving the code generator (`librarian/sidekick`) https://github.com/googleapis/librarian/issues/5343:
Since we updated the generator to produce code without guards before removing the guards manually in `gax-internal`, the resulting generated code failed compilation checks because it attempted to use features that are still feature-gated in the library.

---

Correct Steps:
Manual removal in Rust (This PR).
Librarian change to remove guard generation https://github.com/googleapis/librarian/pull/5103.
Regeneration PR in Rust https://github.com/googleapis/google-cloud-rust/pull/5292.

Note: We also kept `cfg(google_cloud_unstable_tracing)` in Cargo.toml for now, so that the existing generated code still in the repo doesn't fail the `unexpected_cfgs` lint. This should be removed in the regeneration PR for `google-cloud-rust`.

---

Fixes https://github.com/googleapis/librarian/issues/5343