### PR TITLE
impl(pubsub): return successful extends ack ids

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -413,7 +413,7 @@ mod tests {
                 .expect_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(0..30))
-                .returning(move |_| ());
+                .returning(move |ack_ids| ack_ids);
             tokio::time::advance(EXTEND_START).await;
 
             // Yield the current task, so tokio can execute the flush().
@@ -433,7 +433,7 @@ mod tests {
                 .expect_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(10..30))
-                .returning(|_| ());
+                .returning(move |ack_ids| ack_ids);
             tokio::time::advance(EXTEND_PERIOD).await;
 
             // Yield the current task, so tokio can execute the flush().
@@ -584,7 +584,9 @@ mod tests {
                 ack_ids.sort();
                 assert_eq!(ack_ids, test_ids(10..30));
             }
-            async fn extend(&self, _ack_ids: Vec<String>) {}
+            async fn extend(&self, ack_ids: Vec<String>) -> Vec<String> {
+                ack_ids
+            }
             async fn confirmed_ack(&self, _ack_ids: Vec<String>) {}
             async fn confirmed_nack(&self, _ack_ids: Vec<String>) {}
         }

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -177,7 +177,7 @@ where
     //
     // These are held separate from pending acks/nacks because we do not need to
     // await them on shutdown.
-    pending_extends: JoinSet<()>,
+    pending_extends: JoinSet<Vec<String>>,
 }
 
 /// Actions taken by the `LeaseState` in the lease loop.
@@ -763,22 +763,22 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..10))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(10..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -819,12 +819,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..10))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(2)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_confirmed_ack()
             .times(1)
             .in_sequence(&mut seq)
