### PR TITLE
fix(wkt): implement camelCase conversion for FieldMask JSON mapping

### DIFF
--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -294,7 +294,13 @@ impl serde::ser::Serialize for FieldMask {
     where
         S: serde::ser::Serializer,
     {
-        serializer.serialize_str(&self.paths.join(","))
+        let paths = self
+            .paths
+            .iter()
+            .map(|p| to_camel_case(p))
+            .collect::<Vec<_>>()
+            .join(",");
+        serializer.serialize_str(&paths)
     }
 }
 
@@ -326,9 +332,38 @@ impl serde::de::Visitor<'_> for PathVisitor {
         if value.is_empty() {
             Ok(Vec::new())
         } else {
-            Ok(value.split(',').map(str::to_string).collect())
+            Ok(value.split(',').map(to_snake_case).collect())
         }
     }
+}
+
+fn to_camel_case(snake: &str) -> String {
+    let mut camel = String::with_capacity(snake.len());
+    let mut capitalize_next = false;
+    for c in snake.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            camel.push(c.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            camel.push(c);
+        }
+    }
+    camel
+}
+
+fn to_snake_case(camel: &str) -> String {
+    let mut snake = String::with_capacity(camel.len() + 5);
+    for c in camel.chars() {
+        if c.is_ascii_uppercase() {
+            snake.push('_');
+            snake.push(c.to_ascii_lowercase());
+        } else {
+            snake.push(c);
+        }
+    }
+    snake
 }
 
 #[cfg(test)]
@@ -374,5 +409,42 @@ mod tests {
             "message={msg}, debug={err:?}"
         );
         Ok(())
