### PR TITLE
docs(samples): replace ignore, no_run doctests with run_all_samples gating

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -162,11 +162,11 @@ locals {
       script = "workspace-minimal-versions"
     }
 
-    # Runs doctest for samples marked ignore.
+    # Runs doctest for feature-gated samples.
     # These are mostly generated samples which are many and take a long time to build.
-    ignored-samples = {
+    run-all-samples = {
       config = "complex.yaml"
-      script = "test-ignored-samples"
+      script = "test-run-all-samples"
       included_files = [
         "**/generated/**",
       ]

--- a/.gcb/scripts/test-run-all-samples.sh
+++ b/.gcb/scripts/test-run-all-samples.sh
@@ -26,10 +26,10 @@ rustup component add clippy
 cargo version
 rustup show active-toolchain -v
 
-echo "RUSTFLAGS in test-ignored-samples: ${RUSTFLAGS:-}"
-echo "RUSTDOCFLAGS in test-ignored-samples: ${RUSTDOCFLAGS:-}"
+echo "RUSTFLAGS in test-run-all-samples: ${RUSTFLAGS:-}"
+echo "RUSTDOCFLAGS in test-run-all-samples: ${RUSTDOCFLAGS:-}"
 
-cargo test --workspace --doc --all-features -- --ignored --show-output
+cargo test --workspace --doc --all-features -- --show-output
 
 echo "==== DONE ===="
 

--- a/doc/contributor/howto-guide-documentation-standards.md
+++ b/doc/contributor/howto-guide-documentation-standards.md
@@ -61,29 +61,43 @@ attempting to compile and run the block as a doc test.
 /// ```
 ````
 
+### Feature-gated samples (`run_all_samples`)
+
+For Rust samples that should be skipped in presubmit but still compile in a
+dedicated job, prefer a feature-gated snippet over `ignore`:
+
+````rust
+/// ```
+/// # #[cfg(feature = "run_all_samples")]
+/// # async fn sample() -> anyhow::Result<()> {
+/// // sample code
+/// # Ok(())
+/// # }
+/// ```
+````
+
+Then run those snippets with `cargo test --doc --all-features` (or
+`--features run_all_samples`) for the crate.
+
 ### `ignore`
 
-Use the `ignore` tag for valid Rust code blocks that should not be run on
-presubmit.
+Use `ignore` sparingly for valid Rust code blocks that are intentionally
+excluded from doc-test compilation.
 
 > [!NOTE]
-> This project uses the `ignore` tag in a non-standard way. In standard Rust
-> practice, `ignore` often means the test is broken or should not be run. In
-> this repository, we use `ignore` as a filter to separate tests run on
-> presubmit from the large volume of tests run in post-submit (to keep presubmit
-> times reasonable).
+> In standard Rust practice, `ignore` often means the test is broken or should
+> not be run. In this repository, prefer feature-gated snippets for scalable
+> sample testing; reserve `ignore` for rare cases that must remain excluded from
+> doc-test compilation.
 
 **When to use**:
 
-- When the volume of tests is too large to be included in presubmit (to keep
-  presubmit times reasonable). Particularly in generated code.
+- When a snippet is intentionally excluded from doc-test compilation.
 
 **Implications**:
 
 - The code block will be syntax-highlighted as Rust code.
 - `rustdoc` will not run it during normal `cargo test` (presubmit).
-- It **is** run in post-submit or periodic jobs using
-  `cargo test --doc -- --ignored`.
 - It will be marked as "not tested" on docs.rs.
 
 ### `no_run`
@@ -117,8 +131,9 @@ remain valid.
   `cargo test` on the workspace on presubmit. This automatically executes all
   compilable doc tests in library crates that are not marked with `ignore` or
   `no_rust`.
-- **Ignored Doc Tests**: A separate CI job runs `cargo test --doc -- --ignored`
-  (typically in post-submit) to execute tests marked with `ignore`.
+- **Feature-Gated Samples**: Crates may define `run_all_samples`; these snippets
+  are compiled by running `cargo test --doc --all-features` (or
+  `--features run_all_samples`) for that crate.
 
 ### Tag Selection Summary
 
@@ -126,8 +141,9 @@ remain valid.
   expected to compile.
 - Use `no_run` for code that should be checked for compilation but cannot be
   executed (e.g., requires network or side effects).
-- Use `ignore` for valid Rust code that should not be run on presubmit (e.g., to
-  manage the volume of tests and keep presubmit times reasonable) but should be
-  tested in post-submit.
+- Prefer feature-gated snippets (`#[cfg(feature = "run_all_samples")]`) for
+  runnable Rust samples that should be skipped in presubmit.
+- Use `ignore` only when a snippet must remain excluded from doc-test
+  compilation.
 
 [developer documentation style guide]: https://developers.google.com/style/

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -45,6 +45,7 @@ google-cloud-rpc  = { workspace = true }
 wkt.workspace     = true
 
 [features]
+run_all_samples = []
 default = ["default-rustls-provider"]
 # Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
 # TLS and authentication. Applications with specific requirements for

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -52,6 +52,7 @@ uuid.workspace         = true
 wkt.workspace          = true
 
 [features]
+run_all_samples = []
 default = ["default-rustls-provider"]
 # Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
 # TLS and authentication. Applications with specific requirements for

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -78,6 +78,7 @@ gaxi = { workspace = true, features = [
 
 [features]
 default         = ["default-rustls-provider"]
+run_all_samples = []
 unstable-stream = []
 # Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
 # TLS and authentication. Applications with specific requirements for

--- a/src/storage/src/storage/open_object.rs
+++ b/src/storage/src/storage/open_object.rs
@@ -53,9 +53,9 @@ where
     /// Sends the request, returning a new object descriptor.
     ///
     /// Example:
-    /// ```ignore
-    /// # use google_cloud_storage::{model_ext::KeyAes256, client::Storage};
-    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// ```
+    /// # #[cfg(feature = "run_all_samples")]
+    /// # async fn sample(client: &google_cloud_storage::client::Storage) -> anyhow::Result<()> {
     /// let open = client
     ///     .open_object("projects/_/buckets/my-bucket", "my-object")
     ///     .send()
@@ -71,13 +71,13 @@ where
     /// Sends the request, returning a new object descriptor and reader.
     ///
     /// Example:
-    /// ```ignore
-    /// # use google_cloud_storage::client::Storage;
-    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
-    /// use google_cloud_storage::model_ext::ReadRange;
+    /// ```
+    /// # #[cfg(feature = "run_all_samples")]
+    /// # async fn sample(client: &google_cloud_storage::client::Storage) -> anyhow::Result<()> {
+    /// # use futures::StreamExt;
     /// let (descriptor, mut reader) = client
     ///     .open_object("projects/_/buckets/my-bucket", "my-object.parquet")
-    ///     .send_and_read(ReadRange::tail(32))
+    ///     .send_and_read(google_cloud_storage::model_ext::ReadRange::tail(32))
     ///     .await?;
     /// println!("object metadata={:?}", descriptor.object());
     /// let data = reader.next().await.transpose()?;

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -35,6 +35,7 @@ rust-version.workspace = true
 features = ["chrono", "time"]
 
 [features]
+run_all_samples = []
 chrono = ["dep:chrono"]
 time   = []
 # DO NOT USE: this allows us to detect semver changes in types used in the


### PR DESCRIPTION
Fixes #5500.

## Summary

This PR migrates sample doctest handling from `ignore,no_run` to feature-gated samples.

### What changed

1. Replaced ` ```ignore,no_run ` Rust doc fences with feature-gated snippets:
  - `#[cfg(feature = "run_all_samples")]`
  - wrapped snippet bodies in hidden `# { ... # }` blocks

2. Added `run_all_samples = []` feature flags to affected crates so gated snippets compile consistently.

3. Updated post-merge CI wiring for samples:
  - renamed trigger key from `ignored-samples` to `run-all-samples`
  - replaced script `test-ignored-samples.sh` with `test-run-all-samples.sh`
  - switched doctest execution to:
    `cargo test --workspace --doc --all-features -- --show-output`
    (no `--ignored` path)

4. Updated contributor docs to make feature-gated samples the recommended approach and clarify that `ignore` is now for rare cases that must stay excluded from doc-test compilation.

## Why

Using `ignore` marks snippets as “not tested” and relies on a separate `--ignored` workflow.
Feature-gated samples keep snippets in normal doctest compilation while still allowing us to control when they are included.

## Validation

- Ran representative doctests with all features on:
 - `google-cloud-common`
 - `google-cloud-secretmanager-v1`
 - `google-cloud-storage`
 - `google-cloud-pubsub`
 - `google-cloud-firestore`