### PR TITLE
cleanup: enable missing_docs by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -534,6 +534,7 @@ storage-samples          = { path = "src/storage/examples" }
 storage-grpc-mock        = { path = "src/storage/grpc-mock" }
 
 [workspace.lints.rust]
+missing_docs = "warn"
 unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',

--- a/guide/samples/src/bin/getting_started.rs
+++ b/guide/samples/src/bin/getting_started.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 // ANCHOR: all
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/guide/samples/src/lib.rs
+++ b/guide/samples/src/lib.rs
@@ -15,6 +15,8 @@
 //! This crate contains a number of guides showing how to use the
 //! Google Cloud Client Libraries for Rust.
 
+#![allow(missing_docs)]
+
 pub mod authentication;
 pub mod binding_errors;
 pub mod compute;

--- a/src/auth/build.rs
+++ b/src/auth/build.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use google_cloud_auth::credentials::EntityTag;

--- a/src/auth/tests/crypto_provider.rs
+++ b/src/auth/tests/crypto_provider.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_auth::credentials::*;
 
 #[cfg(test)]

--- a/src/gax-internal/build.rs
+++ b/src/gax-internal/build.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;

--- a/src/gax-internal/echo-server/src/lib.rs
+++ b/src/gax-internal/echo-server/src/lib.rs
@@ -17,6 +17,8 @@
 //! Setting up integration tests is a bit complicated. So we refactor that code
 //! to some helper functions.
 
