### PR TITLE
feat(pubsub): retry exactly once lease extensions

### DIFF
--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -784,7 +784,7 @@ mod tests {
         eo_extend_tx.send(results)?;
         tokio::task::yield_now().await; // Let the loop process it the extend result.
 
-        // Since the lease has been sucessfully extended, it should not be extended again.
+        // Since the lease has been successfully extended, it should not be extended again.
         mock.lock().await.expect_eo_extend().times(0);
 
         tokio::time::advance(EXTEND_PERIOD).await;

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -116,6 +116,7 @@ impl LeaseLoop {
                         match extend_results {
                             None => break,
                             Some(r) => {
+                                // TODO(#4804): Emit a log when there is an error.
                                 let extended: Vec<String> = r
                                     .into_iter()
                                     .filter_map(|(id, res)| if res.is_ok() { Some(id) } else { None })
@@ -404,7 +405,7 @@ mod tests {
         let mock = Arc::new(Mutex::new(MockLeaser::new()));
 
         let (_confirmed_tx, confirmed_rx) = unbounded_channel();
-        let (_eo_extend_tx, eo_extend_rx) = unbounded_channel();
+        let (eo_extend_tx, eo_extend_rx) = unbounded_channel();
         let options = LeaseOptions {
             // effectively disable ack/nack flushes to simplify this test.
             flush_start: Duration::from_secs(900),
@@ -449,7 +450,16 @@ mod tests {
                 .expect_eo_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(30..60))
-                .returning(move |_| ());
+                .return_once({
+                    let tx = eo_extend_tx.clone();
+                    move |ack_ids| {
+                        let mut results = HashMap::new();
+                        for id in ack_ids {
+                            results.insert(id, Ok(()));
+                        }
+                        let _ = tx.send(results);
+                    }
+                });
 
             tokio::time::advance(EXTEND_START).await;
 
@@ -487,7 +497,16 @@ mod tests {
                 .expect_eo_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(30..60))
-                .returning(|_| ());
+                .return_once({
+                    let tx = eo_extend_tx.clone();
+                    move |ack_ids| {
+                        let mut results = HashMap::new();
+                        for id in ack_ids {
+                            results.insert(id, Ok(()));
+                        }
+                        let _ = tx.send(results);
+                    }
+                });
 
             tokio::time::advance(EXTEND_PERIOD).await;
 
@@ -773,15 +792,21 @@ mod tests {
             .expect_eo_extend()
             .times(1)
             .withf(|v| *v == vec![test_id(0)])
-            .returning(|_| ());
+            .return_once({
+                let tx = eo_extend_tx.clone();
+                move |ack_ids| {
+                    let mut results = HashMap::new();
+                    for id in ack_ids {
+                        results.insert(id, Ok(()));
+                    }
+                    let _ = tx.send(results);
+                }
+            });
 
         tokio::time::advance(EXTEND_START).await;
         tokio::task::yield_now().await;
         mock.lock().await.checkpoint();
 
-        let mut results = HashMap::new();
-        results.insert(test_id(0), Ok(()));
-        eo_extend_tx.send(results)?;
         tokio::task::yield_now().await; // Let the loop process it the extend result.
 
         // Since the lease has been successfully extended, it should not be extended again.

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -121,9 +121,7 @@ impl LeaseLoop {
                                     .into_iter()
                                     .filter_map(|(id, res)| res.ok().map(|_| id))
                                     .collect();
-                                if !extended.is_empty() {
-                                    state.update_last_extension_eo(extended);
-                                }
+                                state.update_last_extension_eo(extended);
                             }
                         }
                     },

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -119,9 +119,11 @@ impl LeaseLoop {
                                 // TODO(#4804): Emit a log when there is an error.
                                 let extended: Vec<String> = r
                                     .into_iter()
-                                    .filter_map(|(id, res)| if res.is_ok() { Some(id) } else { None })
+                                    .filter_map(|(id, res)| res.ok().map(|_| id))
                                     .collect();
-                                state.update_last_extension_eo(extended);
+                                if !extended.is_empty() {
+                                    state.update_last_extension_eo(extended);
+                                }
                             }
                         }
                     },

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -809,7 +809,7 @@ mod tests {
         tokio::task::yield_now().await;
         mock.lock().await.checkpoint();
 
-        tokio::task::yield_now().await; // Let the loop process it the extend result.
+        tokio::task::yield_now().await; // Let the loop process the extend result.
 
         // Since the lease has been successfully extended, it should not be extended again.
         mock.lock().await.expect_eo_extend().times(0);

--- a/src/pubsub/src/subscriber/lease_loop.rs
+++ b/src/pubsub/src/subscriber/lease_loop.rs
@@ -38,7 +38,7 @@ impl LeaseLoop {
     pub(super) fn new<L>(
         leaser: L,
         mut confirmed_rx: UnboundedReceiver<ConfirmedAcks>,
-        _eo_extend_rx: UnboundedReceiver<ConfirmedAcks>,
+        mut eo_extend_rx: UnboundedReceiver<ConfirmedAcks>,
         options: LeaseOptions,
     ) -> Self
     where
@@ -91,9 +91,7 @@ impl LeaseLoop {
                             LeaseEvent::ExtendCompleted(ack_ids) => {
                                 state.update_last_extension(ack_ids);
                             }
-                            LeaseEvent::ExtendCompletedEO(ack_ids) => {
-                                state.update_last_extension_eo(ack_ids);
-                            }
+
                         }
                     },
                     message = message_rx.recv() => {
@@ -114,8 +112,18 @@ impl LeaseLoop {
                             Some(results) => state.confirm(results),
                         }
                     },
-                    // TODO(#4804): When leaser.eo_extend is merged,
-                    // receive from eo_extend_rx and process the results.
+                    extend_results = eo_extend_rx.recv() => {
+                        match extend_results {
+                            None => break,
+                            Some(r) => {
+                                let extended: Vec<String> = r
+                                    .into_iter()
+                                    .filter_map(|(id, res)| if res.is_ok() { Some(id) } else { None })
+                                    .collect();
+                                state.update_last_extension_eo(extended);
+                            }
+                        }
+                    },
                 }
             }
             drop(shutdown_guard);
@@ -438,10 +446,10 @@ mod tests {
 
             mock.lock()
                 .await
-                .expect_extend()
+                .expect_eo_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(30..60))
-                .returning(move |ack_ids| ack_ids);
+                .returning(move |_| ());
 
             tokio::time::advance(EXTEND_START).await;
 
@@ -476,10 +484,10 @@ mod tests {
 
             mock.lock()
                 .await
-                .expect_extend()
+                .expect_eo_extend()
                 .times(1)
                 .withf(|v| sorted(v) == test_ids(30..60))
-                .returning(|ack_ids| ack_ids);
+                .returning(|_| ());
 
             tokio::time::advance(EXTEND_PERIOD).await;
 
@@ -731,6 +739,58 @@ mod tests {
                 mock.lock().await.checkpoint();
             }
         }
+        Ok(())
+    }
+
+    #[tokio_test_no_panics(start_paused = true)]
+    async fn eo_extend_result_updates_lease_state() -> anyhow::Result<()> {
+        const EXTEND_START: Duration = Duration::from_millis(200);
+        const EXTEND_PERIOD: Duration = Duration::from_secs(1);
+
+        let mock = Arc::new(Mutex::new(MockLeaser::new()));
+
+        let (_confirmed_tx, confirmed_rx) = unbounded_channel();
+        let (eo_extend_tx, eo_extend_rx) = unbounded_channel();
+        let options = LeaseOptions {
+            // effectively disable ack/nack flushes to simplify this test.
+            flush_start: Duration::from_secs(900),
+            extend_period: EXTEND_PERIOD,
+            extend_start: EXTEND_START,
+            max_lease_extension: Duration::from_secs(10),
+            ..Default::default()
+        };
+        let lease_loop = LeaseLoop::new(mock.clone(), confirmed_rx, eo_extend_rx, options);
+        tokio::task::yield_now().await;
+
+        // Seed with an exactly-once message.
+        lease_loop.strong_message_tx().send(NewMessage {
+            ack_id: test_id(0),
+            lease_info: exactly_once_info(),
+        })?;
+
+        mock.lock()
+            .await
+            .expect_eo_extend()
+            .times(1)
+            .withf(|v| *v == vec![test_id(0)])
+            .returning(|_| ());
+
+        tokio::time::advance(EXTEND_START).await;
+        tokio::task::yield_now().await;
+        mock.lock().await.checkpoint();
+
+        let mut results = HashMap::new();
+        results.insert(test_id(0), Ok(()));
+        eo_extend_tx.send(results)?;
+        tokio::task::yield_now().await; // Let the loop process it the extend result.
+
+        // Since the lease has been sucessfully extended, it should not be extended again.
+        mock.lock().await.expect_eo_extend().times(0);
+
+        tokio::time::advance(EXTEND_PERIOD).await;
+        tokio::task::yield_now().await;
+        mock.lock().await.checkpoint();
+
         Ok(())
     }
 }

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -992,11 +992,6 @@ pub(super) mod tests {
             0,
             "Completed at-least-once extensions should be cleaned up"
         );
