### PR TITLE
chore: update Rust versions

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We need to support 1.86. Stop clippy from issuing newer warnings.
-msrv = "1.86.0"
+# We need to support 1.87. Stop clippy from issuing newer warnings.
+msrv = "1.87.0"

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -138,7 +138,7 @@ locals {
       config       = "complex.yaml"
       flags        = local.unstable_flags
       script       = "test"
-      rust_version = "1.86"
+      rust_version = "1.87"
     }
     test-unstable-cfg = {
       config = "complex.yaml"

--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -49,7 +49,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
 # The workspace-minimal-versions build can take over 1h (the default). This is
 # harmless (other than wasting CPU time) for other builds.
 timeout: 7200s

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -76,7 +76,7 @@ substitutions:
   _CODECOV_SHA256: '80b5e6f898d6080be523f53ff169702a008a1c91b20c63c49df1175ed794d822'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -60,7 +60,7 @@ steps:
       done
 
 substitutions:
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -155,7 +155,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
   _GO_VERSION: '1.25.6'
   _PYTHON_VERSION: '3.14'
   _TERRAFORM_VERSION: '1.14.0'

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -57,7 +57,7 @@ steps:
       cargo test --features run-integration-tests --tests
 
 substitutions:
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -22,7 +22,7 @@ on:
   release:
     types: [published]
 env:
-  GHA_RUST_VERSIONS: '{ "rust:current": "1.94" }'
+  GHA_RUST_VERSIONS: '{ "rust:current": "1.95" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
   UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,7 +352,7 @@ license      = "Apache-2.0"
 repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
 keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
 categories   = ["network-programming"]
-rust-version = "1.86.0"
+rust-version = "1.87.0"
 
 # Define a custom profile for builds on GHA. The standard profiles exhaust the
 # available disk space on the free GHA runners. The GHA builds cannot take

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ client libraries for Rust.
 
 ## Minimum Supported Rust Version (MSRV)
 
-We require Rust >= 1.86. We plan to update the MSRV periodically. However, the
+We require Rust >= 1.87. We plan to update the MSRV periodically. However, the
 development branch will always compile with the `rustc` versions released within
 the previous year.
 

--- a/guide/samples/tests/storage/striped.rs
+++ b/guide/samples/tests/storage/striped.rs
@@ -141,7 +141,7 @@ async fn download(
     let mut stripes = (0..count)
         .map(|i| write_stripe(client.clone(), &file, i * limit, limit, &metadata))
         .collect::<Vec<_>>();
-    if size % limit != 0 {
+    if !size.is_multiple_of(limit) {
         stripes.push(write_stripe(
             client.clone(),
             &file,

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -54,6 +54,6 @@ steps:
         --features run-byoid-integration-tests \
         --package integration-tests-auth
 substitutions:
-  _RUST_VERSION: '1.94'
+  _RUST_VERSION: '1.95'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -465,7 +465,7 @@ mod tests {
         let mut got = HashSet::new();
         for batch in batches {
             assert_eq!(batch.len(), MAX_IDS_PER_RPC as usize);
-            got.extend(batch.into_iter());
+            got.extend(batch);
         }
 
         // Make sure all ack IDs are included.

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -94,7 +94,7 @@ impl Leases {
 
         // We want to extract some values from `HashMap`, leaving the rest
         // unchanged.
-        // - `extract_if()` is not available as our MSRV is 1.86 and that appears
+        // - `extract_if()` is not available as our MSRV is 1.87 and that appears
         //   in 1.88.
         // - `retain` does not work because we need a *value* of `info` to
         //   change `tx` and that only gives us a `&mut ExactlyOnceInfo`.
@@ -520,7 +520,7 @@ mod tests {
         let mut got = HashSet::new();
         for batch in batches {
             assert_eq!(batch.len(), MAX_IDS_PER_RPC as usize);
-            got.extend(batch.into_iter());
+            got.extend(batch);
         }
 
         // Make sure all ack IDs are included.

--- a/src/storage/benchmarks/random/src/main.rs
+++ b/src/storage/benchmarks/random/src/main.rs
@@ -108,7 +108,7 @@ async fn runner(
     objects: Vec<String>,
 ) -> anyhow::Result<()> {
     let _guard = enable_tracing(&args);
-    if task % 128 == 0 {
+    if task.is_multiple_of(128) {
         tracing::info!("Task::run({})", task);
     }
 

--- a/src/storage/benchmarks/w1r3/src/main.rs
+++ b/src/storage/benchmarks/w1r3/src/main.rs
@@ -161,7 +161,7 @@ async fn runner(
 ) -> anyhow::Result<()> {
     tokio::time::sleep(args.rampup_period * id as u32).await;
     let task = Task { id, start, tx };
-    if task.id % 128 == 0 {
+    if task.id.is_multiple_of(128) {
         tracing::info!("Task::run({})", task.id);
     }
     let builder = StorageControl::builder().with_credentials(credentials);

--- a/src/storage/tests/scenarios/src/dataset.rs
+++ b/src/storage/tests/scenarios/src/dataset.rs
@@ -78,7 +78,7 @@ async fn create(
     client: &Storage,
 ) -> anyhow::Result<Object> {
     tokio::time::sleep(args.dataset_rampup_period * (task as u32)).await;
-    if task % 128 == 0 {
+    if task.is_multiple_of(128) {
         tracing::info!("create({})", task);
     }
     let name = random_object_name();

--- a/src/storage/tests/scenarios/src/main.rs
+++ b/src/storage/tests/scenarios/src/main.rs
@@ -135,7 +135,7 @@ async fn runner(
     objects: Vec<Object>,
 ) -> anyhow::Result<()> {
     tokio::time::sleep(args.rampup_period * task as u32).await;
-    if task % 128 == 0 {
+    if task.is_multiple_of(128) {
         tracing::info!("runner({})", task);
     }
 

--- a/tests/o11y/src/otlp/metrics.rs
+++ b/tests/o11y/src/otlp/metrics.rs
@@ -132,7 +132,7 @@ impl Builder {
                 KeyValue::new(OTEL_KEY_GCP_PROJECT_ID, self.project_id),
                 KeyValue::new(OTEL_KEY_SERVICE_NAME, self.service_name),
             ])
-            .with_detectors(&Vec::from_iter(self.detector.into_iter()))
+            .with_detectors(&Vec::from_iter(self.detector))
             .build();
         let credentials = match self.credentials {
             Some(c) => c,

--- a/tests/o11y/src/otlp/trace.rs
+++ b/tests/o11y/src/otlp/trace.rs
@@ -133,7 +133,7 @@ impl Builder {
                 opentelemetry::KeyValue::new(OTEL_KEY_GCP_PROJECT_ID, self.project_id),
                 opentelemetry::KeyValue::new(OTEL_KEY_SERVICE_NAME, self.service_name),
             ])
-            .with_detectors(&Vec::from_iter(self.detector.into_iter()))
+            .with_detectors(&Vec::from_iter(self.detector))
             .build();
 
         let is_https = self.endpoint.starts_with("https");

--- a/tests/storage/src/write_object.rs
+++ b/tests/storage/src/write_object.rs
@@ -116,7 +116,7 @@ impl StreamingSource for TestDataSource {
 impl Seek for TestDataSource {
     type Error = std::io::Error;
     async fn seek(&mut self, offset: u64) -> std::result::Result<(), Self::Error> {
-        if offset % Self::LINE_SIZE != 0 {
+        if !offset.is_multiple_of(Self::LINE_SIZE) {
             return Err(Self::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 "bad offset",


### PR DESCRIPTION
1.86 is more than a year old, so I bumped the MSRV to 1.87. That brings with it new warnings and clippys, which I fixed.

A new Rust release (1.95) is out, so we need to start testing with it.