### PR TITLE
test(spanner): use a generic pass-through proxy for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6200,6 +6200,7 @@ dependencies = [
  "google-cloud-lro",
  "google-cloud-spanner",
  "google-cloud-test-utils",
+ "http",
  "prost-types",
  "reqwest 0.13.3",
  "serde_json",
@@ -6207,6 +6208,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
+ "tower",
  "tracing",
 ]
 

--- a/tests/spanner/Cargo.toml
+++ b/tests/spanner/Cargo.toml
@@ -33,6 +33,7 @@ google-cloud-gax        = { workspace = true }
 google-cloud-lro        = { workspace = true }
 google-cloud-spanner    = { workspace = true, features = ["unstable-stream"] }
 google-cloud-test-utils = { workspace = true }
+http                    = { workspace = true }
 prost-types.workspace   = true
 reqwest                 = { workspace = true, features = ["json"] }
 serde_json              = { workspace = true }
@@ -40,6 +41,7 @@ spanner-grpc-mock       = { path = "../../src/spanner/grpc-mock" }
 tokio                   = { workspace = true, features = ["sync"] }
 tokio-stream            = { workspace = true }
 tonic                   = { workspace = true }
+tower                   = { workspace = true }
 tracing.workspace       = true
 
 [lints]

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::{get_database_id, get_emulator_host};
-use crate::test_proxy::{InterceptedSpanner, SpannerInterceptor};
+use crate::client::{get_database_id, get_emulator_host, update_database_ddl};
+use crate::test_proxy::{InterceptionResult, PassThroughProxy, start_proxy_server};
+use futures::future::BoxFuture;
 use google_cloud_spanner::client::{DatabaseClient, Kind, Spanner, Statement, TypeCode};
 use google_cloud_spanner::model::execute_sql_request::{QueryMode, QueryOptions};
 use google_cloud_spanner::model::result_set_stats::RowCount;
 use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
-use spanner_grpc_mock::google::spanner::v1 as spanner_v1;
-use spanner_grpc_mock::google::spanner::v1::spanner_client::SpannerClient;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tonic::transport::Channel;
@@ -419,33 +418,6 @@ fn verify_row_2(row: &google_cloud_spanner::client::Row) {
     );
 }
 
