### PR TITLE
feat(spanner): support timeout, retry- and backoff policy per statement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4460,6 +4460,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-rpc",
+ "google-cloud-test-macros",
  "google-cloud-wkt",
  "http",
  "mockall",

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -53,12 +53,13 @@ url.workspace         = true
 wkt                   = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-anyhow.workspace            = true
-mockall.workspace           = true
-spanner-grpc-mock           = { path = "grpc-mock" }
-static_assertions.workspace = true
-tokio                       = { workspace = true, features = ["test-util"] }
-tokio-stream.workspace      = true
+anyhow.workspace                   = true
+google-cloud-test-macros.workspace = true
+mockall.workspace                  = true
+spanner-grpc-mock                  = { path = "grpc-mock" }
+static_assertions.workspace        = true
+tokio                              = { workspace = true, features = ["test-util"] }
+tokio-stream.workspace             = true
 
 [lints]
 workspace = true

--- a/src/spanner/src/batch_dml.rs
+++ b/src/spanner/src/batch_dml.rs
@@ -16,14 +16,19 @@ use crate::client::Statement;
 use crate::error::{BatchUpdateError, internal_error};
 use crate::model::result_set_stats::RowCount;
 use crate::model::{ExecuteBatchDmlResponse, RequestOptions};
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
 use google_cloud_gax::error::rpc::Code;
 use google_cloud_gax::error::rpc::Status as RpcStatus;
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use std::time::Duration;
 
 /// A builder for [BatchDml].
 #[derive(Clone, Default, Debug)]
 pub struct BatchDmlBuilder {
     statements: Vec<Statement>,
     request_options: Option<RequestOptions>,
+    gax_options: GaxRequestOptions,
 }
 
 impl BatchDmlBuilder {
@@ -59,11 +64,30 @@ impl BatchDmlBuilder {
         self
     }
 
+    /// Sets the per-attempt timeout for this batch DML request.
+    pub fn with_attempt_timeout(mut self, timeout: Duration) -> Self {
+        self.gax_options.set_attempt_timeout(timeout);
+        self
+    }
+
+    /// Sets the retry policy for this batch DML request.
+    pub fn with_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
+        self.gax_options.set_retry_policy(policy);
+        self
+    }
+
+    /// Sets the backoff policy for this batch DML request.
+    pub fn with_backoff_policy(mut self, policy: impl Into<BackoffPolicyArg>) -> Self {
+        self.gax_options.set_backoff_policy(policy);
+        self
+    }
+
     /// Builds and returns the finalized BatchDml object.
     pub fn build(self) -> BatchDml {
         BatchDml {
             statements: self.statements,
             request_options: self.request_options,
+            gax_options: self.gax_options,
         }
     }
 }
