### PR TITLE
feat(spanner): add option for exclude_from_change_streams

### DIFF
--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -40,6 +40,7 @@ use crate::transaction_retry_policy::{
 pub struct PartitionedDmlTransactionBuilder {
     client: DatabaseClient,
     retry_policy: Box<dyn TransactionRetryPolicy>,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl PartitionedDmlTransactionBuilder {
@@ -47,7 +48,36 @@ impl PartitionedDmlTransactionBuilder {
         Self {
             client,
             retry_policy: Box::new(BasicTransactionRetryPolicy::default()),
+            exclude_txn_from_change_streams: false,
         }
+    }
+
+    /// Sets whether to exclude the transaction from change streams.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build_transaction(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    ///     let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    ///     let transaction = db_client
+    ///         .partitioned_dml_transaction()
+    ///         .with_exclude_txn_from_change_streams(true)
+    ///         .build()
+    ///         .await?;
+    /// #   Ok(())
+    /// # }
+    /// ```
+    ///
+    /// When set to `true`, it prevents modifications from this transaction from being tracked in change streams.
+    /// Note that this only affects change streams that have been created with the DDL option `allow_txn_exclusion = true`.
+    /// If `allow_txn_exclusion` is not set or set to `false` for a change stream, updates made within this transaction
+    /// are recorded in that change stream regardless of this setting.
+    ///
+    /// When set to `false` or not specified, modifications from this transaction are recorded in all change streams
+    /// tracking columns modified by this transaction.
+    pub fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.exclude_txn_from_change_streams = exclude;
+        self
     }
 
     /// Sets the retry policy for the transaction.
@@ -87,6 +117,7 @@ impl PartitionedDmlTransactionBuilder {
         Ok(PartitionedDmlTransaction {
             client: self.client,
             retry_policy: self.retry_policy,
+            exclude_txn_from_change_streams: self.exclude_txn_from_change_streams,
         })
     }
 }
@@ -103,6 +134,7 @@ impl PartitionedDmlTransactionBuilder {
 pub struct PartitionedDmlTransaction {
     client: DatabaseClient,
     retry_policy: Box<dyn TransactionRetryPolicy>,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl PartitionedDmlTransaction {
@@ -132,8 +164,9 @@ impl PartitionedDmlTransaction {
         let statement = statement.into();
 
         let session_name = self.client.session_name();
-        let transaction_options =
-            TransactionOptions::default().set_partitioned_dml(PartitionedDml::default());
+        let transaction_options = TransactionOptions::default()
+            .set_partitioned_dml(PartitionedDml::default())
+            .set_exclude_txn_from_change_streams(self.exclude_txn_from_change_streams);
         let begin_request = BeginTransactionRequest {
             session: session_name.clone(),
             options: Some(transaction_options),
@@ -237,6 +270,46 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
         let transaction = db_client
             .partitioned_dml_transaction()
+            .build()
+            .await
+            .unwrap();
+        let statement = Statement::builder("UPDATE Users SET active = true").build();
+        let res: i64 = transaction.execute_update(statement).await.unwrap();
+        assert_eq!(res, 500);
+    }
+
+    #[tokio::test]
+    async fn execute_update_with_exclude_txn_from_change_streams() {
+        let mut mock = create_session_mock();
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            let options = req.options.expect("missing transaction options");
+            assert!(options.exclude_txn_from_change_streams);
+
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![0, 1, 2],
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_execute_streaming_sql()
+            .once()
+            .returning(|_req| {
+                let stream = adapt([Ok(v1::PartialResultSet {
+                    stats: Some(v1::ResultSetStats {
+                        row_count: Some(v1::result_set_stats::RowCount::RowCountLowerBound(500)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })]);
+                Ok(tonic::Response::from(stream))
+            });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let transaction = db_client
+            .partitioned_dml_transaction()
+            .with_exclude_txn_from_change_streams(true)
             .build()
             .await
             .unwrap();

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -86,6 +86,11 @@ impl ReadWriteTransactionBuilder {
         self
     }
 
+    pub(crate) fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.options = self.options.set_exclude_txn_from_change_streams(exclude);
+        self
+    }
+
     pub(crate) async fn begin_transaction(&self) -> crate::Result<ReadWriteTransaction> {
         let session_name = self.session_name.clone();
         let mut request = BeginTransactionRequest::default()
@@ -856,6 +861,30 @@ mod tests {
         let _tx = ReadWriteTransactionBuilder::new(db_client.clone())
             .with_isolation_level(IsolationLevel::Serializable)
             .with_read_lock_mode(ReadLockMode::Pessimistic)
+            .begin_transaction()
+            .await
+            .expect("Failed to build transaction");
+    }
+
+    #[tokio::test]
+    async fn read_write_transaction_with_exclude_txn_from_change_streams() {
+        let mut mock = create_session_mock();
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            let options = req.options.expect("missing transaction options");
+            assert!(options.exclude_txn_from_change_streams);
+
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![9, 9, 9],
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let _tx = ReadWriteTransactionBuilder::new(db_client.clone())
+            .with_exclude_txn_from_change_streams(true)
             .begin_transaction()
             .await
             .expect("Failed to build transaction");

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -123,6 +123,33 @@ impl TransactionRunnerBuilder {
         self
     }
 
+    /// Sets whether to exclude the transaction from change streams.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let runner = db_client.read_write_transaction()
+    ///     .with_exclude_txn_from_change_streams(true)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// When set to `true`, it prevents modifications from this transaction from being tracked in change streams.
+    /// Note that this only affects change streams that have been created with the DDL option `allow_txn_exclusion = true`.
+    /// If `allow_txn_exclusion` is not set or set to `false` for a change stream, updates made within this transaction
+    /// are recorded in that change stream regardless of this setting.
+    ///
+    /// When set to `false` or not specified, modifications from this transaction are recorded in all change streams
+    /// tracking columns modified by this transaction.
+    pub fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.builder = self.builder.with_exclude_txn_from_change_streams(exclude);
+        self
+    }
+
     /// Sets the retry policy for the transaction.
     ///
     /// # Example
@@ -685,6 +712,47 @@ mod tests {
 
         let runner = TransactionRunnerBuilder::new(db_client)
             .with_transaction_tag("my-test-tag")
+            .build()
+            .await?;
+
+        let res = runner
+            .run(async |tx| {
+                let count = tx.execute_update("UPDATE Users SET active = true").await?;
+                Ok(count)
+            })
+            .await?;
+
+        assert_eq!(res, 5);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_with_exclude_txn_from_change_streams() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            let options = req.options.expect("Missing transaction options");
+            assert!(options.exclude_txn_from_change_streams);
+
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![9, 9, 9],
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_execute_sql()
+            .once()
+            .returning(|_req| row_count_exact_response(5));
+        mock.expect_commit()
+            .once()
+            .returning(|_req| commit_response());
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let runner = TransactionRunnerBuilder::new(db_client)
+            .with_exclude_txn_from_change_streams(true)
             .build()
             .await?;
 

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -28,6 +28,7 @@ pub struct WriteOnlyTransactionBuilder {
     client: DatabaseClient,
     transaction_tag: Option<String>,
     retry_policy: Box<dyn TransactionRetryPolicy>,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl WriteOnlyTransactionBuilder {
@@ -36,6 +37,7 @@ impl WriteOnlyTransactionBuilder {
             client,
             transaction_tag: None,
             retry_policy: Box::new(BasicTransactionRetryPolicy::default()),
+            exclude_txn_from_change_streams: false,
         }
     }
 
@@ -56,6 +58,32 @@ impl WriteOnlyTransactionBuilder {
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
     pub fn with_transaction_tag(mut self, tag: impl Into<String>) -> Self {
         self.transaction_tag = Some(tag.into());
+        self
+    }
+
+    /// Sets whether to exclude the transaction from change streams.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.write_only_transaction()
+    ///     .with_exclude_txn_from_change_streams(true)
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// When set to `true`, it prevents modifications from this transaction from being tracked in change streams.
+    /// Note that this only affects change streams that have been created with the DDL option `allow_txn_exclusion = true`.
+    /// If `allow_txn_exclusion` is not set or set to `false` for a change stream, updates made within this transaction
+    /// are recorded in that change stream regardless of this setting.
+    ///
+    /// When set to `false` or not specified, modifications from this transaction are recorded in all change streams
+    /// tracking columns modified by this transaction.
+    pub fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.exclude_txn_from_change_streams = exclude;
         self
     }
 
@@ -106,6 +134,7 @@ impl WriteOnlyTransactionBuilder {
             client: self.client,
             transaction_tag: self.transaction_tag,
             retry_policy: self.retry_policy,
+            exclude_txn_from_change_streams: self.exclude_txn_from_change_streams,
         }
     }
 }
@@ -118,6 +147,7 @@ pub struct WriteOnlyTransaction {
     client: DatabaseClient,
     transaction_tag: Option<String>,
     retry_policy: Box<dyn TransactionRetryPolicy>,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl WriteOnlyTransaction {
@@ -176,10 +206,14 @@ impl WriteOnlyTransaction {
                 let begin_req = BeginTransactionRequest::default()
                     .set_session(session_name.clone())
                     .set_options(
-                        TransactionOptions::default().set_read_write(Box::new(
-                            ReadWrite::default()
-                                .set_multiplexed_session_previous_transaction_id(previous_id),
-                        )),
+                        TransactionOptions::default()
+                            .set_read_write(Box::new(
+                                ReadWrite::default()
+                                    .set_multiplexed_session_previous_transaction_id(previous_id),
+                            ))
+                            .set_exclude_txn_from_change_streams(
+                                self.exclude_txn_from_change_streams,
+                            ),
                     )
                     .set_request_options(req_options.clone())
                     .set_or_clear_mutation_key(mutation_key.clone());
@@ -258,7 +292,9 @@ impl WriteOnlyTransaction {
     where
         I: IntoIterator<Item = Mutation>,
     {
-        let single_use = TransactionOptions::new().set_read_write(Box::new(ReadWrite::new()));
+        let single_use = TransactionOptions::new()
+            .set_read_write(Box::new(ReadWrite::new()))
+            .set_exclude_txn_from_change_streams(self.exclude_txn_from_change_streams);
         let req_options =
             RequestOptions::new().set_transaction_tag(self.transaction_tag.unwrap_or_default());
 
@@ -470,6 +506,109 @@ mod tests {
                 .seconds(),
             5678
         );
+    }
+
+    #[tokio::test]
+    async fn write_at_least_once_with_exclude_txn_from_change_streams() {
+        let mut mock = spanner_grpc_mock::MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                    ..Default::default()
+                },
+            ))
+        });
+
+        mock.expect_commit().once().returning(|req| {
+            let req = req.into_inner();
+            match req.transaction {
+                Some(spanner_grpc_mock::google::spanner::v1::commit_request::Transaction::SingleUseTransaction(opts)) => {
+                    assert!(opts.exclude_txn_from_change_streams);
+                }
+                _ => panic!("Expected SingleUseTransaction"),
+            }
+
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::CommitResponse {
+                    commit_timestamp: Some(prost_types::Timestamp {
+                        seconds: 1234,
+                        nanos: 0,
+                    }),
+                    ..Default::default()
+                },
+            ))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let mutation = Mutation::new_insert_or_update_builder("Users")
+            .set("UserId")
+            .to(&1)
+            .build();
+
+        let res = db_client
+            .write_only_transaction()
+            .with_exclude_txn_from_change_streams(true)
+            .build()
+            .write_at_least_once(vec![mutation])
+            .await;
+
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn write_with_exclude_txn_from_change_streams() {
+        let mut mock = spanner_grpc_mock::MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                    ..Default::default()
+                },
+            ))
+        });
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            let options = req.options.expect("Missing transaction options");
+            assert!(options.exclude_txn_from_change_streams);
+
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::Transaction {
+                    id: vec![42],
+                    ..Default::default()
+                },
+            ))
+        });
+
+        mock.expect_commit().once().returning(|_req| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::CommitResponse {
+                    commit_timestamp: Some(prost_types::Timestamp {
+                        seconds: 5678,
+                        nanos: 0,
+                    }),
+                    ..Default::default()
+                },
+            ))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let mutation = Mutation::new_insert_or_update_builder("Users")
+            .set("UserId")
+            .to(&1)
+            .build();
+
+        let res = db_client
+            .write_only_transaction()
+            .with_exclude_txn_from_change_streams(true)
+            .build()
+            .write(vec![mutation])
+            .await;
+
+        assert!(res.is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds an option for exclude_from_change_streams to the relevant transaction types.