### PR TITLE
ci(pubsub): increase CreateSubscription timeout

### DIFF
--- a/src/pubsub/examples/src/lib.rs
+++ b/src/pubsub/examples/src/lib.rs
@@ -19,10 +19,12 @@ mod subscription;
 mod topic;
 
 use google_cloud_gax::paginator::ItemPaginator as _;
+use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
 use google_cloud_pubsub::client::SchemaService;
 use google_cloud_pubsub::{client::SubscriptionAdmin, model::Subscription};
 use google_cloud_pubsub::{client::TopicAdmin, model::Topic};
 use rand::{RngExt, distr::Alphanumeric};
+use std::time::Duration;
 use tokio::task::JoinSet;
 
 pub async fn run_topic_samples(topic_names: &mut Vec<String>) -> anyhow::Result<()> {
@@ -238,7 +240,17 @@ async fn create_test_subscription_with_request(
     request: Subscription,
 ) -> anyhow::Result<(SubscriptionAdmin, Subscription)> {
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
-    let client = SubscriptionAdmin::builder().with_tracing().build().await?;
+    let client = SubscriptionAdmin::builder()
+        .with_retry_policy(
+            // Use a more generous retry policy to avoid test flakes from
+            // timeouts. See #5450 for details.
+            Aip194Strict
+                .with_attempt_limit(10)
+                .with_time_limit(Duration::from_secs(300)),
+        )
+        .with_tracing()
+        .build()
+        .await?;
 
     let _ = cleanup_stale_subscriptions(&client, &project_id).await;
 

--- a/tests/pubsub/tests/driver.rs
+++ b/tests/pubsub/tests/driver.rs
@@ -138,7 +138,6 @@ mod pubsub {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[ignore = "TODO(#5450) - enable once it is deflaked"]
     async fn run_ordered_roundtrip() -> anyhow::Result<()> {
         let _guard = enable_tracing();
         let (topic_admin, topic) = pubsub_samples::create_test_topic()


### PR DESCRIPTION
Increase the timeout on creating pubsub subscriptions. (I looked and I don't think this is a quota thing. I think it is just a slow operation that is not quite an LRO).

Our default retry policy times out after 1 minute: https://github.com/googleapis/google-cloud-rust/blob/d1388847157fce028d64ea5d485599222c918bd2/src/gax-internal/src/http.rs#L103-L106

While we're here, re-enable a test where we create a subscription to see if this in fact deflakes the test.

Motivated by #5450