-        assert_eq!(
-            state.eo_pending_extends.len(),
-            0,
-            "Completed exactly-once extensions should be cleaned up"
-        );
     }
 
     #[tokio::test]

--- a/src/pubsub/src/subscriber/lease_state.rs
+++ b/src/pubsub/src/subscriber/lease_state.rs
@@ -178,7 +178,7 @@ where
     // These are held separate from pending acks/nacks because we do not need to
     // await them on shutdown.
     pending_extends: JoinSet<Vec<String>>,
-    eo_pending_extends: JoinSet<Vec<String>>,
+    eo_pending_extends: TaskTracker,
 }
 
 /// Actions taken by the `LeaseState` in the lease loop.
@@ -190,8 +190,6 @@ pub(super) enum LeaseEvent {
     Extend,
     /// Pending extensions completed
     ExtendCompleted(Vec<String>),
-    /// Pending exactly-once extensions completed
-    ExtendCompletedEO(Vec<String>),
 }
 
 impl<L> LeaseState<L>
@@ -213,7 +211,7 @@ where
             max_lease_extension: options.max_lease_extension,
             pending_acks_nacks: TaskTracker::new(),
             pending_extends: JoinSet::new(),
-            eo_pending_extends: JoinSet::new(),
+            eo_pending_extends: TaskTracker::new(),
         }
     }
 