@@ -834,12 +834,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -888,7 +888,7 @@ pub(super) mod tests {
         mock.expect_extend()
             .times(2)
             .withf(|v| *v == vec![test_id(1)])
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -1226,8 +1226,9 @@ pub(super) mod tests {
             .times(NUM_BATCHES as usize)
             .returning(move |ack_ids| {
                 ack_id_tx
-                    .send(ack_ids)
+                    .send(ack_ids.clone())
                     .expect("sending on channel always succeeds");
+                ack_ids
             });
         let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
 
@@ -1273,12 +1274,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(10..20))
-            .returning(|_| ());
+            .returning(move |ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease: MAX_LEASE,

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -39,7 +39,7 @@ pub(super) trait Leaser {
     /// Negatively acknowledge a batch of messages.
     async fn nack(&self, ack_ids: Vec<String>);
     /// Extend lease deadlines for a batch of messages.
-    async fn extend(&self, ack_ids: Vec<String>);
+    async fn extend(&self, ack_ids: Vec<String>) -> Vec<String>;
 
     /// Acknowledge a batch of messages with exactly-once semantics.
     ///
@@ -151,15 +151,20 @@ where
             .await;
     }
 
-    async fn extend(&self, ack_ids: Vec<String>) {
+    async fn extend(&self, ack_ids: Vec<String>) -> Vec<String> {
         let req = ModifyAckDeadlineRequest::new()
             .set_subscription(self.subscription.clone())
-            .set_ack_ids(ack_ids)
+            .set_ack_ids(ack_ids.clone())
             .set_ack_deadline_seconds(self.ack_deadline_seconds);
-        let _ = self
+        let response = self
             .inner
             .modify_ack_deadline(req, self.options.clone())
             .await;
+        if response.is_ok() {
+            ack_ids
+        } else {
+            Vec::new()
+        }
     }
 
     /// The exactly-once ack retry loop.
@@ -406,7 +411,7 @@ pub(super) mod tests {
         impl Leaser for Leaser {
             async fn ack(&self, ack_ids: Vec<String>);
             async fn nack(&self, ack_ids: Vec<String>);
-            async fn extend(&self, ack_ids: Vec<String>);
+            async fn extend(&self, ack_ids: Vec<String>) -> Vec<String>;
             async fn confirmed_ack(&self, ack_ids: Vec<String>);
             async fn confirmed_nack(&self, ack_ids: Vec<String>);
         }
@@ -420,7 +425,7 @@ pub(super) mod tests {
         async fn nack(&self, ack_ids: Vec<String>) {
             MockLeaser::nack(self, ack_ids).await
         }
-        async fn extend(&self, ack_ids: Vec<String>) {
+        async fn extend(&self, ack_ids: Vec<String>) -> Vec<String> {
             MockLeaser::extend(self, ack_ids).await
         }
         async fn confirmed_ack(&self, ack_ids: Vec<String>) {
@@ -439,7 +444,7 @@ pub(super) mod tests {
         async fn nack(&self, ack_ids: Vec<String>) {
             self.lock().await.nack(ack_ids).await
         }
-        async fn extend(&self, ack_ids: Vec<String>) {
+        async fn extend(&self, ack_ids: Vec<String>) -> Vec<String> {
             self.lock().await.extend(ack_ids).await
         }
         async fn confirmed_ack(&self, ack_ids: Vec<String>) {
@@ -542,7 +547,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn ack() {
-        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         mock.expect_acknowledge().times(1).return_once(|r, o| {
             assert_eq!(
@@ -554,6 +558,7 @@ pub(super) mod tests {
             Ok(Response::from(()))
         });
 
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
@@ -566,7 +571,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn nack() {
-        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         mock.expect_modify_ack_deadline()
             .times(1)
@@ -581,6 +585,7 @@ pub(super) mod tests {
                 Ok(Response::from(()))
             });
 
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
@@ -593,7 +598,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn extend() {
-        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         mock.expect_modify_ack_deadline()
             .times(1)
@@ -608,6 +612,7 @@ pub(super) mod tests {
                 Ok(Response::from(()))
             });
 
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
@@ -615,12 +620,40 @@ pub(super) mod tests {
             10,
             16_usize,
         );
-        leaser.extend(test_ids(0..10)).await;
+        let extended = leaser.extend(test_ids(0..10)).await;
+        assert_eq!(extended, test_ids(0..10));
+    }
+
+    #[tokio::test]
+    async fn extend_failure() {
+        let mut mock = MockStub::new();
+        mock.expect_modify_ack_deadline()
+            .times(1)
+            .return_once(|r, o| {
+                assert_eq!(r.ack_deadline_seconds, 10);
+                assert_eq!(
+                    r.subscription,
+                    "projects/my-project/subscriptions/my-subscription"
+                );
+                assert_eq!(r.ack_ids, test_ids(0..10));
+                verify_policies(o, 16);
+                Err(Error::service(Status::default().set_code(Code::Internal)))
+            });
+
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let leaser = DefaultLeaser::new(
+            Arc::new(mock),
+            confirmed_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+        );
+        let extended = leaser.extend(test_ids(0..10)).await;
+        assert!(extended.is_empty(), "{extended:?}");
     }
 
     #[tokio::test]
     async fn confirmed_ack_success() -> anyhow::Result<()> {
-        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         mock.expect_acknowledge().times(1).return_once(|r, o| {
             assert_eq!(
@@ -632,6 +665,7 @@ pub(super) mod tests {
             Ok(Response::from(()))
         });
 
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
@@ -659,7 +693,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn confirmed_ack_failure() -> anyhow::Result<()> {
-        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         mock.expect_acknowledge().times(1).return_once(|r, o| {
             assert_eq!(
@@ -675,6 +708,7 @@ pub(super) mod tests {
             ))
         });
 
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
@@ -706,7 +740,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn confirmed_ack_partial_transient_failure_retry_failure() -> anyhow::Result<()> {
-        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         let mut seq = Sequence::new();
 
@@ -739,6 +772,7 @@ pub(super) mod tests {
             .times(1)
             .return_const(std::time::Duration::ZERO);
 
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new_with_backoff(
             Arc::new(mock),
             confirmed_tx,
@@ -769,7 +803,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn confirmed_ack_partial_transient_failure_retry_success() -> anyhow::Result<()> {
-        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
         let mut seq = Sequence::new();
 
@@ -798,6 +831,7 @@ pub(super) mod tests {
             .times(1)
             .return_const(Duration::ZERO);
 
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new_with_backoff(
             Arc::new(mock),
             confirmed_tx,
@@ -821,7 +855,6 @@ pub(super) mod tests {
 
     #[tokio::test]
     async fn confirmed_ack_partial_permanent_failure() -> anyhow::Result<()> {
-        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let mut mock = MockStub::new();
 
         let info =
@@ -835,6 +868,7 @@ pub(super) mod tests {
                 Err(err)
             });
 
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,


### PR DESCRIPTION
Leaser extend fn now return the ack ids that were successfully extended. The return value is currently unused. Followup PRs will update lease state last extension time for successful extensions. This planned improvement yield only a small reliability improvement (only useful when the extend RPC fails) but it paves the way for exactly once lease extension retries that may contain partial failures.

Towards: #5048 