### PR TITLE
chore: make gemini less spammy

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -23,6 +23,7 @@ code_review:
   max_review_comments: -1
   pull_request_opened:
     help: false
-    summary: true
+    # This is spammy, it repeats things we already know.
+    summary: false
     code_review: true
     include_drafts: true


### PR DESCRIPTION
I did the same thing in librarian because I don't need two spammy descriptions repeating what I already said in the description of the PR.
