### PR TITLE
docs(pubsub): add get_schema sample

### DIFF
--- a/src/pubsub/examples/src/lib.rs
+++ b/src/pubsub/examples/src/lib.rs
@@ -117,6 +117,7 @@ pub async fn run_schema_samples(schema_names: &mut Vec<String>) -> anyhow::Resul
     schema_names.push(format!("projects/{project}/schemas/{id}"));
     schema::create_avro_schema::sample(&client, &project, &id).await?;
     schema::list_schemas::sample(&client, &project).await?;
+    schema::get_schema::sample(&client, &project, &id).await?;
     schema::list_schema_revisions::sample(&client, &project, &id).await?;
     schema::delete_schema::sample(&client, &project, &id).await?;
 

--- a/src/pubsub/examples/src/schema/get_schema.rs
+++ b/src/pubsub/examples/src/schema/get_schema.rs
@@ -12,8 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create_avro_schema;
-pub mod delete_schema;
-pub mod get_schema;
-pub mod list_schema_revisions;
-pub mod list_schemas;
+// [START pubsub_get_schema]
+use google_cloud_pubsub::client::SchemaService;
+
+pub async fn sample(client: &SchemaService, project: &str, schema_id: &str) -> anyhow::Result<()> {
+    let schema = client
+        .get_schema()
+        .set_name(format!("projects/{project}/schemas/{schema_id}"))
+        .send()
+        .await?;
+
+    println!("successfully retrieved schema {schema:?}");
+    Ok(())
+}
+// [END pubsub_get_schema]


### PR DESCRIPTION
It is Friday and I have not authored a PR this week, so I had the bot write me a sample.

I asked it:

```
Hey, can you write me the sample for `pubsub_get_schema`? Look at the `write-devrel-sample` skill
```

It would be interesting to keep track of how often this process succeeds without intervention.

Fixes #5573