### PR TITLE
test(gax-internal): stabilize o11y tests

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -141,11 +141,11 @@ mod tests {
     use opentelemetry::{InstrumentationScope, KeyValue};
     use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
     use opentelemetry_sdk::logs::{
-        BatchLogProcessor, InMemoryLogExporter, SdkLogRecord, SdkLoggerProvider,
+        InMemoryLogExporter, SdkLogRecord, SdkLoggerProvider, SimpleLogProcessor,
     };
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
-    use opentelemetry_sdk::trace::{BatchSpanProcessor, InMemorySpanExporter, SdkTracerProvider};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SimpleSpanProcessor};
     use pretty_assertions::assert_eq;
     use std::collections::BTreeSet;
     use std::sync::Arc;
@@ -506,8 +506,9 @@ mod tests {
     }
 
     #[cfg(feature = "_internal-grpc-client")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn grpc_client_request() -> anyhow::Result<()> {
+        tokio::time::pause();
         let (endpoint, _server) = grpc_server::start_echo_server().await?;
         let signals = SignalProviders::new();
 
@@ -599,8 +600,9 @@ mod tests {
     }
 
     #[cfg(feature = "_internal-grpc-client")]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test]
     async fn grpc_client_request_retry() -> anyhow::Result<()> {
+        tokio::time::pause();
         let (endpoint, _server) = grpc_server::start_fixed_responses(vec![
             Err(tonic::Status::unavailable("try again")),
             Ok(tonic::Response::new(EchoResponse {
@@ -761,14 +763,14 @@ mod tests {
             // We need a tracing exporter and provider or the traces get no trace ids.
             let trace_exporter = InMemorySpanExporter::default();
             let trace_provider = SdkTracerProvider::builder()
-                .with_span_processor(BatchSpanProcessor::builder(trace_exporter.clone()).build())
+                .with_span_processor(SimpleSpanProcessor::new(trace_exporter.clone()))
                 .build();
 
             // We also need a logging exporter to capture the `tracing::event!()` logs
             // as they are forwarded to OpenTelemetry logs.
             let logs_exporter = InMemoryLogExporter::default();
             let logs_provider = SdkLoggerProvider::builder()
-                .with_log_processor(BatchLogProcessor::builder(logs_exporter.clone()).build())
+                .with_log_processor(SimpleLogProcessor::new(logs_exporter.clone()))
                 .build();
             // Using a per-thread guard is Okay because all the tests in this module are single-threaded.
             let guard = tracing::subscriber::set_default(


### PR DESCRIPTION
We need to stop `gax-internal` observability tests from hanging in ci due to real-time delays and background processing threads that cause flakes.

This PR:
- Turns on virtual time: we add `tokio::time::pause()` to both `grpc_client_request` and `grpc_client_request_retry`. They now use the default `current_thread` runtime and skip simulated sleeps instantly.
- Removes background threads: we switch `SignalProviders::new` from batch processors to `SimpleSpanProcessor` and `SimpleLogProcessor`. This hands off telemetry data without background worker threads.

I couldn't reproduce the CI hangs on my machine. My local `nextest` setup was skipping tests, and I guess there is a difference in the number of cores.

Note: A few other tests still timed out in ci even though they already use time pausing. This may mean there is another issue under heavy load (probably mock servers) that we might need to look at later if the flakes continue.

Fixes https://github.com/googleapis/google-cloud-rust/issues/5397