### PR TITLE
docs: add observability samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6326,15 +6326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8561,17 +8552,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 
@@ -8659,12 +8647,17 @@ dependencies = [
  "google-cloud-wkt",
  "httptest",
  "mockall",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest 0.13.2",
  "serde_json",
  "storage-samples",
  "tempfile",
  "test-case",
  "tokio",
+ "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -49,7 +49,12 @@ google-cloud-wkt.workspace    = true
 storage-samples.workspace     = true
 serde_json.workspace          = true
 tokio                         = { workspace = true, features = ["full", "macros"] }
-tracing-subscriber            = { workspace = true, default-features = true }
+tracing-subscriber            = { workspace = true, features = ["json"] }
+opentelemetry                 = { workspace = true }
+opentelemetry-otlp            = { workspace = true, features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk             = { workspace = true, features = ["rt-tokio"] }
+tracing-opentelemetry         = { workspace = true }
+tracing                       = { workspace = true }
 # Formatting trick: this comment preserves formatting in the preceding block.
 google-cloud-compute-v1 = { workspace = true, default-features = false, features = [
   "default-rustls-provider",

--- a/guide/samples/src/observability/logging.rs
+++ b/guide/samples/src/observability/logging.rs
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START rust_observability_logging] ANCHOR: rust_observability_logging
+use google_cloud_secretmanager_v1::client::SecretManagerService;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+pub async fn sample() -> anyhow::Result<()> {
+    // Output `WARN` logs for failed logical client requests, and `DEBUG` logs
+    // for failed low-level RPC attempts from the client library crate.
+    let filter = tracing_subscriber::EnvFilter::new("warn,google_cloud_secretmanager=debug");
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer().json())
+        .init();
+
+    let _client = SecretManagerService::builder()
+        .with_tracing()
+        .build()
+        .await?;
+
+    Ok(())
+}
+// [END rust_observability_logging] ANCHOR_END: rust_observability_logging

--- a/guide/samples/src/observability/logging.rs
+++ b/guide/samples/src/observability/logging.rs
@@ -12,15 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START rust_observability_logging] ANCHOR: rust_observability_logging
+// [START rust_observability_logging]
 use google_cloud_secretmanager_v1::client::SecretManagerService;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub async fn sample() -> anyhow::Result<()> {
-    // Output `WARN` logs for failed logical client requests, and `DEBUG` logs
-    // for failed low-level RPC attempts from the client library crate.
-    let filter = tracing_subscriber::EnvFilter::new("warn,google_cloud_secretmanager=debug");
+    // Enable all `WARN` logs to include failed client requests in all client libraries.
+    let filter = tracing_subscriber::EnvFilter::new("warn");
 
     tracing_subscriber::registry()
         .with(filter)
@@ -34,4 +33,4 @@ pub async fn sample() -> anyhow::Result<()> {
 
     Ok(())
 }
-// [END rust_observability_logging] ANCHOR_END: rust_observability_logging
+// [END rust_observability_logging]

--- a/guide/samples/src/observability/mod.rs
+++ b/guide/samples/src/observability/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This crate contains a number of guides showing how to use the
-//! Google Cloud Client Libraries for Rust.
-
-pub mod authentication;
-pub mod binding_errors;
-pub mod compute;
-pub mod endpoint;
-pub mod error_handling;
-pub mod examine_error_details;
-pub mod gemini;
 pub mod logging;
-pub mod observability;
-pub mod pagination;
-pub mod retry_policies;
-pub mod update_resource;
+pub mod tracing;

--- a/guide/samples/src/observability/tracing.rs
+++ b/guide/samples/src/observability/tracing.rs
@@ -1,0 +1,44 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START rust_observability_tracing] ANCHOR: rust_observability_tracing
+use google_cloud_secretmanager_v1::client::SecretManagerService;
+use tracing_subscriber::Registry;
+use tracing_subscriber::layer::SubscriberExt;
+
+pub async fn sample() -> anyhow::Result<()> {
+    use opentelemetry::trace::TracerProvider as _;
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()?;
+    let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .build();
+    let tracer = provider.tracer("example");
+
+    // Create a tracing layer that sends data to an OpenTelemetry Collector running on localhost.
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    // Register the subscriber globally
+    let subscriber = Registry::default().with(telemetry);
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    let _client = SecretManagerService::builder()
+        .with_tracing()
+        .build()
+        .await?;
+
+    Ok(())
+}
+// [END rust_observability_tracing] ANCHOR_END: rust_observability_tracing

--- a/guide/samples/src/observability/tracing.rs
+++ b/guide/samples/src/observability/tracing.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START rust_observability_tracing] ANCHOR: rust_observability_tracing
+// [START rust_observability_tracing]
 use google_cloud_secretmanager_v1::client::SecretManagerService;
+use opentelemetry::trace::TracerProvider as _;
 use tracing_subscriber::Registry;
 use tracing_subscriber::layer::SubscriberExt;
 
 pub async fn sample() -> anyhow::Result<()> {
-    use opentelemetry::trace::TracerProvider as _;
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
         .build()?;
@@ -41,4 +41,4 @@ pub async fn sample() -> anyhow::Result<()> {
 
     Ok(())
 }
-// [END rust_observability_tracing] ANCHOR_END: rust_observability_tracing
+// [END rust_observability_tracing]


### PR DESCRIPTION
These are snippets to include in the product-neutral guide for observability.