### PR TITLE
impl(lro): gate tracing dependency under cfg flag

### DIFF
--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -44,12 +44,14 @@ futures         = { workspace = true, optional = true }
 pin-project     = { workspace = true, optional = true }
 serde.workspace = true
 tokio           = { workspace = true, features = ["time"] }
-tracing         = { workspace = true }
 # Local crates
 google-cloud-gax         = { workspace = true }
 google-cloud-longrunning = { workspace = true }
 google-cloud-rpc         = { workspace = true }
 google-cloud-wkt         = { workspace = true }
+
+[target.'cfg(google_cloud_unstable_tracing)'.dependencies]
+tracing = { workspace = true }
 
 [features]
 unstable-stream = ["dep:futures", "dep:pin-project"]


### PR DESCRIPTION
This change moves the `tracing` dependency in `google-cloud-lro` to a target-specific dependency block gated by `cfg(google_cloud_unstable_tracing)`. This reduces the default dependency footprint when tracing is not needed.