### PR TITLE
ci(workspace): add strict clippy checks to selected handwritten crates

### DIFF
--- a/.gcb/scripts/lint-unstable.sh
+++ b/.gcb/scripts/lint-unstable.sh
@@ -24,5 +24,8 @@ set +v
 echo "==== cargo clippy ===="
 cargo clippy --all-features --all-targets --profile=test --workspace -- --deny warnings
 
+echo "==== cargo clippy strict (handwritten crates non-test mode) ===="
+cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
+
 echo "==== DONE ===="
 /workspace/.bin/sccache --show-stats

--- a/.gcb/scripts/lint.sh
+++ b/.gcb/scripts/lint.sh
@@ -24,5 +24,8 @@ set +v
 echo "==== cargo clippy ===="
 cargo clippy --all-features --all-targets --profile=test --workspace -- --deny warnings
 
+echo "==== cargo clippy strict (handwritten crates non-test mode) ===="
+cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
+
 echo "==== DONE ===="
 /workspace/.bin/sccache --show-stats

--- a/src/auth/build.rs
+++ b/src/auth/build.rs
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Build script for `google-cloud-auth` to generate environment variables
+//! at compile time, such as the active rustc version and package version.
+
 use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
+/// The main entry point for the build script.
 fn main() {
     let out_dir = std::env::var_os("OUT_DIR").expect("OUT_DIR not specified");
     let out_path = Path::new(&out_dir).to_owned();

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -71,6 +71,7 @@ impl EntityTag {
 /// indicate that the caller's cached version (identified by a previously provided [EntityTag])
 /// is still valid.
 #[derive(Clone, PartialEq, Debug)]
+#[allow(clippy::exhaustive_enums)]
 pub enum CacheableResource<T> {
     /// Indicates that the resource has not been modified and the cached version is still valid.
     NotModified,

--- a/src/auth/src/credentials/idtoken/mds.rs
+++ b/src/auth/src/credentials/idtoken/mds.rs
@@ -108,6 +108,7 @@ where
 
 /// Specifies what assertions are included in ID Tokens fetched from the Metadata Service.
 #[derive(Debug, Clone)]
+#[allow(clippy::exhaustive_enums)]
 pub enum Format {
     /// Omit project and instance details from the payload. It's the default value.
     Standard,

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -100,6 +100,7 @@ use tokio::time::Instant;
 /// [JWT]: https://google.aip.dev/auth/4111
 /// [scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum AccessSpecifier {
     /// Use [AccessSpecifier::Audience] for setting audience in the token.
     /// `aud` is a [JWT] claim specifying intended recipient of the token,

--- a/src/gax/src/error/binding.rs
+++ b/src/gax/src/error/binding.rs
@@ -52,6 +52,7 @@ pub struct PathMismatch {
 ///
 /// [uri]: https://clouddocs.f5.com/api/irules/HTTP__uri.html
 #[derive(Debug, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum SubstitutionFail {
     /// A required field was not set
     Unset,

--- a/src/gax/src/retry_result.rs
+++ b/src/gax/src/retry_result.rs
@@ -43,6 +43,7 @@ use crate::error::Error;
 /// }
 /// ```
 #[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
 pub enum RetryResult {
     /// The error is non-retryable, stop the loop.
     Permanent(Error),

--- a/src/gax/src/throttle_result.rs
+++ b/src/gax/src/throttle_result.rs
@@ -46,6 +46,7 @@ use crate::error::Error;
 /// }
 /// ```
 #[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
 pub enum ThrottleResult {
     /// The error is retryable, but the policy is stopping the loop.
     ///

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -102,6 +102,7 @@ use std::future::Future;
 /// * `MetadataType` - The LRO may return values of this type while the
 ///   operation is in progress. This may include some measure of "progress".
 #[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
 pub enum PollingResult<ResponseType, MetadataType> {
     /// The operation is still in progress.
     InProgress(Option<MetadataType>),

--- a/src/storage/src/signed_url.rs
+++ b/src/storage/src/signed_url.rs
@@ -20,6 +20,7 @@
 ///
 /// [resource path]: https://docs.cloud.google.com/storage/docs/authentication/canonical-requests#about-resource-path
 #[derive(Debug, Clone, Copy, Default)]
+#[allow(clippy::exhaustive_enums)]
 pub enum UrlStyle {
     /// Path style URL: `https://storage.googleapis.com/bucket/object`.
     ///

--- a/src/wkt/src/internal/enums.rs
+++ b/src/wkt/src/internal/enums.rs
@@ -15,6 +15,7 @@
 use std::marker::PhantomData;
 
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum UnknownEnumValue {
     Integer(i32),
     String(String),


### PR DESCRIPTION
Add a strict clippy check to the GCB `lint.sh` and `lint-unstable.sh` scripts that runs with `--no-deps` on a targeted set of handwritten client libraries in non-test mode.

The strict clippy run checks for `missing_docs` and `clippy::exhaustive_enums` on: `auth`, `bigquery`, `bigtable`, `datastore`, `firestore`, `gax`, `lro`, `pubsub`, `storage`, and `wkt`.

To prepare the target crates for these checks, this commit:
- Documents the `src/auth/build.rs` build script to resolve `missing_docs`.
- Adds `#[allow(clippy::exhaustive_enums)]` to stable public and internal enums across the target crates to avoid public API breaking changes.