### PR TITLE
chore(auth): make `gdch` feature undocumented

### DIFF
--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -80,8 +80,8 @@ default = ["default-idtoken-backend", "default-rustls-provider"]
 # The `idtoken` feature enables support to create and validate OIDC ID Tokens.
 # See the create top-level documentation for more information.
 idtoken = ["dep:jsonwebtoken", "jsonwebtoken"]
-# The `gdch` feature enables support for GDCH service account credentials.
-gdch = ["dep:p256"]
+# The `__gdch` feature enables support for GDCH service account credentials.
+__gdch = ["dep:p256"]
 # By default this crate enables the `aws_lc_rs` backend. Applications can
 # link `google-cloud-auth` with `default-features = false, features = ["idtoken"]
 # and then directly configure the `jsonwebtoken` features to select the

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -31,7 +31,7 @@ pub mod api_key_credentials;
 pub(crate) mod crypto_provider;
 pub mod external_account;
 pub(crate) mod external_account_sources;
-#[cfg(feature = "gdch")]
+#[cfg(feature = "__gdch")]
 pub(crate) mod gdch;
 #[cfg(feature = "idtoken")]
 pub mod idtoken;
@@ -1129,7 +1129,7 @@ pub(crate) mod tests {
             .expect("Failed to create RsaPrivateKey from primes")
     });
 
-    #[cfg(any(feature = "idtoken", feature = "gdch"))]
+    #[cfg(any(feature = "idtoken", feature = "__gdch"))]
     pub static ES256_PRIVATE_KEY: LazyLock<p256::SecretKey> = LazyLock::new(|| {
         let secret_key_bytes = [
             0x4c, 0x0c, 0x11, 0x6e, 0x6e, 0xb0, 0x07, 0xbd, 0x48, 0x0c, 0xc0, 0x48, 0xc0, 0x1f,
@@ -1139,7 +1139,7 @@ pub(crate) mod tests {
         p256::SecretKey::from_bytes((&secret_key_bytes).into()).unwrap()
     });
 
-    #[cfg(feature = "gdch")]
+    #[cfg(feature = "__gdch")]
     pub static ES256_PEM: LazyLock<String> = LazyLock::new(|| {
         (*ES256_PRIVATE_KEY)
             .to_sec1_pem(LineEnding::LF)


### PR DESCRIPTION
Features that start with `_` are undocumented and not part of the public API. `cargo semver-checks` ignores them.