### PR TITLE
cleanup(storage): update rust storage module template to storage

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1549,7 +1549,7 @@ libraries:
           output: src/storage/src/control/generated
           specification_format: none
           api_path: google/storage/v2
-          template: prost
+          template: storage
   - name: google-cloud-storagebatchoperations-v1
     version: 1.9.0
     copyright_year: "2025"


### PR DESCRIPTION
Librarian, https://github.com/googleapis/librarian/pull/5368, will
be updated to use template from rust module to generate
the storage module, rather than a custom "rust_storage" language.

Will follow up to remove language from rust modules, since its implied
by being in rust module.