@@ -73,6 +97,7 @@ impl BatchDmlBuilder {
 pub struct BatchDml {
     pub(crate) statements: Vec<Statement>,
     pub(crate) request_options: Option<RequestOptions>,
+    pub(crate) gax_options: GaxRequestOptions,
 }
 
 impl BatchDml {
@@ -146,6 +171,38 @@ mod tests {
             "Unexpected request_options set: {:#?}",
             batch.request_options
         );
+    }
+
+    #[test]
+    fn builder_with_gax_options() {
+        use google_cloud_gax::backoff_policy::BackoffPolicy;
+        use google_cloud_gax::retry_policy::Aip194Strict;
+        use google_cloud_gax::retry_state::RetryState;
+        use std::time::Duration;
+
+        #[derive(Debug)]
+        struct DummyBackoff;
+        impl BackoffPolicy for DummyBackoff {
+            fn on_failure(&self, _state: &RetryState) -> Duration {
+                Duration::ZERO
+            }
+        }
+
+        let stmt = Statement::builder("UPDATE t SET c = 1 WHERE id = 1").build();
+
+        let batch = BatchDml::builder()
+            .add_statement(stmt)
+            .with_attempt_timeout(Duration::from_secs(5))
+            .with_retry_policy(Aip194Strict)
+            .with_backoff_policy(DummyBackoff)
+            .build();
+
+        assert_eq!(
+            *batch.gax_options.attempt_timeout(),
+            Some(Duration::from_secs(5))
+        );
+        assert!(batch.gax_options.retry_policy().is_some());
+        assert!(batch.gax_options.backoff_policy().is_some());
     }
 
     #[test]

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -253,14 +253,21 @@ mod tests {
     use gaxi::grpc::tonic::{Code as GrpcCode, Response, Status};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::error::rpc::Code;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::google::rpc as mock_rpc;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
     use spanner_grpc_mock::google::spanner::v1::Session;
     use spanner_grpc_mock::{MockSpanner, start};
     use static_assertions::{assert_impl_all, assert_not_impl_any};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+
+    mockall::mock! {
+        #[derive(Debug)]
+        BackoffPolicy {}
+        impl google_cloud_gax::backoff_policy::BackoffPolicy for BackoffPolicy {
+            fn on_failure(&self, state: &google_cloud_gax::retry_state::RetryState) -> std::time::Duration;
+        }
+    }
 
     #[test]
     fn auto_traits() {
@@ -841,7 +848,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn timeout_respected() -> anyhow::Result<()> {
         use crate::batch_dml::BatchDml;
         use std::time::Duration;
@@ -988,24 +995,10 @@ mod tests {
 
     #[tokio::test]
     async fn retry_policy_respected() -> anyhow::Result<()> {
-        use google_cloud_gax::backoff_policy::BackoffPolicy;
         use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
-        use google_cloud_gax::retry_state::RetryState;
 
         // Extend the default retry policy to also retry on ResourceExhausted.
         let retry_policy = Aip194Strict.continue_on_too_many_requests();
-
-        // Custom Backoff Policy with a counter that allows us to verify that
-        // it was used.
-        #[derive(Debug)]
-        struct ConstantBackoff(Duration, Arc<AtomicUsize>);
-
-        impl BackoffPolicy for ConstantBackoff {
-            fn on_failure(&self, _state: &RetryState) -> Duration {
-                self.1.fetch_add(1, Ordering::SeqCst);
-                self.0
-            }
-        }
 
         // 1. Setup Mock Server
         let mut mock = MockSpanner::new();
@@ -1072,13 +1065,15 @@ mod tests {
         let runner = db.read_write_transaction().build().await?;
 
         // 4. Call execute_update with custom retry and backoff
-        let backoff_count = Arc::new(AtomicUsize::new(0));
+        let mut mock_backoff = MockBackoffPolicy::new();
+        mock_backoff
+            .expect_on_failure()
+            .once()
+            .returning(|_| Duration::from_nanos(1));
+
         let stmt = Statement::builder("UPDATE t SET c = 1")
             .with_retry_policy(retry_policy)
-            .with_backoff_policy(ConstantBackoff(
-                Duration::from_nanos(1),
-                backoff_count.clone(),
-            ))
+            .with_backoff_policy(mock_backoff)
             .build();
 
         let result = runner
@@ -1088,13 +1083,8 @@ mod tests {
             })
             .await?;
 
-        // 5. Verify success after retry and that backoff was called
+        // 5. Verify success after retry
         assert_eq!(result, 1);
-        assert_eq!(
-            backoff_count.load(Ordering::SeqCst),
-            1,
-            "Backoff policy should have been called once"
-        );
 
         Ok(())
     }

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -250,7 +250,7 @@ mod tests {
     use super::*;
     use crate::model::CreateSessionRequest;
     use crate::result_set::tests::adapt;
-    use gaxi::grpc::tonic::{Response, Status};
+    use gaxi::grpc::tonic::{Code as GrpcCode, Response, Status};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::error::rpc::Code;
     use spanner_grpc_mock::google::rpc as mock_rpc;
@@ -258,6 +258,9 @@ mod tests {
     use spanner_grpc_mock::google::spanner::v1::Session;
     use spanner_grpc_mock::{MockSpanner, start};
     use static_assertions::{assert_impl_all, assert_not_impl_any};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     #[test]
     fn auto_traits() {
@@ -834,6 +837,264 @@ mod tests {
         assert!(result.is_err(), "Expected error, got {:?}", result);
         let err = result.unwrap_err();
         assert_eq!(err.status().map(|s| s.code), Some(Code::Unavailable));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn timeout_respected() -> anyhow::Result<()> {
+        use crate::batch_dml::BatchDml;
+        use std::time::Duration;
+
+        // 1. Setup Mock Server
+        let mut mock = MockSpanner::new();
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(Session {
+                name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_begin_transaction().returning(|_| {
+            Ok(Response::new(mock_v1::Transaction {
+                id: vec![42],
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_execute_streaming_sql().once().returning(|req| {
+            let metadata = req.metadata();
+            let timeout = metadata.get("grpc-timeout");
+            assert!(
+                timeout.is_some(),
+                "grpc-timeout header should be present for query"
+            );
+
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(rx))
+        });
+
+        mock.expect_streaming_read().once().returning(|req| {
+            let metadata = req.metadata();
+            let timeout = metadata.get("grpc-timeout");
+            assert!(
+                timeout.is_some(),
+                "grpc-timeout header should be present for read"
+            );
+
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            Ok(Response::new(rx))
+        });
+
+        mock.expect_execute_sql().once().returning(|req| {
+            let metadata = req.metadata();
+            let timeout = metadata.get("grpc-timeout");
+            assert!(
+                timeout.is_some(),
+                "grpc-timeout header should be present for single DML"
+            );
+
+            Ok(Response::new(mock_v1::ResultSet {
+                stats: Some(mock_v1::ResultSetStats {
+                    row_count: Some(mock_v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_execute_batch_dml().once().returning(|req| {
+            let metadata = req.metadata();
+            let timeout = metadata.get("grpc-timeout");
+            assert!(
+                timeout.is_some(),
+                "grpc-timeout header should be present for batch dml"
+            );
+
+            Ok(Response::new(mock_v1::ExecuteBatchDmlResponse {
+                result_sets: vec![mock_v1::ResultSet {
+                    stats: Some(mock_v1::ResultSetStats {
+                        row_count: Some(mock_v1::result_set_stats::RowCount::RowCountExact(1)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_commit().returning(|_| {
+            Ok(Response::new(mock_v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1234,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        // 2. Start mock server
+        let (address, _server) = start("0.0.0.0:0", mock).await?;
+
+        // 3. Configure Client
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let db = client
+            .database_client("projects/p/instances/i/databases/d")
+            .build()
+            .await?;
+        let runner = db.read_write_transaction().build().await?;
+
+        // 4. Run transaction
+        runner
+            .run(async |tx| {
+                // Query
+                let stmt = Statement::builder("SELECT 1")
+                    .with_attempt_timeout(Duration::from_secs(10))
+                    .build();
+                let _ = tx.execute_query(stmt).await?;
+
+                // Read
+                let req = ReadRequest::builder("Table", vec!["Col"])
+                    .with_keys(crate::key::KeySet::all())
+                    .with_attempt_timeout(Duration::from_secs(5))
+                    .build();
+                let _ = tx.execute_read(req).await?;
+
+                // Single DML
+                let dml = Statement::builder("UPDATE t SET c = 1")
+                    .with_attempt_timeout(Duration::from_secs(7))
+                    .build();
+                let _ = tx.execute_update(dml).await?;
+
+                // Batch DML
+                let batch = BatchDml::builder()
+                    .add_statement("UPDATE t SET c = 2")
+                    .with_attempt_timeout(Duration::from_secs(8))
+                    .build();
+                let _ = tx.execute_batch_update(batch).await?;
+
+                Ok(())
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_policy_respected() -> anyhow::Result<()> {
+        use google_cloud_gax::backoff_policy::BackoffPolicy;
+        use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
+        use google_cloud_gax::retry_state::RetryState;
+
+        // Extend the default retry policy to also retry on ResourceExhausted.
+        let retry_policy = Aip194Strict.continue_on_too_many_requests();
+
+        // Custom Backoff Policy with a counter that allows us to verify that
+        // it was used.
+        #[derive(Debug)]
+        struct ConstantBackoff(Duration, Arc<AtomicUsize>);
+
+        impl BackoffPolicy for ConstantBackoff {
+            fn on_failure(&self, _state: &RetryState) -> Duration {
+                self.1.fetch_add(1, Ordering::SeqCst);
+                self.0
+            }
+        }
+
+        // 1. Setup Mock Server
+        let mut mock = MockSpanner::new();
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(Session {
+                name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_begin_transaction().returning(|_| {
+            Ok(Response::new(mock_v1::Transaction {
+                id: vec![42],
+                ..Default::default()
+            }))
+        });
+
+        // Mock ExecuteSql to first return RESOURCE_EXHAUSTED and then succeed.
+        let mut seq = mockall::Sequence::new();
+
+        mock.expect_execute_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| Err(Status::new(GrpcCode::ResourceExhausted, "quota exceeded")));
+
+        mock.expect_execute_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Ok(Response::new(mock_v1::ResultSet {
+                    stats: Some(mock_v1::ResultSetStats {
+                        row_count: Some(mock_v1::result_set_stats::RowCount::RowCountExact(1)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+            });
+
+        mock.expect_commit().returning(|_| {
+            Ok(Response::new(mock_v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1234,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        // 2. Start mock server
+        let (address, _server) = start("0.0.0.0:0", mock).await?;
+
+        // 3. Configure Client
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let db = client
+            .database_client("projects/p/instances/i/databases/d")
+            .build()
+            .await?;
+        let runner = db.read_write_transaction().build().await?;
+
+        // 4. Call execute_update with custom retry and backoff
+        let backoff_count = Arc::new(AtomicUsize::new(0));
+        let stmt = Statement::builder("UPDATE t SET c = 1")
+            .with_retry_policy(retry_policy)
+            .with_backoff_policy(ConstantBackoff(
+                Duration::from_nanos(1),
+                backoff_count.clone(),
+            ))
+            .build();
+
+        let result = runner
+            .run(async |tx| {
+                let count = tx.execute_update(stmt.clone()).await?;
+                Ok(count)
+            })
+            .await?;
+
+        // 5. Verify success after retry and that backoff was called
+        assert_eq!(result, 1);
+        assert_eq!(
+            backoff_count.load(Ordering::SeqCst),
+            1,
+            "Backoff policy should have been called once"
+        );
 
         Ok(())
     }

--- a/src/spanner/src/read.rs
+++ b/src/spanner/src/read.rs
@@ -14,6 +14,10 @@
 
 use crate::key::KeySet;
 use crate::model::DirectedReadOptions;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
+use std::time::Duration;
 
 /// Represents an incomplete read operation that requires specifying keys.
 ///
@@ -63,6 +67,7 @@ impl ReadRequestBuilder {
             limit: None,
             request_options: None,
             directed_read_options: None,
+            gax_options: GaxRequestOptions::default(),
         }
     }
 
@@ -90,12 +95,13 @@ impl ReadRequestBuilder {
             limit: None,
             request_options: None,
             directed_read_options: None,
+            gax_options: GaxRequestOptions::default(),
         }
     }
 }
 
 /// A fully configured read request that is ready to be built.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ConfiguredReadRequestBuilder {
     table: String,
     index: Option<String>,
@@ -104,6 +110,7 @@ pub struct ConfiguredReadRequestBuilder {
     limit: Option<i64>,
     request_options: Option<crate::model::RequestOptions>,
     directed_read_options: Option<DirectedReadOptions>,
+    gax_options: GaxRequestOptions,
 }
 
 impl ConfiguredReadRequestBuilder {
@@ -163,6 +170,24 @@ impl ConfiguredReadRequestBuilder {
         self
     }
 
+    /// Sets the per-attempt timeout for this read request.
+    pub fn with_attempt_timeout(mut self, timeout: Duration) -> Self {
+        self.gax_options.set_attempt_timeout(timeout);
+        self
+    }
+
+    /// Sets the retry policy for this read request.
+    pub fn with_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
+        self.gax_options.set_retry_policy(policy);
+        self
+    }
+
+    /// Sets the backoff policy for this read request.
+    pub fn with_backoff_policy(mut self, policy: impl Into<BackoffPolicyArg>) -> Self {
+        self.gax_options.set_backoff_policy(policy);
+        self
+    }
+
     /// Builds the configured `ReadRequest`.
     pub fn build(self) -> ReadRequest {
         ReadRequest {
@@ -173,6 +198,7 @@ impl ConfiguredReadRequestBuilder {
             limit: self.limit,
             request_options: self.request_options,
             directed_read_options: self.directed_read_options,
+            gax_options: self.gax_options,
         }
     }
 }
@@ -181,7 +207,7 @@ impl ConfiguredReadRequestBuilder {
 ///
 /// Contains the table, optional index, keys, and columns.
 /// Allows configuring optional parameters on the read operation, such as a limit.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ReadRequest {
     pub(crate) table: String,
     pub(crate) index: Option<String>,
@@ -190,6 +216,7 @@ pub struct ReadRequest {
     pub(crate) limit: Option<i64>,
     pub(crate) request_options: Option<crate::model::RequestOptions>,
     pub(crate) directed_read_options: Option<DirectedReadOptions>,
+    pub(crate) gax_options: GaxRequestOptions,
 }
 
 impl ReadRequest {
@@ -238,9 +265,9 @@ mod tests {
 
     #[test]
     fn auto_traits() {
-        static_assertions::assert_impl_all!(ReadRequestBuilder: Send, Sync, Clone, std::fmt::Debug, PartialEq);
-        static_assertions::assert_impl_all!(ConfiguredReadRequestBuilder: Send, Sync, Clone, std::fmt::Debug, PartialEq);
-        static_assertions::assert_impl_all!(ReadRequest: Send, Sync, Clone, std::fmt::Debug, PartialEq);
+        static_assertions::assert_impl_all!(ReadRequestBuilder: Send, Sync, Clone, std::fmt::Debug);
+        static_assertions::assert_impl_all!(ConfiguredReadRequestBuilder: Send, Sync, Clone, std::fmt::Debug);
+        static_assertions::assert_impl_all!(ReadRequest: Send, Sync, Clone, std::fmt::Debug);
     }
 
     #[test]
@@ -300,5 +327,28 @@ mod tests {
             .with_directed_read_options(dro.clone())
             .build();
         assert_eq!(req.directed_read_options, Some(dro));
+    }
+
+    #[test]
+    fn with_gax_options() -> anyhow::Result<()> {
+        use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+        use google_cloud_gax::retry_policy::NeverRetry;
+        use std::time::Duration;
+
+        let req = ReadRequest::builder("MyTable", vec!["col1"])
+            .with_keys(KeySet::all())
+            .with_attempt_timeout(Duration::from_secs(10))
+            .with_retry_policy(NeverRetry)
+            .with_backoff_policy(ExponentialBackoff::default())
+            .build();
+
+        assert_eq!(
+            req.gax_options.attempt_timeout(),
+            &Some(Duration::from_secs(10))
+        );
+        assert!(req.gax_options.retry_policy().is_some());
+        assert!(req.gax_options.backoff_policy().is_some());
+
+        Ok(())
     }
 }

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -579,12 +579,11 @@ impl ReadContext {
 
 /// Helper macro to execute a streaming SQL or streaming read RPC with retry logic.
 macro_rules! execute_stream_with_retry {
-    ($self:expr, $request:ident, $rpc_method:ident, $operation_variant:path) => {{
+    ($self:expr, $request:ident, $gax_options:ident, $rpc_method:ident, $operation_variant:path) => {{
         let stream = match $self
             .client
             .spanner
-            // TODO(#4972): make request options configurable
-            .$rpc_method($request.clone(), crate::RequestOptions::default())
+            .$rpc_method($request.clone(), $gax_options.clone())
             .send()
             .await
         {
@@ -595,8 +594,7 @@ macro_rules! execute_stream_with_retry {
                     $self
                         .client
                         .spanner
-                        // TODO(#4972): make request options configurable
-                        .$rpc_method($request.clone(), crate::RequestOptions::default())
+                        .$rpc_method($request.clone(), $gax_options.clone())
                         .send()
                         .await?
                 } else {
@@ -621,28 +619,42 @@ impl ReadContext {
         &self,
         statement: T,
     ) -> crate::Result<ResultSet> {
+        let statement = statement.into();
+        let gax_options = statement.gax_options().clone();
         let mut request = statement
-            .into()
             .into_request()
             .set_session(self.session_name.clone())
             .set_transaction(self.transaction_selector.selector());
         request.request_options = self.amend_request_options(request.request_options);
 
-        execute_stream_with_retry!(self, request, execute_streaming_sql, StreamOperation::Query)
+        execute_stream_with_retry!(
+            self,
+            request,
+            gax_options,
+            execute_streaming_sql,
+            StreamOperation::Query
+        )
     }
 
     pub(crate) async fn execute_read<T: Into<crate::read::ReadRequest>>(
         &self,
         read: T,
     ) -> crate::Result<ResultSet> {
+        let read = read.into();
+        let gax_options = read.gax_options.clone();
         let mut request = read
-            .into()
             .into_request()
             .set_session(self.session_name.clone())
             .set_transaction(self.transaction_selector.selector());
         request.request_options = self.amend_request_options(request.request_options);
 
-        execute_stream_with_retry!(self, request, streaming_read, StreamOperation::Read)
+        execute_stream_with_retry!(
+            self,
+            request,
+            gax_options,
+            streaming_read,
+            StreamOperation::Read
+        )
     }
 }
 

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -164,8 +164,9 @@ impl ReadWriteTransaction {
     /// Executes an update using this transaction.
     pub async fn execute_update<T: Into<Statement>>(&self, statement: T) -> crate::Result<i64> {
         let seqno = self.seqno.fetch_add(1, Ordering::SeqCst);
+        let statement = statement.into();
+        let gax_options = statement.gax_options().clone();
         let mut request = statement
-            .into()
             .into_request()
             .set_session(self.context.session_name.clone())
             .set_transaction(self.context.transaction_selector.selector())
@@ -176,7 +177,7 @@ impl ReadWriteTransaction {
             .context
             .client
             .spanner
-            .execute_sql(request, RequestOptions::default())
+            .execute_sql(request, gax_options)
             .await?;
         self.context
             .precommit_token_tracker
@@ -280,7 +281,7 @@ impl ReadWriteTransaction {
             .context
             .client
             .spanner
-            .execute_batch_dml(request, RequestOptions::default())
+            .execute_batch_dml(request, batch.gax_options)
             .await;
 
         match response_result {

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -18,7 +18,11 @@ use crate::model::execute_sql_request::QueryOptions;
 use crate::to_value::ToValue;
 use crate::types::Type;
 use crate::value::Value;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 /// A builder for [Statement].
 ///
@@ -29,7 +33,7 @@ use std::collections::BTreeMap;
 ///     .add_param("id", &42)
 ///     .build();
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct StatementBuilder {
     sql: String,
     params: BTreeMap<String, Value>,
@@ -38,6 +42,7 @@ pub struct StatementBuilder {
     directed_read_options: Option<DirectedReadOptions>,
     query_options: Option<QueryOptions>,
     query_mode: Option<QueryMode>,
+    gax_options: GaxRequestOptions,
 }
 
 impl StatementBuilder {
@@ -50,6 +55,7 @@ impl StatementBuilder {
             directed_read_options: None,
             query_options: None,
             query_mode: None,
+            gax_options: GaxRequestOptions::default(),
         }
     }
 
@@ -149,6 +155,24 @@ impl StatementBuilder {
         self
     }
 
+    /// Sets the per-attempt timeout for this statement.
+    pub fn with_attempt_timeout(mut self, timeout: Duration) -> Self {
+        self.gax_options.set_attempt_timeout(timeout);
+        self
+    }
+
+    /// Sets the retry policy for this statement.
+    pub fn with_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
+        self.gax_options.set_retry_policy(policy);
+        self
+    }
+
+    /// Sets the backoff policy for this statement.
+    pub fn with_backoff_policy(mut self, policy: impl Into<BackoffPolicyArg>) -> Self {
+        self.gax_options.set_backoff_policy(policy);
+        self
+    }
+
     /// Builds and returns the finalized Statement object.
     pub fn build(self) -> Statement {
         Statement {
@@ -159,6 +183,7 @@ impl StatementBuilder {
             directed_read_options: self.directed_read_options,
             query_options: self.query_options,
             query_mode: self.query_mode,
+            gax_options: self.gax_options,
         }
     }
 }
@@ -186,7 +211,7 @@ impl StatementBuilder {
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Statement {
     pub sql: String,
     pub(crate) params: BTreeMap<String, Value>,
@@ -195,12 +220,17 @@ pub struct Statement {
     pub(crate) directed_read_options: Option<DirectedReadOptions>,
     pub(crate) query_options: Option<QueryOptions>,
     pub(crate) query_mode: Option<QueryMode>,
+    gax_options: GaxRequestOptions,
 }
 
 impl Statement {
     /// Creates a new statement builder.
     pub fn builder(sql: impl Into<String>) -> StatementBuilder {
         StatementBuilder::new(sql)
+    }
+
+    pub(crate) fn gax_options(&self) -> &GaxRequestOptions {
+        &self.gax_options
     }
 
     /// Sets the query mode to use for this statement.
@@ -308,8 +338,8 @@ mod tests {
 
     #[test]
     fn test_auto_traits() {
-        static_assertions::assert_impl_all!(Statement: Clone, std::fmt::Debug, PartialEq, Send, Sync);
-        static_assertions::assert_impl_all!(StatementBuilder: Clone, std::fmt::Debug, PartialEq, Send, Sync);
+        static_assertions::assert_impl_all!(Statement: Clone, std::fmt::Debug, Send, Sync);
+        static_assertions::assert_impl_all!(StatementBuilder: Clone, std::fmt::Debug, Send, Sync);
     }
 
     #[test]
@@ -474,6 +504,28 @@ mod tests {
 
         let req = stmt.into_request();
         assert_eq!(req.query_mode, QueryMode::Profile);
+        Ok(())
+    }
+
+    #[test]
+    fn with_gax_options() -> anyhow::Result<()> {
+        use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+        use google_cloud_gax::retry_policy::NeverRetry;
+        use std::time::Duration;
+
+        let stmt = Statement::builder("SELECT * FROM users")
+            .with_attempt_timeout(Duration::from_secs(10))
+            .with_retry_policy(NeverRetry)
+            .with_backoff_policy(ExponentialBackoff::default())
+            .build();
+
+        assert_eq!(
+            stmt.gax_options.attempt_timeout(),
+            &Some(Duration::from_secs(10))
+        );
+        assert!(stmt.gax_options.retry_policy().is_some());
+        assert!(stmt.gax_options.backoff_policy().is_some());
+
         Ok(())
     }
 }


### PR DESCRIPTION
Adds support for setting a timeout, retry policy, and backoff policy per statement and read. This allows an application to override the defaults for these options on a per statement-basis.

Note: This change adds the API for all types of statements. However, the retry and backoff policies are not respected for the streaming RPCs ExecuteStreamingSql and StreamingRead yet. This will be added in a follow-up pull request.