+#![allow(missing_docs)]
+
 use axum::{
     extract::Query,
     http::{HeaderMap, StatusCode},

--- a/src/gax-internal/grpc-server/build.rs
+++ b/src/gax-internal/grpc-server/build.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 fn main() {
     #[cfg(google_cloud_generate_protos)]
     {

--- a/src/gax-internal/grpc-server/src/lib.rs
+++ b/src/gax-internal/grpc-server/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google::test::v1::{EchoRequest, EchoResponse};
 use google_cloud_auth::credentials::Credentials;
 use google_cloud_gax::client_builder::ClientBuilder;

--- a/src/gax-internal/src/lib.rs
+++ b/src/gax-internal/src/lib.rs
@@ -24,6 +24,8 @@
 //! This is intentional, as they are not intended for general use and will be
 //! changed without notice.
 
+#![allow(missing_docs)]
+
 #[cfg(feature = "_internal-common")]
 pub mod api_header;
 

--- a/src/pubsub/benchmarks/throughput/src/main.rs
+++ b/src/pubsub/benchmarks/throughput/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Benchmarks for measuring the throughput of the Pub/Sub client.
+
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod args;

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -20,6 +20,7 @@
 //! about the APIs, documentation, missing features, bugs, etc.
 //!
 
+// TODO(#5537): Remove this allow once all public APIs are documented.
 #![allow(missing_docs)]
 
 pub use batch_dml::BatchDml;

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -20,6 +20,8 @@
 //! about the APIs, documentation, missing features, bugs, etc.
 //!
 
+#![allow(missing_docs)]
+
 pub use batch_dml::BatchDml;
 pub use batch_dml::BatchDmlBuilder;
 pub use batch_read_only_transaction::{

--- a/tests/auto-populated/src/lib.rs
+++ b/tests/auto-populated/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::Result;
 use futures::stream::StreamExt;
 use google_cloud_bigquery_v2::client::{DatasetService, JobService};

--- a/tests/crypto-providers/auth-with-default/src/main.rs
+++ b/tests/crypto-providers/auth-with-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     test_metadata::has_default_crypto_provider(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;

--- a/tests/crypto-providers/auth-without-default/src/main.rs
+++ b/tests/crypto-providers/auth-without-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/gaxi-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/gaxi-with-aws-lc-rs/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/gaxi-with-default/src/main.rs
+++ b/tests/crypto-providers/gaxi-with-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     test_metadata::has_default_crypto_provider(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;

--- a/tests/crypto-providers/gaxi-with-ring/src/main.rs
+++ b/tests/crypto-providers/gaxi-with-ring/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/idtoken-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/idtoken-with-aws-lc-rs/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_auth::credentials::idtoken::verifier::Builder;
 
 fn main() -> anyhow::Result<()> {

--- a/tests/crypto-providers/idtoken-with-default/src/main.rs
+++ b/tests/crypto-providers/idtoken-with-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_auth::credentials::idtoken::verifier::Builder;
 
 fn main() -> anyhow::Result<()> {

--- a/tests/crypto-providers/idtoken-with-rust-crypto/src/main.rs
+++ b/tests/crypto-providers/idtoken-with-rust-crypto/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_auth::credentials::idtoken::verifier::Builder;
 
 fn main() -> anyhow::Result<()> {

--- a/tests/crypto-providers/secret-manager-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/secret-manager-with-aws-lc-rs/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/secret-manager-with-default/src/main.rs
+++ b/tests/crypto-providers/secret-manager-with-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     test_metadata::has_default_crypto_provider(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;

--- a/tests/crypto-providers/secret-manager-with-ring/src/main.rs
+++ b/tests/crypto-providers/secret-manager-with-ring/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/storage-with-aws-lc-rs/src/main.rs
+++ b/tests/crypto-providers/storage-with-aws-lc-rs/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, aws_lc_rs::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/storage-with-default/src/main.rs
+++ b/tests/crypto-providers/storage-with-default/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     test_metadata::has_default_crypto_provider(env!("CARGO"), env!("CARGO_MANIFEST_DIR"))?;

--- a/tests/crypto-providers/storage-with-ring/src/main.rs
+++ b/tests/crypto-providers/storage-with-ring/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use rustls::crypto::{CryptoProvider, ring::default_provider};
 
 #[tokio::main]

--- a/tests/crypto-providers/test-auth/src/lib.rs
+++ b/tests/crypto-providers/test-auth/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::bail;
 use std::time::Duration;
 

--- a/tests/crypto-providers/test-gaxi/src/lib.rs
+++ b/tests/crypto-providers/test-gaxi/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::bail;
 use google_cloud_auth::credentials::Builder as CredentialsBuilder;
 use google_cloud_gax::options::RequestOptions;

--- a/tests/crypto-providers/test-metadata/src/lib.rs
+++ b/tests/crypto-providers/test-metadata/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::bail;
 use cargo_metadata::{
     FeatureName, Metadata, MetadataCommand, PackageId, PackageName, semver::Version,

--- a/tests/crypto-providers/test-secret-manager/src/lib.rs
+++ b/tests/crypto-providers/test-secret-manager/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_gax::paginator::ItemPaginator as _;
 use google_cloud_secretmanager_v1::Error;
 use google_cloud_secretmanager_v1::client::SecretManagerService;

--- a/tests/crypto-providers/test-storage/src/lib.rs
+++ b/tests/crypto-providers/test-storage/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_gax::paginator::ItemPaginator as _;
 use google_cloud_storage::Error;
 use google_cloud_storage::client::{Storage, StorageControl};

--- a/tests/default-idempotency/src/lib.rs
+++ b/tests/default-idempotency/src/lib.rs
@@ -19,6 +19,8 @@
 //! idempotent or not. We use this to verify that the operation's default
 //! idempotency is correct.
 
+#![allow(missing_docs)]
+
 #[cfg(test)]
 mod tests {
     type Result = anyhow::Result<()>;

--- a/tests/discovery/src/lib.rs
+++ b/tests/discovery/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::Result;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_compute_v1::client::{Images, Instances, MachineTypes, Zones};

--- a/tests/dns/src/lib.rs
+++ b/tests/dns/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_dns_v1::{client::ManagedZones, model::ManagedZone};
 use google_cloud_gax::paginator::ItemPaginator as _;
 use google_cloud_lro::Poller as _;

--- a/tests/endurance/src/main.rs
+++ b/tests/endurance/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_gax::{
     options::RequestOptionsBuilder,
     paginator::ItemPaginator,

--- a/tests/enums-query-parameters/src/lib.rs
+++ b/tests/enums-query-parameters/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::Result;
 use google_cloud_gax::exponential_backoff::{ExponentialBackoff, ExponentialBackoffBuilder};
 use google_cloud_gax::options::RequestOptionsBuilder;

--- a/tests/integration-auth/src/lib.rs
+++ b/tests/integration-auth/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_auth::credentials::idtoken::{
     Builder as IDTokenCredentialBuilder, impersonated::Builder as ImpersonatedIDTokenBuilder,
     mds::Builder as IDTokenMDSBuilder, mds::Format,

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -12,4 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod error_details;

--- a/tests/locational-endpoints/src/lib.rs
+++ b/tests/locational-endpoints/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use google_cloud_aiplatform_v1::client::ModelService;
 use google_cloud_test_utils::runtime_config::{project_id, region_id};
 

--- a/tests/lro/src/lib.rs
+++ b/tests/lro/src/lib.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod fake;
 pub mod production;

--- a/tests/o11y/src/lib.rs
+++ b/tests/o11y/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod auth;
 pub mod detector;
 pub mod mock_collector;

--- a/tests/openapi/src/lib.rs
+++ b/tests/openapi/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod global;
 pub mod locational;
 

--- a/tests/protobuf/src/lib.rs
+++ b/tests/protobuf/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 mod mocking;
 mod pagination;
 

--- a/tests/protojson-conformance/src/lib.rs
+++ b/tests/protojson-conformance/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod generated;
 
 pub mod conformance {

--- a/tests/protojson-conformance/src/main.rs
+++ b/tests/protojson-conformance/src/main.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use prost::{
     Message,
     bytes::{Buf, BufMut},

--- a/tests/pubsub/src/lib.rs
+++ b/tests/pubsub/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod exactly_once;
 pub mod ordering;
 

--- a/tests/showcase/src/lib.rs
+++ b/tests/showcase/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 use anyhow::{Error, Result};
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_gax::options::RequestOptionsBuilder;

--- a/tests/spanner/src/lib.rs
+++ b/tests/spanner/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod batch_read_only_transaction;
 pub mod client;
 pub mod directed_read;

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 pub mod bidi_read;
 pub mod read_object;
 pub mod write_object;


### PR DESCRIPTION
Alternatively, we document these things, but that can be done as follow up work. Cargo.toml does not allow inheriting some lints from the workspace and overriding others, so we have to put the annotations in the code.

For #5459 