### PR TITLE
chore(dns): skip generation

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -749,6 +749,7 @@ libraries:
     roots:
       - discovery
       - googleapis
+    skip_generate: true
     specification_format: discovery
     rust:
       package_dependencies:


### PR DESCRIPTION
Cause: https://github.com/googleapis/librarian/issues/5868