### PR TITLE
cleanup(gax): enable missing_docs warning

### DIFF
--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -463,6 +463,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
 }
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod internal {
     use super::*;
 

--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -26,7 +26,7 @@ type BoxError = Box<dyn StdError + Send + Sync>;
 /// necessary connection to make a request, the request may timeout before a
 /// response is received, the retry policy may be exhausted, or the library may
 /// be unable to format the request due to invalid or missing application
-/// application inputs.
+/// inputs.
 ///
 /// Most applications will just return the error or log it, without any further
 /// action. However, some applications may need to interrogate the error

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -231,6 +231,7 @@ pub enum Code {
 }
 
 impl Code {
+    /// Returns the string representation of the error code.
     pub fn name(&self) -> &'static str {
         match self {
             Code::Ok => "OK",
@@ -398,6 +399,7 @@ impl From<&google_cloud_rpc::model::Status> for Status {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 #[serde(tag = "@type")]
+#[allow(missing_docs)]
 pub enum StatusDetails {
     #[serde(rename = "type.googleapis.com/google.rpc.BadRequest")]
     BadRequest(google_cloud_rpc::model::BadRequest),

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -399,28 +399,69 @@ impl From<&google_cloud_rpc::model::Status> for Status {
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 #[serde(tag = "@type")]
-#[allow(missing_docs)]
+/// Detailed information about the error.
 pub enum StatusDetails {
+    /// Describes violations in a client request.
+    ///
+    /// See [BadRequest][google_cloud_rpc::model::BadRequest] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.BadRequest")]
     BadRequest(google_cloud_rpc::model::BadRequest),
+
+    /// Describes additional debugging info.
+    ///
+    /// See [DebugInfo][google_cloud_rpc::model::DebugInfo] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.DebugInfo")]
     DebugInfo(google_cloud_rpc::model::DebugInfo),
+
+    /// Describes the cause of the error with structured details.
+    ///
+    /// See [ErrorInfo][google_cloud_rpc::model::ErrorInfo] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.ErrorInfo")]
     ErrorInfo(google_cloud_rpc::model::ErrorInfo),
+
+    /// Provides links to documentation or for performing an out of band action.
+    ///
+    /// See [Help][google_cloud_rpc::model::Help] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.Help")]
     Help(google_cloud_rpc::model::Help),
+
+    /// Provides a localized error message that is safe to return to the user.
+    ///
+    /// See [LocalizedMessage][google_cloud_rpc::model::LocalizedMessage] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.LocalizedMessage")]
     LocalizedMessage(google_cloud_rpc::model::LocalizedMessage),
+
+    /// Describes what preconditions have failed.
+    ///
+    /// See [PreconditionFailure][google_cloud_rpc::model::PreconditionFailure] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.PreconditionFailure")]
     PreconditionFailure(google_cloud_rpc::model::PreconditionFailure),
+
+    /// Describes a single quota violation.
+    ///
+    /// See [QuotaFailure][google_cloud_rpc::model::QuotaFailure] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.QuotaFailure")]
     QuotaFailure(google_cloud_rpc::model::QuotaFailure),
+
+    /// Contains metadata about the request that clients can attach when filing a bug.
+    ///
+    /// See [RequestInfo][google_cloud_rpc::model::RequestInfo] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.RequestInfo")]
     RequestInfo(google_cloud_rpc::model::RequestInfo),
+
+    /// Describes the resource that is being accessed.
+    ///
+    /// See [ResourceInfo][google_cloud_rpc::model::ResourceInfo] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.ResourceInfo")]
     ResourceInfo(google_cloud_rpc::model::ResourceInfo),
+
+    /// Describes when the clients can retry a failed request.
+    ///
+    /// See [RetryInfo][google_cloud_rpc::model::RetryInfo] for more information.
     #[serde(rename = "type.googleapis.com/google.rpc.RetryInfo")]
     RetryInfo(google_cloud_rpc::model::RetryInfo),
+
+    /// Other details (represented as Any).
     #[serde(untagged)]
     Other(wkt::Any),
 }

--- a/src/gax/src/exponential_backoff.rs
+++ b/src/gax/src/exponential_backoff.rs
@@ -28,7 +28,6 @@ use std::time::Duration;
 /// The error type for exponential backoff creation.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
-/// Errors that can occur when building an [ExponentialBackoffBuilder].
 pub enum Error {
     /// The scaling factor is invalid (must be >= 1.0).
     #[error("the scaling value ({0}) should be >= 1.0")]

--- a/src/gax/src/exponential_backoff.rs
+++ b/src/gax/src/exponential_backoff.rs
@@ -28,16 +28,22 @@ use std::time::Duration;
 /// The error type for exponential backoff creation.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
+/// Errors that can occur when building an [ExponentialBackoffBuilder].
 pub enum Error {
+    /// The scaling factor is invalid (must be >= 1.0).
     #[error("the scaling value ({0}) should be >= 1.0")]
     InvalidScalingFactor(f64),
+    /// The initial delay is invalid (must be > 0).
     #[error("the initial delay ({0:?}) should be greater than zero")]
     InvalidInitialDelay(Duration),
+    /// The delay range is empty or invalid.
     #[error(
         "the maximum delay ({maximum:?}) should be greater than or equal to the initial delay ({initial:?})"
     )]
     EmptyRange {
+        /// The maximum delay.
         maximum: Duration,
+        /// The initial delay.
         initial: Duration,
     },
 }

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -54,6 +54,7 @@ pub mod retry_throttler;
 pub mod throttle_result;
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod retry_loop_internal;
 
 #[cfg(test)]

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -26,6 +26,7 @@
 //! </div>
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
 
 /// An alias of [std::result::Result] where the error is always [Error][crate::error::Error].
 ///

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -192,6 +192,7 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
 }
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod internal {
     //! This module contains implementation details. It is not part of the
     //! public API. Types and functions in this module may be changed or removed

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -86,6 +86,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod internal {
     //! This module contains implementation details. It is not part of the
     //! public API. Types and functions in this module may be changed or removed

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -466,6 +466,7 @@ pub struct Exhausted {
 }
 
 impl Exhausted {
+    /// Creates a new `Exhausted` error.
     pub fn new(
         operation_name: &str,
         limit_name: &'static str,

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -340,8 +340,8 @@ impl RetryPolicy for NeverRetry {
     }
 }
 
-#[derive(thiserror::Error, Debug)]
 /// Error indicating that the maximum elapsed time for retries has been exceeded.
+#[derive(thiserror::Error, Debug)]
 pub struct LimitedElapsedTimeError {
     maximum_duration: Duration,
     #[source]

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -341,6 +341,7 @@ impl RetryPolicy for NeverRetry {
 }
 
 #[derive(thiserror::Error, Debug)]
+/// Error indicating that the maximum elapsed time for retries has been exceeded.
 pub struct LimitedElapsedTimeError {
     maximum_duration: Duration,
     #[source]
@@ -585,7 +586,7 @@ where
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
     use super::*;
     use http::HeaderMap;
     use std::error::Error as StdError;

--- a/src/gax/src/retry_result.rs
+++ b/src/gax/src/retry_result.rs
@@ -65,6 +65,7 @@ impl RetryResult {
             Self::Exhausted(_) | Self::Continue(_) => false,
         }
     }
+
     /// Returns `true` if the operation should not be retried because the retry policy is exhausted.
     pub fn is_exhausted(&self) -> bool {
         match &self {
@@ -72,6 +73,7 @@ impl RetryResult {
             Self::Permanent(_) | Self::Continue(_) => false,
         }
     }
+
     /// Returns `true` if the operation should be retried.
     pub fn is_continue(&self) -> bool {
         match &self {

--- a/src/gax/src/retry_result.rs
+++ b/src/gax/src/retry_result.rs
@@ -58,21 +58,21 @@ pub enum RetryResult {
 }
 
 impl RetryResult {
-    /// Returns true if the result is Permanent.
+    /// Returns `true` if the operation should not be retried due to a permanent error.
     pub fn is_permanent(&self) -> bool {
         match &self {
             Self::Permanent(_) => true,
             Self::Exhausted(_) | Self::Continue(_) => false,
         }
     }
-    /// Returns true if the result is Exhausted.
+    /// Returns `true` if the operation should not be retried because the retry policy is exhausted.
     pub fn is_exhausted(&self) -> bool {
         match &self {
             Self::Exhausted(_) => true,
             Self::Permanent(_) | Self::Continue(_) => false,
         }
     }
-    /// Returns true if the result is Continue.
+    /// Returns `true` if the operation should be retried.
     pub fn is_continue(&self) -> bool {
         match &self {
             Self::Continue(_) => true,

--- a/src/gax/src/retry_result.rs
+++ b/src/gax/src/retry_result.rs
@@ -58,18 +58,21 @@ pub enum RetryResult {
 }
 
 impl RetryResult {
+    /// Returns true if the result is Permanent.
     pub fn is_permanent(&self) -> bool {
         match &self {
             Self::Permanent(_) => true,
             Self::Exhausted(_) | Self::Continue(_) => false,
         }
     }
+    /// Returns true if the result is Exhausted.
     pub fn is_exhausted(&self) -> bool {
         match &self {
             Self::Exhausted(_) => true,
             Self::Permanent(_) | Self::Continue(_) => false,
         }
     }
+    /// Returns true if the result is Continue.
     pub fn is_continue(&self) -> bool {
         match &self {
             Self::Continue(_) => true,

--- a/src/gax/src/retry_throttler.rs
+++ b/src/gax/src/retry_throttler.rs
@@ -69,13 +69,21 @@ use std::sync::{Arc, Mutex};
 /// The error type for throttler policy creation.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
+/// Errors that can occur when building a retry throttler.
 pub enum Error {
+    /// The scaling factor is out of range (must be >= 0.0).
     #[error("the scaling factor ({0}) must be greater or equal than 0.0")]
     ScalingOutOfRange(f64),
+    /// The minimum tokens must be less than or equal to the initial tokens.
     #[error(
         "the minimum tokens ({min}) must be less than or equal to the initial token ({initial}) count"
     )]
-    TooFewMinTokens { min: u64, initial: u64 },
+    TooFewMinTokens {
+        /// The minimum tokens.
+        min: u64,
+        /// The initial tokens.
+        initial: u64,
+    },
 }
 
 /// Implementations of this trait prevent a client from sending too many retries.


### PR DESCRIPTION
This change also adds missing documentation.

For #5459 
