### PR TITLE
feat(storage): accept `Into<Arc<S>>` in `from_stub`

### DIFF
--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -127,10 +127,7 @@ where
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub<U>(stub: U) -> Self
-    where
-        U: Into<std::sync::Arc<S>>,
-    {
+    pub fn from_stub(stub: impl Into<std::sync::Arc<S>>) -> Self {
         Self {
             stub: stub.into(),
             options: RequestOptions::new(),
@@ -823,6 +820,20 @@ pub(crate) mod tests {
             config.grpc_subchannel_count.is_some_and(|v| v == 42),
             "{config:?}"
         );
+    }
+
+    #[derive(Debug)]
+    struct DummyStorage;
+
+    impl crate::storage::stub::Storage for DummyStorage {}
+
+    #[test]
+    fn from_stub_accepts_both_raw_and_arc() {
+        let stub = DummyStorage;
+        let _client = Storage::from_stub(stub);
+
+        let stub_arc = std::sync::Arc::new(DummyStorage);
+        let _client_arc = Storage::from_stub(stub_arc);
     }
 
     pub(crate) fn test_builder() -> ClientBuilder {

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -127,12 +127,12 @@ where
     ///
     /// The most common case for calling this function is in tests mocking the
     /// client's behavior.
-    pub fn from_stub(stub: S) -> Self
+    pub fn from_stub<U>(stub: U) -> Self
     where
-        S: super::stub::Storage + 'static,
+        U: Into<std::sync::Arc<S>>,
     {
         Self {
-            stub: std::sync::Arc::new(stub),
+            stub: stub.into(),
             options: RequestOptions::new(),
         }
     }

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -830,10 +830,18 @@ pub(crate) mod tests {
     #[test]
     fn from_stub_accepts_both_raw_and_arc() {
         let stub = DummyStorage;
-        let _client = Storage::from_stub(stub);
+        let _client = Storage::<DummyStorage>::from_stub(stub);
 
         let stub_arc = std::sync::Arc::new(DummyStorage);
-        let _client_arc = Storage::from_stub(stub_arc);
+        let _client_arc = Storage::<DummyStorage>::from_stub(stub_arc);
+    }
+
+    #[test]
+    fn from_stub_allows_sharing_stub() {
+        let stub_arc = std::sync::Arc::new(DummyStorage);
+
+        let _client1 = Storage::<DummyStorage>::from_stub(stub_arc.clone());
+        let _client2 = Storage::<DummyStorage>::from_stub(stub_arc);
     }
 
     pub(crate) fn test_builder() -> ClientBuilder {

--- a/src/storage/tests/mocking.rs
+++ b/src/storage/tests/mocking.rs
@@ -112,6 +112,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mock_read_object_success_with_arc() -> anyhow::Result<()> {
+        const LAZY: &str = "the quick brown fox jumps over the lazy dog";
+        let object = {
+            let mut o = ObjectHighlights::default();
+            o.etag = "custom-etag".to_string();
+            o
+        };
+
+        let mut mock = MockStorage::new();
+        mock.expect_read_object().return_once({
+            let o = object.clone();
+            move |_, _| Ok(ReadObjectResponse::from_source(o, LAZY))
+        });
+
+        let mock_arc = std::sync::Arc::new(mock);
+        let client = gcs::client::Storage::<MockStorage>::from_stub(mock_arc);
+        let mut reader = client
+            .read_object("projects/_/buckets/my-bucket", "my-object")
+            .send()
+            .await?;
+        assert_eq!(&object, &reader.object());
+
+        let mut contents = Vec::new();
+        while let Some(chunk) = reader.next().await.transpose()? {
+            contents.extend_from_slice(&chunk);
+        }
+        let contents = bytes::Bytes::from_owner(contents);
+        assert_eq!(contents, LAZY);
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn mock_write_object_buffered() {
         let mut mock = MockStorage::new();
         mock.expect_write_object_buffered()


### PR DESCRIPTION
Update handwritten Storage client initialization via `from_stub` to accept `U: Into<Arc<S>>`. This allows passing either a raw stub or a pre-built `Arc<S>`.

For #2146 