### PR TITLE
cleanup(wkt, lro): allow missing docs for internal features

### DIFF
--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -86,6 +86,7 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
 
 use google_cloud_gax::Result;
 use google_cloud_gax::error::Error;
@@ -124,6 +125,7 @@ pub enum PollingResult<ResponseType, MetadataType> {
 }
 
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod internal;
 
 pub(crate) mod sealed {

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -19,6 +19,7 @@
 //! native or commonly used Rust types.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
 
 mod any;
 pub use crate::any::*;
@@ -29,9 +30,10 @@ pub use crate::empty::*;
 mod field_mask;
 pub use crate::field_mask::*;
 // The generated code contains (and uses) deprecated code.
-#[allow(deprecated)]
+#[allow(deprecated, missing_docs)]
 mod generated;
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+#[allow(missing_docs)]
 pub mod internal;
 pub use crate::generated::*;
 mod timestamp;


### PR DESCRIPTION
This change adds #[allow(missing_docs)] to the internal modules in both crates, and to the generated module in wkt to suppress errors in generated code.

For #5459 