### PR TITLE
cleanup(firestore): enable missing docs and document status mod

### DIFF
--- a/src/firestore/src/lib.rs
+++ b/src/firestore/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![warn(missing_docs)]
+
 //! Google Cloud Client Libraries for Rust - Cloud Firestore API
 //!
 //! **WARNING:** this crate is under active development. We expect multiple
@@ -37,6 +39,7 @@ pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 // TODO(#1549) - remove this workaround once all code is generated.
 #[allow(rustdoc::broken_intra_doc_links)]
+#[allow(missing_docs)]
 pub(crate) mod generated;
 
 pub use generated::gapic::builder;

--- a/src/firestore/src/status.rs
+++ b/src/firestore/src/status.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Status conversions for Firestore.
+
 use crate::google;
 use gaxi::grpc::status::{any_from_prost, any_to_prost};
 use gaxi::prost::{ConvertError, FromProto, ToProto};


### PR DESCRIPTION
Enabled #![warn(missing_docs)] for Firestore and addressed the resulting failures. Suppressed warnings in generated code by adding #[allow(missing_docs)] to the generated module, and added a file-level doc comment to status.rs to document the module.

For #5459 