### PR TITLE
feat(pubsub): add delivery attempt tracking to subscriber

### DIFF
--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -82,6 +82,23 @@ pub(super) enum Action {
 /// To reject (nack) a message, you call [`Handler::nack()`]. The
 /// service will redeliver the message.
 ///
+/// ## Delivery attempts
+///
+/// If the subscription has a [dead-letter topic] configured, you can retrieve
+/// the delivery attempt count.
+///
+/// [dead-letter topic]: https://cloud.google.com/pubsub/docs/dead-letter-topics
+///
+/// ```
+/// # use google_cloud_pubsub::subscriber::handler::Handler;
+/// fn on_message(h: Handler) {
+///   if let Some(attempt) = h.delivery_attempt() {
+///       println!("Delivery attempt: {}", attempt);
+///   }
+///   h.ack();
+/// }
+/// ```
+///
 /// ## Exactly-once delivery
 ///
 /// If your subscription has [exactly-once delivery] enabled, you should
@@ -181,12 +198,36 @@ impl Handler {
             Handler::ExactlyOnce(h) => h.nack(),
         }
     }
+
+    /// Returns the delivery attempt count for this message, if available.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_pubsub::subscriber::handler::Handler;
+    /// fn on_message(h: Handler) {
+    ///   if let Some(attempt) = h.delivery_attempt() {
+    ///       println!("Delivery attempt: {}", attempt);
+    ///   }
+    ///   h.ack();
+    /// }
+    /// ```
+    ///
+    /// This returns `None` if there is no delivery attempt recorded (e.g., if
+    /// dead-letter topics are not configured on the subscription).
+    pub fn delivery_attempt(&self) -> Option<i32> {
+        match self {
+            Handler::AtLeastOnce(h) => h.delivery_attempt(),
+            Handler::ExactlyOnce(h) => h.delivery_attempt(),
+        }
+    }
 }
 
 #[derive(Debug)]
 struct AtLeastOnceImpl {
     ack_id: String,
     ack_tx: UnboundedSender<Action>,
+    delivery_attempt: Option<i32>,
 }
 
 impl AtLeastOnceImpl {
@@ -206,9 +247,9 @@ pub struct AtLeastOnce {
 }
 
 impl AtLeastOnce {
-    pub(super) fn new(ack_id: String, ack_tx: UnboundedSender<Action>) -> Self {
+    pub(super) fn new(ack_id: String, ack_tx: UnboundedSender<Action>, delivery_attempt: Option<i32>) -> Self {
         Self {
-            inner: Some(AtLeastOnceImpl { ack_id, ack_tx }),
+            inner: Some(AtLeastOnceImpl { ack_id, ack_tx, delivery_attempt }),
         }
     }
 
@@ -242,6 +283,26 @@ impl AtLeastOnce {
             inner.nack();
         }
     }
+
+    /// Returns the delivery attempt count for this message, if available.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_pubsub::subscriber::handler::AtLeastOnce;
+    /// fn on_message(h: AtLeastOnce) {
+    ///   if let Some(attempt) = h.delivery_attempt() {
+    ///       println!("Delivery attempt: {}", attempt);
+    ///   }
+    ///   h.ack();
+    /// }
+    /// ```
+    ///
+    /// This returns `None` if there is no delivery attempt recorded (e.g., if
+    /// dead-letter topics are not configured on the subscription).
+    pub fn delivery_attempt(&self) -> Option<i32> {
+        self.inner.as_ref().and_then(|i| i.delivery_attempt)
+    }
 }
 
 impl Drop for AtLeastOnce {
@@ -267,12 +328,14 @@ impl ExactlyOnce {
         ack_id: String,
         ack_tx: UnboundedSender<Action>,
         result_rx: Receiver<AckResult>,
+        delivery_attempt: Option<i32>,
     ) -> Self {
         Self {
             inner: Some(ExactlyOnceImpl {
                 ack_id,
                 ack_tx,
                 result_rx,
+                delivery_attempt,
             }),
         }
     }
@@ -339,6 +402,26 @@ impl ExactlyOnce {
         let inner = self.inner.take().expect("handler impl is always some");
         inner.confirmed_nack().await
     }
+
+    /// Returns the delivery attempt count for this message, if available.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_pubsub::subscriber::handler::ExactlyOnce;
+    /// async fn on_message(h: ExactlyOnce) {
+    ///   if let Some(attempt) = h.delivery_attempt() {
+    ///       println!("Delivery attempt: {}", attempt);
+    ///   }
+    ///   let _ = h.confirmed_ack().await;
+    /// }
+    /// ```
+    ///
+    /// This returns `None` if there is no delivery attempt recorded (e.g., if
+    /// dead-letter topics are not configured on the subscription).
+    pub fn delivery_attempt(&self) -> Option<i32> {
+        self.inner.as_ref().and_then(|i| i.delivery_attempt)
+    }
 }
 
 impl Drop for ExactlyOnce {
@@ -358,6 +441,7 @@ struct ExactlyOnceImpl {
     pub(super) ack_id: String,
     pub(super) ack_tx: UnboundedSender<Action>,
     pub(super) result_rx: Receiver<AckResult>,
+    pub(super) delivery_attempt: Option<i32>,
 }
 
 impl ExactlyOnceImpl {
@@ -429,9 +513,51 @@ mod tests {
     }
 
     #[test]
+    fn handler_delivery_attempt() -> anyhow::Result<()> {
+        let (ack_tx, _) = unbounded_channel();
+        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx, Some(5)));
+        assert_eq!(h.delivery_attempt(), Some(5));
+        Ok(())
+    }
+
+    #[test]
+    fn at_least_once_delivery_attempt() -> anyhow::Result<()> {
+        let (ack_tx, _) = unbounded_channel();
+        let h = AtLeastOnce::new(test_id(1), ack_tx, Some(5));
+        assert_eq!(h.delivery_attempt(), Some(5));
+        Ok(())
+    }
+
+    #[test]
+    fn at_least_once_delivery_attempt_none() -> anyhow::Result<()> {
+        let (ack_tx, _) = unbounded_channel();
+        let h = AtLeastOnce::new(test_id(1), ack_tx, None);
+        assert_eq!(h.delivery_attempt(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn exactly_once_delivery_attempt() -> anyhow::Result<()> {
+        let (ack_tx, _) = unbounded_channel();
+        let (_result_tx, result_rx) = channel();
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, Some(5));
+        assert_eq!(h.delivery_attempt(), Some(5));
+        Ok(())
+    }
+
+    #[test]
+    fn exactly_once_delivery_attempt_none() -> anyhow::Result<()> {
+        let (ack_tx, _) = unbounded_channel();
+        let (_result_tx, result_rx) = channel();
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
+        assert_eq!(h.delivery_attempt(), None);
+        Ok(())
+    }
+
+    #[test]
     fn handler_at_least_once_ack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx));
+        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.ack();
@@ -444,7 +570,7 @@ mod tests {
     #[test]
     fn handler_at_least_once_nack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx));
