### PR TITLE
feat(spanner): support QueryMode when executing statements

### DIFF
--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -15,6 +15,7 @@
 use crate::database_client::DatabaseClient;
 use crate::error::internal_error;
 use crate::google::spanner::v1::PartialResultSet;
+use crate::model::ResultSetStats;
 use crate::precommit::PrecommitTokenTracker;
 use crate::read_only_transaction::ReadContextTransactionSelector;
 use crate::result_set_metadata::ResultSetMetadata;
@@ -49,6 +50,7 @@ pub struct ResultSet {
     chunked: bool,
     ready_rows: VecDeque<Row>,
     metadata: Option<ResultSetMetadata>,
+    stats: Option<crate::model::ResultSetStats>,
     precommit_token_tracker: PrecommitTokenTracker,
 
     // Fields for retries and buffering of a stream of PartialResultSets.
@@ -109,6 +111,7 @@ impl ResultSet {
             max_buffered_partial_result_sets: MAX_BUFFERED_PARTIAL_RESULT_SETS,
             retry_count: 0,
             transaction_selector,
+            stats: None,
         }
     }
 
@@ -134,6 +137,29 @@ impl ResultSet {
         self.metadata
             .clone()
             .ok_or(ResultSetError::MetadataNotAvailable)
+    }
+
+    /// Returns the stats of the result set, if available.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::{ResultSet, Row};
+    /// # async fn process_stats(mut rs: ResultSet) -> Result<(), google_cloud_spanner::Error> {
+    /// while let Some(row) = rs.next().await {
+    ///     let row = row?;
+    ///     // Process row
+    /// }
+    /// if let Some(stats) = rs.stats() {
+    ///     println!("Query plan: {:?}", stats.query_plan);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Stats are only available after the results have been fully consumed
+    /// and the query was run in PLAN or PROFILE mode.
+    pub fn stats(&self) -> Option<&ResultSetStats> {
+        self.stats.as_ref()
     }
 
     /// Fetches the next row from the result set.
