### PR TITLE
refactor(test-utils): use Vec::extract_if in take_by_test_id

### DIFF
--- a/src/test-utils/src/test_layer.rs
+++ b/src/test-utils/src/test_layer.rs
@@ -174,16 +174,11 @@ impl CapturedSpanLog {
     /// Spans with the name "test_layer" are excluded.
     fn take_by_test_id(&self, test_id: &str) -> Vec<CapturedSpan> {
         let mut spans = self.spans.lock().unwrap();
-        let mut taken = Vec::new();
-        let mut i = 0;
-        while i < spans.len() {
-            if spans[i].test_id.as_deref() == Some(test_id) && spans[i].name != "test_layer" {
-                taken.push(spans.remove(i));
-            } else {
-                i += 1;
-            }
-        }
-        taken
+        spans
+            .extract_if(.., |span| {
+                span.test_id.as_deref() == Some(test_id) && span.name != "test_layer"
+            })
+            .collect()
     }
 
     /// Removes all spans associated with a given `test_id`.


### PR DESCRIPTION
Replaces a manual loop with remove(i) with Vec::extract_if (available in Rust 1.87) to improve readability.