### PR TITLE
chore: add taplo-cli in tools.cargo in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -41,6 +41,8 @@ tools:
       version: 0.46.0
     - name: cargo-workspaces
       version: 0.4.0
+    - name: taplo-cli
+      version: 0.10.0
 release:
   ignored_changes:
     - .repo-metadata.json


### PR DESCRIPTION
I hit this error:

```
$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all

...

2026/04/28 18:11:27 librarian: format library "bigquery-grpc-mock" (rust): taplo fmt src/bigquery/grpc-mock/Cargo.toml: exec: "taplo": executable file not found in $PATH
exit status 1
```

https://crates.io/crates/taplo-cli is needed to run the command.

```
suztomo@suztomo:/tmp/suztomo-patch-1$ gh pr checkout 5554
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Unpacking objects: 100% (3/3), 10.92 KiB | 2.73 MiB/s, done.
From https://github.com/googleapis/google-cloud-rust
 * [new branch]          suztomo-patch-1 -> upstream-bkup/suztomo-patch-1
Already on 'suztomo-patch-1'
Updating 615f139e8..a43219ffb
Fast-forward
 librarian.yaml | 2 ++
 1 file changed, 2 insertions(+)
suztomo@suztomo:/tmp/suztomo-patch-1$ go run github.com/googleapis/librarian/cmd/librarian@${V} install rust
go: github.com/googleapis/librarian@v0.11.0 requires go >= 1.26.1; switching to go1.26.2
suztomo@suztomo:/tmp/suztomo-patch-1$ taplo
Usage: taplo [OPTIONS] <COMMAND>

Commands:
  lint         Lint TOML documents [aliases: check, validate]
  format       Format TOML documents [aliases: fmt]
  lsp          Language server operations
  config       Operations with the Taplo config file [aliases: cfg]
  get          Extract a value from the given TOML document
  toml-test    Start a decoder for `toml-test` (https://github.com/BurntSushi/toml-test)
  completions  Generate completions for Taplo CLI
  help         Print this message or the help of the given subcommand(s)

Options:
      --colors <COLORS>  [default: auto] [possible values: auto, always, never]
      --verbose          Enable a verbose logging format
      --log-spans        Enable logging spans
  -h, --help             Print help (see more with '--help')
  -V, --version          Print version
```