@@ -293,7 +319,14 @@ impl ResultSet {
         &mut self,
         partial_result_set: PartialResultSet,
     ) -> crate::Result<()> {
-        match (self.metadata.as_ref(), partial_result_set.metadata) {
+        let PartialResultSet {
+            metadata,
+            stats,
+            values,
+            chunked_value,
+            ..
+        } = partial_result_set;
+        match (self.metadata.as_ref(), metadata) {
             (Some(_), None) => {}
             (None, None) => {
                 return Err(internal_error(
@@ -329,7 +362,20 @@ impl ResultSet {
             }
         }
 
-        if partial_result_set.values.is_empty() {
+        match (&self.stats, stats) {
+            (Some(_), Some(_)) => {
+                return Err(internal_error("Additional stats received after first"));
+            }
+            (None, Some(s)) => {
+                self.stats = Some(
+                    s.cnv()
+                        .map_err(|e| internal_error(format!("failed to convert stats: {}", e)))?,
+                );
+            }
+            _ => {}
+        }
+
+        if values.is_empty() {
             return Ok(());
         }
         let metadata = self.metadata.as_ref().unwrap();
@@ -339,7 +385,7 @@ impl ResultSet {
             ));
         }
 
-        let mut values_iter = partial_result_set.values.into_iter();
+        let mut values_iter = values.into_iter();
         if self.chunked {
             if let Some(last_val) = self.buffered_values.last_mut() {
                 if let Some(first_new) = values_iter.next() {
@@ -349,7 +395,7 @@ impl ResultSet {
         }
 
         self.buffered_values.extend(values_iter);
-        self.chunked = partial_result_set.chunked_value;
+        self.chunked = chunked_value;
 
         while self.buffered_values.len() >= metadata.column_types.len() {
             let column_count = metadata.column_types.len();
@@ -512,6 +558,7 @@ pub(crate) mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use prost_types::Value;
     use spanner_grpc_mock::MockSpanner;
+    use spanner_grpc_mock::google::spanner::v1 as spanner_v1;
     use spanner_grpc_mock::google::spanner::v1::struct_type::Field;
     use spanner_grpc_mock::google::spanner::v1::{
         PartialResultSet, ResultSetMetadata, Session, StructType,
@@ -1884,6 +1931,71 @@ pub(crate) mod tests {
             "Caught implicit gap boundary: {}",
             err_str
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn result_set_stats() -> anyhow::Result<()> {
+        let mock_stats = spanner_v1::ResultSetStats {
+            query_plan: Some(spanner_v1::QueryPlan::default()),
+            ..Default::default()
+        };
+
+        let mut rs = run_mock_query(vec![PartialResultSet {
+            metadata: metadata(2),
+            values: vec![string_val("a"), string_val("b")],
+            last: true,
+            stats: Some(mock_stats),
+            ..Default::default()
+        }])
+        .await;
+
+        rs.next().await.transpose()?;
+
+        let received_stats = rs.stats().expect("stats should be available");
+        assert!(received_stats.query_plan.is_some());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn result_set_duplicate_stats() -> anyhow::Result<()> {
+        let mock_stats = spanner_v1::ResultSetStats {
+            query_plan: Some(spanner_v1::QueryPlan::default()),
+            ..Default::default()
+        };
+
+        let mut rs = run_mock_query(vec![
+            PartialResultSet {
+                metadata: metadata(2),
+                values: vec![string_val("a"), string_val("b")],
+                stats: Some(mock_stats.clone()),
+                resume_token: b"token1".to_vec(),
+                ..Default::default()
+            },
+            PartialResultSet {
+                values: vec![string_val("c"), string_val("d")],
+                stats: Some(mock_stats),
+                last: true,
+                resume_token: b"token2".to_vec(),
+                ..Default::default()
+            },
+        ])
+        .await;
+
+        // First row should be processed and returned successfully
+        let next = rs.next().await;
+        assert!(next.is_some());
+        assert!(next.expect("should yield a row").is_ok());
+
+        // Second call should process the second message and fail due to duplicate stats
+        let res2 = rs.next().await;
+        assert!(res2.is_some());
+        let res2 = res2.expect("should yield an error");
+        assert!(res2.is_err());
+        let err_str = res2.expect_err("should be an error").to_string();
+        assert!(err_str.contains("Additional stats received after first"));
 
         Ok(())
     }

--- a/src/spanner/src/result_set_metadata.rs
+++ b/src/spanner/src/result_set_metadata.rs
@@ -40,12 +40,23 @@ use std::sync::Arc;
 pub struct ResultSetMetadata {
     pub(crate) column_names: Arc<Vec<String>>,
     pub(crate) column_types: Arc<Vec<crate::types::Type>>,
+    pub(crate) undeclared_parameters: Arc<std::collections::BTreeMap<String, crate::types::Type>>,
 }
 
 impl ResultSetMetadata {
     pub(crate) fn new(metadata: Option<crate::google::spanner::v1::ResultSetMetadata>) -> Self {
         let mut column_names = Vec::new();
         let mut column_types = Vec::new();
+        let mut undeclared_parameters = std::collections::BTreeMap::new();
+
+        if let Some(m) = &metadata {
+            if let Some(undeclared) = &m.undeclared_parameters {
+                for field in &undeclared.fields {
+                    let param_type = field.r#type.clone().map(Into::into).unwrap_or_default();
+                    undeclared_parameters.insert(field.name.clone(), param_type);
+                }
+            }
+        }
 
         let fields = metadata
             .and_then(|m| m.row_type)
@@ -60,6 +71,7 @@ impl ResultSetMetadata {
         Self {
             column_names: Arc::new(column_names),
             column_types: Arc::new(column_types),
+            undeclared_parameters: Arc::new(undeclared_parameters),
         }
     }
 
@@ -71,6 +83,10 @@ impl ResultSetMetadata {
     /// Returns the types of the columns in the result set.
     pub fn column_types(&self) -> &[crate::types::Type] {
         &self.column_types
+    }
+    /// Returns the types of the undeclared parameters in the result set.
+    pub fn undeclared_parameters(&self) -> &std::collections::BTreeMap<String, crate::types::Type> {
+        &self.undeclared_parameters
     }
 }
 

--- a/src/spanner/src/row.rs
+++ b/src/spanner/src/row.rs
@@ -300,6 +300,7 @@ mod tests {
             metadata: ResultSetMetadata {
                 column_names: Arc::new(names),
                 column_types: Arc::new(types),
+                undeclared_parameters: Arc::new(std::collections::BTreeMap::new()),
             },
         };
 

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::model::DirectedReadOptions;
+use crate::model::execute_sql_request::QueryMode;
 use crate::model::execute_sql_request::QueryOptions;
 use crate::to_value::ToValue;
 use crate::types::Type;
@@ -36,6 +37,7 @@ pub struct StatementBuilder {
     request_options: Option<crate::model::RequestOptions>,
     directed_read_options: Option<DirectedReadOptions>,
     query_options: Option<QueryOptions>,
+    query_mode: Option<QueryMode>,
 }
 
 impl StatementBuilder {
@@ -47,6 +49,7 @@ impl StatementBuilder {
             request_options: None,
             directed_read_options: None,
             query_options: None,
+            query_mode: None,
         }
     }
 
@@ -131,6 +134,21 @@ impl StatementBuilder {
         self
     }
 
+    /// Sets the query mode to use for this statement.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Statement;
+    /// # use google_cloud_spanner::model::execute_sql_request::QueryMode;
+    /// let statement = Statement::builder("SELECT * FROM users")
+    ///     .with_query_mode(QueryMode::Plan)
+    ///     .build();
+    /// ```
+    pub fn with_query_mode(mut self, mode: QueryMode) -> Self {
+        self.query_mode = Some(mode);
+        self
+    }
+
     /// Builds and returns the finalized Statement object.
     pub fn build(self) -> Statement {
         Statement {
@@ -140,6 +158,7 @@ impl StatementBuilder {
             request_options: self.request_options,
             directed_read_options: self.directed_read_options,
             query_options: self.query_options,
+            query_mode: self.query_mode,
         }
     }
 }
@@ -175,12 +194,35 @@ pub struct Statement {
     pub(crate) request_options: Option<crate::model::RequestOptions>,
     pub(crate) directed_read_options: Option<DirectedReadOptions>,
     pub(crate) query_options: Option<QueryOptions>,
+    pub(crate) query_mode: Option<QueryMode>,
 }
 
 impl Statement {
     /// Creates a new statement builder.
     pub fn builder(sql: impl Into<String>) -> StatementBuilder {
         StatementBuilder::new(sql)
+    }
+
+    /// Sets the query mode to use for this statement.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Statement;
+    /// # use google_cloud_spanner::model::execute_sql_request::QueryMode;
+    /// # use google_cloud_spanner::client::SingleUseReadOnlyTransaction;
+    /// # async fn test_doc(tx: SingleUseReadOnlyTransaction) -> Result<(), google_cloud_spanner::Error> {
+    /// let statement = Statement::builder("SELECT * FROM users WHERE id = @id")
+    ///     .add_param("id", &42)
+    ///     .build();
+    /// let mut query_plan = tx.execute_query(statement.clone().with_query_mode(QueryMode::Plan)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This method consumes the statement and returns a new one with the specified mode.
+    pub fn with_query_mode(mut self, mode: QueryMode) -> Self {
+        self.query_mode = Some(mode);
+        self
     }
 
     fn into_parts(
@@ -212,6 +254,7 @@ impl Statement {
         let request_options = self.request_options.clone();
         let directed_read_options = self.directed_read_options.clone();
         let query_options = self.query_options.clone();
+        let query_mode = self.query_mode.clone();
         let (sql, params, param_types) = self.into_parts();
         crate::model::ExecuteSqlRequest::default()
             .set_sql(sql)
@@ -220,6 +263,7 @@ impl Statement {
             .set_or_clear_request_options(request_options)
             .set_or_clear_directed_read_options(directed_read_options)
             .set_or_clear_query_options(query_options)
+            .set_query_mode(query_mode.unwrap_or_default())
     }
 
     pub(crate) fn into_batch_statement(self) -> crate::model::execute_batch_dml_request::Statement {
@@ -405,6 +449,31 @@ mod tests {
                 .optimizer_version,
             "1"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn with_query_mode() -> anyhow::Result<()> {
+        let stmt = Statement::builder("SELECT * FROM users")
+            .with_query_mode(QueryMode::Plan)
+            .build();
+        assert_eq!(stmt.query_mode, Some(QueryMode::Plan));
+
+        let req = stmt.into_request();
+        assert_eq!(req.query_mode, QueryMode::Plan);
+        Ok(())
+    }
+
+    #[test]
+    fn statement_with_query_mode() -> anyhow::Result<()> {
+        let stmt = Statement::builder("SELECT * FROM users").build();
+        assert_eq!(stmt.query_mode, None);
+
+        let stmt = stmt.with_query_mode(QueryMode::Profile);
+        assert_eq!(stmt.query_mode, Some(QueryMode::Profile));
+
+        let req = stmt.into_request();
+        assert_eq!(req.query_mode, QueryMode::Profile);
         Ok(())
     }
 }

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -14,8 +14,9 @@
 
 use crate::client::{get_database_id, get_emulator_host};
 use crate::test_proxy::{InterceptedSpanner, SpannerInterceptor};
-use google_cloud_spanner::client::{DatabaseClient, Kind, Spanner, Statement};
-use google_cloud_spanner::model::execute_sql_request::QueryOptions;
+use google_cloud_spanner::client::{DatabaseClient, Kind, Spanner, Statement, TypeCode};
+use google_cloud_spanner::model::execute_sql_request::{QueryMode, QueryOptions};
+use google_cloud_spanner::model::result_set_stats::RowCount;
 use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
 use spanner_grpc_mock::google::spanner::v1 as spanner_v1;
 use spanner_grpc_mock::google::spanner::v1::spanner_client::SpannerClient;
@@ -560,6 +561,86 @@ pub async fn query_with_options(db_client: &DatabaseClient) -> anyhow::Result<()
     let row = rs.next().await.transpose()?.expect("should yield a row");
     let val: i64 = row.get(0);
     assert_eq!(val, 1);
+
+    Ok(())
+}
+
+pub async fn query_plan(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    let rot = db_client.single_use().build();
+
+    let sql = "SELECT 1 as num";
+    let stmt = Statement::builder(sql)
+        .with_query_mode(QueryMode::Plan)
+        .build();
+
+    let mut rs = rot.execute_query(stmt).await?;
+    let next = rs.next().await.transpose()?;
+    assert!(next.is_none());
+
+    let metadata = rs.metadata()?;
+    assert_eq!(metadata.column_names(), &["num".to_string()]);
+
+    let stats = rs.stats();
+    assert!(stats.is_none());
+
+    Ok(())
+}
+
+pub async fn query_profile(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    if get_emulator_host().is_some() {
+        println!("Skipping query_profile test on emulator");
+        return Ok(());
+    }
+    let rot = db_client.single_use().build();
+
+    let sql = "SELECT 1 as num";
+    let stmt = Statement::builder(sql)
+        .with_query_mode(QueryMode::Profile)
+        .build();
+
+    let mut rs = rot.execute_query(stmt).await?;
+    let mut rows = Vec::new();
+    while let Some(row) = rs.next().await {
+        rows.push(row?);
+    }
+    assert_eq!(rows.len(), 1);
+
+    let stats = rs.stats().expect("Expected stats in PROFILE mode");
+    assert!(stats.query_plan.is_some());
+    assert!(stats.query_stats.is_some());
+
+    Ok(())
+}
+
+pub async fn dml_plan(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    let runner = db_client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |tx| {
+            let sql = "UPDATE AllTypes SET ColBool = TRUE WHERE Id = @id";
+            let stmt = Statement::builder(sql)
+                .with_query_mode(QueryMode::Plan)
+                .build();
+
+            let mut rs = tx.execute_query(stmt).await?;
+            let next = rs.next().await.transpose()?;
+            assert!(next.is_none());
+
+            let metadata = rs.metadata().expect("metadata should be available");
+            assert!(metadata.column_names().is_empty());
+
+            // Verify undeclared parameters
+            let undeclared = metadata.undeclared_parameters();
+            assert_eq!(undeclared.len(), 1);
+            let param_type = undeclared.get("id").expect("missing param 'id'");
+            assert_eq!(param_type.code(), TypeCode::String);
+
+            let stats = rs.stats().expect("Expected stats in PLAN mode for DML");
+            assert_eq!(stats.row_count, Some(RowCount::RowCountExact(0)));
+
+            Ok(())
+        })
+        .await?;
 
     Ok(())
 }

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -32,6 +32,9 @@ mod spanner {
         .await?;
         integration_tests_spanner::query::inline_begin_fallback(&db_client).await?;
         integration_tests_spanner::query::query_with_options(&db_client).await?;
+        integration_tests_spanner::query::query_plan(&db_client).await?;
+        integration_tests_spanner::query::query_profile(&db_client).await?;
+        integration_tests_spanner::query::dml_plan(&db_client).await?;
 
         Ok(())
     }


### PR DESCRIPTION
Spanner supports multiple QueryModes when executing a statement:
- PLAN: Only parse and plan the query. Parameter values may be omitted.
- NORMAL: Normal execution. Parameter values must be supplied.
- PROFILE: Execute and profile the query. Returns execution stats.