### PR TITLE
fix(ci): add sleep between service enablement and resource creation

### DIFF
--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -18,6 +18,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.11.0"
+    }
   }
 }
 
@@ -33,12 +37,19 @@ module "services" {
   project = var.project
 }
 
+# Wait for services to be fully active before creating resources.
+# Service enablement can take time to propagate.
+resource "time_sleep" "wait_for_services" {
+  create_duration = "60s"
+  depends_on      = [module.services]
+}
+
 # Create the resources we will need to run integration tests on.
 module "resources" {
   source     = "./resources"
   project    = var.project
   region     = var.region
-  depends_on = [module.services]
+  depends_on = [time_sleep.wait_for_services]
 }
 
 # Create the service account needed for GCB and grant it the necessary

--- a/.gcb/builds/main.tf
+++ b/.gcb/builds/main.tf
@@ -41,7 +41,12 @@ module "services" {
 # Service enablement can take time to propagate.
 resource "time_sleep" "wait_for_services" {
   create_duration = "60s"
-  depends_on      = [module.services]
+
+  triggers = {
+    services = join(",", module.services.services)
+  }
+
+  depends_on = [module.services]
 }
 
 # Create the resources we will need to run integration tests on.

--- a/.gcb/builds/services/main.tf
+++ b/.gcb/builds/services/main.tf
@@ -14,9 +14,33 @@
 
 variable "project" {}
 
-resource "google_project_service" "aiplatform" {
+locals {
+  services = [
+    "aiplatform.googleapis.com",
+    "bigquery.googleapis.com",
+    "compute.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "dns.googleapis.com",
+    "firestore.googleapis.com",
+    "cloudkms.googleapis.com",
+    "language.googleapis.com",
+    "pubsub.googleapis.com",
+    "secretmanager.googleapis.com",
+    "workflows.googleapis.com",
+    "speech.googleapis.com",
+    "storage.googleapis.com",
+    "sqladmin.googleapis.com",
+    "telemetry.googleapis.com",
+    "cloudtrace.googleapis.com",
+  ]
+}
+
+resource "google_project_service" "services" {
+  for_each = toset(local.services)
+
   project = var.project
-  service = "aiplatform.googleapis.com"
+  service = each.value
 
   timeouts {
     create = "30m"
@@ -26,194 +50,87 @@ resource "google_project_service" "aiplatform" {
   disable_dependent_services = true
 }
 
-resource "google_project_service" "bigquery" {
-  project = var.project
-  service = "bigquery.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.aiplatform
+  to   = google_project_service.services["aiplatform.googleapis.com"]
 }
 
-resource "google_project_service" "compute" {
-  project = var.project
-  service = "compute.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.bigquery
+  to   = google_project_service.services["bigquery.googleapis.com"]
 }
 
-resource "google_project_service" "cloudbuild" {
-  project = var.project
-  service = "cloudbuild.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.compute
+  to   = google_project_service.services["compute.googleapis.com"]
 }
 
-resource "google_project_service" "cloudscheduler" {
-  project = var.project
-  service = "cloudscheduler.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.cloudbuild
+  to   = google_project_service.services["cloudbuild.googleapis.com"]
 }
 
-resource "google_project_service" "dns" {
-  project = var.project
-  service = "dns.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.cloudscheduler
+  to   = google_project_service.services["cloudscheduler.googleapis.com"]
 }
 
-resource "google_project_service" "firestore" {
-  project = var.project
-  service = "firestore.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.dns
+  to   = google_project_service.services["dns.googleapis.com"]
 }
 
-resource "google_project_service" "kms" {
-  project = var.project
-  service = "cloudkms.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.firestore
+  to   = google_project_service.services["firestore.googleapis.com"]
 }
 
-resource "google_project_service" "language" {
-  project = var.project
-  service = "language.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.kms
+  to   = google_project_service.services["cloudkms.googleapis.com"]
 }
 
-resource "google_project_service" "pubsub" {
-  project = var.project
-  service = "pubsub.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.language
+  to   = google_project_service.services["language.googleapis.com"]
 }
 
-resource "google_project_service" "secretmanager" {
-  project = var.project
-  service = "secretmanager.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.pubsub
+  to   = google_project_service.services["pubsub.googleapis.com"]
 }
 
-resource "google_project_service" "workflows" {
-  project = var.project
-  service = "workflows.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.secretmanager
+  to   = google_project_service.services["secretmanager.googleapis.com"]
 }
 
-resource "google_project_service" "speech" {
-  project = var.project
-  service = "speech.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.workflows
+  to   = google_project_service.services["workflows.googleapis.com"]
 }
 
-resource "google_project_service" "storage" {
-  project = var.project
-  service = "storage.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.speech
+  to   = google_project_service.services["speech.googleapis.com"]
 }
 
-resource "google_project_service" "sqladmin" {
-  project = var.project
-  service = "sqladmin.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.storage
+  to   = google_project_service.services["storage.googleapis.com"]
 }
 
-resource "google_project_service" "telemetry" {
-  project = var.project
-  service = "telemetry.googleapis.com"
-
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.sqladmin
+  to   = google_project_service.services["sqladmin.googleapis.com"]
 }
 
-resource "google_project_service" "cloudtrace" {
-  project = var.project
-  service = "cloudtrace.googleapis.com"
+moved {
+  from = google_project_service.telemetry
+  to   = google_project_service.services["telemetry.googleapis.com"]
+}
 
-  timeouts {
-    create = "30m"
-    update = "40m"
-  }
-
-  disable_dependent_services = true
+moved {
+  from = google_project_service.cloudtrace
+  to   = google_project_service.services["cloudtrace.googleapis.com"]
 }

--- a/.gcb/builds/services/outputs.tf
+++ b/.gcb/builds/services/outputs.tf
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "services" {
+  value = [
+    google_project_service.aiplatform.id,
+    google_project_service.bigquery.id,
+    google_project_service.compute.id,
+    google_project_service.cloudbuild.id,
+    google_project_service.cloudscheduler.id,
+    google_project_service.dns.id,
+    google_project_service.firestore.id,
+    google_project_service.kms.id,
+    google_project_service.language.id,
+    google_project_service.pubsub.id,
+    google_project_service.secretmanager.id,
+    google_project_service.workflows.id,
+    google_project_service.speech.id,
+    google_project_service.storage.id,
+    google_project_service.sqladmin.id,
+    google_project_service.telemetry.id,
+    google_project_service.cloudtrace.id,
+  ]
+}

--- a/.gcb/builds/services/outputs.tf
+++ b/.gcb/builds/services/outputs.tf
@@ -13,23 +13,5 @@
 # limitations under the License.
 
 output "services" {
-  value = [
-    google_project_service.aiplatform.id,
-    google_project_service.bigquery.id,
-    google_project_service.compute.id,
-    google_project_service.cloudbuild.id,
-    google_project_service.cloudscheduler.id,
-    google_project_service.dns.id,
-    google_project_service.firestore.id,
-    google_project_service.kms.id,
-    google_project_service.language.id,
-    google_project_service.pubsub.id,
-    google_project_service.secretmanager.id,
-    google_project_service.workflows.id,
-    google_project_service.speech.id,
-    google_project_service.storage.id,
-    google_project_service.sqladmin.id,
-    google_project_service.telemetry.id,
-    google_project_service.cloudtrace.id,
-  ]
+  value = [for s in google_project_service.services : s.id]
 }


### PR DESCRIPTION
To prevent flakes of `services not enabled` immediately after activation, I'm proposing to add a `time_sleep` delay of 60 seconds.

As noted in the [Official Google Provider Guide](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/google_project_service#using-the-time-provider), GCP APIs often return success at the global control plane before propagation to regional infrastructure is complete. This delay ensures resources like Firestore and KMS create successfully on the first run.

For reference, this pattern is also used in the official [Google Cloud Datastore Module](https://github.com/terraform-google-modules/terraform-google-cloud-datastore/blob/main/examples/simple_example/main.tf) example, where they use a 120-second delay to make sure App Engine applications are initialized before creating indexes.