### PR TITLE
impl(pubsub): bind exactly once modack time to max lease extension

### DIFF
--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -14,7 +14,7 @@
 
 use super::exactly_once_retry::exactly_once_retry_loop;
 use super::handler::AckResult;
-use super::retry_policy::{StreamRetryPolicy, exactly_once_options, rpc_options};
+use super::retry_policy::{StreamRetryPolicy, eo_ack_options, eo_modack_options, rpc_options};
 use super::stub::Stub;
 use crate::RequestOptions;
 use crate::model::{AcknowledgeRequest, ModifyAckDeadlineRequest};
@@ -24,6 +24,7 @@ use google_cloud_gax::retry_policy::RetryPolicy;
 use google_cloud_gax::retry_throttler::{CircuitBreaker, SharedRetryThrottler};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
 /// A trait representing leaser actions.
@@ -57,7 +58,8 @@ where
     inner: Arc<T>,
     confirmed_tx: UnboundedSender<ConfirmedAcks>,
     options: RequestOptions,
-    exactly_once_options: RequestOptions,
+    eo_ack_options: RequestOptions,
+    eo_modack_options: RequestOptions,
     subscription: String,
     ack_deadline_seconds: i32,
     backoff: Arc<dyn BackoffPolicy>,
@@ -72,7 +74,8 @@ where
             inner: self.inner.clone(),
             confirmed_tx: self.confirmed_tx.clone(),
             options: self.options.clone(),
-            exactly_once_options: self.exactly_once_options.clone(),
+            eo_ack_options: self.eo_ack_options.clone(),
+            eo_modack_options: self.eo_modack_options.clone(),
             subscription: self.subscription.clone(),
             ack_deadline_seconds: self.ack_deadline_seconds,
             backoff: self.backoff.clone(),
@@ -91,8 +94,8 @@ where
         ack_deadline_seconds: i32,
         grpc_subchannel_count: usize,
     ) -> Self {
-        let eo_options = exactly_once_options();
-        let backoff = backoff_policy(&eo_options);
+        let eo_ack_options = eo_ack_options();
+        let backoff = backoff_policy(&eo_ack_options);
         Self::new_with_backoff(
             inner,
             confirmed_tx,
@@ -117,7 +120,8 @@ where
             inner,
             confirmed_tx,
             options: rpc_options(grpc_subchannel_count),
-            exactly_once_options: exactly_once_options(),
+            eo_ack_options: eo_ack_options(),
+            eo_modack_options: eo_modack_options(Duration::from_secs(ack_deadline_seconds as u64)),
             subscription,
             ack_deadline_seconds,
             backoff,
@@ -181,8 +185,8 @@ where
             ack_ids,
             inner,
             self.confirmed_tx.clone(),
-            retry_throttler(&self.exactly_once_options),
-            retry_policy(&self.exactly_once_options),
+            retry_throttler(&self.eo_ack_options),
+            retry_policy(&self.eo_ack_options),
             self.backoff.clone(),
         )
         .await;
@@ -202,13 +206,12 @@ where
                 .await
                 .map(|_| ())
         };
-        // TODO(#4804): update retry policy time limit to max lease extension.
         exactly_once_retry_loop(
             ack_ids,
             inner,
             self.confirmed_tx.clone(),
-            retry_throttler(&self.exactly_once_options),
-            retry_policy(&self.exactly_once_options),
+            retry_throttler(&self.eo_modack_options),
+            retry_policy(&self.eo_modack_options),
             self.backoff.clone(),
         )
         .await;
@@ -642,6 +645,63 @@ pub(super) mod tests {
                 result.is_ok(),
                 "Expected success for {ack_id}, got {result:?}"
             );
