### PR TITLE
refactor: top-level tools section (from release.tools) for cargo tools

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -31,19 +31,19 @@ sources:
   showcase:
     commit: 3fd9cb2f682d5f8263d913eaba8b78e045acc4d2
     sha256: ed1e698886cb4ab9b90ca98cfee38023d813e9729fca7297578c81c4af3e1e9e
+tools:
+  cargo:
+    - name: cargo-hack
+      version: 0.6.44
+    - name: cargo-minimal-versions
+      version: 0.1.37
+    - name: cargo-semver-checks
+      version: 0.46.0
+    - name: cargo-workspaces
+      version: 0.4.0
 release:
   ignored_changes:
     - .repo-metadata.json
-  tools:
-    cargo:
-      - name: cargo-hack
-        version: 0.6.44
-      - name: cargo-minimal-versions
-        version: 0.1.37
-      - name: cargo-semver-checks
-        version: 0.46.0
-      - name: cargo-workspaces
-        version: 0.4.0
 default:
   output: src/generated/
   rust:


### PR DESCRIPTION
As per the survey, Rust is the only language that uses `release.tools` field. Julie implemented the top-level `tools.cargo` field in librarian.yaml (https://github.com/googleapis/librarian/pull/5207). Let's use the field in google-cloud-rust.

Fixes https://github.com/googleapis/librarian/issues/5159

## Confirmation

### Librarian publish

e3c0870ef6d40eacf6ee050e806445d0d0921b97 is the commit for the last release (https://github.com/googleapis/google-cloud-rust/commit/e3c0870ef6d40eacf6ee050e806445d0d0921b97).

Setting up "upstream" remote:

```
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ git remote -v
upstream        https://github.com/suztomo/google-cloud-rust.git (fetch)
upstream        https://github.com/suztomo/google-cloud-rust.git (push)
upstream-bkup   https://github.com/googleapis/google-cloud-rust (fetch)
upstream-bkup   https://github.com/googleapis/google-cloud-rust (push)
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ git push -f upstream e3c0870ef6d40eacf6ee050e806445d0d0921b97:main
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
To https://github.com/suztomo/google-cloud-rust.git
   e10ef50a7..e3c0870ef  e3c0870ef6d40eacf6ee050e806445d0d0921b97 -> main
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ git log -1
commit e3c0870ef6d40eacf6ee050e806445d0d0921b97 (HEAD -> last-release, upstream/main)
Author: Joe Wang <106995533+JoeWang1127@users.noreply.github.com>
Date:   Wed Mar 25 18:00:20 2026 -0400

    chore: bump library versions 2025-03-25 (#5142)
```

I ran "librarian publish --dry-run"

```
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ librarian publish --dry-run
2026/04/14 16:51:01 librarian: google-cloud-dataplex-v1: semver check failed: /usr/local/google/home/suztomo/.cargo/bin/cargo semver-checks --all-features -p google-cloud-dataplex-v1:     Building google-cloud-dataplex-v1 v1.9.0 (current)
       Built [  66.017s] (current)
     Parsing google-cloud-dataplex-v1 v1.9.0 (current)
      Parsed [   0.317s] (current)
    Building google-cloud-dataplex-v1 v1.8.0 (baseline)
       Built [  53.794s] (baseline)
     Parsing google-cloud-dataplex-v1 v1.8.0 (baseline)
      Parsed [   0.491s] (baseline)
    Checking google-cloud-dataplex-v1 v1.8.0 -> v1.9.0 (minor change)
     Checked [   0.207s] 196 checks: 191 pass, 5 fail, 0 warn, 49 skip

     Summary semver requires new major version: 5 major and 0 minor checks failed
    Finished [ 126.381s] google-cloud-dataplex-v1
: exit status 1
```

I think this means it ran cargo command correctly.

### Librarian bump

`librarian bump -all` continues to work. (It's not using `release.tools.cargo`)

```
suztomo@suztomo:~/librarian-2026/google-cloud-rust-target$  librarian bump -all
suztomo@suztomo:~/librarian-2026/google-cloud-rust-target$ librarian publish --dry-run
2026/04/14 15:28:32 librarian: the local repository does not match its branch point from upstream/main, change files:
librarian.yaml
suztomo@suztomo:~/librarian-2026/google-cloud-rust-target$ git diff
diff --git a/librarian.yaml b/librarian.yaml
index 8efed48c2..16dfae24e 100644
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1545,8 +1545,7 @@ libraries:
         - output: src/storage/src/generated/protos/storage
           api_path: google/storage/v2
           template: prost
-        - language: rust_storage
-          output: src/storage/src/control/generated
+        - output: src/storage/src/control/generated
           specification_format: none
           api_path: google/storage/v2
           template: storage```
```

(This is showing the rust_storage diff for recent change in Librarian https://github.com/googleapis/librarian/commit/dab13c8548cc08007f957497e6f26cf306fd52a0)