### PR TITLE
impl(pubsub): process confirm_ack remaining ids after final attempt

### DIFF
--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -18,7 +18,6 @@ use super::stub::Stub;
 use crate::RequestOptions;
 use crate::error::AckError;
 use crate::model::{AcknowledgeRequest, ModifyAckDeadlineRequest};
-use crate::{Response, Result};
 use google_cloud_gax::error::rpc::StatusDetails;
 use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 use google_cloud_gax::retry_loop_internal::retry_loop;
@@ -145,24 +144,50 @@ where
     /// keep the retry logic in the leaser, while allowing for partial results
     /// to be reported before the entire operation completes.
     async fn confirmed_ack(&self, ack_ids: Vec<String>) {
-        let leaser = self.clone();
-        let mut remaining_ids = ack_ids;
+        // TODO(#5408): Investigate solutions that avoid using Arc/Mutex.
+        let remaining_ids = Arc::new(Mutex::new(ack_ids));
+        let last_error = Arc::new(Mutex::new(None));
 
-        let attempt = async move |_| {
-            let ids = std::mem::take(&mut remaining_ids);
-            let req = AcknowledgeRequest::new()
-                .set_subscription(leaser.subscription.clone())
-                .set_ack_ids(ids.clone());
-            let response = leaser.inner.acknowledge(req, leaser.options.clone()).await;
+        let attempt = {
+            let remaining_ids = remaining_ids.clone();
+            let last_error = last_error.clone();
+            let leaser = self.clone();
+            async move |_| {
+                let ids = {
+                    let mut ids_guard = remaining_ids.lock().expect("mutex should not be poisoned");
+                    std::mem::take(&mut *ids_guard)
+                };
 
-            let (to_confirm, remaining) = process_ack_attempt(ids, response);
-            let _ = leaser.confirmed_tx.send(to_confirm);
-            if remaining.is_empty() {
-                Ok(())
-            } else {
-                remaining_ids = remaining;
-                // Return a synthetic error to indicate that we should retry.
-                Err(crate::Error::timeout("retry me"))
+                let req = AcknowledgeRequest::new()
+                    .set_subscription(leaser.subscription.clone())
+                    .set_ack_ids(ids.clone());
+                let response = leaser.inner.acknowledge(req, leaser.options.clone()).await;
+
+                let (to_confirm, remaining) = match response {
+                    Ok(_) => (ids.into_iter().map(|id| (id, Ok(()))).collect(), Vec::new()),
+                    Err(e) => {
+                        let shared_err = Arc::new(e);
+                        let (to_confirm, remaining) =
+                            process_ack_attempt_error(ids, shared_err.clone());
+
+                        if !remaining.is_empty() {
+                            let mut err_guard =
+                                last_error.lock().expect("mutex should not be poisoned");
+                            *err_guard = Some(shared_err);
+                        }
+
+                        (to_confirm, remaining)
+                    }
+                };
+                let _ = leaser.confirmed_tx.send(to_confirm);
+                if remaining.is_empty() {
+                    Ok(())
+                } else {
+                    let mut ids_guard = remaining_ids.lock().expect("mutex should not be poisoned");
+                    *ids_guard = remaining;
+                    // Return a synthetic error to indicate that we should retry.
+                    Err(crate::Error::timeout("retry me"))
+                }
             }
         };
 
@@ -176,8 +201,27 @@ where
             backoff_policy(),
         )
         .await;
-        // TODO(#4804): Process the transient error after the final attempt to
-        // propagate it back to the application.
+
+        let final_remaining =
+            std::mem::take(&mut *remaining_ids.lock().expect("mutex should not be poisoned"));
+        if !final_remaining.is_empty() {
+            let err =
+                std::mem::take(&mut *last_error.lock().expect("mutex should not be poisoned"));
+            if let Some(shared_err) = err {
+                let confirmed_acks = final_remaining
+                    .into_iter()
+                    .map(|id| {
+                        (
+                            id,
+                            Err(AckError::Rpc {
+                                source: shared_err.clone(),
+                            }),
+                        )
+                    })
+                    .collect();
+                let _ = self.confirmed_tx.send(confirmed_acks);
+            }
+        }
     }
 
     async fn confirmed_nack(&self, ack_ids: Vec<String>) {
@@ -206,8 +250,6 @@ where
 }
 
 fn retry_policy() -> Arc<NeverRetry> {
-    // TODO(#4804): Update the retry_policy to retry for the following error
-    // codes: [DeadlineExceeded, ResourceExhausted, Aborted, Internal, Unavailable].
     Arc::new(NeverRetry)
 }
 
@@ -226,23 +268,18 @@ fn retry_throttler(
     })
 }
 