+    }
+
+    #[test_case("field_one", "fieldOne")]
+    #[test_case("user.display_name", "user.displayName")]
+    #[test_case("field_1", "field1")]
+    #[test_case("active__user", "activeUser")]
+    #[test_case("field", "field")]
+    #[test_case("alreadyCamel", "alreadyCamel")]
+    #[test_case("a_b_c", "aBC")]
+    fn test_to_camel_case_fn(input: &str, expected: &str) {
+        assert_eq!(to_camel_case(input), expected);
+    }
+
+    #[test_case("fieldOne", "field_one")]
+    #[test_case("user.displayName", "user.display_name")]
+    #[test_case("field", "field")]
+    #[test_case("already_snake", "already_snake")]
+    fn test_to_snake_case_fn(input: &str, expected: &str) {
+        assert_eq!(to_snake_case(input), expected);
+    }
+
+    #[test]
+    fn test_exhaustive_roundtrip() {
+        let chars = b"abcdefghijklmnopqrstuvwxyz_";
+        for &c1 in chars {
+            for &c2 in chars {
+                for &c3 in chars {
+                    let s = String::from_utf8(vec![c1, c2, c3]).unwrap();
+                    if s.starts_with('_') || s.ends_with('_') || s.contains("__") {
+                        continue;
+                    }
+                    let camel = to_camel_case(&s);
+                    let snake = to_snake_case(&camel);
+                    assert_eq!(snake, s, "Failed for s='{}', camel='{}'", s, camel);
+                }
+            }
+        }
     }
 }

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -433,16 +433,23 @@ mod tests {
     #[test]
     fn test_exhaustive_roundtrip() {
         let chars = b"abcdefghijklmnopqrstuvwxyz_";
+        let mut buf = [0u8; 4];
         for &c1 in chars {
+            buf[0] = c1;
             for &c2 in chars {
+                buf[1] = c2;
                 for &c3 in chars {
-                    let s = String::from_utf8(vec![c1, c2, c3]).unwrap();
-                    if s.starts_with('_') || s.ends_with('_') || s.contains("__") {
-                        continue;
+                    buf[2] = c3;
+                    for &c4 in chars {
+                        buf[3] = c4;
+                        let s = std::str::from_utf8(&buf).unwrap();
+                        if s.starts_with('_') || s.ends_with('_') || s.contains("__") {
+                            continue;
+                        }
+                        let camel = to_camel_case(s);
+                        let snake = to_snake_case(&camel);
+                        assert_eq!(snake, s, "Failed for s='{}', camel='{}'", s, camel);
                     }
-                    let camel = to_camel_case(&s);
-                    let snake = to_snake_case(&camel);
-                    assert_eq!(snake, s, "Failed for s='{}', camel='{}'", s, camel);
                 }
             }
         }

--- a/src/wkt/src/field_mask.rs
+++ b/src/wkt/src/field_mask.rs
@@ -342,6 +342,8 @@ mod tests {
     #[test_case(vec![], ""; "Serialize empty")]
     #[test_case(vec!["field1"], "field1"; "Serialize single")]
     #[test_case(vec!["field1", "field2", "field3"], "field1,field2,field3"; "Serialize multiple")]
+    #[test_case(vec!["field_one"], "fieldOne"; "Serialize snake to camel")]
+    #[test_case(vec!["user.display_name"], "user.displayName"; "Serialize path snake to camel")]
     fn test_serialize(paths: Vec<&str>, want: &str) -> Result {
         let value = serde_json::to_value(FieldMask::default().set_paths(paths))?;
         assert!(matches!(&value, Value::String(s) if s == want), "{value:?}");
@@ -351,6 +353,8 @@ mod tests {
     #[test_case("", vec![]; "Deserialize empty")]
     #[test_case("field1", vec!["field1"]; "Deserialize single")]
     #[test_case("field1,field2,field3", vec!["field1" ,"field2", "field3"]; "Deserialize multiple")]
+    #[test_case("fieldOne", vec!["field_one"]; "Deserialize camel to snake")]
+    #[test_case("user.displayName", vec!["user.display_name"]; "Deserialize path camel to snake")]
     fn test_deserialize(paths: &str, mut want: Vec<&str>) -> Result {
         let value = json!(paths);
         let mut got = serde_json::from_value::<FieldMask>(value)?;

--- a/tests/protobuf/src/lib.rs
+++ b/tests/protobuf/src/lib.rs
@@ -80,9 +80,14 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
                 .set_name(&get.name)
                 .set_etag(get.etag)
                 .set_labels(tag(get.labels.clone(), "test-1"))
-                .set_annotations(tag(get.annotations.clone(), "test-1")),
+                .set_annotations(tag(get.annotations.clone(), "test-1"))
+                .set_version_aliases([("test-alias".to_string(), 1i64)]),
         )
-        .set_update_mask(FieldMask::default().set_paths(["annotations", "labels"]))
+        .set_update_mask(FieldMask::default().set_paths([
+            "annotations",
+            "labels",
+            "version_aliases",
+        ]))
         // Avoid flakes, safe to retry because of the etag.
         .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
         .send()
@@ -96,6 +101,7 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
         update.annotations.get("updated").map(String::as_str),
         Some("test-1")
     );
+    assert_eq!(update.version_aliases.get("test-alias"), Some(&1i64));
 
     println!("\nTesting update_secret() [2]");
     let update = client

--- a/tests/protobuf/src/lib.rs
+++ b/tests/protobuf/src/lib.rs
@@ -68,6 +68,20 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
     // - The mask has the desired effect, only the fields in the mask are set
     // This test assumes the service works correctly, we are not trying to write
     // service tests.
+    println!("\nTesting create_secret_version() for alias");
+    let data = "The quick brown fox jumps over the lazy dog".as_bytes();
+    let checksum = crc32c::crc32c(data);
+    let _version = client
+        .add_secret_version()
+        .set_parent(&get.name)
+        .set_payload(
+            SecretPayload::new()
+                .set_data(bytes::Bytes::from(data))
+                .set_data_crc32c(checksum as i64),
+        )
+        .send()
+        .await?;
+
     println!("\nTesting update_secret() [1]");
     let tag = |mut map: std::collections::HashMap<String, String>, msg: &str| {
         map.insert("updated".to_string(), msg.to_string());

--- a/tests/protobuf/src/lib.rs
+++ b/tests/protobuf/src/lib.rs
@@ -62,12 +62,6 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
     println!("GET = {get:?}");
     assert_eq!(get, create);
 
-    // We need to verify that FieldMask as query parameters are sent correctly
-    // by the client library. This involves:
-    // - Setting the mask does not result in a RPC error
-    // - The mask has the desired effect, only the fields in the mask are set
-    // This test assumes the service works correctly, we are not trying to write
-    // service tests.
     println!("\nTesting create_secret_version() for alias");
     let data = "The quick brown fox jumps over the lazy dog".as_bytes();
     let checksum = crc32c::crc32c(data);
@@ -82,6 +76,12 @@ pub async fn run(builder: ClientBuilder) -> Result<()> {
         .send()
         .await?;
 
+    // We need to verify that FieldMask as query parameters are sent correctly
+    // by the client library. This involves:
+    // - Setting the mask does not result in a RPC error
+    // - The mask has the desired effect, only the fields in the mask are set
+    // This test assumes the service works correctly, we are not trying to write
+    // service tests.
     println!("\nTesting update_secret() [1]");
     let tag = |mut map: std::collections::HashMap<String, String>, msg: &str| {
         map.insert("updated".to_string(), msg.to_string());


### PR DESCRIPTION
Fix a discrepancy between our implementation of FieldMask serialization/deserialization and the official Protocol Buffers JSON mapping specification.

According to the spec, in JSON, a FieldMask is represented as a string listing the paths separated by a comma, and each path is converted to camelCase. Our previous implementation simply joined and split paths with commas without performing any case conversion.

Fixes #5410 