@@ -236,14 +234,6 @@ where
                 res = self.pending_extends.join_next(), if !self.pending_extends.is_empty() => {
                     if let Some(Ok(ack_ids)) = res {
                         return LeaseEvent::ExtendCompleted(ack_ids);
-                    } else {
-                        // swallow the JoinError.
-                        continue;
-                    }
-                }
-                res = self.eo_pending_extends.join_next(), if !self.eo_pending_extends.is_empty() => {
-                    if let Some(Ok(ack_ids)) = res {
-                        return LeaseEvent::ExtendCompletedEO(ack_ids);
                     } else {
                         // swallow the JoinError.
                         continue;
@@ -337,9 +327,8 @@ where
             .retain(self.max_lease, self.max_lease_extension);
         for ack_ids in batches {
             let leaser = self.leaser.clone();
-            // TODO(#4804): When leaser.eo_extend is merged, use leaser.eo_extend instead.
             self.eo_pending_extends
-                .spawn(async move { leaser.extend(ack_ids).await });
+                .spawn(async move { leaser.eo_extend(ack_ids).await });
         }
     }
 
@@ -383,7 +372,8 @@ where
         #[cfg(test)]
         {
             self.pending_extends.join_all().await;
-            self.eo_pending_extends.join_all().await;
+            self.eo_pending_extends.close();
+            self.eo_pending_extends.wait().await;
         }
     }
 }
@@ -396,7 +386,6 @@ pub(super) mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::sync::Arc;
-    use test_case::test_case;
     use tokio::sync::mpsc::unbounded_channel;
     use tokio::sync::oneshot::channel;
 