+        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.nack();
@@ -458,7 +584,7 @@ mod tests {
     fn handler_exactly_once_ack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx));
+        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.ack();
@@ -472,7 +598,7 @@ mod tests {
     fn handler_exactly_once_nack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx));
+        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.nack();
@@ -485,7 +611,7 @@ mod tests {
     #[test]
     fn at_least_once_ack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = AtLeastOnce::new(test_id(1), ack_tx);
+        let h = AtLeastOnce::new(test_id(1), ack_tx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.ack();
@@ -498,7 +624,7 @@ mod tests {
     #[test]
     fn at_least_once_nack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = AtLeastOnce::new(test_id(1), ack_tx);
+        let h = AtLeastOnce::new(test_id(1), ack_tx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.nack();
@@ -512,7 +638,7 @@ mod tests {
     fn exactly_once_ack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.ack();
@@ -526,7 +652,7 @@ mod tests {
     async fn exactly_once_success() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         let task = tokio::task::spawn(async move { h.confirmed_ack().await });
@@ -546,7 +672,7 @@ mod tests {
     async fn exactly_once_nack_success() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         let task = tokio::task::spawn(async move { h.confirmed_nack().await });
@@ -566,7 +692,7 @@ mod tests {
     async fn exactly_once_error() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         let task = tokio::task::spawn(async move { h.confirmed_ack().await });
@@ -587,7 +713,7 @@ mod tests {
     async fn exactly_once_nack_error() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         let task = tokio::task::spawn(async move { h.confirmed_nack().await });
@@ -608,7 +734,7 @@ mod tests {
     async fn exactly_once_action_channel_closed() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
         drop(ack_rx);
 
@@ -622,7 +748,7 @@ mod tests {
     async fn exactly_once_nack_action_channel_closed() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
         drop(ack_rx);
 
@@ -642,7 +768,7 @@ mod tests {
     async fn exactly_once_result_channel_closed() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         let task = tokio::task::spawn(async move { h.confirmed_ack().await });
@@ -661,7 +787,7 @@ mod tests {
     fn exactly_once_nack() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         h.nack();
@@ -674,7 +800,7 @@ mod tests {
     #[test]
     fn handler_at_least_once_nack_on_drop() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx));
+        let h = Handler::AtLeastOnce(AtLeastOnce::new(test_id(1), ack_tx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         drop(h);
@@ -688,7 +814,7 @@ mod tests {
     fn handler_exactly_once_nack_on_drop() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx));
+        let h = Handler::ExactlyOnce(ExactlyOnce::new(test_id(1), ack_tx, result_rx, None));
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         drop(h);
@@ -701,7 +827,7 @@ mod tests {
     #[test]
     fn at_least_once_nack_on_drop() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
-        let h = AtLeastOnce::new(test_id(1), ack_tx);
+        let h = AtLeastOnce::new(test_id(1), ack_tx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         drop(h);
@@ -715,7 +841,7 @@ mod tests {
     fn exactly_once_nack_on_drop() -> anyhow::Result<()> {
         let (ack_tx, mut ack_rx) = unbounded_channel();
         let (_result_tx, result_rx) = channel();
-        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx);
+        let h = ExactlyOnce::new(test_id(1), ack_tx, result_rx, None);
         assert_eq!(ack_rx.try_recv(), Err(TryRecvError::Empty));
 
         drop(h);

--- a/src/pubsub/src/subscriber/handler.rs
+++ b/src/pubsub/src/subscriber/handler.rs
@@ -92,10 +92,10 @@ pub(super) enum Action {
 /// ```
 /// # use google_cloud_pubsub::subscriber::handler::Handler;
 /// fn on_message(h: Handler) {
-///   if let Some(attempt) = h.delivery_attempt() {
-///       println!("Delivery attempt: {}", attempt);
-///   }
-///   h.ack();
+///     match h.delivery_attempt() {
+///         Some(i) => println!("Delivery attempt: {i}"),
+///         None => println!("Delivery attempt: unknown"),
+///     }
 /// }
 /// ```
 ///
@@ -206,10 +206,10 @@ impl Handler {
     /// ```
     /// # use google_cloud_pubsub::subscriber::handler::Handler;
     /// fn on_message(h: Handler) {
-    ///   if let Some(attempt) = h.delivery_attempt() {
-    ///       println!("Delivery attempt: {}", attempt);
-    ///   }
-    ///   h.ack();
+    ///     match h.delivery_attempt() {
+    ///         Some(i) => println!("Delivery attempt: {i}"),
+    ///         None => println!("Delivery attempt: unknown"),
+    ///     }
     /// }
     /// ```
     ///
@@ -247,9 +247,17 @@ pub struct AtLeastOnce {
 }
 
 impl AtLeastOnce {
-    pub(super) fn new(ack_id: String, ack_tx: UnboundedSender<Action>, delivery_attempt: Option<i32>) -> Self {
+    pub(super) fn new(
+        ack_id: String,
+        ack_tx: UnboundedSender<Action>,
+        delivery_attempt: Option<i32>,
+    ) -> Self {
         Self {
-            inner: Some(AtLeastOnceImpl { ack_id, ack_tx, delivery_attempt }),
+            inner: Some(AtLeastOnceImpl {
+                ack_id,
+                ack_tx,
+                delivery_attempt,
+            }),
         }
     }
 
@@ -291,10 +299,10 @@ impl AtLeastOnce {
     /// ```
     /// # use google_cloud_pubsub::subscriber::handler::AtLeastOnce;
     /// fn on_message(h: AtLeastOnce) {
-    ///   if let Some(attempt) = h.delivery_attempt() {
-    ///       println!("Delivery attempt: {}", attempt);
-    ///   }
-    ///   h.ack();
+    ///     match h.delivery_attempt() {
+    ///         Some(i) => println!("Delivery attempt: {i}"),
+    ///         None => println!("Delivery attempt: unknown"),
+    ///     }
     /// }
     /// ```
     ///
@@ -409,11 +417,11 @@ impl ExactlyOnce {
     ///
     /// ```
     /// # use google_cloud_pubsub::subscriber::handler::ExactlyOnce;
-    /// async fn on_message(h: ExactlyOnce) {
-    ///   if let Some(attempt) = h.delivery_attempt() {
-    ///       println!("Delivery attempt: {}", attempt);
-    ///   }
-    ///   let _ = h.confirmed_ack().await;
+    /// fn on_message(h: ExactlyOnce) {
+    ///     match h.delivery_attempt() {
+    ///         Some(i) => println!("Delivery attempt: {i}"),
+    ///         None => println!("Delivery attempt: unknown"),
+    ///     }
     /// }
     /// ```
     ///

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -365,6 +365,8 @@ impl MessageStreamImpl {
                 continue;
             };
 
+            let delivery_attempt = (rm.delivery_attempt > 0).then_some(rm.delivery_attempt);
+
             let (lease_info, handler_info) = if exactly_once {
                 let (result_tx, result_rx) = tokio::sync::oneshot::channel();
                 (
@@ -372,6 +374,7 @@ impl MessageStreamImpl {
                     HandlerInfo::ExactlyOnce {
                         ack_id: rm.ack_id.clone(),
                         result_rx,
+                        delivery_attempt,
                     },
                 )
             } else {
@@ -379,6 +382,7 @@ impl MessageStreamImpl {
                     LeaseInfo::AtLeastOnce(AtLeastOnceInfo::new()),
                     HandlerInfo::AtLeastOnce {
                         ack_id: rm.ack_id.clone(),
+                        delivery_attempt,
                     },
                 )
             };
@@ -419,10 +423,12 @@ impl MessageStreamImpl {
 enum HandlerInfo {
     AtLeastOnce {
         ack_id: String,
+        delivery_attempt: Option<i32>,
     },
     ExactlyOnce {
         ack_id: String,
         result_rx: Receiver<AckResult>,
+        delivery_attempt: Option<i32>,
     },
 }
 
@@ -431,12 +437,20 @@ impl HandlerInfo {
     /// serving it to the application.
     fn into_handler(self, ack_tx: UnboundedSender<Action>) -> Handler {
         match self {
-            HandlerInfo::AtLeastOnce { ack_id } => {
-                Handler::AtLeastOnce(AtLeastOnce::new(ack_id, ack_tx))
-            }
-            HandlerInfo::ExactlyOnce { ack_id, result_rx } => {
-                Handler::ExactlyOnce(ExactlyOnce::new(ack_id, ack_tx, result_rx))
-            }
+            HandlerInfo::AtLeastOnce {
+                ack_id,
+                delivery_attempt,
+            } => Handler::AtLeastOnce(AtLeastOnce::new(ack_id, ack_tx, delivery_attempt)),
+            HandlerInfo::ExactlyOnce {
+                ack_id,
+                result_rx,
+                delivery_attempt,
+            } => Handler::ExactlyOnce(ExactlyOnce::new(
+                ack_id,
+                ack_tx,
+                result_rx,
+                delivery_attempt,
+            )),
         }
     }
 }
@@ -478,6 +492,7 @@ mod tests {
                         data: test_data(i).to_vec(),
                         ..Default::default()
                     }),
+                    delivery_attempt: i,
                     ..Default::default()
                 })
                 .collect(),
@@ -499,6 +514,7 @@ mod tests {
                         data: test_data(i).to_vec(),
                         ..Default::default()
                     }),
+                    delivery_attempt: i,
                     ..Default::default()
                 })
                 .collect(),
@@ -659,6 +675,71 @@ mod tests {
         Ok(())
     }
 
+    #[test_case(0, None, false; "at_least_once_zero_maps_to_none")]
+    #[test_case(5, Some(5), false; "at_least_once_positive_maps_to_some")]
+    #[test_case(-1, None, false; "at_least_once_negative_maps_to_none")]
+    #[test_case(1, Some(1), false; "at_least_once_one_maps_to_some")]
+    #[test_case(i32::MAX, Some(i32::MAX), false; "at_least_once_max_maps_to_some")]
+    #[test_case(0, None, true; "exactly_once_zero_maps_to_none")]
+    #[test_case(5, Some(5), true; "exactly_once_positive_maps_to_some")]
+    #[test_case(-1, None, true; "exactly_once_negative_maps_to_none")]
+    #[test_case(1, Some(1), true; "exactly_once_one_maps_to_some")]
+    #[test_case(i32::MAX, Some(i32::MAX), true; "exactly_once_max_maps_to_some")]
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn delivery_attempt_mapping(
+        input: i32,
+        expected: Option<i32>,
+        exactly_once: bool,
+    ) -> anyhow::Result<()> {
+        let (response_tx, response_rx) = channel(10);
+
+        let mut mock = MockSubscriber::new();
+        mock.expect_streaming_pull()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+        mock.expect_acknowledge()
+            .returning(move |_| Ok(TonicResponse::from(())));
+        mock.expect_modify_ack_deadline()
+            .returning(|_| Ok(TonicResponse::from(())));
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = test_client(endpoint).await?;
+        let mut stream = client.subscribe("projects/p/subscriptions/s").build();
+
+        let resp = v1::StreamingPullResponse {
+            subscription_properties: exactly_once.then_some(
+                v1::streaming_pull_response::SubscriptionProperties {
+                    exactly_once_delivery_enabled: true,
+                    ..Default::default()
+                },
+            ),
+            received_messages: vec![v1::ReceivedMessage {
+                ack_id: test_id(0),
+                message: Some(v1::PubsubMessage {
+                    data: test_data(0).to_vec(),
+                    ..Default::default()
+                }),
+                delivery_attempt: input,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        response_tx.send(Ok(resp)).await?;
+        drop(response_tx);
+
+        let Some((_, h)) = stream.next().await.transpose()? else {
+            anyhow::bail!("expected message")
+        };
+        assert_eq!(h.delivery_attempt(), expected);
+
+        match h {
+            Handler::AtLeastOnce(_) => assert!(!exactly_once),
+            Handler::ExactlyOnce(_) => assert!(exactly_once),
+        }
+
+        Ok(())
+    }
+
     #[tokio_test_no_panics(start_paused = true)]
     async fn basic_success_exactly_once() -> anyhow::Result<()> {
         let (response_tx, response_rx) = channel(10);
@@ -700,6 +781,7 @@ mod tests {
             };
             assert_eq!(m.data, test_data(i));
             assert_eq!(h.ack_id(), test_id(i));
+            assert_eq!(h.delivery_attempt(), Some(i));
             acks.spawn(h.confirmed_ack());
         }
         let end = stream.next().await.transpose()?;

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -492,7 +492,6 @@ mod tests {
                         data: test_data(i).to_vec(),
                         ..Default::default()
                     }),
-                    delivery_attempt: i,
                     ..Default::default()
                 })
                 .collect(),
@@ -514,7 +513,6 @@ mod tests {
                         data: test_data(i).to_vec(),
                         ..Default::default()
                     }),
-                    delivery_attempt: i,
                     ..Default::default()
                 })
                 .collect(),
@@ -696,22 +694,16 @@ mod tests {
         let mut mock = MockSubscriber::new();
         mock.expect_streaming_pull()
             .return_once(|_| Ok(TonicResponse::from(response_rx)));
-        mock.expect_acknowledge()
-            .returning(move |_| Ok(TonicResponse::from(())));
-        mock.expect_modify_ack_deadline()
-            .returning(|_| Ok(TonicResponse::from(())));
 
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let client = test_client(endpoint).await?;
         let mut stream = client.subscribe("projects/p/subscriptions/s").build();
 
         let resp = v1::StreamingPullResponse {
-            subscription_properties: exactly_once.then_some(
-                v1::streaming_pull_response::SubscriptionProperties {
-                    exactly_once_delivery_enabled: true,
-                    ..Default::default()
-                },
-            ),
+            subscription_properties: Some(v1::streaming_pull_response::SubscriptionProperties {
+                exactly_once_delivery_enabled: exactly_once,
+                ..Default::default()
+            }),
             received_messages: vec![v1::ReceivedMessage {
                 ack_id: test_id(0),
                 message: Some(v1::PubsubMessage {
@@ -731,11 +723,6 @@ mod tests {
             anyhow::bail!("expected message")
         };
         assert_eq!(h.delivery_attempt(), expected);
-
-        match h {
-            Handler::AtLeastOnce(_) => assert!(!exactly_once),
-            Handler::ExactlyOnce(_) => assert!(exactly_once),
-        }
 
         Ok(())
     }
@@ -781,7 +768,6 @@ mod tests {
             };
             assert_eq!(m.data, test_data(i));
             assert_eq!(h.ack_id(), test_id(i));
-            assert_eq!(h.delivery_attempt(), Some(i));
             acks.spawn(h.confirmed_ack());
         }
         let end = stream.next().await.transpose()?;

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -711,7 +711,6 @@ mod tests {
                     ..Default::default()
                 }),
                 delivery_attempt: input,
-                ..Default::default()
             }],
             ..Default::default()
         };


### PR DESCRIPTION
This change exposes the delivery attempt count for received messages through the `Handler` API. This allows users to determine how many times a message has been attempted for delivery.

The delivery attempt is exposed as an `Option<i32>` via the `delivery_attempt()` method on `Handler`. A value of `None` indicates that the count was 0 or not provided by the server.

The `MessageStream` has been updated to extract the `delivery_attempt` from the gRPC `ReceivedMessage` and propagate it to the constructed `Handler`. 

Fixes #5455 