### PR TITLE
docs(storage): add storage_quota_project sample

### DIFF
--- a/src/storage/examples/src/client.rs
+++ b/src/storage/examples/src/client.rs
@@ -13,4 +13,5 @@
 // limitations under the License.
 
 pub mod configure_retries;
+pub mod quota_project;
 pub mod set_client_endpoint;

--- a/src/storage/examples/src/client/quota_project.rs
+++ b/src/storage/examples/src/client/quota_project.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_quota_project]
+use google_cloud_gax::options::RequestOptionsBuilder;
+use google_cloud_storage::client::Storage;
+use google_cloud_storage::client::StorageControl;
+
+pub async fn sample(bucket_id: &str, project_id: &str) -> anyhow::Result<()> {
+    let control = StorageControl::builder().build().await?;
+
+    // Request using a specific quota project for control plane operations
+    let bucket = control
+        .get_bucket()
+        .set_name(format!("projects/_/buckets/{bucket_id}"))
+        .with_quota_project(project_id)
+        .send()
+        .await?;
+    println!("Bucket {bucket_id} metadata is {bucket:?}");
+
+    let client = Storage::builder().build().await?;
+
+    const NAME: &str = "hello-world.txt";
+
+    // Request using a specific quota project for data plane operations
+    let reader = client
+        .read_object(format!("projects/_/buckets/{bucket_id}"), NAME)
+        .with_quota_project(project_id)
+        .send()
+        .await?;
+    println!("Object highlights: {:?}", reader.object());
+
+    Ok(())
+}
+// [END storage_quota_project]

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -592,6 +592,9 @@ pub async fn run_client_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     tracing::info!("running storage_configure_retries example");
     client::configure_retries::sample(&id).await?;
 
+    tracing::info!("running storage_quota_project example");
+    client::quota_project::sample(&id, &project_id).await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Adds a new sample `quota_project.rs` to demonstrate using the `with_quota_project` option on both `Storage` and `StorageControl` clients.