### PR TITLE
feat(lro): instrument until_done polling with T2 spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -67,6 +67,7 @@ anyhow.workspace     = true
 httptest.workspace   = true
 serde_json.workspace = true
 tokio                = { workspace = true, features = ["test-util"] }
+tracing-subscriber   = { workspace = true, default-features = false, features = ["registry", "std"] }
 # Local dependencies
 google-cloud-auth.workspace = true
 google-cloud-lro            = { path = ".", features = ["unstable-stream"] }

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -390,23 +390,21 @@ where
                     }
                     state.attempt_count += 1;
                     let wait = self.backoff_policy.wait_period(&state);
-                    pending = match &self.lro_span {
-                        Some(parent) => {
+                    pending = {
+                        let parent_for_poll_span = self.lro_span.clone();
+                        let next_poll = async {
+                            tokio::time::sleep(wait).await;
+                            self.poll().await
+                        };
+                        if let Some(ref parent) = parent_for_poll_span {
                             let poll_span = tracing::info_span!(
                                 parent: parent,
                                 "LRO Polling",
                                 "gcp.lro.poll_attempt" = state.attempt_count
                             );
-                            async {
-                                tokio::time::sleep(wait).await;
-                                self.poll().await
-                            }
-                            .instrument(poll_span)
-                            .await
-                        }
-                        None => {
-                            tokio::time::sleep(wait).await;
-                            self.poll().await
+                            next_poll.instrument(poll_span).await
+                        } else {
+                            next_poll.await
                         }
                     };
                 }
@@ -1131,11 +1129,13 @@ mod tests {
     }
 
     #[cfg(google_cloud_unstable_tracing)]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn until_done_tracing_emits_lro_polling_under_lro_wait() -> Result<()> {
+    mod tracing_tests {
+        use super::*;
         use std::sync::{Arc, Mutex};
-        use tracing_subscriber::Registry;
-        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+        use tracing_subscriber::{
+            Registry,
+            layer::{Context, Layer, SubscriberExt},
+        };
 
         type SpanCreated = (String, Option<String>);
 
@@ -1149,6 +1149,10 @@ mod tests {
 
             fn snapshots(&self) -> Vec<SpanCreated> {
                 self.0.lock().unwrap().clone()
+            }
+
+            fn names(&self) -> Vec<String> {
+                self.snapshots().into_iter().map(|(s, _)| s).collect()
             }
         }
 
@@ -1174,150 +1178,120 @@ mod tests {
             }
         }
 
-        let cap = Capture::default();
-        let subscriber = Registry::default().with(RecordNewSpans { cap: cap.clone() });
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let start = || async move {
-            let any = Any::from_msg(&Timestamp::clamp(123, 0))
-                .expect("test message deserializes via Any::from_msg");
-            let op = OperationAny::default()
-                .set_name("test-only-name")
-                .set_metadata(any);
-            let op = TestOperation::new(op);
-            Ok::<TestOperation, Error>(op)
-        };
-
-        let query = |_: String| async move {
-            let any = Any::from_msg(&Duration::clamp(234, 0))
-                .expect("test message deserializes via Any::from_msg");
-            let result = ResultAny::Response(any.into());
-            let op = OperationAny::default().set_done(true).set_result(result);
-            let op = TestOperation::new(op);
-            Ok::<TestOperation, Error>(op)
-        };
-
-        let poller = new_poller_with_options(
-            Arc::new(AlwaysContinue),
-            Arc::new(
-                ExponentialBackoffBuilder::new()
-                    .with_initial_delay(StdDuration::from_millis(1))
-                    .clamp(),
-            ),
-            start,
-            query,
-            PollerOptions {
-                tracing: Some(TracingDetails {
-                    method_name: "test.LroMethod",
-                }),
-            },
-        );
-        let response = poller.until_done().await?;
-        assert_eq!(response, Duration::clamp(234, 0));
-
-        let spans = cap.snapshots();
-        let polling: Vec<_> = spans
-            .iter()
-            .filter(|(name, _)| name == "LRO Polling")
-            .collect();
-        assert_eq!(
-            polling.len(),
-            1,
-            "expected one LRO Polling span, got: {spans:?}"
-        );
-        assert_eq!(
-            polling[0].1.as_deref(),
-            Some("LRO Wait"),
-            "LRO Polling should be a child of LRO Wait, got: {spans:?}"
-        );
-        assert!(
-            spans.iter().any(|(name, _)| name == "LRO Wait"),
-            "expected LRO Wait span, got: {spans:?}"
-        );
-
-        Ok(())
-    }
-
-    #[cfg(google_cloud_unstable_tracing)]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn until_done_tracing_skips_lro_polling_when_immediate_completion() -> Result<()> {
-        use std::sync::{Arc, Mutex};
-        use tracing_subscriber::Registry;
-        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
-
-        #[derive(Clone, Default)]
-        struct Capture(Arc<Mutex<Vec<String>>>);
-
-        impl Capture {
-            fn record(&self, name: String) {
-                self.0.lock().unwrap().push(name);
-            }
-
-            fn names(&self) -> Vec<String> {
-                self.0.lock().unwrap().clone()
-            }
+        fn setup_tracing_subscriber() -> (Capture, tracing::subscriber::DefaultGuard) {
+            let cap = Capture::default();
+            let subscriber = Registry::default().with(RecordNewSpans { cap: cap.clone() });
+            let guard = tracing::subscriber::set_default(subscriber);
+            (cap, guard)
         }
 
-        struct RecordNewSpans {
-            cap: Capture,
+        #[tokio::test(flavor = "multi_thread")]
+        async fn until_done_tracing_emits_lro_polling_under_lro_wait() -> Result<()> {
+            let (cap, _guard) = setup_tracing_subscriber();
+
+            let start = || async move {
+                let any = Any::from_msg(&Timestamp::clamp(123, 0))
+                    .expect("test message deserializes via Any::from_msg");
+                let op = OperationAny::default()
+                    .set_name("test-only-name")
+                    .set_metadata(any);
+                let op = TestOperation::new(op);
+                Ok::<TestOperation, Error>(op)
+            };
+
+            let query = |_: String| async move {
+                let any = Any::from_msg(&Duration::clamp(234, 0))
+                    .expect("test message deserializes via Any::from_msg");
+                let result = ResultAny::Response(any.into());
+                let op = OperationAny::default().set_done(true).set_result(result);
+                let op = TestOperation::new(op);
+                Ok::<TestOperation, Error>(op)
+            };
+
+            let poller = new_poller_with_options(
+                Arc::new(AlwaysContinue),
+                Arc::new(
+                    ExponentialBackoffBuilder::new()
+                        .with_initial_delay(StdDuration::from_millis(1))
+                        .clamp(),
+                ),
+                start,
+                query,
+                PollerOptions {
+                    tracing: Some(TracingDetails {
+                        method_name: "test.LroMethod",
+                    }),
+                },
+            );
+            let response = poller.until_done().await?;
+            assert_eq!(response, Duration::clamp(234, 0));
+
+            let spans = cap.snapshots();
+            let polling: Vec<_> = spans
+                .iter()
+                .filter(|(name, _)| name == "LRO Polling")
+                .collect();
+            assert_eq!(
+                polling.len(),
+                1,
+                "expected one LRO Polling span, got: {spans:?}"
+            );
+            assert_eq!(
+                polling[0].1.as_deref(),
+                Some("LRO Wait"),
+                "LRO Polling should be a child of LRO Wait, got: {spans:?}"
+            );
+            assert!(
+                spans.iter().any(|(name, _)| name == "LRO Wait"),
+                "expected LRO Wait span, got: {spans:?}"
+            );
+
+            Ok(())
         }
 
-        impl<S> Layer<S> for RecordNewSpans
-        where
-            S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
-        {
-            fn on_new_span(
-                &self,
-                attrs: &tracing::span::Attributes<'_>,
-                _id: &tracing::span::Id,
-                _ctx: Context<'_, S>,
-            ) {
-                self.cap.record(attrs.metadata().name().to_string());
-            }
+        #[tokio::test(flavor = "multi_thread")]
+        async fn until_done_tracing_skips_lro_polling_when_immediate_completion() -> Result<()> {
+            let (cap, _guard) = setup_tracing_subscriber();
+
+            let start = || async move {
+                let any = Any::from_msg(&Duration::clamp(234, 0))
+                    .expect("test message deserializes via Any::from_msg");
+                let result = ResultAny::Response(any.into());
+                let op = OperationAny::default().set_done(true).set_result(result);
+                let op = TestOperation::new(op);
+                Ok::<TestOperation, Error>(op)
+            };
+
+            let query = |_: String| async move {
+                panic!("query should not run when the operation completes on start");
+            };
+
+            let poller = new_poller_with_options(
+                Arc::new(AlwaysContinue),
+                Arc::new(
+                    ExponentialBackoffBuilder::new()
+                        .with_initial_delay(StdDuration::from_millis(1))
+                        .clamp(),
+                ),
+                start,
+                query,
+                PollerOptions {
+                    tracing: Some(TracingDetails {
+                        method_name: "test.LroMethod",
+                    }),
+                },
+            );
+            let response = poller.until_done().await?;
+            assert_eq!(response, Duration::clamp(234, 0));
+
+            assert!(
+                !cap.names().iter().any(|n| n == "LRO Polling"),
+                "unexpected LRO Polling spans: {:?}",
+                cap.names()
+            );
+
+            Ok(())
         }
-
-        let cap = Capture::default();
-        let subscriber = Registry::default().with(RecordNewSpans { cap: cap.clone() });
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let start = || async move {
-            let any = Any::from_msg(&Duration::clamp(234, 0))
-                .expect("test message deserializes via Any::from_msg");
-            let result = ResultAny::Response(any.into());
-            let op = OperationAny::default().set_done(true).set_result(result);
-            let op = TestOperation::new(op);
-            Ok::<TestOperation, Error>(op)
-        };
-
-        let query = |_: String| async move {
-            panic!("query should not run when the operation completes on start");
-        };
-
-        let poller = new_poller_with_options(
-            Arc::new(AlwaysContinue),
-            Arc::new(
-                ExponentialBackoffBuilder::new()
-                    .with_initial_delay(StdDuration::from_millis(1))
-                    .clamp(),
-            ),
-            start,
-            query,
-            PollerOptions {
-                tracing: Some(TracingDetails {
-                    method_name: "test.LroMethod",
-                }),
-            },
-        );
-        let response = poller.until_done().await?;
-        assert_eq!(response, Duration::clamp(234, 0));
-
-        assert!(
-            !cap.names().iter().any(|n| n == "LRO Polling"),
-            "unexpected LRO Polling spans: {:?}",
-            cap.names()
-        );
-
-        Ok(())
     }
 
     fn service_error() -> Error {

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -24,6 +24,9 @@ use google_cloud_wkt::Empty;
 use google_cloud_wkt::message::Message;
 use std::sync::Arc;
 
+#[cfg(google_cloud_unstable_tracing)]
+use tracing::Instrument;
+
 pub type Operation<R, M> = crate::details::Operation<R, M>;
 
 /// Creates a new `impl Poller<R, M>` from the closures created by the generator.
@@ -295,7 +298,6 @@ struct PollerImpl<S, Q> {
     operation: Option<String>,
     state: PollingState,
     #[cfg(google_cloud_unstable_tracing)]
-    #[expect(dead_code)]
     lro_span: Option<tracing::Span>,
 }
 
@@ -368,26 +370,79 @@ where
     }
 
     async fn until_done(mut self) -> Result<ResponseType> {
-        let mut state = PollingState::default();
-        while let Some(p) = self.poll().await {
-            match p {
-                // Return, the operation completed or the polling policy is
-                // exhausted.
-                PollingResult::Completed(r) => return r,
-                // Continue, the operation was successfully polled and the
-                // polling policy was queried.
-                PollingResult::InProgress(_) => (),
-                // Continue, the polling policy was queried and decided the
-                // error is recoverable.
-                PollingResult::PollingError(_) => (),
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let lro_span = self.lro_span.clone();
+            let wait_loop = async {
+                let mut state = PollingState::default();
+                let mut pending = self.poll().await;
+                while let Some(p) = pending {
+                    match p {
+                        // Return, the operation completed or the polling policy is
+                        // exhausted.
+                        PollingResult::Completed(r) => return r,
+                        // Continue, the operation was successfully polled and the
+                        // polling policy was queried.
+                        PollingResult::InProgress(_) => (),
+                        // Continue, the polling policy was queried and decided the
+                        // error is recoverable.
+                        PollingResult::PollingError(_) => (),
+                    }
+                    state.attempt_count += 1;
+                    let wait = self.backoff_policy.wait_period(&state);
+                    pending = match &self.lro_span {
+                        Some(parent) => {
+                            let poll_span = tracing::info_span!(
+                                parent: parent,
+                                "LRO Polling",
+                                "gcp.lro.poll_attempt" = state.attempt_count
+                            );
+                            async {
+                                tokio::time::sleep(wait).await;
+                                self.poll().await
+                            }
+                            .instrument(poll_span)
+                            .await
+                        }
+                        None => {
+                            tokio::time::sleep(wait).await;
+                            self.poll().await
+                        }
+                    };
+                }
+                // We can only get here if `poll()` returns `None`, but it only returns
+                // `None` after it returned `Polling::Completed` and therefore this is
+                // never reached.
+                unreachable!("loop should exit via the `Completed` branch vs. this line");
+            };
+            match lro_span {
+                Some(span) => wait_loop.instrument(span).await,
+                None => wait_loop.await,
             }
-            state.attempt_count += 1;
-            tokio::time::sleep(self.backoff_policy.wait_period(&state)).await;
         }
-        // We can only get here if `poll()` returns `None`, but it only returns
-        // `None` after it returned `Polling::Completed` and therefore this is
-        // never reached.
-        unreachable!("loop should exit via the `Completed` branch vs. this line");
+        #[cfg(not(google_cloud_unstable_tracing))]
+        {
+            let mut state = PollingState::default();
+            while let Some(p) = self.poll().await {
+                match p {
+                    // Return, the operation completed or the polling policy is
+                    // exhausted.
+                    PollingResult::Completed(r) => return r,
+                    // Continue, the operation was successfully polled and the
+                    // polling policy was queried.
+                    PollingResult::InProgress(_) => (),
+                    // Continue, the polling policy was queried and decided the
+                    // error is recoverable.
+                    PollingResult::PollingError(_) => (),
+                }
+                state.attempt_count += 1;
+                tokio::time::sleep(self.backoff_policy.wait_period(&state)).await;
+            }
+            // We can only get here if `poll()` returns `None`, but it only returns
+            // `None` after it returned `Polling::Completed` and therefore this is
+            // never reached.
+            unreachable!("loop should exit via the `Completed` branch vs. this line");
+        }
     }
 
     #[cfg(feature = "unstable-stream")]
@@ -1070,6 +1125,196 @@ mod tests {
         assert!(
             format!("{response:?}").contains("unrecoverable"),
             "{response:?}"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn until_done_tracing_emits_lro_polling_under_lro_wait() -> Result<()> {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::Registry;
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+
+        type SpanCreated = (String, Option<String>);
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<SpanCreated>>>);
+
+        impl Capture {
+            fn record(&self, name: String, parent: Option<String>) {
+                self.0.lock().unwrap().push((name, parent));
+            }
+
+            fn snapshots(&self) -> Vec<SpanCreated> {
+                self.0.lock().unwrap().clone()
+            }
+        }
+
+        struct RecordNewSpans {
+            cap: Capture,
+        }
+
+        impl<S> Layer<S> for RecordNewSpans
+        where
+            S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+        {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                _id: &tracing::span::Id,
+                ctx: Context<'_, S>,
+            ) {
+                let name = attrs.metadata().name().to_string();
+                let parent = attrs
+                    .parent()
+                    .and_then(|pid| ctx.span(pid).map(|s| s.metadata().name().to_string()));
+                self.cap.record(name, parent);
+            }
+        }
+
+        let cap = Capture::default();
+        let subscriber = Registry::default().with(RecordNewSpans { cap: cap.clone() });
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let start = || async move {
+            let any = Any::from_msg(&Timestamp::clamp(123, 0))
+                .expect("test message deserializes via Any::from_msg");
+            let op = OperationAny::default()
+                .set_name("test-only-name")
+                .set_metadata(any);
+            let op = TestOperation::new(op);
+            Ok::<TestOperation, Error>(op)
+        };
+
+        let query = |_: String| async move {
+            let any = Any::from_msg(&Duration::clamp(234, 0))
+                .expect("test message deserializes via Any::from_msg");
+            let result = ResultAny::Response(any.into());
+            let op = OperationAny::default().set_done(true).set_result(result);
+            let op = TestOperation::new(op);
+            Ok::<TestOperation, Error>(op)
+        };
+
+        let poller = new_poller_with_options(
+            Arc::new(AlwaysContinue),
+            Arc::new(
+                ExponentialBackoffBuilder::new()
+                    .with_initial_delay(StdDuration::from_millis(1))
+                    .clamp(),
+            ),
+            start,
+            query,
+            PollerOptions {
+                tracing: Some(TracingDetails {
+                    method_name: "test.LroMethod",
+                }),
+            },
+        );
+        let response = poller.until_done().await?;
+        assert_eq!(response, Duration::clamp(234, 0));
+
+        let spans = cap.snapshots();
+        let polling: Vec<_> = spans
+            .iter()
+            .filter(|(name, _)| name == "LRO Polling")
+            .collect();
+        assert_eq!(
+            polling.len(),
+            1,
+            "expected one LRO Polling span, got: {spans:?}"
+        );
+        assert_eq!(
+            polling[0].1.as_deref(),
+            Some("LRO Wait"),
+            "LRO Polling should be a child of LRO Wait, got: {spans:?}"
+        );
+        assert!(
+            spans.iter().any(|(name, _)| name == "LRO Wait"),
+            "expected LRO Wait span, got: {spans:?}"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn until_done_tracing_skips_lro_polling_when_immediate_completion() -> Result<()> {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::Registry;
+        use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<String>>>);
+
+        impl Capture {
+            fn record(&self, name: String) {
+                self.0.lock().unwrap().push(name);
+            }
+
+            fn names(&self) -> Vec<String> {
+                self.0.lock().unwrap().clone()
+            }
+        }
+
+        struct RecordNewSpans {
+            cap: Capture,
+        }
+
+        impl<S> Layer<S> for RecordNewSpans
+        where
+            S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+        {
+            fn on_new_span(
+                &self,
+                attrs: &tracing::span::Attributes<'_>,
+                _id: &tracing::span::Id,
+                _ctx: Context<'_, S>,
+            ) {
+                self.cap.record(attrs.metadata().name().to_string());
+            }
+        }
+
+        let cap = Capture::default();
+        let subscriber = Registry::default().with(RecordNewSpans { cap: cap.clone() });
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let start = || async move {
+            let any = Any::from_msg(&Duration::clamp(234, 0))
+                .expect("test message deserializes via Any::from_msg");
+            let result = ResultAny::Response(any.into());
+            let op = OperationAny::default().set_done(true).set_result(result);
+            let op = TestOperation::new(op);
+            Ok::<TestOperation, Error>(op)
+        };
+
+        let query = |_: String| async move {
+            panic!("query should not run when the operation completes on start");
+        };
+
+        let poller = new_poller_with_options(
+            Arc::new(AlwaysContinue),
+            Arc::new(
+                ExponentialBackoffBuilder::new()
+                    .with_initial_delay(StdDuration::from_millis(1))
+                    .clamp(),
+            ),
+            start,
+            query,
+            PollerOptions {
+                tracing: Some(TracingDetails {
+                    method_name: "test.LroMethod",
+                }),
+            },
+        );
+        let response = poller.until_done().await?;
+        assert_eq!(response, Duration::clamp(234, 0));
+
+        assert!(
+            !cap.names().iter().any(|n| n == "LRO Polling"),
+            "unexpected LRO Polling spans: {:?}",
+            cap.names()
         );
 
         Ok(())


### PR DESCRIPTION
### Summary
This change implements **T2-style tracing** for the automatic long-running operation (LRO) wait loop in AIP-151 `PollerImpl::until_done`, gated on `google_cloud_unstable_tracing`.
### Behavior
- The **`LRO Wait`** span created when building the poller (`new_poller_with_options`) is now **entered for the entire `until_done` future**, so LRO wait work is consistently attributed to that span.
- Each **backoff plus the following `poll()`** is wrapped in a child span named **`LRO Polling`**, parented under **`LRO Wait`**, with **`gcp.lro.poll_attempt`** set from the wait-loop `PollingState` (the counter used for backoff), matching one iteration of the automated polling loop.
- When tracing details are not supplied (`lro_span` is `None`), behavior matches the previous non-tracing path.
### Tests
- **`tracing-subscriber`** is added as a **dev-dependency** only.
- New unit tests (same cfg gate) record span creation and assert:
    - one **`LRO Polling`** span whose parent is **`LRO Wait`** when a start + wait + poll completes the operation; and
    - **no** **`LRO Polling`** spans when the operation completes on the first response (no wait loop).
### Links
- Closes #5624
- Related tracking issue: #5622