### PR TITLE
impl(pubsub): use fewer exactly-once lease extensions

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -39,6 +39,10 @@ const MAX_IDS_PER_RPC: usize = 1000;
 // How often we extend deadlines for messages under lease
 const EXTEND_PERIOD: Duration = Duration::from_secs(3);
 
+/// The buffer applied to the lease extension period to account for network
+/// latency and processing time.
+const EXTEND_BUFFER: Duration = Duration::from_secs(2);
+
 // Helper function to chunk ack ids into chunks of MAX_IDS_PER_RPC.
 fn batch(ack_ids: Vec<String>) -> Vec<Vec<String>> {
     ack_ids
@@ -130,6 +134,7 @@ pub(super) struct ExactlyOnceInfo {
     receive_time: Instant,
     result_tx: Sender<AckResult>,
     status: MessageStatus,
+    last_extension: Option<Instant>,
 }
 
 impl ExactlyOnceInfo {
@@ -138,6 +143,7 @@ impl ExactlyOnceInfo {
             receive_time: Instant::now(),
             result_tx,
             status: MessageStatus::Leased,
+            last_extension: None,
         }
     }
 }
@@ -290,7 +296,9 @@ where
                 .spawn(async move { leaser.extend(ack_ids).await });
         }
 
-        let batches = self.eo_leases.retain(self.max_lease);
+        let batches = self
+            .eo_leases
+            .retain(self.max_lease, self.max_lease_extension);
         for ack_ids in batches {
             let leaser = self.leaser.clone();
             self.pending_extends
@@ -833,7 +841,11 @@ pub(super) mod tests {
             .withf(|v| sorted(v) == test_ids(5..20))
             .returning(|_| ());
 
-        let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
+        let options = LeaseOptions {
+            max_lease_extension: Duration::ZERO,
+            ..Default::default()
+        };
+        let mut state = LeaseState::new(Arc::new(mock), options);
 
         // Add 10 messages. These are now under lease management.
         for i in 0..10 {

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{AtLeastOnceInfo, EXTEND_PERIOD, MAX_IDS_PER_RPC};
+use super::{AtLeastOnceInfo, EXTEND_BUFFER, EXTEND_PERIOD, MAX_IDS_PER_RPC};
 use std::collections::HashMap;
 // Use a `tokio::time::Instant` to facilitate time-based unit testing.
 use tokio::time::{Duration, Instant};
-
-/// The buffer applied to the lease extension period to account for network
-/// latency and processing time.
-const EXTEND_BUFFER: Duration = Duration::from_secs(2);
 
 /// Leases for messages with at-least-once delivery semantics.
 #[derive(Debug, Default)]

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use super::super::handler::AckResult;
-use super::MAX_IDS_PER_RPC;
-use super::{ExactlyOnceInfo, MessageStatus};
+use super::{EXTEND_BUFFER, EXTEND_PERIOD, ExactlyOnceInfo, MAX_IDS_PER_RPC, MessageStatus};
 use crate::error::AckError;
 use std::collections::HashMap;
 // Use a `tokio::time::Instant` to facilitate time-based unit testing.
@@ -89,7 +88,11 @@ impl Leases {
     /// Returns batches of ack IDs to extend.
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
-    pub fn retain(&mut self, max_lease: Duration) -> Vec<Vec<String>> {
+    pub fn retain(
+        &mut self,
+        max_lease: Duration,
+        max_lease_extension: Duration,
+    ) -> Vec<Vec<String>> {
         let now = Instant::now();
 
         // We want to extract some values from `HashMap`, leaving the rest
@@ -105,15 +108,34 @@ impl Leases {
         let mut expired = Vec::new();
         let remaining = self
             .under_lease
-            .iter()
+            .iter_mut()
             .filter_map(|(id, info)| match info.status {
                 MessageStatus::Nacking => None,
-                MessageStatus::Acking => Some(id.clone()),
-                MessageStatus::Leased => {
-                    if info.receive_time + max_lease < now {
-                        expired.push(id.clone());
+                MessageStatus::Acking => {
+                    if info.last_extension.is_some_and(|i| {
+                        i + max_lease_extension > now + EXTEND_PERIOD + EXTEND_BUFFER
+                    }) {
+                        // The lease is still valid for a while. No need to extend.
                         None
                     } else {
+                        // Continue to extend messages being acked.
+                        info.last_extension = Some(now);
+                        Some(id.clone())
+                    }
+                }
+                MessageStatus::Leased => {
+                    if info.receive_time + max_lease < now {
+                        // Drop messages that have been held for too long.
+                        expired.push(id.clone());
+                        None
+                    } else if info.last_extension.is_some_and(|i| {
+                        i + max_lease_extension > now + EXTEND_PERIOD + EXTEND_BUFFER
+                    }) {
+                        // The lease is still valid for a while. No need to extend.
+                        None
+                    } else {
+                        // Extend leases for all other messages
+                        info.last_extension = Some(now);
                         Some(id.clone())
                     }
                 }
@@ -189,6 +211,7 @@ mod tests {
             receive_time: Instant::now(),
             result_tx,
             status: MessageStatus::Leased,
+            last_extension: None,
         }
     }
 
@@ -315,6 +338,7 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(3),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
         assert_eq!(
@@ -514,7 +538,7 @@ mod tests {
             want.insert(test_id(i));
         }
 
-        let batches = leases.retain(Duration::from_secs(1));
+        let batches = leases.retain(Duration::from_secs(1), Duration::ZERO);
         assert_eq!(batches.len(), NUM_BATCHES as usize);
 
         let mut got = HashSet::new();
@@ -540,6 +564,7 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(3),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
 
@@ -550,11 +575,12 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(1),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
 
         // No messages expired.
-        let mut batches = leases.retain(Duration::from_secs(4));
+        let mut batches = leases.retain(Duration::from_secs(4), Duration::ZERO);
         for batch in &mut batches {
             batch.sort();
         }
@@ -569,7 +595,7 @@ mod tests {
         );
 
         // Message 1 expires.
-        let batches = leases.retain(Duration::from_secs(2));
+        let batches = leases.retain(Duration::from_secs(2), Duration::ZERO);
         assert_eq!(batches, vec![vec![test_id(2)]]);
         assert_eq!(
             TestLeases {
@@ -583,7 +609,7 @@ mod tests {
         assert!(matches!(err, AckError::LeaseExpired), "{err:?}");
 
         // Message 2 expires.
-        let batches = leases.retain(Duration::ZERO);
+        let batches = leases.retain(Duration::ZERO, Duration::ZERO);
         assert!(batches.is_empty(), "{batches:?}");
         assert_eq!(
             TestLeases {
@@ -610,6 +636,7 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(1),
                 result_tx,
                 status: MessageStatus::Acking,
+                last_extension: None,
             },
         );
 
@@ -620,10 +647,11 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(1),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
 
-        let batches = leases.retain(Duration::ZERO);
+        let batches = leases.retain(Duration::ZERO, Duration::ZERO);
         assert_eq!(batches, vec![vec![test_id(1)]]);
         assert_eq!(
             TestLeases {
@@ -652,6 +680,7 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(1),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
         leases.nack(test_id(1));
@@ -663,10 +692,11 @@ mod tests {
                 receive_time: Instant::now() - Duration::from_secs(1),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
 
-        let batches = leases.retain(Duration::ZERO);
+        let batches = leases.retain(Duration::ZERO, Duration::ZERO);
         assert!(batches.is_empty(), "{batches:?}");
 
         assert_eq!(
@@ -699,6 +729,7 @@ mod tests {
                 // Even pending acks will be evicted, and satisfied with
                 // `Shutdown` errors.
                 status: MessageStatus::Acking,
+                last_extension: None,
             },
         );
         let (result_tx, result_rx2) = channel();
@@ -708,6 +739,7 @@ mod tests {
                 receive_time: Instant::now(),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
         let (result_tx, result_rx3) = channel();
@@ -717,6 +749,7 @@ mod tests {
                 receive_time: Instant::now(),
                 result_tx,
                 status: MessageStatus::Leased,
+                last_extension: None,
             },
         );
         leases.nack(test_id(3));
@@ -770,6 +803,64 @@ mod tests {
         let to_nack = Batches::flatten(to_nack);
         assert_eq!(to_nack.counts, vec![MAX_IDS_PER_RPC, 20]);
         assert_eq!(sorted(&to_nack.ack_ids), test_ids(0..MAX_IDS_PER_RPC + 20));
+
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn necessary_extensions() -> anyhow::Result<()> {
+        const MAX_LEASE: Duration = Duration::from_secs(900);
+        const MAX_LEASE_EXTENSION: Duration = Duration::from_secs(10);
+
+        let mut leases = Leases::default();
+        leases.add(test_id(0), test_info());
+
+        // Add an acked message.
+        leases.add(test_id(1), test_info());
+        leases.ack(test_id(1));
+
+        // We should always send a receipt lease extension upon receiving a
+        // message.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        let flattened = Batches::flatten(batches);
+        assert_eq!(sorted(&flattened.ack_ids), test_ids(0..2));
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..2),
+                to_ack: vec![test_id(1)],
+                to_nack: Vec::new(),
+            },
+            leases
+        );
+
+        // The clock has not advanced, and we just sent out an extension. We
+        // should not send another extension.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        assert!(batches.is_empty(), "{batches:?}");
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..2),
+                to_ack: vec![test_id(1)],
+                to_nack: Vec::new(),
+            },
+            leases
+        );
+
+        // Advance the time close to the expiration of the initial lease.
+        tokio::time::advance(MAX_LEASE_EXTENSION - Duration::from_secs(1)).await;
+
+        // We need to extend the lease again.
+        let batches = leases.retain(MAX_LEASE, MAX_LEASE_EXTENSION);
+        let flattened = Batches::flatten(batches);
+        assert_eq!(sorted(&flattened.ack_ids), test_ids(0..2));
+        assert_eq!(
+            TestLeases {
+                under_lease: test_ids(0..2),
+                to_ack: vec![test_id(1)],
+                to_nack: Vec::new(),
+            },
+            leases
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This PR extends the logic in https://github.com/googleapis/google-cloud-rust/pull/5241 to exactly-once leases. Specifically, we only extend exactly-once leases if they are within 5 seconds of expiring.

Towards #5048 