### PR TITLE
impl(pubsub): add update_last_extension fn to lease state

### DIFF
--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -263,15 +263,15 @@ where
     /// Updates the `last_extension` timestamp for the given at-least-once ack IDs
     /// with the completion time of a successful extension RPC.
     #[allow(dead_code)]
-    pub(super) fn update_last_extension(&mut self, ack_ids: Vec<String>, time: Instant) {
-        self.leases.update_last_extension(&ack_ids, time);
+    pub(super) fn update_last_extension(&mut self, ack_ids: Vec<String>) {
+        self.leases.update_last_extension(&ack_ids);
     }
 
     /// Updates the `last_extension` timestamp for the given exactly-once ack IDs
     /// with the completion time of a successful extension RPC.
     #[allow(dead_code)]
-    pub(super) fn update_last_extension_eo(&mut self, ack_ids: Vec<String>, time: Instant) {
-        self.eo_leases.update_last_extension(&ack_ids, time);
+    pub(super) fn update_last_extension_eo(&mut self, ack_ids: Vec<String>) {
+        self.eo_leases.update_last_extension(&ack_ids);
     }
 
     /// Flush pending acks/nacks
@@ -444,11 +444,10 @@ pub(super) mod tests {
     async fn update_last_extension() {
         let mock = MockLeaser::new();
         let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
-        let now = Instant::now();
 
         // Test at-least-once
         state.add(test_id(1), at_least_once_info());
-        state.update_last_extension(test_ids(1..2), now);
+        state.update_last_extension(test_ids(1..2));
 
         // Verify no extension immediately
         let batches = state
@@ -468,9 +467,8 @@ pub(super) mod tests {
         assert_eq!(flattened.ack_ids, test_ids(1..2));
 
         // Test exactly-once
-        let now = Instant::now();
         state.add(test_id(2), exactly_once_info());
-        state.update_last_extension_eo(test_ids(2..3), now);
+        state.update_last_extension_eo(test_ids(2..3));
 
         // Verify no extension immediately
         let batches = state

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -448,7 +448,7 @@ pub(super) mod tests {
 
         // Test at-least-once
         state.add(test_id(1), at_least_once_info());
-        state.update_last_extension(vec![test_id(1)], now);
+        state.update_last_extension(test_ids(1..2), now);
 
         // Verify no extension immediately
         let batches = state
@@ -470,7 +470,7 @@ pub(super) mod tests {
         // Test exactly-once
         let now = Instant::now();
         state.add(test_id(2), exactly_once_info());
-        state.update_last_extension_eo(vec![test_id(2)], now);
+        state.update_last_extension_eo(test_ids(2..3), now);
 
         // Verify no extension immediately
         let batches = state

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -178,6 +178,7 @@ where
     // These are held separate from pending acks/nacks because we do not need to
     // await them on shutdown.
     pending_extends: JoinSet<Vec<String>>,
+    eo_pending_extends: JoinSet<Vec<String>>,
 }
 
 /// Actions taken by the `LeaseState` in the lease loop.
@@ -208,6 +209,7 @@ where
             max_lease_extension: options.max_lease_extension,
             pending_acks_nacks: TaskTracker::new(),
             pending_extends: JoinSet::new(),
+            eo_pending_extends: JoinSet::new(),
         }
     }
 
@@ -258,6 +260,20 @@ where
         }
     }
 
+    /// Updates the `last_extension` timestamp for the given at-least-once ack IDs
+    /// with the completion time of a successful extension RPC.
+    #[allow(dead_code)]
+    pub(super) fn update_last_extension(&mut self, ack_ids: Vec<String>, time: Instant) {
+        self.leases.update_last_extension(&ack_ids, time);
+    }
+
+    /// Updates the `last_extension` timestamp for the given exactly-once ack IDs
+    /// with the completion time of a successful extension RPC.
+    #[allow(dead_code)]
+    pub(super) fn update_last_extension_eo(&mut self, ack_ids: Vec<String>, time: Instant) {
+        self.eo_leases.update_last_extension(&ack_ids, time);
+    }
+
     /// Flush pending acks/nacks
     pub(super) fn flush(&mut self) {
         let (to_ack, to_nack) = self.leases.drain();
@@ -301,7 +317,7 @@ where
             .retain(self.max_lease, self.max_lease_extension);
         for ack_ids in batches {
             let leaser = self.leaser.clone();
-            self.pending_extends
+            self.eo_pending_extends
                 .spawn(async move { leaser.extend(ack_ids).await });
         }
 
@@ -347,7 +363,10 @@ where
         // practice, because we are nacking all the messages, but it simplifies
         // our tests.
         #[cfg(test)]
-        self.pending_extends.join_all().await;
+        {
+            self.pending_extends.join_all().await;
+            self.eo_pending_extends.join_all().await;
+        }
     }
 }
 
@@ -417,6 +436,58 @@ pub(super) mod tests {
         state.extend();
         let pending_extends = std::mem::take(&mut state.pending_extends);
         let _ = pending_extends.join_all().await;
+        let eo_pending_extends = std::mem::take(&mut state.eo_pending_extends);
+        let _ = eo_pending_extends.join_all().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn update_last_extension() {
+        let mock = MockLeaser::new();
+        let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
+        let now = Instant::now();
+
+        // Test at-least-once
+        state.add(test_id(1), at_least_once_info());
+        state.update_last_extension(vec![test_id(1)], now);
+
+        // Verify no extension immediately
+        let batches = state
+            .leases
+            .retain(Duration::from_secs(600), Duration::from_secs(60));
+        assert!(
+            batches.is_empty(),
+            "lease should not be extended since time has not advanced"
+        );
+
+        // Advance time past the extension buffer (60s max_lease_extension)
+        tokio::time::advance(Duration::from_secs(61)).await;
+        let batches = state
+            .leases
+            .retain(Duration::from_secs(600), Duration::from_secs(60));
+        let flattened = Batches::flatten(batches);
+        assert_eq!(flattened.ack_ids, test_ids(1..2));
+
+        // Test exactly-once
+        let now = Instant::now();
+        state.add(test_id(2), exactly_once_info());
+        state.update_last_extension_eo(vec![test_id(2)], now);
+
+        // Verify no extension immediately
+        let batches = state
+            .eo_leases
+            .retain(Duration::from_secs(600), Duration::from_secs(60));
+        assert!(
+            batches.is_empty(),
+            "lease should not be extended since time has not advanced"
+        );
+
+        // Advance time past the extension buffer
+        tokio::time::advance(Duration::from_secs(61)).await;
+        let batches = state
+            .eo_leases
+            .retain(Duration::from_secs(600), Duration::from_secs(60));
+        let flattened = Batches::flatten(batches);
+        assert_eq!(flattened.ack_ids, test_ids(2..3));
     }
 
     async fn flush_and_await<L>(state: &mut LeaseState<L>)
@@ -763,22 +834,22 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..10))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(10..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -819,12 +890,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..10))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(2)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_confirmed_ack()
             .times(1)
             .in_sequence(&mut seq)
