### PR TITLE
docs(pubsub): add delivery attempt sample

### DIFF
--- a/src/pubsub/examples/src/lib.rs
+++ b/src/pubsub/examples/src/lib.rs
@@ -78,6 +78,10 @@ pub async fn run_subscription_samples(
         let (project_id, id) = (project_id.clone(), id.clone());
         async move { subscriber::error_listener::sample(&project_id, &id).await }
     });
+    slow_tasks.spawn({
+        let (project_id, id) = (project_id.clone(), id.clone());
+        async move { subscriber::dead_letter_delivery_attempt::sample(&project_id, &id).await }
+    });
 
     let id = random_subscription_id();
     subscription_names.push(format!("projects/{project_id}/subscriptions/{id}"));

--- a/src/pubsub/examples/src/subscriber.rs
+++ b/src/pubsub/examples/src/subscriber.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod concurrency_control;
+pub mod dead_letter_delivery_attempt;
 pub mod error_listener;
 pub mod exactly_once;
 pub mod flow_settings;

--- a/src/pubsub/examples/src/subscriber/dead_letter_delivery_attempt.rs
+++ b/src/pubsub/examples/src/subscriber/dead_letter_delivery_attempt.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START pubsub_dead_letter_delivery_attempt]
+use google_cloud_pubsub::client::Subscriber;
+use std::time::Duration;
+
+pub async fn sample(project_id: &str, subscription_id: &str) -> anyhow::Result<()> {
+    let subscription_name = format!("projects/{project_id}/subscriptions/{subscription_id}");
+    let client = Subscriber::builder().build().await?;
+    let mut stream = client.subscribe(subscription_name).build();
+
+    // Terminate the example after 10 seconds.
+    let shutdown_token = stream.shutdown_token();
+    let shutdown = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        shutdown_token.shutdown().await;
+    });
+
+    println!("listening for messages...");
+
+    while let Some((message, handler)) = stream.next().await.transpose()? {
+        println!("received message: {message:?}");
+        if let Some(attempt) = handler.delivery_attempt() {
+            println!("delivery attempt: {attempt}");
+        }
+        handler.ack();
+    }
+    shutdown.await?;
+
+    println!("done listening for messages");
+    Ok(())
+}
+// [END pubsub_dead_letter_delivery_attempt]

--- a/src/pubsub/examples/src/subscriber/dead_letter_delivery_attempt.rs
+++ b/src/pubsub/examples/src/subscriber/dead_letter_delivery_attempt.rs
@@ -32,8 +32,9 @@ pub async fn sample(project_id: &str, subscription_id: &str) -> anyhow::Result<(
 
     while let Some((message, handler)) = stream.next().await.transpose()? {
         println!("received message: {message:?}");
-        if let Some(attempt) = handler.delivery_attempt() {
-            println!("delivery attempt: {attempt}");
+        match handler.delivery_attempt() {
+            Some(i) => println!("delivery attempt: {i}"),
+            None => println!("delivery attempt: unknown"),
         }
         handler.ack();
     }


### PR DESCRIPTION
Add pubsub delivery attempt sample. Credit to @suzmue for adding the APIs in question to unblock this work.

I prompted Gemini CLI with: https://github.com/dbolduc/google-cloud-rust/commit/a377ccdde1314fd2a22c3d2b6e48809afd4a071d. I will add this to the repo in some capacity shortly.

I considered taking a `MessageStream` as input for the sample, but most other languages show the full client construction. So I decided it was OK to follow suit.

Fixes #5456 