### PR TITLE
cleanup(auth): fix typo on trust boundaries flag name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,7 +539,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',
   'cfg(google_cloud_unstable_tracing)',
-  'cfg(google_cloud_unstable_trusted_boundaries)',
+  'cfg(google_cloud_unstable_trust_boundaries)',
   # Enables re-generation of protos. Only needed on major version updates to
   # Prost and/or Tonic.
   'cfg(google_cloud_generate_protos)',

--- a/src/auth/src/access_boundary.rs
+++ b/src/auth/src/access_boundary.rs
@@ -91,11 +91,11 @@ impl AccessBoundary {
         Self { rx_header }
     }
     fn is_enabled() -> bool {
-        #[cfg(google_cloud_unstable_trusted_boundaries)]
+        #[cfg(google_cloud_unstable_trust_boundaries)]
         {
             true
         }
-        #[cfg(not(google_cloud_unstable_trusted_boundaries))]
+        #[cfg(not(google_cloud_unstable_trust_boundaries))]
         {
             false
         }
@@ -259,7 +259,7 @@ where
         }
     }
 
-    #[cfg(all(test, google_cloud_unstable_trusted_boundaries))]
+    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
     pub(crate) async fn wait_for_boundary(&self) {
         let mut rx = self.access_boundary.rx_header.clone();
         if rx.borrow().0.is_some() {
@@ -447,7 +447,7 @@ where
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct AllowedLocationsResponse {
-    #[allow(dead_code)]
+    
     locations: Vec<String>,
     #[serde(rename = "encodedLocations")]
     encoded_locations: String,
@@ -715,7 +715,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_fetch_access_boundary_success() -> TestResult {
         let server = Server::run();
         server.expect(
@@ -764,7 +764,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_fetch_access_boundary_mds_success() -> TestResult {
         use crate::mds::MDS_DEFAULT_URI;
 
@@ -1069,7 +1069,7 @@ pub(crate) mod tests {
 
     #[tokio::test(start_paused = true)]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_entity_tag_caching_behavior() -> TestResult {
         let mut mock_creds = MockCredentials::new();
         let latest_token_etag = Arc::new(std::sync::RwLock::new(EntityTag::new()));
@@ -1246,7 +1246,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_credentials_with_access_boundary_non_default_universe() -> TestResult {
         let mut mock = MockCredentials::new();
         mock.expect_headers().returning(|_extensions| {
@@ -1279,7 +1279,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_mds_provider_non_default_universe() -> TestResult {
         let mut mock = MockCredentials::new();
         mock.expect_universe_domain()

--- a/src/auth/src/access_boundary.rs
+++ b/src/auth/src/access_boundary.rs
@@ -447,7 +447,7 @@ where
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct AllowedLocationsResponse {
-    
+    #[allow(dead_code)]
     locations: Vec<String>,
     #[serde(rename = "encodedLocations")]
     encoded_locations: String,

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -746,7 +746,7 @@ impl Builder {
         self
     }
 
-    #[cfg(all(test, google_cloud_unstable_trusted_boundaries))]
+    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
     fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
         self.iam_endpoint_override = iam_endpoint_override;
         self
@@ -2476,7 +2476,7 @@ mod tests {
         "workforce_pool"
     )]
     #[tokio::test]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary(audience: &str, iam_path: &str) -> anyhow::Result<()> {
         use crate::credentials::tests::get_access_boundary_from_headers;
 

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -2542,7 +2542,7 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::{get_access_boundary_from_headers, get_token_from_headers};
         let server = Server::run();
@@ -2587,6 +2587,9 @@ mod tests {
                 "encodedLocations": "0x1234"
             }))),
         );
+        let impersonation_url = server
+            .url("/v1/projects/-/serviceAccounts/test-principal:generateAccessToken")
+            .to_string();
         let endpoint = server.url("/").to_string();
         let endpoint = endpoint.trim_end_matches('/');
 

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -1382,7 +1382,7 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::get_access_boundary_from_headers;
         use crate::mds::MDS_UNIVERSE_DOMAIN_URI;

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -293,7 +293,7 @@ impl Builder {
         self
     }
 
-    #[cfg(all(test, google_cloud_unstable_trusted_boundaries))]
+    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
     fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
         self.iam_endpoint_override = iam_endpoint_override;
         self
@@ -1117,7 +1117,7 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trusted_boundaries)]
+    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::get_access_boundary_from_headers;
         use httptest::responders::json_encoded;


### PR DESCRIPTION
The CI checks and terraform files uses the correct name.