### PR TITLE
chore: allow chore commits in AI styleguide

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -75,7 +75,7 @@ When reviewing or generating code, apply rigorous scrutiny:
 - **Conventional Commits:** Follow the conventions in
   [CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages).
 - **Format:** `<type>(<scope>): <description>`
-- **Types:** `feat`, `fix`, `docs`, `impl`, `refactor`, `cleanup`, `test`, `ci`.
+- **Types:** `feat`, `fix`, `docs`, `impl`, `refactor`, `cleanup`, `test`, `ci`, `chore`.
 - **Scope:** Crate name without the `google-cloud-` prefix.
 - **Description:** Short one-line summary completing the sentence "This change
   modifies the crate to ...".

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -75,7 +75,8 @@ When reviewing or generating code, apply rigorous scrutiny:
 - **Conventional Commits:** Follow the conventions in
   [CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages).
 - **Format:** `<type>(<scope>): <description>`
-- **Types:** `feat`, `fix`, `docs`, `impl`, `refactor`, `cleanup`, `test`, `ci`, `chore`.
+- **Types:** `feat`, `fix`, `docs`, `impl`, `refactor`, `cleanup`, `test`, `ci`,
+  `chore`.
 - **Scope:** Crate name without the `google-cloud-` prefix.
 - **Description:** Short one-line summary completing the sentence "This change
   modifies the crate to ...".


### PR DESCRIPTION
Allow `chore` as a conventional commit in the AI reviewer styleguide.

<img width="928" height="233" alt="image" src="https://github.com/user-attachments/assets/937cf3f0-656d-4f93-8453-55fde42f9436" />