@@ -454,8 +443,10 @@ pub(super) mod tests {
         state.extend();
         let pending_extends = std::mem::take(&mut state.pending_extends);
         let _ = pending_extends.join_all().await;
-        let eo_pending_extends = std::mem::take(&mut state.eo_pending_extends);
-        let _ = eo_pending_extends.join_all().await;
+        let eo_pending_extends =
+            std::mem::replace(&mut state.eo_pending_extends, TaskTracker::new());
+        eo_pending_extends.close();
+        eo_pending_extends.wait().await;
     }
 
     #[tokio::test(start_paused = true)]
@@ -902,31 +893,31 @@ pub(super) mod tests {
     async fn extend_exactly_once() {
         let mut seq = mockall::Sequence::new();
         let mut mock = MockLeaser::new();
-        mock.expect_extend()
+        mock.expect_eo_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..10))
-            .returning(|ack_ids| ack_ids);
-        mock.expect_extend()
+            .returning(|_| ());
+        mock.expect_eo_extend()
             .times(2)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..20))
-            .returning(|ack_ids| ack_ids);
+            .returning(|_| ());
         mock.expect_confirmed_ack()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(0..5))
             .returning(|_| ());
-        mock.expect_extend()
+        mock.expect_eo_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(|ack_ids| ack_ids);
-        mock.expect_extend()
+            .returning(|_| ());
+        mock.expect_eo_extend()
             .times(1)
             .in_sequence(&mut seq)
             .withf(|v| sorted(v) == test_ids(5..20))
