### PR TITLE
fix(pubsub)!: make ShutdownBehavior non_exhaustive

### DIFF
--- a/src/pubsub/src/subscriber/shutdown_behavior.rs
+++ b/src/pubsub/src/subscriber/shutdown_behavior.rs
@@ -14,6 +14,7 @@
 
 /// The behavior on shutdown.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ShutdownBehavior {
     /// The subscriber stops reading from the underlying gRPC stream.
     ///


### PR DESCRIPTION
We want to make ShutdownBehavior non_exhaustive to support possible new shutdown behaviors in the future. This is a breaking change, but we are already planning to release a major version in our next change. We don't expect this to cause many issues since it seems unlikely that users will be matching on this enum. It is only used as the input in a single setter.

Fixes #5532 