### PR TITLE
impl(pubsub): add eo_extend to leaser that retries

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -38,6 +38,7 @@ impl LeaseLoop {
     pub(super) fn new<L>(
         leaser: L,
         mut confirmed_rx: UnboundedReceiver<ConfirmedAcks>,
+        _eo_extend_rx: UnboundedReceiver<ConfirmedAcks>,
         options: LeaseOptions,
     ) -> Self
     where
@@ -113,6 +114,8 @@ impl LeaseLoop {
                             Some(results) => state.confirm(results),
                         }
                     },
+                    // TODO(#4804): When leaser.eo_extend is merged,
+                    // receive from eo_extend_rx and process the results.
                 }
             }
             drop(shutdown_guard);
@@ -184,13 +187,14 @@ mod tests {
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             flush_start: FLUSH_START,
             // effectively disable extensions to simplify this test.
             extend_start: Duration::from_secs(900),
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -243,13 +247,13 @@ mod tests {
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
         let (confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             flush_start: FLUSH_START,
-            // effectively disable extensions to simplify this test.
             extend_start: Duration::from_secs(900),
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -291,6 +295,7 @@ mod tests {
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             flush_period: FLUSH_PERIOD,
             flush_start: FLUSH_START,
@@ -298,7 +303,7 @@ mod tests {
             extend_start: Duration::from_secs(900),
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -391,6 +396,7 @@ mod tests {
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             // effectively disable ack/nack flushes to simplify this test.
             flush_start: Duration::from_secs(900),
@@ -401,7 +407,7 @@ mod tests {
             max_lease_extension: Duration::from_secs(7),
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -490,7 +496,13 @@ mod tests {
         let start = Instant::now();
         let mock = MockLeaser::new();
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
-        let lease_loop = LeaseLoop::new(Arc::new(mock), confirmed_rx, LeaseOptions::default());
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
+        let lease_loop = LeaseLoop::new(
+            Arc::new(mock),
+            confirmed_rx,
+            eo_extend_rx,
+            LeaseOptions::default(),
+        );
         // Yield execution, so tokio can actually start the lease loop.
         tokio::task::yield_now().await;
 
@@ -530,11 +542,12 @@ mod tests {
             .returning(|_| ());
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             shutdown_behavior: ShutdownBehavior::NackImmediately,
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock, confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock, confirmed_rx, eo_extend_rx, options);
 
         // Seed the lease loop with some messages
         for i in 0..30 {
@@ -570,11 +583,12 @@ mod tests {
             .returning(|_| ());
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             shutdown_behavior: ShutdownBehavior::WaitForProcessing,
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(mock, confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(mock, confirmed_rx, eo_extend_rx, options);
         let ack_tx = lease_loop.strong_ack_tx();
 
         // Seed the lease loop with some messages
@@ -630,13 +644,15 @@ mod tests {
             }
             async fn confirmed_ack(&self, _ack_ids: Vec<String>) {}
             async fn confirmed_nack(&self, _ack_ids: Vec<String>) {}
+            async fn eo_extend(&self, _ack_ids: Vec<String>) {}
         }
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             shutdown_behavior,
             ..Default::default()
         };
-        let lease_loop = LeaseLoop::new(FakeLeaser, confirmed_rx, options);
+        let lease_loop = LeaseLoop::new(FakeLeaser, confirmed_rx, eo_extend_rx, options);
 
         // Seed the lease loop with some messages
         for i in 0..30 {
@@ -675,12 +691,13 @@ mod tests {
 
             let mock = Arc::new(Mutex::new(MockLeaser::new()));
             let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+            let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
             let options = LeaseOptions {
                 flush_start: Duration::from_millis(100),
                 extend_start: Duration::from_millis(200),
                 ..Default::default()
             };
-            let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, options);
+            let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
             // Yield execution, so tokio can actually start the lease loop.
             tokio::task::yield_now().await;
 

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -337,6 +337,7 @@ where
             .retain(self.max_lease, self.max_lease_extension);
         for ack_ids in batches {
             let leaser = self.leaser.clone();
+            // TODO(#4804): When leaser.eo_extend is merged, use leaser.eo_extend instead.
             self.eo_pending_extends
                 .spawn(async move { leaser.extend(ack_ids).await });
         }

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -46,6 +46,9 @@ pub(super) trait Leaser {
     async fn confirmed_ack(&self, ack_ids: Vec<String>);
     /// Negatively acknowledge a batch of messages and confirm the result.
     async fn confirmed_nack(&self, ack_ids: Vec<String>);
+    /// Extend lease deadlines for a batch of messages with exactly-once semantics.
+    #[allow(dead_code)]
+    async fn eo_extend(&self, ack_ids: Vec<String>);
 }
 
 /// A map of exactly-once ack IDs to their final result.
@@ -63,6 +66,7 @@ where
     subscription: String,
     ack_deadline_seconds: i32,
     backoff: Arc<dyn BackoffPolicy>,
+    eo_extend_tx: UnboundedSender<ConfirmedAcks>,
 }
 
 impl<T> Clone for DefaultLeaser<T>
@@ -79,6 +83,7 @@ where
             subscription: self.subscription.clone(),
             ack_deadline_seconds: self.ack_deadline_seconds,
             backoff: self.backoff.clone(),
+            eo_extend_tx: self.eo_extend_tx.clone(),
         }
     }
 }
@@ -90,6 +95,7 @@ where
     pub(super) fn new(
         inner: Arc<T>,
         confirmed_tx: UnboundedSender<ConfirmedAcks>,
+        eo_extend_tx: UnboundedSender<ConfirmedAcks>,
         subscription: String,
         ack_deadline_seconds: i32,
         grpc_subchannel_count: usize,
@@ -99,6 +105,7 @@ where
         Self::new_with_backoff(
             inner,
             confirmed_tx,
+            eo_extend_tx,
             subscription,
             ack_deadline_seconds,
             grpc_subchannel_count,
@@ -109,6 +116,7 @@ where
     pub(super) fn new_with_backoff(
         inner: Arc<T>,
         confirmed_tx: UnboundedSender<ConfirmedAcks>,
+        eo_extend_tx: UnboundedSender<ConfirmedAcks>,
         subscription: String,
         ack_deadline_seconds: i32,
         grpc_subchannel_count: usize,
@@ -125,6 +133,7 @@ where
             subscription,
             ack_deadline_seconds,
             backoff,
+            eo_extend_tx,
         }
     }
 }
@@ -216,6 +225,33 @@ where
         )
         .await;
     }
+
+    #[allow(dead_code)]
+    async fn eo_extend(&self, ack_ids: Vec<String>) {
+        let leaser = self.clone();
+        let options = self.options.clone();
+        // TODO(#4804): Limit the number of attempts to at most 3.
+        let inner = async move |ids: Vec<String>| {
+            let req = ModifyAckDeadlineRequest::new()
+                .set_subscription(leaser.subscription.clone())
+                .set_ack_ids(ids)
+                .set_ack_deadline_seconds(leaser.ack_deadline_seconds);
+            leaser
+                .inner
+                .modify_ack_deadline(req, options.clone())
+                .await
+                .map(|_| ())
+        };
+        exactly_once_retry_loop(
+            ack_ids,
+            inner,
+            self.eo_extend_tx.clone(),
+            retry_throttler(&self.eo_modack_options),
+            retry_policy(&self.eo_modack_options),
+            self.backoff.clone(),
+        )
+        .await;
+    }
 }
 
 fn retry_policy(options: &RequestOptions) -> Arc<dyn RetryPolicy> {
@@ -264,6 +300,7 @@ pub(super) mod tests {
             async fn extend(&self, ack_ids: Vec<String>) -> Vec<String>;
             async fn confirmed_ack(&self, ack_ids: Vec<String>);
             async fn confirmed_nack(&self, ack_ids: Vec<String>);
+            async fn eo_extend(&self, ack_ids: Vec<String>);
         }
     }
 
@@ -292,6 +329,9 @@ pub(super) mod tests {
         async fn confirmed_nack(&self, ack_ids: Vec<String>) {
             MockLeaser::confirmed_nack(self, ack_ids).await
         }
+        async fn eo_extend(&self, ack_ids: Vec<String>) {
+            MockLeaser::eo_extend(self, ack_ids).await
+        }
     }
 
     #[async_trait::async_trait]
@@ -311,14 +351,19 @@ pub(super) mod tests {
         async fn confirmed_nack(&self, ack_ids: Vec<String>) {
             self.lock().await.confirmed_nack(ack_ids).await
         }
+        async fn eo_extend(&self, ack_ids: Vec<String>) {
+            self.lock().await.eo_extend(ack_ids).await
+        }
     }
 
     #[test]
     fn clone() {
         let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(MockStub::new()),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             1_usize,
@@ -345,9 +390,11 @@ pub(super) mod tests {
         });
 
         let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -372,9 +419,11 @@ pub(super) mod tests {
             });
 
         let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -399,9 +448,11 @@ pub(super) mod tests {
             });
 
         let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -427,9 +478,11 @@ pub(super) mod tests {
             });
 
         let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -452,9 +505,11 @@ pub(super) mod tests {
         });
 
         let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -515,9 +570,11 @@ pub(super) mod tests {
             .return_const(std::time::Duration::ZERO);
 
         let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new_with_backoff(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -558,9 +615,11 @@ pub(super) mod tests {
             });
 
         let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -623,9 +682,11 @@ pub(super) mod tests {
             .return_const(std::time::Duration::ZERO);
 
         let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new_with_backoff(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -670,9 +731,11 @@ pub(super) mod tests {
             .expect_on_failure()
             .return_const(Duration::from_secs(5));
         let (confirmed_tx, mut confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, _eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new_with_backoff(
             Arc::new(mock),
             confirmed_tx,
+            eo_extend_tx,
             "projects/my-project/subscriptions/my-subscription".to_string(),
             10,
             16_usize,
@@ -695,6 +758,133 @@ pub(super) mod tests {
 
         // Verify all nacks failed with the error.
         for (ack_id, result) in &confirmed_nacks {
+            match result {
+                Err(crate::error::AckError::Rpc { source, .. }) => {
+                    let status = source.status().expect("RPC source should have a status");
+                    assert_eq!(status.code, Code::Unavailable);
+                }
+                _ => panic!("Expected RPC error for {ack_id}, got {result:?}"),
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn eo_extend_retry() -> anyhow::Result<()> {
+        let mut mock = MockStub::new();
+        let mut seq = mockall::Sequence::new();
+        mock.expect_modify_ack_deadline()
+            .once()
+            .in_sequence(&mut seq)
+            .return_once(|r, o| {
+                assert_eq!(
+                    r.subscription,
+                    "projects/my-project/subscriptions/my-subscription"
+                );
+                assert_eq!(r.ack_deadline_seconds, 10);
+                assert_eq!(sorted(&r.ack_ids), test_ids(0..10));
+                verify_policies(o, 16);
+                Err(Error::service(
+                    Status::default().set_code(Code::Unavailable),
+                ))
+            });
+        mock.expect_modify_ack_deadline()
+            .once()
+            .in_sequence(&mut seq)
+            .return_once(|r, o| {
+                assert_eq!(
+                    r.subscription,
+                    "projects/my-project/subscriptions/my-subscription"
+                );
+                assert_eq!(r.ack_deadline_seconds, 10);
+                assert_eq!(sorted(&r.ack_ids), test_ids(0..10));
+                verify_policies(o, 16);
+                Ok(Response::from(()))
+            });
+
+        let mut mock_backoff = MockBackoffPolicy::new();
+        mock_backoff
+            .expect_on_failure()
+            .once()
+            .return_const(std::time::Duration::ZERO);
+
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, mut eo_extend_rx) = unbounded_channel();
+        let leaser = DefaultLeaser::new_with_backoff(
+            Arc::new(mock),
+            confirmed_tx,
+            eo_extend_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+            Arc::new(mock_backoff),
+        );
+        leaser.eo_extend(test_ids(0..10)).await;
+
+        let confirmed_extends = eo_extend_rx.recv().await.expect("results were not sent");
+
+        // Verify all ids have a result.
+        let ack_ids: Vec<_> = confirmed_extends.keys().cloned().collect();
+        assert_eq!(sorted(&ack_ids), test_ids(0..10));
+
+        // Verify all extends were successful.
+        for (ack_id, result) in &confirmed_extends {
+            assert!(
+                result.is_ok(),
+                "Expected success for {ack_id}, got {result:?}"
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eo_extend_retry_time_limit() -> anyhow::Result<()> {
+        let mut mock = MockStub::new();
+        mock.expect_modify_ack_deadline().returning(|r, o| {
+            assert_eq!(
+                r.subscription,
+                "projects/my-project/subscriptions/my-subscription"
+            );
+            assert_eq!(r.ack_deadline_seconds, 10);
+            assert_eq!(sorted(&r.ack_ids), test_ids(0..10));
+            verify_policies(o, 16);
+            Err(Error::service(
+                Status::default().set_code(Code::Unavailable),
+            ))
+        });
+
+        let mut mock_backoff = MockBackoffPolicy::new();
+        mock_backoff
+            .expect_on_failure()
+            .return_const(Duration::from_secs(5));
+        let (confirmed_tx, _confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, mut eo_extend_rx) = unbounded_channel();
+        let leaser = DefaultLeaser::new_with_backoff(
+            Arc::new(mock),
+            confirmed_tx,
+            eo_extend_tx,
+            "projects/my-project/subscriptions/my-subscription".to_string(),
+            10,
+            16_usize,
+            Arc::new(mock_backoff),
+        );
+
+        let start = tokio::time::Instant::now();
+
+        leaser.eo_extend(test_ids(0..10)).await;
+
+        // Since mock_backoff is exactly 5 secs, we expect 2 retries to take exactly 10
+        // secs to cross the time limit threshold.
+        assert_eq!(start.elapsed(), Duration::from_secs(10));
+
+        let confirmed_extends = eo_extend_rx.recv().await.expect("results were not sent");
+
+        // Verify all ids have a result.
+        let ack_ids: Vec<_> = confirmed_extends.keys().cloned().collect();
+        assert_eq!(sorted(&ack_ids), test_ids(0..10));
+
+        // Verify all extends failed with the error.
+        for (ack_id, result) in &confirmed_extends {
             match result {
                 Err(crate::error::AckError::Rpc { source, .. }) => {
                     let status = source.status().expect("RPC source should have a status");

--- a/src/pubsub/src/subscriber/message_stream.rs
+++ b/src/pubsub/src/subscriber/message_stream.rs
@@ -134,9 +134,11 @@ impl MessageStream {
         let subscription = builder.subscription;
 
         let (confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let leaser = DefaultLeaser::new(
             stub.clone(),
             confirmed_tx,
+            eo_extend_tx,
             subscription.clone(),
             builder.ack_deadline_seconds,
             builder.grpc_subchannel_count,
@@ -152,7 +154,7 @@ impl MessageStream {
             message_tx,
             ack_tx,
             cancel: shutdown,
-        } = LeaseLoop::new(leaser, confirmed_rx, options);
+        } = LeaseLoop::new(leaser, confirmed_rx, eo_extend_rx, options);
         let lease_loop = handle.map(|_| ()).boxed().shared();
         let _shutdown_guard = shutdown.clone().drop_guard();
 


### PR DESCRIPTION
Implement a new function eo_extend in Leaser that extends exactly once leases with retry logic. The results are returned by a new eo_extend channel which will be processed in LeaseLoop in a future PR.

Instead of using the new eo_extend channel, an alternative is to continue using the function return value and the ExtendCompletedEO lease event. However, we would have to await for all the retries to complete and collect the value before it can be used.

Towards https://github.com/googleapis/google-cloud-rust/issues/4804