@@ -834,12 +905,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -1274,12 +1345,12 @@ pub(super) mod tests {
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
         mock.expect_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(10..20))
-            .returning(move |ack_ids| ack_ids);
+            .returning(|ack_ids| ack_ids);
 
         let options = LeaseOptions {
             max_lease: MAX_LEASE,

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -68,6 +68,16 @@ impl Leases {
         )
     }
 
+    /// Updates the `last_extension` timestamp for the given ack IDs with the
+    /// completion time of a successful extension RPC.
+    pub fn update_last_extension(&mut self, ack_ids: &[String], time: Instant) {
+        for id in ack_ids {
+            if let Some(info) = self.under_lease.get_mut(id) {
+                info.last_extension = Some(time);
+            }
+        }
+    }
+
     /// Returns batches of ack IDs to extend.
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
@@ -100,6 +110,8 @@ impl Leases {
                     // Flush the batch when it is full.
                     batches.push(std::mem::take(&mut batch));
                 }
+                // TODO(#5048): Do not update last_extension here after update_last_extension fn
+                // is used to report successful extends.
                 info.last_extension = Some(now);
                 true
             }
@@ -150,6 +162,59 @@ mod tests {
 
     // Cover the constant, converting it to an integer for convenience.
     const MAX_IDS_PER_RPC: i32 = super::MAX_IDS_PER_RPC as i32;
+
+    #[test]
+    fn update_last_extension() {
+        let mut leases = Leases::default();
+        let now = Instant::now();
+
+        leases.add(test_id(1), AtLeastOnceInfo::new());
+        leases.add(test_id(2), AtLeastOnceInfo::new());
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            None
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            None
+        );
+
+        leases.update_last_extension(&[test_id(1)], now);
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(now)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            None
+        );
+
+        let later = now + Duration::from_secs(5);
+        leases.update_last_extension(&[test_id(1), test_id(2)], later);
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(later)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            Some(later)
+        );
+
+        // Test with non-existent ID
+        leases.update_last_extension(&[test_id(3)], later + Duration::from_secs(1));
+        // Should not have side effects.
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(later)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            Some(later)
+        );
+    }
 
     #[test]
     fn basic_add_ack_nack() {

--- a/src/pubsub/src/subscriber/lease_state/at_least_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/at_least_once.rs
@@ -70,10 +70,11 @@ impl Leases {
 
     /// Updates the `last_extension` timestamp for the given ack IDs with the
     /// completion time of a successful extension RPC.
-    pub fn update_last_extension(&mut self, ack_ids: &[String], time: Instant) {
+    pub fn update_last_extension(&mut self, ack_ids: &[String]) {
+        let now = Instant::now();
         for id in ack_ids {
             if let Some(info) = self.under_lease.get_mut(id) {
-                info.last_extension = Some(time);
+                info.last_extension = Some(now);
             }
         }
     }
@@ -163,57 +164,13 @@ mod tests {
     // Cover the constant, converting it to an integer for convenience.
     const MAX_IDS_PER_RPC: i32 = super::MAX_IDS_PER_RPC as i32;
 
-    #[test]
-    fn update_last_extension() {
-        let mut leases = Leases::default();
-        let now = Instant::now();
-
-        leases.add(test_id(1), AtLeastOnceInfo::new());
-        leases.add(test_id(2), AtLeastOnceInfo::new());
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            None
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            None
-        );
-
-        leases.update_last_extension(&[test_id(1)], now);
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(now)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            None
-        );
-
-        let later = now + Duration::from_secs(5);
-        leases.update_last_extension(&[test_id(1), test_id(2)], later);
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(later)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            Some(later)
-        );
-
-        // Test with non-existent ID
-        leases.update_last_extension(&[test_id(3)], later + Duration::from_secs(1));
-        // Should not have side effects.
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(later)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            Some(later)
-        );
+    impl Leases {
+        fn last_extension(&self, id: &str) -> Option<Instant> {
+            self.under_lease
+                .get(id)
+                .expect("test id should be under lease")
+                .last_extension
+        }
     }
 
     #[test]
@@ -342,6 +299,34 @@ mod tests {
             },
             leases
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn update_last_extension() {
+        let mut leases = Leases::default();
+        let now = Instant::now();
+
+        leases.add(test_id(1), AtLeastOnceInfo::new());
+        leases.add(test_id(2), AtLeastOnceInfo::new());
+
+        assert_eq!(leases.last_extension(&test_id(1)), None);
+        assert_eq!(leases.last_extension(&test_id(2)), None);
+
+        leases.update_last_extension(&[test_id(1)]);
+        assert_eq!(leases.last_extension(&test_id(1)), Some(now));
+        assert_eq!(leases.last_extension(&test_id(2)), None);
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let later = Instant::now();
+        leases.update_last_extension(&[test_id(1), test_id(2)]);
+        assert_eq!(leases.last_extension(&test_id(1)), Some(later));
+        assert_eq!(leases.last_extension(&test_id(2)), Some(later));
+
+        // Test with non-existent ID
+        leases.update_last_extension(&[test_id(3)]);
+        // Should not have side effects.
+        assert_eq!(leases.last_extension(&test_id(1)), Some(later));
+        assert_eq!(leases.last_extension(&test_id(2)), Some(later));
     }
 
     #[test]

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -87,10 +87,11 @@ impl Leases {
 
     /// Updates the `last_extension` timestamp for the given ack IDs with the
     /// completion time of a successful extension RPC.
-    pub fn update_last_extension(&mut self, ack_ids: &[String], time: Instant) {
+    pub fn update_last_extension(&mut self, ack_ids: &[String]) {
+        let now = Instant::now();
         for id in ack_ids {
             if let Some(info) = self.under_lease.get_mut(id) {
-                info.last_extension = Some(time);
+                info.last_extension = Some(now);
             }
         }
     }
@@ -219,6 +220,15 @@ mod tests {
     // Cover the constant, converting it to an integer for convenience.
     const MAX_IDS_PER_RPC: i32 = super::MAX_IDS_PER_RPC as i32;
 
+    impl Leases {
+        fn last_extension(&self, id: &str) -> Option<Instant> {
+            self.under_lease
+                .get(id)
+                .expect("test id should be under lease")
+                .last_extension
+        }
+    }
+
     fn test_info() -> ExactlyOnceInfo {
         let (result_tx, _result_rx) = channel();
         ExactlyOnceInfo {
@@ -227,59 +237,6 @@ mod tests {
             status: MessageStatus::Leased,
             last_extension: None,
         }
-    }
-
-    #[test]
-    fn update_last_extension() {
-        let mut leases = Leases::default();
-        let now = Instant::now();
-
-        leases.add(test_id(1), test_info());
-        leases.add(test_id(2), test_info());
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            None
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            None
-        );
-
-        leases.update_last_extension(&[test_id(1)], now);
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(now)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            None
-        );
-
-        let later = now + Duration::from_secs(5);
-        leases.update_last_extension(&[test_id(1), test_id(2)], later);
-
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(later)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            Some(later)
-        );
-
-        // Test with non-existent ID
-        leases.update_last_extension(&[test_id(3)], later + Duration::from_secs(1));
-        // Should not have side effects.
-        assert_eq!(
-            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
-            Some(later)
-        );
-        assert_eq!(
-            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
-            Some(later)
-        );
     }
 
     #[test]
@@ -533,6 +490,34 @@ mod tests {
             },
             leases
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn update_last_extension() {
+        let mut leases = Leases::default();
+        let now = Instant::now();
+
+        leases.add(test_id(1), test_info());
+        leases.add(test_id(2), test_info());
+
+        assert_eq!(leases.last_extension(&test_id(1)), None);
+        assert_eq!(leases.last_extension(&test_id(2)), None);
+
+        leases.update_last_extension(&[test_id(1)]);
+        assert_eq!(leases.last_extension(&test_id(1)), Some(now));
+        assert_eq!(leases.last_extension(&test_id(2)), None);
+
+        tokio::time::advance(Duration::from_secs(5)).await;
+        let later = Instant::now();
+        leases.update_last_extension(&[test_id(1), test_id(2)]);
+        assert_eq!(leases.last_extension(&test_id(1)), Some(later));
+        assert_eq!(leases.last_extension(&test_id(2)), Some(later));
+
+        // Test with non-existent ID
+        leases.update_last_extension(&[test_id(3)]);
+        // Should not have side effects.
+        assert_eq!(leases.last_extension(&test_id(1)), Some(later));
+        assert_eq!(leases.last_extension(&test_id(2)), Some(later));
     }
 
     #[test]

--- a/src/pubsub/src/subscriber/lease_state/exactly_once.rs
+++ b/src/pubsub/src/subscriber/lease_state/exactly_once.rs
@@ -85,6 +85,16 @@ impl Leases {
         )
     }
 
+    /// Updates the `last_extension` timestamp for the given ack IDs with the
+    /// completion time of a successful extension RPC.
+    pub fn update_last_extension(&mut self, ack_ids: &[String], time: Instant) {
+        for id in ack_ids {
+            if let Some(info) = self.under_lease.get_mut(id) {
+                info.last_extension = Some(time);
+            }
+        }
+    }
+
     /// Returns batches of ack IDs to extend.
     ///
     /// Drops messages whose lease deadline cannot be extended any further.
@@ -119,6 +129,8 @@ impl Leases {
                         None
                     } else {
                         // Continue to extend messages being acked.
+                        // TODO(#5048): Do not update last_extension here after update_last_extension fn
+                        // is used to report successful extends.
                         info.last_extension = Some(now);
                         Some(id.clone())
                     }
@@ -135,6 +147,8 @@ impl Leases {
                         None
                     } else {
                         // Extend leases for all other messages
+                        // TODO(#5048): Do not update last_extension here after update_last_extension fn
+                        // is used to report successful extends.
                         info.last_extension = Some(now);
                         Some(id.clone())
                     }
@@ -213,6 +227,59 @@ mod tests {
             status: MessageStatus::Leased,
             last_extension: None,
         }
+    }
+
+    #[test]
+    fn update_last_extension() {
+        let mut leases = Leases::default();
+        let now = Instant::now();
+
+        leases.add(test_id(1), test_info());
+        leases.add(test_id(2), test_info());
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            None
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            None
+        );
+
+        leases.update_last_extension(&[test_id(1)], now);
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(now)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            None
+        );
+
+        let later = now + Duration::from_secs(5);
+        leases.update_last_extension(&[test_id(1), test_id(2)], later);
+
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(later)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            Some(later)
+        );
+
+        // Test with non-existent ID
+        leases.update_last_extension(&[test_id(3)], later + Duration::from_secs(1));
+        // Should not have side effects.
+        assert_eq!(
+            leases.under_lease.get(&test_id(1)).unwrap().last_extension,
+            Some(later)
+        );
+        assert_eq!(
+            leases.under_lease.get(&test_id(2)).unwrap().last_extension,
+            Some(later)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add helper functions {update_last_extension, update_last_extension_eo} to LeaseState to update ack ids that were successfully extended. These functions are currently unused. The followup PR will plumb successful extends using LeaseEvent.

This PR also split pending_extends into pending_extends and eo_pending_extends to differentiate successful extends for at least once and exactly once leases.

Towards: https://github.com/googleapis/google-cloud-rust/issues/5048