### PR TITLE
fix(o11y): ensure retry on empty data for metrics e2e test

### DIFF
--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -127,11 +127,7 @@ pub async fn try_get_metric(
         ))
         .send()
         .await?;
-    if response.time_series.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(response))
-    }
+    Ok(Some(response).filter(|r| !r.time_series.is_empty()))
 }
 
 pub async fn set_up_providers(

--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -127,7 +127,11 @@ pub async fn try_get_metric(
         ))
         .send()
         .await?;
-    Ok(Some(response))
+    if response.time_series.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(response))
+    }
 }
 
 pub async fn set_up_providers(

--- a/tests/o11y/tests/metrics.rs
+++ b/tests/o11y/tests/metrics.rs
@@ -16,7 +16,6 @@
 mod metrics {
     use google_cloud_test_utils::errors::anydump;
 
-    #[ignore = "TODO(#5577) - disabled because the test is flaky"]
     #[tokio::test(flavor = "multi_thread")]
     async fn run() -> anyhow::Result<()> {
         integration_tests_o11y::e2e::metrics::run()


### PR DESCRIPTION
The test was flaking because it queried Cloud Monitoring immediately after sending metrics, causing failure since data had not propagated. 

This PR ensures the retry loop in the test continues to poll until actual data is found or it times out.

Fixes #5577 