-            .returning(|ack_ids| ack_ids);
+            .returning(|_| ());
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -976,10 +967,10 @@ pub(super) mod tests {
             .times(1)
             .withf(|v| *v == vec![test_id(1)])
             .returning(|ack_ids| ack_ids);
-        mock.expect_extend()
+        mock.expect_eo_extend()
             .times(1)
             .withf(|v| *v == vec![test_id(2)])
-            .returning(|ack_ids| ack_ids);
+            .returning(|_| ());
 
         let options = LeaseOptions {
             max_lease_extension: Duration::ZERO,
@@ -991,12 +982,10 @@ pub(super) mod tests {
         state.add(test_id(2), exactly_once_info());
         state.extend();
 
-        let mut events = Vec::new();
-        events.push(state.next_event().await);
-        events.push(state.next_event().await);
-
-        assert!(events.contains(&LeaseEvent::ExtendCompleted(test_ids(1..2))));
-        assert!(events.contains(&LeaseEvent::ExtendCompletedEO(test_ids(2..3))));
+        assert_eq!(
+            state.next_event().await,
+            LeaseEvent::ExtendCompleted(test_ids(1..2))
+        );
 
         assert_eq!(
             state.pending_extends.len(),
@@ -1308,10 +1297,8 @@ pub(super) mod tests {
         assert_eq!(start.elapsed(), FLUSH_START);
     }
 
-    #[test_case(super::at_least_once_info)]
-    #[test_case(super::exactly_once_info)]
     #[tokio::test(start_paused = true)]
-    async fn limit_size_of_extends(lease_info_factory: fn() -> LeaseInfo) -> anyhow::Result<()> {
+    async fn limit_size_of_extends_at_least_once() -> anyhow::Result<()> {
         const NUM_BATCHES: i32 = 5;
 
         // We use this channel to surface ack_ids from the mock expectation.
@@ -1330,7 +1317,7 @@ pub(super) mod tests {
 
         let mut want = HashSet::new();
         for i in 0..NUM_BATCHES * MAX_IDS_PER_RPC {
-            state.add(test_id(i), lease_info_factory());
+            state.add(test_id(i), at_least_once_info());
 
             // All ack IDs should be extended.
             want.insert(test_id(i));
@@ -1357,10 +1344,54 @@ pub(super) mod tests {
         Ok(())
     }
 
-    #[test_case(super::at_least_once_info)]
-    #[test_case(super::exactly_once_info)]
     #[tokio::test(start_paused = true)]
-    async fn message_expiration(lease_info_factory: fn() -> LeaseInfo) -> anyhow::Result<()> {
+    async fn limit_size_of_extends_exactly_once() -> anyhow::Result<()> {
+        const NUM_BATCHES: i32 = 5;
+
+        // We use this channel to surface ack_ids from the mock expectation.
+        let (ack_id_tx, mut ack_id_rx) = unbounded_channel();
+
+        let mut mock = MockLeaser::new();
+        mock.expect_eo_extend()
+            .times(NUM_BATCHES as usize)
+            .returning(move |ack_ids| {
+                ack_id_tx
+                    .send(ack_ids.clone())
+                    .expect("sending on channel always succeeds");
+            });
+        let mut state = LeaseState::new(Arc::new(mock), LeaseOptions::default());
+
+        let mut want = HashSet::new();
+        for i in 0..NUM_BATCHES * MAX_IDS_PER_RPC {
+            state.add(test_id(i), exactly_once_info());
+
+            // All ack IDs should be extended.
+            want.insert(test_id(i));
+        }
+        extend_and_await(&mut state).await;
+
+        let mut got = HashSet::new();
+        for i in 0..NUM_BATCHES {
+            let Some(ack_ids) = ack_id_rx.recv().await else {
+                anyhow::bail!("expected batch {i}/{NUM_BATCHES}");
+            };
+            assert_eq!(ack_ids.len(), MAX_IDS_PER_RPC as usize);
+            for ack_id in ack_ids {
+                got.insert(ack_id);
+            }
+        }
+        assert!(
+            ack_id_rx.is_empty(),
+            "There should be exactly {NUM_BATCHES} batches"
+        );
+
+        // Make sure all ack IDs were extended.
+        assert_eq!(got, want);
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn message_expiration_at_least_once() -> anyhow::Result<()> {
         const MAX_LEASE: Duration = Duration::from_secs(300);
         const DELTA: Duration = Duration::from_secs(1);
 
@@ -1385,13 +1416,60 @@ pub(super) mod tests {
 
         // Add 10 messages under lease management
         for i in 0..10 {
-            state.add(test_id(i), lease_info_factory());
+            state.add(test_id(i), at_least_once_info());
         }
 
         // Add 10 more messages under lease management, a little later.
         tokio::time::advance(DELTA * 2).await;
         for i in 10..20 {
-            state.add(test_id(i), lease_info_factory());
+            state.add(test_id(i), at_least_once_info());
+        }
+        extend_and_await(&mut state).await;
+
+        // Advance the time past the expiration of the original 10 messages.
+        tokio::time::advance(MAX_LEASE - DELTA).await;
+        extend_and_await(&mut state).await;
+
+        // Advance the time past the expiration of the subsequent 10 messages.
+        tokio::time::advance(DELTA * 2).await;
+        extend_and_await(&mut state).await;
+
+        Ok(())
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn message_expiration_exactly_once() -> anyhow::Result<()> {
+        const MAX_LEASE: Duration = Duration::from_secs(300);
+        const DELTA: Duration = Duration::from_secs(1);
+
+        let mut seq = mockall::Sequence::new();
+        let mut mock = MockLeaser::new();
+        mock.expect_eo_extend()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|v| sorted(v) == test_ids(0..20))
+            .returning(|_| ());
+        mock.expect_eo_extend()
+            .times(1)
+            .in_sequence(&mut seq)
+            .withf(|v| sorted(v) == test_ids(10..20))
+            .returning(|_| ());
+
+        let options = LeaseOptions {
+            max_lease: MAX_LEASE,
+            ..Default::default()
+        };
+        let mut state = LeaseState::new(Arc::new(mock), options);
+
+        // Add 10 messages under lease management
+        for i in 0..10 {
+            state.add(test_id(i), exactly_once_info());
+        }
+
+        // Add 10 more messages under lease management, a little later.
+        tokio::time::advance(DELTA * 2).await;
+        for i in 10..20 {
+            state.add(test_id(i), exactly_once_info());
         }
         extend_and_await(&mut state).await;
 


### PR DESCRIPTION
Enable retry exactly once lease extensions. Retry failures due to permanent or retry exhaustion are currently ignored. A follow up PR will add the logic to emit a tracing log when this occurs.

Towards https://github.com/googleapis/google-cloud-rust/issues/4804