### PR TITLE
chore: add more tool deps to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -36,6 +36,10 @@ release:
     - .repo-metadata.json
   tools:
     cargo:
+      - name: cargo-hack
+        version: 0.6.44
+      - name: cargo-minimal-versions
+        version: 0.1.37
       - name: cargo-semver-checks
         version: 0.46.0
       - name: cargo-workspaces


### PR DESCRIPTION
Adds missing necessary `cargo` dependencies to `tools.cargo` section.

Picked latest versions as of opening this PR.