-fn process_ack_attempt(
+fn process_ack_attempt_error(
     ack_ids: Vec<String>,
-    response: Result<Response<()>>,
+    shared_err: Arc<crate::Error>,
 ) -> (HashMap<String, AckResult>, Vec<String>) {
-    let e = match response {
-        Ok(_) => {
-            let to_confirm = ack_ids.into_iter().map(|id| (id, Ok(()))).collect();
-            return (to_confirm, Vec::new());
-        }
-        Err(e) => e,
-    };
+    // TODO(#4804): For the following error codes:
+    // [DeadlineExceeded, ResourceExhausted, Aborted, Internal, Unavailable],
+    // retry the entire RPC.
 
-    let (transient_failures, permanent_failures) = extract_failures(&e);
-    let shared_err = Arc::new(e);
+    let (transient_failures, permanent_failures) = extract_failures(&shared_err);
 
-    // If the response lacks specific per ack_id failure info, we treat the response as all sharing the same
-    // RPC error.
+    // If the response lacks specific per ack_id failure info, we treat the
+    // response as all sharing the same RPC error.
     if transient_failures.is_empty() && permanent_failures.is_empty() {
         let to_confirm = ack_ids
             .into_iter()
@@ -307,7 +344,7 @@ pub(super) mod tests {
     use super::super::retry_policy::tests::verify_policies;
     use super::super::stub::tests::MockStub;
     use super::*;
-    use crate::{Error, Response};
+    use crate::{Error, Response, Result};
     use google_cloud_gax::error::rpc::{Code, Status};
     use google_cloud_rpc::model::ErrorInfo;
     use tokio::sync::Mutex;
@@ -611,26 +648,90 @@ pub(super) mod tests {
     }
 
     #[tokio::test]
-    async fn process_ack_attempt_success() -> anyhow::Result<()> {
-        let response = Ok(Response::from(()));
-        let (confirmed_acks, remaining) = process_ack_attempt(test_ids(1..3), response);
+    async fn confirmed_ack_partial_transient_failure() -> anyhow::Result<()> {
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let mut mock = MockStub::new();
 
-        assert!(remaining.is_empty(), "{remaining:?}");
+        let info = ErrorInfo::new().set_metadata([(test_id(1), "TRANSIENT_FAILURE_OTHER")]);
+        let err = response_with_error_info(vec![info.clone()]).unwrap_err();
 
-        let expected = test_ids(1..3).into_iter().map(|id| (id, Ok(()))).collect();
+        mock.expect_acknowledge()
+            .times(1)
+            .return_once(move |r, _o| {
+                assert_eq!(sorted(&r.ack_ids), test_ids(1..3));
+                Err(err)
+            });
+
+        let leaser = DefaultLeaser::new(
+            Arc::new(mock),
+            confirmed_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+        );
+        leaser.confirmed_ack(test_ids(1..3)).await;
+
+        let confirmed_acks = confirmed_rx.recv().await.expect("results were not sent");
+        let expected = [(test_id(2), Ok(()))].into_iter().collect();
+        assert_eq!(confirmed_acks, expected);
+
+        let confirmed_acks_final = confirmed_rx.recv().await.expect("results were not sent");
+        let err = AckError::Rpc {
+            source: Arc::new(response_with_error_info(vec![info]).unwrap_err()),
+        };
+        let expected_final = [(test_id(1), Err(err))].into_iter().collect();
+        assert_eq!(confirmed_acks_final, expected_final);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn confirmed_ack_partial_permanent_failure() -> anyhow::Result<()> {
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let mut mock = MockStub::new();
+
+        let info =
+            ErrorInfo::new().set_metadata([(test_id(1), "PERMANENT_FAILURE_INVALID_ACK_ID")]);
+        let err = response_with_error_info(vec![info.clone()]).unwrap_err();
+
+        mock.expect_acknowledge()
+            .times(1)
+            .return_once(move |r, _o| {
+                assert_eq!(sorted(&r.ack_ids), test_ids(1..3));
+                Err(err)
+            });
+
+        let leaser = DefaultLeaser::new(
+            Arc::new(mock),
+            confirmed_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+        );
+        leaser.confirmed_ack(test_ids(1..3)).await;
+
+        let confirmed_acks = confirmed_rx.recv().await.expect("results were not sent");
+
+        let err = AckError::Rpc {
+            source: Arc::new(response_with_error_info(vec![info]).unwrap_err()),
+        };
+        let expected = [(test_id(1), Err(err)), (test_id(2), Ok(()))]
+            .into_iter()
+            .collect();
         assert_eq!(confirmed_acks, expected);
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn process_ack_attempt_failure_no_error_info() -> anyhow::Result<()> {
-        let response = Err(Error::service(
+    async fn process_ack_attempt_error_without_error_info() -> anyhow::Result<()> {
+        let err_val = Arc::new(Error::service(
             Status::default()
                 .set_code(Code::Internal)
                 .set_message("internal error"),
         ));
-        let (confirmed_acks, remaining) = process_ack_attempt(test_ids(1..3), response);
+        let (confirmed_acks, remaining) =
+            process_ack_attempt_error(test_ids(1..3), err_val.clone());
 
         assert!(remaining.is_empty(), "{remaining:?}");
 
@@ -653,12 +754,13 @@ pub(super) mod tests {
     }
 
     #[tokio::test]
-    async fn process_ack_attempt_permanent_failure() -> anyhow::Result<()> {
+    async fn process_ack_attempt_error_permanent_failure() -> anyhow::Result<()> {
         let info =
             ErrorInfo::new().set_metadata([(test_id(1), "PERMANENT_FAILURE_INVALID_ACK_ID")]);
 
-        let response = response_with_error_info(vec![info.clone()]);
-        let (confirmed_acks, remaining) = process_ack_attempt(test_ids(1..3), response);
+        let err_val = Arc::new(response_with_error_info(vec![info.clone()]).unwrap_err());
+        let (confirmed_acks, remaining) =
+            process_ack_attempt_error(test_ids(1..3), err_val.clone());
 
         assert!(remaining.is_empty(), "{remaining:?}");
 
@@ -674,11 +776,12 @@ pub(super) mod tests {
     }
 
     #[tokio::test]
-    async fn process_ack_attempt_transient_failure() -> anyhow::Result<()> {
+    async fn process_ack_attempt_error_transient_failure() -> anyhow::Result<()> {
         let info = ErrorInfo::new().set_metadata([(test_id(1), "TRANSIENT_FAILURE_OTHER")]);
 
-        let response = response_with_error_info(vec![info]);
-        let (confirmed_acks, remaining) = process_ack_attempt(test_ids(1..3), response);
+        let err_val = Arc::new(response_with_error_info(vec![info]).unwrap_err());
+        let (confirmed_acks, remaining) =
+            process_ack_attempt_error(test_ids(1..3), err_val.clone());
 
         assert_eq!(remaining, test_ids(1..2));
 


### PR DESCRIPTION
Note: the policy to enable retry will be added in a followup PR

Towards https://github.com/googleapis/google-cloud-rust/issues/4804