### PR TITLE
refactor(o11y): switch LRO tracing from feature to cfg flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -538,6 +538,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',
   'cfg(google_cloud_unstable_trusted_boundaries)',
+  'cfg(google_cloud_unstable_tracing)',
   # Enables re-generation of protos. Only needed on major version updates to
   # Prost and/or Tonic.
   'cfg(google_cloud_generate_protos)',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,8 +537,8 @@ storage-grpc-mock        = { path = "src/storage/grpc-mock" }
 unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',
-  'cfg(google_cloud_unstable_trusted_boundaries)',
   'cfg(google_cloud_unstable_tracing)',
+  'cfg(google_cloud_unstable_trusted_boundaries)',
   # Enables re-generation of protos. Only needed on major version updates to
   # Prost and/or Tonic.
   'cfg(google_cloud_generate_protos)',

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -36,12 +36,15 @@ rust-version.workspace = true
 # [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 features = ["unstable-stream"]
 
+[lints]
+workspace = true
+
 [dependencies]
 futures         = { workspace = true, optional = true }
 pin-project     = { workspace = true, optional = true }
 serde.workspace = true
 tokio           = { workspace = true, features = ["time"] }
-tracing         = { workspace = true, optional = true }
+tracing         = { workspace = true }
 # Local crates
 google-cloud-gax         = { workspace = true }
 google-cloud-longrunning = { workspace = true }
@@ -55,8 +58,7 @@ unstable-stream = ["dep:futures", "dep:pin-project"]
 # by this feature are intended for general use. We do not plan to document these
 # features and offer no guarantees on their stability.
 _internal-semver = []
-# Feature gate for unstable tracing in complex flows (LROs, pagination, etc.)
-google-cloud-rust-unstable-tracing = ["dep:tracing"]
+
 
 [dev-dependencies]
 anyhow.workspace     = true

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -82,7 +82,7 @@ where
         + Send
         + 'static,
 {
-    #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+    #[cfg(google_cloud_unstable_tracing)]
     let lro_span = if enable_tracing {
         Some(tracing::info_span!(
             "LRO Wait",
@@ -93,7 +93,7 @@ where
         None
     };
 
-    #[cfg(not(feature = "google-cloud-rust-unstable-tracing"))]
+    #[cfg(not(google_cloud_unstable_tracing))]
     {
         let _ = method_name;
         let _ = enable_tracing;
@@ -104,7 +104,7 @@ where
         polling_backoff_policy,
         start,
         query,
-        #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+        #[cfg(google_cloud_unstable_tracing)]
         lro_span,
     )
 }
@@ -267,7 +267,7 @@ struct PollerImpl<S, Q> {
     query: Q,
     operation: Option<String>,
     state: PollingState,
-    #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+    #[cfg(google_cloud_unstable_tracing)]
     #[expect(dead_code)]
     lro_span: Option<tracing::Span>,
 }
@@ -278,7 +278,7 @@ impl<S, Q> PollerImpl<S, Q> {
         backoff_policy: Arc<dyn PollingBackoffPolicy>,
         start: S,
         query: Q,
-        #[cfg(feature = "google-cloud-rust-unstable-tracing")] lro_span: Option<tracing::Span>,
+        #[cfg(google_cloud_unstable_tracing)] lro_span: Option<tracing::Span>,
     ) -> Self {
         Self {
             error_policy,
@@ -287,7 +287,7 @@ impl<S, Q> PollerImpl<S, Q> {
             query,
             operation: None,
             state: PollingState::default(),
-            #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+            #[cfg(google_cloud_unstable_tracing)]
             lro_span,
         }
     }
@@ -427,7 +427,7 @@ mod tests {
             Arc::new(ExponentialBackoff::default()),
             start,
             query,
-            #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+            #[cfg(google_cloud_unstable_tracing)]
             None,
         );
         let p0 = poller.poll().await;
@@ -455,11 +455,17 @@ mod tests {
         assert!(p2.is_none(), "{p2:?}");
     }
 
-    #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+    #[cfg(google_cloud_unstable_tracing)]
     #[test]
     fn test_poller_initialization_with_tracing() {
-        let start = || async { panic!() };
-        let query = |_: String| async { panic!() };
+        let start = || async {
+            let op = google_cloud_longrunning::model::Operation::default();
+            Ok(TestOperation::new(op))
+        };
+        let query = |_: String| async {
+            let op = google_cloud_longrunning::model::Operation::default();
+            Ok(TestOperation::new(op))
+        };
 
         let _poller = new_poller_with_tracing::<Duration, Timestamp, _, _, _, _>(
             Arc::new(AlwaysContinue),
@@ -471,7 +477,7 @@ mod tests {
         );
     }
 
-    #[cfg(not(feature = "google-cloud-rust-unstable-tracing"))]
+    #[cfg(not(google_cloud_unstable_tracing))]
     #[test]
     fn test_poller_initialization_no_tracing() {
         let start = || async { panic!() };
@@ -573,7 +579,7 @@ mod tests {
             ),
             start,
             query,
-            #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+            #[cfg(google_cloud_unstable_tracing)]
             None,
         );
         let response = poller.until_done().await?;
@@ -990,7 +996,7 @@ mod tests {
             ),
             start,
             query,
-            #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+            #[cfg(google_cloud_unstable_tracing)]
             None,
         );
         let response = poller.until_done().await?;
@@ -1022,7 +1028,7 @@ mod tests {
             ),
             start,
             query,
-            #[cfg(feature = "google-cloud-rust-unstable-tracing")]
+            #[cfg(google_cloud_unstable_tracing)]
             None,
         );
         let response = poller.until_done().await;


### PR DESCRIPTION
Use a compiler flag instead of a Cargo feature for gating unstable tracing features, preventing accidental stabilization.

For https://github.com/googleapis/google-cloud-rust/issues/5623