### PR TITLE
chore: update librarian version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.10.2-0.20260417212934-1a6932227f88
+version: v0.10.2-0.20260421180302-dc35d110f9bb
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Updates the version of `librarian` used in `librarian.yaml`.