+        }
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn confirmed_nack_retry_time_limit() -> anyhow::Result<()> {
+        let mut mock = MockStub::new();
+        mock.expect_modify_ack_deadline().returning(|r, o| {
+            assert_eq!(
+                r.subscription,
+                "projects/my-project/subscriptions/my-subscription"
+            );
+            assert_eq!(r.ack_deadline_seconds, 0);
+            assert_eq!(sorted(&r.ack_ids), test_ids(0..10));
+            verify_policies(o, 16);
+            Err(Error::service(
+                Status::default().set_code(Code::Unavailable),
+            ))
+        });
+
+        let mut mock_backoff = MockBackoffPolicy::new();
+        mock_backoff
+            .expect_on_failure()
+            .return_const(Duration::from_secs(5));
+        let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let leaser = DefaultLeaser::new_with_backoff(
+            Arc::new(mock),
+            confirmed_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+            Arc::new(mock_backoff),
+        );
+
+        let start = tokio::time::Instant::now();
+
+        leaser.confirmed_nack(test_ids(0..10)).await;
+
+        // Since mock_backoff is exactly 5 secs, we expect 2 retries to take exactly 10
+        // secs to cross the time limit threshold.
+        assert_eq!(start.elapsed(), Duration::from_secs(10));
+
+        let confirmed_nacks = confirmed_rx.recv().await.expect("results were not sent");
+
+        // Verify all ids have a result.
+        let ack_ids: Vec<_> = confirmed_nacks.keys().cloned().collect();
+        assert_eq!(sorted(&ack_ids), test_ids(0..10));
+
+        // Verify all nacks failed with the error.
+        for (ack_id, result) in &confirmed_nacks {
+            match result {
+                Err(crate::error::AckError::Rpc { source, .. }) => {
+                    let status = source.status().expect("RPC source should have a status");
+                    assert_eq!(status.code, Code::Unavailable);
+                }
+                _ => panic!("Expected RPC error for {ack_id}, got {result:?}"),
+            }
         }
         Ok(())
     }

--- a/src/pubsub/src/subscriber/retry_policy.rs
+++ b/src/pubsub/src/subscriber/retry_policy.rs
@@ -104,10 +104,9 @@ pub(super) fn rpc_options(grpc_subchannel_count: usize) -> RequestOptions {
     o
 }
 
-/// The policies for retrying RPCs in exactly-once delivery.
-pub(super) fn exactly_once_options() -> RequestOptions {
+fn exactly_once_options(time_limit: Duration) -> RequestOptions {
     let mut o = RequestOptions::default();
-    o.set_retry_policy(OnlyTransportErrors.with_time_limit(Duration::from_secs(600)));
+    o.set_retry_policy(OnlyTransportErrors.with_time_limit(time_limit));
     o.set_backoff_policy(
         ExponentialBackoffBuilder::new()
             .with_initial_delay(Duration::from_secs(1))
@@ -116,6 +115,16 @@ pub(super) fn exactly_once_options() -> RequestOptions {
             .clamp(),
     );
     o
+}
+
+/// The policies for retrying ack RPCs in exactly-once delivery.
+pub(super) fn eo_ack_options() -> RequestOptions {
+    exactly_once_options(Duration::from_secs(600))
+}
+
+/// The policies for retrying modack RPCs in exactly-once delivery.
+pub(super) fn eo_modack_options(time_limit: Duration) -> RequestOptions {
+    exactly_once_options(time_limit)
 }
 
 #[cfg(test)]
@@ -338,8 +347,18 @@ pub(super) mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn exactly_once_options() {
-        let o = super::exactly_once_options();
+    async fn eo_ack_options() {
+        verify_exactly_once_options(super::eo_ack_options(), Duration::from_secs(600));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eo_modack_options() {
+        let time_limit = Duration::from_secs(20);
+        verify_exactly_once_options(super::eo_modack_options(time_limit), time_limit);
+    }
+
+    #[track_caller]
+    fn verify_exactly_once_options(o: RequestOptions, time_limit: Duration) {
         let retry = o.retry_policy().clone().unwrap();
         let backoff = o.backoff_policy().clone().unwrap();
 
@@ -396,10 +415,9 @@ pub(super) mod tests {
         let state = RetryState::default().set_start(tokio::time::Instant::now());
         let r = retry.remaining_time(&state).unwrap();
         assert_eq!(
-            r,
-            Duration::from_secs(600),
-            "Expected time limit of exactly 600s, got {:?}",
-            r
+            time_limit, r,
+            "Expected time limit of exactly {:?}, got {:?}",
+            time_limit, r
         );
 
         // Verify backoff behavior


### PR DESCRIPTION
Add exactly once modack `RequestOptions` which sets the retries time limit to max lease extension instead of the 10 mins used for exactly once ack.

Towards https://github.com/googleapis/google-cloud-rust/issues/4804