### PR TITLE
chore: update librarian version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.11.1-0.20260501172357-df069b47c27a
+version: v0.12.1
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Updates librarian version to v0.12.1.

Regeneration produced no diffs.