-/// A test proxy that intercepts and delays `BeginTransaction` requests.
-///
-/// It notifies `begin_transaction_entered_latch` when a `BeginTransaction` request is received,
-/// and blocks the request execution until `latch` is notified. This allows tests to
-/// synchronize the order of execution of `BeginTransaction` with other operations.
-struct DelayedBeginProxy {
-    emulator_client: SpannerClient<Channel>,
-    latch: Arc<Notify>,
-    begin_transaction_entered_latch: Arc<Notify>,
-}
-
-#[tonic::async_trait]
-impl SpannerInterceptor for DelayedBeginProxy {
-    fn emulator_client(&self) -> SpannerClient<Channel> {
-        self.emulator_client.clone()
-    }
-
-    async fn begin_transaction(
-        &self,
-        request: tonic::Request<spanner_v1::BeginTransactionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Transaction>, tonic::Status> {
-        self.begin_transaction_entered_latch.notify_one();
-        self.latch.notified().await;
-        self.emulator_client().begin_transaction(request).await
-    }
-}
-
 // This test verifies that the client correctly falls back to `BeginTransaction` when the
 // first statement in a transaction fails. It also shows that the statement is retried and
 // could (theoretically) succeed during this retry. It achieves this by doing the following:
@@ -474,18 +446,35 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
     let endpoint = Channel::from_shared(format!("http://{}", emulator_host))?
         .connect()
         .await?;
-    let raw_client = SpannerClient::new(endpoint);
+    let latch_clone = Arc::clone(&latch);
+    let begin_entered_clone = Arc::clone(&begin_transaction_entered_latch);
 
-    let proxy = DelayedBeginProxy {
-        emulator_client: raw_client,
-        latch: Arc::clone(&latch),
-        begin_transaction_entered_latch: Arc::clone(&begin_transaction_entered_latch),
+    // Define an interceptor that intercepts `BeginTransaction` requests,
+    // notifies the test that the request has been received, and blocks
+    // until the test allows it to proceed. All other requests are passed through.
+    let interceptor = move |req: http::Request<tonic::body::Body>| {
+        let l = latch_clone.clone();
+        let be = begin_entered_clone.clone();
+        Box::pin(async move {
+            if req.uri().path() == "/google.spanner.v1.Spanner/BeginTransaction" {
+                be.notify_one();
+                l.notified().await;
+            }
+            InterceptionResult::Continue(req)
+        }) as BoxFuture<'static, InterceptionResult>
     };
 
-    let (proxy_uri, _guard) =
-        crate::client::start_guarded_server("127.0.0.1:0", InterceptedSpanner(proxy)).await?;
+    let proxy = PassThroughProxy::new(endpoint, interceptor);
+    let (proxy_uri, handle) = start_proxy_server("127.0.0.1:0", proxy).await?;
+    struct Guard(tokio::task::JoinHandle<()>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.0.abort();
+        }
+    }
+    let _guard = Guard(handle);
 
-    // We build the Spanner DatabaseClient pointing directly to our proxy address over HTTP.
+    // We build the Spanner DatabaseClient pointing directly to our proxy address over gRPC.
     let proxy_db_client = Spanner::builder()
         .with_endpoint(proxy_uri)
         .build()
@@ -531,7 +520,7 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
 
     // Create the table on the emulator while the BeginTransaction RPC is blocked.
     let statement = format!("CREATE TABLE {} (Id INT64) PRIMARY KEY (Id)", table_name);
-    crate::client::update_database_ddl(statement).await?;
+    update_database_ddl(statement).await?;
 
     // Unblock the BeginTransaction RPC.
     latch.notify_one();

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::client::{get_database_id, get_emulator_host, update_database_ddl};
-use crate::test_proxy::{InterceptionResult, PassThroughProxy, start_proxy_server};
+use crate::test_proxy::{InterceptionResult, PassThroughProxy};
 use futures::future::BoxFuture;
 use google_cloud_spanner::client::{DatabaseClient, Kind, Spanner, Statement, TypeCode};
 use google_cloud_spanner::model::execute_sql_request::{QueryMode, QueryOptions};
@@ -465,18 +465,11 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
     };
 
     let proxy = PassThroughProxy::new(endpoint, interceptor);
-    let (proxy_uri, handle) = start_proxy_server("127.0.0.1:0", proxy).await?;
-    struct Guard(tokio::task::JoinHandle<()>);
-    impl Drop for Guard {
-        fn drop(&mut self) {
-            self.0.abort();
-        }
-    }
-    let _guard = Guard(handle);
+    let proxy_server = proxy.start("127.0.0.1:0").await?;
 
     // We build the Spanner DatabaseClient pointing directly to our proxy address over gRPC.
     let proxy_db_client = Spanner::builder()
-        .with_endpoint(proxy_uri)
+        .with_endpoint(proxy_server.uri())
         .build()
         .await?
         .database_client(format!(

--- a/tests/spanner/src/test_proxy.rs
+++ b/tests/spanner/src/test_proxy.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use futures::future::BoxFuture;
-use http::{HeaderValue, Request, Response, StatusCode};
+use http::{Request, Response, StatusCode};
 use spanner_grpc_mock::to_uri;
 use std::convert::Infallible;
 use tokio::net::TcpListener;
@@ -96,14 +96,9 @@ where
                     let status = Status::from_error(Box::new(e));
                     let mut resp = Response::new(Body::empty());
                     *resp.status_mut() = StatusCode::OK;
-                    resp.headers_mut().insert(
-                        "grpc-status",
-                        HeaderValue::from_str(&format!("{}", status.code() as i32)).unwrap(),
-                    );
-                    resp.headers_mut().insert(
-                        "grpc-message",
-                        HeaderValue::from_str(status.message()).unwrap(),
-                    );
+                    status
+                        .add_header(resp.headers_mut())
+                        .expect("Failed to add gRPC status header");
                     resp
                 }
             };

