### PR TITLE
cleanup(pubsub): remove unnecessary dead_code annotation

### DIFF
--- a/src/pubsub/src/publisher/client.rs
+++ b/src/pubsub/src/publisher/client.rs
@@ -65,7 +65,9 @@ pub use super::base_publisher::BasePublisher;
 /// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 #[derive(Debug, Clone)]
 pub struct Publisher {
-    #[allow(dead_code)]
+    // A copy of the batching options are stored in the Publisher for testing
+    // purposes and also to include in the Debug output.
+    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) batching_options: BatchingOptions,
     pub(crate) tx: UnboundedSender<ToDispatcher>,
 }

--- a/src/pubsub/src/subscriber/leaser.rs
+++ b/src/pubsub/src/subscriber/leaser.rs
@@ -47,7 +47,6 @@ pub(super) trait Leaser {
     /// Negatively acknowledge a batch of messages and confirm the result.
     async fn confirmed_nack(&self, ack_ids: Vec<String>);
     /// Extend lease deadlines for a batch of messages with exactly-once semantics.
-    #[allow(dead_code)]
     async fn eo_extend(&self, ack_ids: Vec<String>);
 }
 
@@ -226,7 +225,6 @@ where
         .await;
     }
 
-    #[allow(dead_code)]
     async fn eo_extend(&self, ack_ids: Vec<String>) {
         let leaser = self.clone();
         let options = self.options.clone();


### PR DESCRIPTION
eo_extend is now used so no longer needs to be decorated. This change also adds a comment to the batching_options to explain why it is unused (and checks the expectation) so it can be cleaned up if no longer necessary.