### PR TITLE
cleanup: remove unnecessary allow(missing_docs) on generated modules

### DIFF
--- a/src/firestore/src/lib.rs
+++ b/src/firestore/src/lib.rs
@@ -39,7 +39,6 @@ pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 // TODO(#1549) - remove this workaround once all code is generated.
 #[allow(rustdoc::broken_intra_doc_links)]
-#[allow(missing_docs)]
 pub(crate) mod generated;
 
 pub use generated::gapic::builder;

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -53,7 +53,6 @@
 #![warn(missing_docs)]
 
 #[allow(rustdoc::broken_intra_doc_links)]
-#[allow(missing_docs)]
 pub(crate) mod generated;
 
 /// Types related to publishing messages with a [Publisher][client::Publisher]

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -124,7 +124,6 @@ pub mod stub {
 }
 
 #[allow(dead_code)]
-#[allow(missing_docs)]
 pub(crate) mod generated;
 
 #[allow(dead_code)]

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::empty::*;
 mod field_mask;
 pub use crate::field_mask::*;
 // The generated code contains (and uses) deprecated code.
-#[allow(deprecated, missing_docs)]
+#[allow(deprecated)]
 mod generated;
 #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
 #[allow(missing_docs)]


### PR DESCRIPTION
Remove `#[allow(missing_docs)]` from `lib.rs` files in `storage`, `firestore`, `pubsub`, and `wkt` where it was applied to generated modules. These are unnecessary after code regeneration.

For #5459 