--- a/tests/spanner/src/test_proxy.rs
+++ b/tests/spanner/src/test_proxy.rs
@@ -116,25 +116,44 @@ where
     const NAME: &'static str = "google.spanner.v1.Spanner";
 }
 
-/// Starts a proxy server and returns the URI and a join handle.
-pub(crate) async fn start_proxy_server<F>(
-    address: &str,
-    proxy: PassThroughProxy<F>,
-) -> anyhow::Result<(String, JoinHandle<()>)>
+pub(crate) struct ProxyServer {
+    uri: String,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for ProxyServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl ProxyServer {
+    pub fn uri(&self) -> &str {
+        &self.uri
+    }
+}
+
+impl<F> PassThroughProxy<F>
 where
     F: Fn(Request<Body>) -> BoxFuture<'static, InterceptionResult> + Clone + Send + Sync + 'static,
 {
-    let listener = TcpListener::bind(address).await?;
-    let addr = listener.local_addr()?;
+    /// Starts the proxy server and returns a `ProxyServer`.
+    pub async fn start(self, address: &str) -> anyhow::Result<ProxyServer> {
+        let listener = TcpListener::bind(address).await?;
+        let addr = listener.local_addr()?;
 
-    let server = spawn(async {
-        let stream = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        let server = spawn(async {
+            let stream = tokio_stream::wrappers::TcpListenerStream::new(listener);
 
-        let _ = Server::builder()
-            .add_service(proxy)
-            .serve_with_incoming(stream)
-            .await;
-    });
+            let _ = Server::builder()
+                .add_service(self)
+                .serve_with_incoming(stream)
+                .await;
+        });
 
-    Ok((to_uri(addr), server))
+        Ok(ProxyServer {
+            uri: to_uri(addr),
+            handle: server,
+        })
+    }
 }

--- a/tests/spanner/src/test_proxy.rs
+++ b/tests/spanner/src/test_proxy.rs
@@ -12,277 +12,134 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use spanner_grpc_mock::google::spanner::v1 as spanner_v1;
-use spanner_grpc_mock::google::spanner::v1::spanner_client::SpannerClient;
+use futures::future::BoxFuture;
+use http::{HeaderValue, Request, Response, StatusCode};
+use spanner_grpc_mock::to_uri;
+use std::convert::Infallible;
+use tokio::net::TcpListener;
+use tokio::spawn;
+use tokio::task::JoinHandle;
+use tonic::Status;
+use tonic::body::Body;
+use tonic::server::NamedService;
+use tonic::transport::Channel;
+use tonic::transport::Server;
+use tower::{Service, ServiceExt};
 
-#[tonic::async_trait]
-pub trait SpannerInterceptor: Send + Sync + 'static {
-    fn emulator_client(&self) -> SpannerClient<tonic::transport::Channel>;
+/// The result of an interception operation.
+///
+/// It allows the interceptor to either let the request `Continue` to the emulator,
+/// or `Complete` the request immediately with a mock response.
+#[allow(dead_code)]
+pub(crate) enum InterceptionResult {
+    Continue(Request<Body>),
+    Complete(Response<Body>),
+}
 
-    async fn create_session(
-        &self,
-        request: tonic::Request<spanner_v1::CreateSessionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Session>, tonic::Status> {
-        self.emulator_client().create_session(request).await
-    }
+/// A generic pass-through proxy for the Spanner gRPC service.
+///
+/// It forwards all requests to the emulator channel by default, but allows
+/// an interceptor closure to inspect and potentially handle specific requests.
+#[derive(Clone)]
+pub(crate) struct PassThroughProxy<F> {
+    emulator_channel: Channel,
+    interceptor: F,
+}
 
-    async fn batch_create_sessions(
-        &self,
-        request: tonic::Request<spanner_v1::BatchCreateSessionsRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::BatchCreateSessionsResponse>, tonic::Status>
-    {
-        self.emulator_client().batch_create_sessions(request).await
-    }
-
-    async fn get_session(
-        &self,
-        request: tonic::Request<spanner_v1::GetSessionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Session>, tonic::Status> {
-        self.emulator_client().get_session(request).await
-    }
-
-    async fn list_sessions(
-        &self,
-        request: tonic::Request<spanner_v1::ListSessionsRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ListSessionsResponse>, tonic::Status> {
-        self.emulator_client().list_sessions(request).await
-    }
-
-    async fn delete_session(
-        &self,
-        request: tonic::Request<spanner_v1::DeleteSessionRequest>,
-    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-        self.emulator_client().delete_session(request).await
-    }
-
-    async fn execute_sql(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteSqlRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ResultSet>, tonic::Status> {
-        self.emulator_client().execute_sql(request).await
-    }
-
-    async fn execute_streaming_sql(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteSqlRequest>,
-    ) -> std::result::Result<
-        tonic::Response<tonic::codec::Streaming<spanner_v1::PartialResultSet>>,
-        tonic::Status,
-    > {
-        self.emulator_client().execute_streaming_sql(request).await
-    }
-
-    async fn execute_batch_dml(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteBatchDmlRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ExecuteBatchDmlResponse>, tonic::Status>
-    {
-        self.emulator_client().execute_batch_dml(request).await
-    }
-
-    async fn read(
-        &self,
-        request: tonic::Request<spanner_v1::ReadRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ResultSet>, tonic::Status> {
-        self.emulator_client().read(request).await
-    }
-
-    async fn streaming_read(
-        &self,
-        request: tonic::Request<spanner_v1::ReadRequest>,
-    ) -> std::result::Result<
-        tonic::Response<tonic::codec::Streaming<spanner_v1::PartialResultSet>>,
-        tonic::Status,
-    > {
-        self.emulator_client().streaming_read(request).await
-    }
-
-    async fn begin_transaction(
-        &self,
-        request: tonic::Request<spanner_v1::BeginTransactionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Transaction>, tonic::Status> {
-        self.emulator_client().begin_transaction(request).await
-    }
-
-    async fn commit(
-        &self,
-        request: tonic::Request<spanner_v1::CommitRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::CommitResponse>, tonic::Status> {
-        self.emulator_client().commit(request).await
-    }
-
-    async fn rollback(
-        &self,
-        request: tonic::Request<spanner_v1::RollbackRequest>,
-    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-        self.emulator_client().rollback(request).await
-    }
-
-    async fn partition_query(
-        &self,
-        request: tonic::Request<spanner_v1::PartitionQueryRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::PartitionResponse>, tonic::Status> {
-        self.emulator_client().partition_query(request).await
-    }
-
-    async fn partition_read(
-        &self,
-        request: tonic::Request<spanner_v1::PartitionReadRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::PartitionResponse>, tonic::Status> {
-        self.emulator_client().partition_read(request).await
-    }
-
-    async fn batch_write(
-        &self,
-        request: tonic::Request<spanner_v1::BatchWriteRequest>,
-    ) -> std::result::Result<
-        tonic::Response<tonic::codec::Streaming<spanner_v1::BatchWriteResponse>>,
-        tonic::Status,
-    > {
-        self.emulator_client().batch_write(request).await
-    }
-
-    async fn fetch_cache_update(
-        &self,
-        request: tonic::Request<spanner_v1::FetchCacheUpdateRequest>,
-    ) -> std::result::Result<
-        tonic::Response<tonic::codec::Streaming<spanner_v1::CacheUpdate>>,
-        tonic::Status,
-    > {
-        self.emulator_client().fetch_cache_update(request).await
+impl<F> PassThroughProxy<F> {
+    pub(crate) fn new(emulator_channel: Channel, interceptor: F) -> Self {
+        Self {
+            emulator_channel,
+            interceptor,
+        }
     }
 }
 
-pub struct InterceptedSpanner<T>(pub T);
+/// Implement the Tower `Service` trait for `PassThroughProxy`.
+///
+/// This allows the proxy to be used as a gRPC service by Tonic.
+impl<F> Service<Request<Body>> for PassThroughProxy<F>
+where
+    F: Fn(Request<Body>) -> BoxFuture<'static, InterceptionResult> + Clone + Send + Sync + 'static,
+{
+    type Response = Response<Body>;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-#[tonic::async_trait]
-impl<T: SpannerInterceptor> spanner_v1::spanner_server::Spanner for InterceptedSpanner<T> {
-    async fn create_session(
-        &self,
-        request: tonic::Request<spanner_v1::CreateSessionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Session>, tonic::Status> {
-        self.0.create_session(request).await
+    // We always return `Ready` because we don't have any backpressure logic
+    // of our own, and we use `oneshot` in `call` which handles waiting for the
+    // inner channel to be ready.
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
     }
 
-    async fn batch_create_sessions(
-        &self,
-        request: tonic::Request<spanner_v1::BatchCreateSessionsRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::BatchCreateSessionsResponse>, tonic::Status>
-    {
-        self.0.batch_create_sessions(request).await
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let channel = self.emulator_channel.clone();
+        let interceptor = self.interceptor.clone();
+
+        Box::pin(async move {
+            let req = match interceptor(req).await {
+                InterceptionResult::Continue(r) => r,
+                InterceptionResult::Complete(resp) => return Ok(resp),
+            };
+
+            let response = match channel.oneshot(req).await {
+                Ok(resp) => resp,
+                // gRPC errors from the emulator are returned as successful HTTP responses
+                // with `grpc-status` headers and are handled by the `Ok` branch above.
+                // This `Err` branch only handles transport-level errors. We must convert
+                // them to a valid gRPC response because Tonic requires `Error = Infallible`.
+                Err(e) => {
+                    let status = Status::from_error(Box::new(e));
+                    let mut resp = Response::new(Body::empty());
+                    *resp.status_mut() = StatusCode::OK;
+                    resp.headers_mut().insert(
+                        "grpc-status",
+                        HeaderValue::from_str(&format!("{}", status.code() as i32)).unwrap(),
+                    );
+                    resp.headers_mut().insert(
+                        "grpc-message",
+                        HeaderValue::from_str(status.message()).unwrap(),
+                    );
+                    resp
+                }
+            };
+            Ok(response)
+        })
     }
+}
 
-    async fn get_session(
-        &self,
-        request: tonic::Request<spanner_v1::GetSessionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Session>, tonic::Status> {
-        self.0.get_session(request).await
-    }
+// Tonic's `add_service` requires the service to implement `NamedService`
+// so it knows the gRPC service name for routing.
+impl<F> NamedService for PassThroughProxy<F>
+where
+    F: Send + Sync + 'static,
+{
+    const NAME: &'static str = "google.spanner.v1.Spanner";
+}
 
-    async fn list_sessions(
-        &self,
-        request: tonic::Request<spanner_v1::ListSessionsRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ListSessionsResponse>, tonic::Status> {
-        self.0.list_sessions(request).await
-    }
+/// Starts a proxy server and returns the URI and a join handle.
+pub(crate) async fn start_proxy_server<F>(
+    address: &str,
+    proxy: PassThroughProxy<F>,
+) -> anyhow::Result<(String, JoinHandle<()>)>
+where
+    F: Fn(Request<Body>) -> BoxFuture<'static, InterceptionResult> + Clone + Send + Sync + 'static,
+{
+    let listener = TcpListener::bind(address).await?;
+    let addr = listener.local_addr()?;
 
-    async fn delete_session(
-        &self,
-        request: tonic::Request<spanner_v1::DeleteSessionRequest>,
-    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-        self.0.delete_session(request).await
-    }
+    let server = spawn(async {
+        let stream = tokio_stream::wrappers::TcpListenerStream::new(listener);
 
-    async fn execute_sql(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteSqlRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ResultSet>, tonic::Status> {
-        self.0.execute_sql(request).await
-    }
+        let _ = Server::builder()
+            .add_service(proxy)
+            .serve_with_incoming(stream)
+            .await;
+    });
 
-    type ExecuteStreamingSqlStream = tonic::codec::Streaming<spanner_v1::PartialResultSet>;
-
-    async fn execute_streaming_sql(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteSqlRequest>,
-    ) -> std::result::Result<tonic::Response<Self::ExecuteStreamingSqlStream>, tonic::Status> {
-        self.0.execute_streaming_sql(request).await
-    }
-
-    async fn execute_batch_dml(
-        &self,
-        request: tonic::Request<spanner_v1::ExecuteBatchDmlRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ExecuteBatchDmlResponse>, tonic::Status>
-    {
-        self.0.execute_batch_dml(request).await
-    }
-
-    async fn read(
-        &self,
-        request: tonic::Request<spanner_v1::ReadRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::ResultSet>, tonic::Status> {
-        self.0.read(request).await
-    }
-
-    type StreamingReadStream = tonic::codec::Streaming<spanner_v1::PartialResultSet>;
-
-    async fn streaming_read(
-        &self,
-        request: tonic::Request<spanner_v1::ReadRequest>,
-    ) -> std::result::Result<tonic::Response<Self::StreamingReadStream>, tonic::Status> {
-        self.0.streaming_read(request).await
-    }
-
-    async fn begin_transaction(
-        &self,
-        request: tonic::Request<spanner_v1::BeginTransactionRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::Transaction>, tonic::Status> {
-        self.0.begin_transaction(request).await
-    }
-
-    async fn commit(
-        &self,
-        request: tonic::Request<spanner_v1::CommitRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::CommitResponse>, tonic::Status> {
-        self.0.commit(request).await
-    }
-
-    async fn rollback(
-        &self,
-        request: tonic::Request<spanner_v1::RollbackRequest>,
-    ) -> std::result::Result<tonic::Response<()>, tonic::Status> {
-        self.0.rollback(request).await
-    }
-
-    async fn partition_query(
-        &self,
-        request: tonic::Request<spanner_v1::PartitionQueryRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::PartitionResponse>, tonic::Status> {
-        self.0.partition_query(request).await
-    }
-
-    async fn partition_read(
-        &self,
-        request: tonic::Request<spanner_v1::PartitionReadRequest>,
-    ) -> std::result::Result<tonic::Response<spanner_v1::PartitionResponse>, tonic::Status> {
-        self.0.partition_read(request).await
-    }
-
-    type BatchWriteStream = tonic::codec::Streaming<spanner_v1::BatchWriteResponse>;
-
-    async fn batch_write(
-        &self,
-        request: tonic::Request<spanner_v1::BatchWriteRequest>,
-    ) -> std::result::Result<tonic::Response<Self::BatchWriteStream>, tonic::Status> {
-        self.0.batch_write(request).await
-    }
-
-    type FetchCacheUpdateStream = tonic::codec::Streaming<spanner_v1::CacheUpdate>;
-
-    async fn fetch_cache_update(
-        &self,
-        request: tonic::Request<spanner_v1::FetchCacheUpdateRequest>,
-    ) -> std::result::Result<tonic::Response<Self::FetchCacheUpdateStream>, tonic::Status> {
-        self.0.fetch_cache_update(request).await
-    }
+    Ok((to_uri(addr), server))
 }


### PR DESCRIPTION
Use a generic pass-through proxy for testing, instead of a Spanner-specific proxy. This prevents build errors when new RPCs are added to Spanner.

Fixes #5608