### PR TITLE
fix(auth): jitter token refresh sleep to spread load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "mockall",
  "mutants",
  "p256",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.13.3",
  "rsa",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -41,6 +41,7 @@ chrono                = { workspace = true, features = ["clock"] }
 hex                   = { workspace = true, features = ["std"] }
 hmac.workspace        = true
 http.workspace        = true
+rand                  = { workspace = true, features = ["thread_rng"] }
 reqwest               = { workspace = true, features = ["form", "json", "query", "rustls-no-provider"] }
 rustls                = { workspace = true, features = ["logging", "std", "tls12"] }
 rustls-pki-types      = { workspace = true, features = ["std"] }
@@ -53,7 +54,6 @@ tokio                 = { workspace = true, features = ["fs", "process"] }
 url.workspace         = true
 p256                  = { workspace = true, features = ["ecdsa", "pem"], optional = true }
 jsonwebtoken          = { workspace = true, optional = true }
-rand                  = { workspace = true, features = ["thread_rng"] }
 # We do not use this directly, but without it the minimal-versions build breaks.
 # See: https://github.com/Keats/jsonwebtoken/pull/481
 aws-lc-rs = { workspace = true, optional = true }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -53,6 +53,7 @@ tokio                 = { workspace = true, features = ["fs", "process"] }
 url.workspace         = true
 p256                  = { workspace = true, features = ["ecdsa", "pem"], optional = true }
 jsonwebtoken          = { workspace = true, optional = true }
+rand                  = { workspace = true, features = ["thread_rng"] }
 # We do not use this directly, but without it the minimal-versions build breaks.
 # See: https://github.com/Keats/jsonwebtoken/pull/481
 aws-lc-rs = { workspace = true, optional = true }

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -18,7 +18,6 @@ use crate::Result;
 use crate::credentials::{CacheableResource, EntityTag};
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use http::Extensions;
-#[cfg(not(test))]
 use rand::RngExt;
 use std::sync::Arc;
 use tokio::sync::watch;
@@ -28,13 +27,14 @@ use tokio::time::{Duration, Instant, sleep};
 // determine when to refresh a token. Most MDS' refresh token 5 mins before
 // expiry, except for Serverless which refresh tokens 4 mins before
 // expiry. So we are using 4 mins as the staleness limit for our refresh logic.
-const NORMAL_REFRESH_SLACK: Duration = Duration::from_secs(240);
-const SHORT_REFRESH_SLACK: Duration = Duration::from_secs(10);
-/// Upper bound on how much we randomize the scheduled refresh instant. Spreads
-/// load when many independent caches refresh on a similar cadence (#1587).
-const REFRESH_JITTER_CAP: Duration = Duration::from_secs(60);
-/// Jitter cap for the short fixed delays (`SHORT_REFRESH_SLACK`).
-const SHORT_REFRESH_JITTER_CAP: Duration = Duration::from_secs(5);
+const NORMAL_REFRESH_SLACK_SECS: u64 = 240;
+const SHORT_REFRESH_SLACK_SECS: u64 = 10;
+const NORMAL_REFRESH_SLACK: Duration = Duration::from_secs(NORMAL_REFRESH_SLACK_SECS);
+const SHORT_REFRESH_SLACK: Duration = Duration::from_secs(SHORT_REFRESH_SLACK_SECS);
+/// Upper bound on jitter for the main refresh sleep: `NORMAL_REFRESH_SLACK / 4` (#1587).
+const REFRESH_JITTER_CAP: Duration = Duration::from_secs(NORMAL_REFRESH_SLACK_SECS / 4);
+/// Upper bound on jitter for [`SHORT_REFRESH_SLACK`] sleeps: `SHORT_REFRESH_SLACK / 2` (#1587).
+const SHORT_REFRESH_JITTER_CAP: Duration = Duration::from_secs(SHORT_REFRESH_SLACK_SECS / 2);
 
 #[derive(Debug, Clone)]
 pub(crate) struct TokenCache {
@@ -102,34 +102,42 @@ async fn wait_for_next_token(
 
 /// Returns a duration in `[base - max_jitter, base]` (uniformly) so independent
 /// credential caches are less likely to hit the token endpoint at the same
-/// instant. In unit tests the crate is built with `cfg(test)` and jitter is
-/// disabled so timing assertions stay stable.
-fn jittered_sleep_duration(base: Duration, jitter_cap: Duration) -> Duration {
+/// instant (#1587).
+fn jittered_sleep_duration_with_rng<R: RngExt + ?Sized>(
+    base: Duration,
+    jitter_cap: Duration,
+    rng: &mut R,
+) -> Duration {
     if base.is_zero() {
         return base;
     }
-
-    #[cfg(test)]
-    {
-        let _ = jitter_cap;
+    let max_jitter = jitter_cap.min(base / 4);
+    if max_jitter.is_zero() {
         base
-    }
-
-    #[cfg(not(test))]
-    {
-        let max_jitter = jitter_cap.min(base / 4);
-        if max_jitter.is_zero() {
-            base
-        } else {
-            let jitter = rand::rng().random_range(Duration::ZERO..=max_jitter);
-            base.saturating_sub(jitter)
-        }
+    } else {
+        let jitter = rng.random_range(Duration::ZERO..=max_jitter);
+        base.saturating_sub(jitter)
     }
 }
 
 async fn refresh_task<T>(
     token_provider: Arc<T>,
     tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
+) where
+    T: TokenProvider + Send + Sync + 'static,
+{
+    fn sleep_duration_with_thread_rng(base: Duration, cap: Duration) -> Duration {
+        let mut rng = rand::rng();
+        jittered_sleep_duration_with_rng(base, cap, &mut rng)
+    }
+
+    refresh_task_impl(token_provider, tx_token, sleep_duration_with_thread_rng).await;
+}
+
+async fn refresh_task_impl<T>(
+    token_provider: Arc<T>,
+    tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
+    mut jitter_fn: impl FnMut(Duration, Duration) -> Duration + Send,
 ) where
     T: TokenProvider + Send + Sync + 'static,
 {
@@ -154,7 +162,7 @@ async fn refresh_task<T>(
                     }
                     Some(time_until_expiry) => {
                         if time_until_expiry > NORMAL_REFRESH_SLACK {
-                            let wait = jittered_sleep_duration(
+                            let wait = jitter_fn(
                                 time_until_expiry - NORMAL_REFRESH_SLACK,
                                 REFRESH_JITTER_CAP,
                             );
@@ -162,10 +170,7 @@ async fn refresh_task<T>(
                         } else if time_until_expiry > SHORT_REFRESH_SLACK {
                             // If expiry is less than 4 mins, try to refresh every 10 seconds
                             // This is to handle cases where MDS **repeatedly** returns about to expire tokens.
-                            let wait = jittered_sleep_duration(
-                                SHORT_REFRESH_SLACK,
-                                SHORT_REFRESH_JITTER_CAP,
-                            );
+                            let wait = jitter_fn(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
                             sleep(wait).await;
                         }
                     }
@@ -191,7 +196,7 @@ async fn refresh_task<T>(
                 if !err.is_transient() {
                     break;
                 }
-                let wait = jittered_sleep_duration(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
+                let wait = jitter_fn(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
                 sleep(wait).await;
             }
         }
@@ -203,13 +208,58 @@ mod tests {
     use super::*;
     use crate::errors;
     use crate::token::tests::MockTokenProvider;
+    use core::convert::Infallible;
     use google_cloud_gax::error::CredentialsError;
+    use rand::rand_core::TryRng;
     use std::ops::{Add, Sub};
     use std::sync::{Arc, Mutex};
     use tokio::time::{Duration, Instant};
 
     static TOKEN_VALID_DURATION: Duration = Duration::from_secs(3600);
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    /// Deterministic `TryRng` for tests. A stream of identical values can make
+    /// `random_range` reject forever for some sampled types, so this advances.
+    #[derive(Clone, Default)]
+    struct CountingRng(u64);
+
+    impl TryRng for CountingRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
+            self.try_next_u64().map(|v| v as u32)
+        }
+
+        fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
+            let v = self.0;
+            self.0 = self.0.wrapping_add(1);
+            Ok(v)
+        }
+
+        fn try_fill_bytes(
+            &mut self,
+            dest: &mut [u8],
+        ) -> std::result::Result<(), Self::Error> {
+            for d in dest.iter_mut() {
+                *d = self.try_next_u32()? as u8;
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn jittered_sleep_duration_with_counting_rng_stays_in_bounds() {
+        let base = Duration::from_secs(3300);
+        let mut rng = CountingRng::default();
+        let got = jittered_sleep_duration_with_rng(base, REFRESH_JITTER_CAP, &mut rng);
+        let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
+        assert!(got <= base, "{got:?} <= {base:?}");
+        assert!(
+            base.saturating_sub(max_jitter) <= got,
+            "{got:?} >= {:?}",
+            base.saturating_sub(max_jitter)
+        );
+    }
 
     fn get_cached_token(cache: CacheableResource<Token>) -> Result<Token> {
         match cache {
@@ -430,7 +480,11 @@ mod tests {
         let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            let mut rng = CountingRng::default();
+            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
+                jittered_sleep_duration_with_rng(base, cap, &mut rng)
+            })
+            .await;
         });
 
         // Give the refresh task a chance to run
@@ -493,7 +547,11 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            let mut rng = CountingRng::default();
+            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
+                jittered_sleep_duration_with_rng(base, cap, &mut rng)
+            })
+            .await;
         });
 
         rx.changed().await.unwrap();
@@ -567,7 +625,11 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            let mut rng = CountingRng::default();
+            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
+                jittered_sleep_duration_with_rng(base, cap, &mut rng)
+            })
+            .await;
         });
 
         rx.changed().await.unwrap();
@@ -632,7 +694,11 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            let mut rng = CountingRng::default();
+            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
+                jittered_sleep_duration_with_rng(base, cap, &mut rng)
+            })
+            .await;
         });
 
         rx.changed().await.unwrap();

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -204,11 +204,8 @@ async fn refresh_task_impl<T, R>(
                 if !err.is_transient() {
                     break;
                 }
-                let wait = jittered_sleep_duration(
-                    SHORT_REFRESH_SLACK,
-                    SHORT_REFRESH_JITTER_CAP,
-                    rng,
-                );
+                let wait =
+                    jittered_sleep_duration(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP, rng);
                 sleep(wait).await;
             }
         }
@@ -230,39 +227,25 @@ mod tests {
     static TOKEN_VALID_DURATION: Duration = Duration::from_secs(3600);
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-    /// Test RNG that returns the same `u64` for every word. Works with [`super::jittered_sleep_duration`]
-    /// because jitter uses one uniform draw via `% (max_nanos + 1)` instead of `rand`'s
-    /// `UniformDuration` rejection sampler (which can loop on pathological generators).
-    #[derive(Clone, Copy)]
-    struct ConstU64Rng(u64);
+    mockall::mock! {
+        pub JitterRng {}
 
-    impl TryRng for ConstU64Rng {
-        type Error = Infallible;
-
-        fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
-            self.try_next_u64().map(|v| v as u32)
-        }
-
-        fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
-            Ok(self.0)
-        }
-
-        fn try_fill_bytes(
-            &mut self,
-            dest: &mut [u8],
-        ) -> std::result::Result<(), Self::Error> {
-            let b = self.0.to_le_bytes();
-            for (i, d) in dest.iter_mut().enumerate() {
-                *d = b[i % 8];
-            }
-            Ok(())
+        impl TryRng for JitterRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> std::result::Result<u32, Infallible>;
+            fn try_next_u64(&mut self) -> std::result::Result<u64, Infallible>;
+            fn try_fill_bytes(
+                &mut self,
+                dest: &mut [u8],
+            ) -> std::result::Result<(), Infallible>;
         }
     }
 
     #[test]
     fn jittered_sleep_duration_const_zero_is_unjittered_base() {
         let base = Duration::from_secs(3360);
-        let mut rng = ConstU64Rng(0);
+        let mut rng = MockJitterRng::new();
+        rng.expect_try_next_u64().returning(|| Ok(0u64)).times(1..);
         let got = jittered_sleep_duration(base, REFRESH_JITTER_CAP, &mut rng);
         assert_eq!(got, base);
     }
@@ -270,7 +253,10 @@ mod tests {
     #[test]
     fn jittered_sleep_duration_const_max_stays_in_bounds() {
         let base = Duration::from_secs(3300);
-        let mut rng = ConstU64Rng(u64::MAX);
+        let mut rng = MockJitterRng::new();
+        rng.expect_try_next_u64()
+            .returning(|| Ok(u64::MAX))
+            .times(1..);
         let got = jittered_sleep_duration(base, REFRESH_JITTER_CAP, &mut rng);
         let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
         assert!(got <= base, "{got:?} <= {base:?}");
@@ -544,10 +530,6 @@ mod tests {
 
         let base = long_expiry - NORMAL_REFRESH_SLACK;
         let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
-        assert!(
-            max_jitter > Duration::ZERO,
-            "test requires non-zero jitter cap"
-        );
         let max_nanos: u64 = max_jitter
             .as_nanos()
             .try_into()
@@ -556,15 +538,16 @@ mod tests {
         let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
 
         tokio::spawn(async move {
-            let mut rng = ConstU64Rng(max_nanos);
+            let mut rng = MockJitterRng::new();
+            rng.expect_try_next_u64()
+                .returning(move || Ok(max_nanos))
+                .times(1..);
             refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
         rx.changed().await.unwrap();
-        assert_eq!(
-            rx.borrow().as_ref().unwrap().as_ref().unwrap().0.token,
-            "token1"
-        );
+        let (actual, ..) = rx.borrow().clone().unwrap().unwrap();
+        assert_eq!(actual.token, "token1");
 
         tokio::time::advance(base - max_jitter).await;
         tokio::task::yield_now().await;

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -101,7 +101,7 @@ async fn wait_for_next_token(
 /// Returns a duration in `[base - max_jitter, base]` (uniformly) so independent
 /// credential caches are less likely to hit the token endpoint at the same
 /// instant.
-fn jittered_sleep_duration_with_rng<R: RngExt + ?Sized>(
+fn jittered_sleep_duration<R: RngExt + ?Sized>(
     base: Duration,
     jitter_cap: Duration,
     rng: &mut R,
@@ -113,7 +113,12 @@ fn jittered_sleep_duration_with_rng<R: RngExt + ?Sized>(
     if max_jitter.is_zero() {
         base
     } else {
-        let jitter = rng.random_range(Duration::ZERO..=max_jitter);
+        let max_nanos: u64 = max_jitter
+            .as_nanos()
+            .try_into()
+            .expect("jitter cap must fit in u64 nanoseconds");
+        let jitter_nanos = rng.random::<u64>() % max_nanos.saturating_add(1);
+        let jitter = Duration::from_nanos(jitter_nanos);
         base.saturating_sub(jitter)
     }
 }
@@ -124,6 +129,8 @@ async fn refresh_task<T>(
 ) where
     T: TokenProvider + Send + Sync + 'static,
 {
+    // `rand::rng()` returns `ThreadRng`, which is not `Send` and cannot be held
+    // across `.await` in this `tokio::spawn` task. Seed a `StdRng` from the OS instead.
     let mut sys = SysRng;
     let mut rng = StdRng::try_from_rng(&mut sys).expect("SysRng must seed StdRng");
     refresh_task_impl(token_provider, tx_token, &mut rng).await;
@@ -158,7 +165,7 @@ async fn refresh_task_impl<T, R>(
                     }
                     Some(time_until_expiry) => {
                         if time_until_expiry > NORMAL_REFRESH_SLACK {
-                            let wait = jittered_sleep_duration_with_rng(
+                            let wait = jittered_sleep_duration(
                                 time_until_expiry - NORMAL_REFRESH_SLACK,
                                 REFRESH_JITTER_CAP,
                                 rng,
@@ -167,7 +174,7 @@ async fn refresh_task_impl<T, R>(
                         } else if time_until_expiry > SHORT_REFRESH_SLACK {
                             // If expiry is less than 4 mins, try to refresh every 10 seconds
                             // This is to handle cases where MDS **repeatedly** returns about to expire tokens.
-                            let wait = jittered_sleep_duration_with_rng(
+                            let wait = jittered_sleep_duration(
                                 SHORT_REFRESH_SLACK,
                                 SHORT_REFRESH_JITTER_CAP,
                                 rng,
@@ -179,17 +186,17 @@ async fn refresh_task_impl<T, R>(
             }
             Ok(None) => {
                 // If there is no expiry, the token is valid forever, so no need to refresh
-                // TODO: Validate that all auth backends provide expiry and make expiry not optional.
+                // TODO(#1553): Validate that all auth backends provide expiry and make expiry not optional.
                 break;
             }
             Err(err) => {
                 // On transient errors, even if the retry policy is exhausted,
                 // we want to continue running this retry loop.
                 // This loop cannot stop because that may leave the
-                // credentials in an unrecoverable state.
+                // credentials in an unrecoverable state (see #4541).
                 // We considered using a notification to wake up the next time
                 // a caller wants to retrieve a token, but that seemed prone to
-                // deadlocks. We may implement this as an improvement.
+                // deadlocks. We may implement this as an improvement (#4593).
                 // On permanent errors, then there is really no point in trying
                 // again, by definition of "permanent". If the error was misclassified
                 // as permanent, that is a bug in the retry policy and better fixed
@@ -197,7 +204,7 @@ async fn refresh_task_impl<T, R>(
                 if !err.is_transient() {
                     break;
                 }
-                let wait = jittered_sleep_duration_with_rng(
+                let wait = jittered_sleep_duration(
                     SHORT_REFRESH_SLACK,
                     SHORT_REFRESH_JITTER_CAP,
                     rng,
@@ -223,38 +230,13 @@ mod tests {
     static TOKEN_VALID_DURATION: Duration = Duration::from_secs(3600);
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-    /// [`TryRng`] that always draws `u64::MAX` so `random_range` tends to sample
-    /// the upper end of the jitter range (see `refresh_task_impl_jitter_shortens_main_refresh_sleep`).
-    #[derive(Clone, Copy, Default)]
-    struct AlwaysMaxU64Rng;
+    /// Test RNG that returns the same `u64` for every word. Works with [`super::jittered_sleep_duration`]
+    /// because jitter uses one uniform draw via `% (max_nanos + 1)` instead of `rand`'s
+    /// `UniformDuration` rejection sampler (which can loop on pathological generators).
+    #[derive(Clone, Copy)]
+    struct ConstU64Rng(u64);
 
-    impl TryRng for AlwaysMaxU64Rng {
-        type Error = Infallible;
-
-        fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
-            Ok(u32::MAX)
-        }
-
-        fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
-            Ok(u64::MAX)
-        }
-
-        fn try_fill_bytes(
-            &mut self,
-            dest: &mut [u8],
-        ) -> std::result::Result<(), Self::Error> {
-            dest.fill(0xff);
-            Ok(())
-        }
-    }
-
-    /// Deterministic `TryRng` for tests. First `try_next_u64` is `0`, so the first jitter
-    /// draw is unjittered (legacy behavior). Values then increase: a constant stream breaks
-    /// `rand`'s `UniformDuration` rejection sampling.
-    #[derive(Clone, Default)]
-    struct CountingRng(u64);
-
-    impl TryRng for CountingRng {
+    impl TryRng for ConstU64Rng {
         type Error = Infallible;
 
         fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
@@ -262,35 +244,34 @@ mod tests {
         }
 
         fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
-            let v = self.0;
-            self.0 = self.0.wrapping_add(1);
-            Ok(v)
+            Ok(self.0)
         }
 
         fn try_fill_bytes(
             &mut self,
             dest: &mut [u8],
         ) -> std::result::Result<(), Self::Error> {
-            for d in dest.iter_mut() {
-                *d = self.try_next_u32()? as u8;
+            let b = self.0.to_le_bytes();
+            for (i, d) in dest.iter_mut().enumerate() {
+                *d = b[i % 8];
             }
             Ok(())
         }
     }
 
     #[test]
-    fn jittered_sleep_duration_counting_rng_first_draw_is_unjittered_base() {
+    fn jittered_sleep_duration_const_zero_is_unjittered_base() {
         let base = Duration::from_secs(3360);
-        let mut rng = CountingRng::default();
-        let got = jittered_sleep_duration_with_rng(base, REFRESH_JITTER_CAP, &mut rng);
+        let mut rng = ConstU64Rng(0);
+        let got = jittered_sleep_duration(base, REFRESH_JITTER_CAP, &mut rng);
         assert_eq!(got, base);
     }
 
     #[test]
-    fn jittered_sleep_duration_with_counting_rng_stays_in_bounds() {
+    fn jittered_sleep_duration_const_max_stays_in_bounds() {
         let base = Duration::from_secs(3300);
-        let mut rng = CountingRng::default();
-        let got = jittered_sleep_duration_with_rng(base, REFRESH_JITTER_CAP, &mut rng);
+        let mut rng = ConstU64Rng(u64::MAX);
+        let got = jittered_sleep_duration(base, REFRESH_JITTER_CAP, &mut rng);
         let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
         assert!(got <= base, "{got:?} <= {base:?}");
         assert!(
@@ -370,7 +351,7 @@ mod tests {
         assert!(result.is_err(), "{result:?}");
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn expired_token_success() -> TestResult {
         let now = Instant::now();
 
@@ -415,7 +396,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn expired_token_failure() -> TestResult {
         let now = Instant::now();
 
@@ -519,8 +500,7 @@ mod tests {
         let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
 
         tokio::spawn(async move {
-            let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
+            refresh_task(Arc::new(mock), tx).await;
         });
 
         // Give the refresh task a chance to run
@@ -535,7 +515,7 @@ mod tests {
         assert_eq!(actual, token2.clone());
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn refresh_task_impl_jitter_shortens_main_refresh_sleep() {
         let now = Instant::now();
         let long_expiry = TOKEN_VALID_DURATION;
@@ -562,10 +542,21 @@ mod tests {
             .times(1)
             .return_once(|| Ok(token2_clone));
 
+        let base = long_expiry - NORMAL_REFRESH_SLACK;
+        let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
+        assert!(
+            max_jitter > Duration::ZERO,
+            "test requires non-zero jitter cap"
+        );
+        let max_nanos: u64 = max_jitter
+            .as_nanos()
+            .try_into()
+            .expect("jitter must fit in u64 nanoseconds");
+
         let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
 
         tokio::spawn(async move {
-            let mut rng = AlwaysMaxU64Rng;
+            let mut rng = ConstU64Rng(max_nanos);
             refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
@@ -573,13 +564,6 @@ mod tests {
         assert_eq!(
             rx.borrow().as_ref().unwrap().as_ref().unwrap().0.token,
             "token1"
-        );
-
-        let base = long_expiry - NORMAL_REFRESH_SLACK;
-        let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
-        assert!(
-            max_jitter > Duration::ZERO,
-            "test requires non-zero jitter cap"
         );
 
         tokio::time::advance(base - max_jitter).await;
@@ -594,7 +578,7 @@ mod tests {
         assert_eq!(actual.token, "token2");
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn refresh_task_loop() {
         let now = Instant::now();
 
@@ -642,8 +626,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
+            refresh_task(Arc::new(mock), tx).await;
         });
 
         rx.changed().await.unwrap();
@@ -676,7 +659,7 @@ mod tests {
         assert_eq!(actual, token3);
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn refresh_task_loop_less_expiry() {
         let now = Instant::now();
 
@@ -717,8 +700,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
+            refresh_task(Arc::new(mock), tx).await;
         });
 
         rx.changed().await.unwrap();
@@ -747,7 +729,7 @@ mod tests {
         assert_eq!(actual, token2);
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn refresh_task_loop_long_expiry_waits_long_time_before_refresh() {
         let now = Instant::now();
 
@@ -783,8 +765,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
+            refresh_task(Arc::new(mock), tx).await;
         });
 
         rx.changed().await.unwrap();
@@ -803,7 +784,7 @@ mod tests {
         assert_eq!(actual, token2);
     }
 
-    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    #[tokio::test(start_paused = true)]
     async fn refresh_task_sleeps_on_transient_error_and_recovers_on_next_loop() -> TestResult {
         let now = Instant::now();
 

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -47,7 +47,7 @@ impl TokenCache {
         let (tx_token, rx_token) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
         let token_provider = Arc::new(inner);
 
-        tokio::spawn(refresh_task(token_provider, tx_token));
+        tokio::spawn(refresh_task(token_provider, tx_token, refresh_task_rng));
 
         Self { rx_token }
     }
@@ -123,22 +123,25 @@ fn jittered_sleep_duration<R: RngExt + ?Sized>(
     }
 }
 
-/// Returns an RNG for [`refresh_task_impl`] when the refresh loop runs under `tokio::spawn`.
-///
-/// `rand::rng()` yields `ThreadRng`, which is not `Send`. This task holds `&mut rng` across `.await`,
-/// so the future must stay `Send`; an OS-seeded [`StdRng`] is the usual lightweight `Send` substitute.
-fn new_refresh_task_rng() -> StdRng {
+/// OS-seeded [`StdRng`] used as the default RNG for [`refresh_task`].
+fn refresh_task_rng() -> StdRng {
     let mut sys = SysRng;
     StdRng::try_from_rng(&mut sys).expect("SysRng must seed StdRng")
 }
 
+/// Background loop that refreshes tokens before expiry.
+///
+/// `rng_factory` supplies jitter randomness. We pass a `fn() -> StdRng` instead of calling
+/// `rand::rng()` inside this task because the latter returns `ThreadRng`, which is not `Send`; this
+/// async task holds `&mut rng` across `.await`, so the future must be `Send` for `tokio::spawn`.
 async fn refresh_task<T>(
     token_provider: Arc<T>,
     tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
+    rng_factory: fn() -> StdRng,
 ) where
     T: TokenProvider + Send + Sync + 'static,
 {
-    let mut rng = new_refresh_task_rng();
+    let mut rng = rng_factory();
     refresh_task_impl(token_provider, tx_token, &mut rng).await;
 }
 
@@ -492,7 +495,7 @@ mod tests {
         let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            refresh_task(Arc::new(mock), tx, refresh_task_rng).await;
         });
 
         // Give the refresh task a chance to run
@@ -620,7 +623,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            refresh_task(Arc::new(mock), tx, refresh_task_rng).await;
         });
 
         rx.changed().await.unwrap();
@@ -694,7 +697,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            refresh_task(Arc::new(mock), tx, refresh_task_rng).await;
         });
 
         rx.changed().await.unwrap();
@@ -759,7 +762,7 @@ mod tests {
         assert!(actual.is_none(), "{actual:?}");
 
         tokio::spawn(async move {
-            refresh_task(Arc::new(mock), tx).await;
+            refresh_task(Arc::new(mock), tx, refresh_task_rng).await;
         });
 
         rx.changed().await.unwrap();

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -123,16 +123,22 @@ fn jittered_sleep_duration<R: RngExt + ?Sized>(
     }
 }
 
+/// Returns an RNG for [`refresh_task_impl`] when the refresh loop runs under `tokio::spawn`.
+///
+/// `rand::rng()` yields `ThreadRng`, which is not `Send`. This task holds `&mut rng` across `.await`,
+/// so the future must stay `Send`; an OS-seeded [`StdRng`] is the usual lightweight `Send` substitute.
+fn new_refresh_task_rng() -> StdRng {
+    let mut sys = SysRng;
+    StdRng::try_from_rng(&mut sys).expect("SysRng must seed StdRng")
+}
+
 async fn refresh_task<T>(
     token_provider: Arc<T>,
     tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
 ) where
     T: TokenProvider + Send + Sync + 'static,
 {
-    // `rand::rng()` returns `ThreadRng`, which is not `Send` and cannot be held
-    // across `.await` in this `tokio::spawn` task. Seed a `StdRng` from the OS instead.
-    let mut sys = SysRng;
-    let mut rng = StdRng::try_from_rng(&mut sys).expect("SysRng must seed StdRng");
+    let mut rng = new_refresh_task_rng();
     refresh_task_impl(token_provider, tx_token, &mut rng).await;
 }
 

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -19,6 +19,8 @@ use crate::credentials::{CacheableResource, EntityTag};
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use http::Extensions;
 use rand::RngExt;
+use rand::SeedableRng;
+use rand::rngs::{StdRng, SysRng};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant, sleep};
@@ -27,14 +29,10 @@ use tokio::time::{Duration, Instant, sleep};
 // determine when to refresh a token. Most MDS' refresh token 5 mins before
 // expiry, except for Serverless which refresh tokens 4 mins before
 // expiry. So we are using 4 mins as the staleness limit for our refresh logic.
-const NORMAL_REFRESH_SLACK_SECS: u64 = 240;
-const SHORT_REFRESH_SLACK_SECS: u64 = 10;
-const NORMAL_REFRESH_SLACK: Duration = Duration::from_secs(NORMAL_REFRESH_SLACK_SECS);
-const SHORT_REFRESH_SLACK: Duration = Duration::from_secs(SHORT_REFRESH_SLACK_SECS);
-/// Upper bound on jitter for the main refresh sleep: `NORMAL_REFRESH_SLACK / 4` (#1587).
-const REFRESH_JITTER_CAP: Duration = Duration::from_secs(NORMAL_REFRESH_SLACK_SECS / 4);
-/// Upper bound on jitter for [`SHORT_REFRESH_SLACK`] sleeps: `SHORT_REFRESH_SLACK / 2` (#1587).
-const SHORT_REFRESH_JITTER_CAP: Duration = Duration::from_secs(SHORT_REFRESH_SLACK_SECS / 2);
+const NORMAL_REFRESH_SLACK: Duration = Duration::from_secs(240);
+const REFRESH_JITTER_CAP: Duration = NORMAL_REFRESH_SLACK.checked_div(4).unwrap();
+const SHORT_REFRESH_SLACK: Duration = Duration::from_secs(10);
+const SHORT_REFRESH_JITTER_CAP: Duration = SHORT_REFRESH_SLACK.checked_div(2).unwrap();
 
 #[derive(Debug, Clone)]
 pub(crate) struct TokenCache {
@@ -102,7 +100,7 @@ async fn wait_for_next_token(
 
 /// Returns a duration in `[base - max_jitter, base]` (uniformly) so independent
 /// credential caches are less likely to hit the token endpoint at the same
-/// instant (#1587).
+/// instant.
 fn jittered_sleep_duration_with_rng<R: RngExt + ?Sized>(
     base: Duration,
     jitter_cap: Duration,
@@ -126,20 +124,18 @@ async fn refresh_task<T>(
 ) where
     T: TokenProvider + Send + Sync + 'static,
 {
-    fn sleep_duration_with_thread_rng(base: Duration, cap: Duration) -> Duration {
-        let mut rng = rand::rng();
-        jittered_sleep_duration_with_rng(base, cap, &mut rng)
-    }
-
-    refresh_task_impl(token_provider, tx_token, sleep_duration_with_thread_rng).await;
+    let mut sys = SysRng;
+    let mut rng = StdRng::try_from_rng(&mut sys).expect("SysRng must seed StdRng");
+    refresh_task_impl(token_provider, tx_token, &mut rng).await;
 }
 
-async fn refresh_task_impl<T>(
+async fn refresh_task_impl<T, R>(
     token_provider: Arc<T>,
     tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
-    mut jitter_fn: impl FnMut(Duration, Duration) -> Duration + Send,
+    rng: &mut R,
 ) where
     T: TokenProvider + Send + Sync + 'static,
+    R: RngExt + Send + ?Sized,
 {
     loop {
         let token_result = token_provider.token().await;
@@ -162,15 +158,20 @@ async fn refresh_task_impl<T>(
                     }
                     Some(time_until_expiry) => {
                         if time_until_expiry > NORMAL_REFRESH_SLACK {
-                            let wait = jitter_fn(
+                            let wait = jittered_sleep_duration_with_rng(
                                 time_until_expiry - NORMAL_REFRESH_SLACK,
                                 REFRESH_JITTER_CAP,
+                                rng,
                             );
                             sleep(wait).await;
                         } else if time_until_expiry > SHORT_REFRESH_SLACK {
                             // If expiry is less than 4 mins, try to refresh every 10 seconds
                             // This is to handle cases where MDS **repeatedly** returns about to expire tokens.
-                            let wait = jitter_fn(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
+                            let wait = jittered_sleep_duration_with_rng(
+                                SHORT_REFRESH_SLACK,
+                                SHORT_REFRESH_JITTER_CAP,
+                                rng,
+                            );
                             sleep(wait).await;
                         }
                     }
@@ -178,17 +179,17 @@ async fn refresh_task_impl<T>(
             }
             Ok(None) => {
                 // If there is no expiry, the token is valid forever, so no need to refresh
-                // TODO(#1553): Validate that all auth backends provide expiry and make expiry not optional.
+                // TODO: Validate that all auth backends provide expiry and make expiry not optional.
                 break;
             }
             Err(err) => {
                 // On transient errors, even if the retry policy is exhausted,
                 // we want to continue running this retry loop.
                 // This loop cannot stop because that may leave the
-                // credentials in an unrecoverable state (see #4541).
+                // credentials in an unrecoverable state.
                 // We considered using a notification to wake up the next time
                 // a caller wants to retrieve a token, but that seemed prone to
-                // deadlocks. We may implement this as an improvement (#4593).
+                // deadlocks. We may implement this as an improvement.
                 // On permanent errors, then there is really no point in trying
                 // again, by definition of "permanent". If the error was misclassified
                 // as permanent, that is a bug in the retry policy and better fixed
@@ -196,7 +197,11 @@ async fn refresh_task_impl<T>(
                 if !err.is_transient() {
                     break;
                 }
-                let wait = jitter_fn(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
+                let wait = jittered_sleep_duration_with_rng(
+                    SHORT_REFRESH_SLACK,
+                    SHORT_REFRESH_JITTER_CAP,
+                    rng,
+                );
                 sleep(wait).await;
             }
         }
@@ -218,8 +223,34 @@ mod tests {
     static TOKEN_VALID_DURATION: Duration = Duration::from_secs(3600);
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
-    /// Deterministic `TryRng` for tests. A stream of identical values can make
-    /// `random_range` reject forever for some sampled types, so this advances.
+    /// [`TryRng`] that always draws `u64::MAX` so `random_range` tends to sample
+    /// the upper end of the jitter range (see `refresh_task_impl_jitter_shortens_main_refresh_sleep`).
+    #[derive(Clone, Copy, Default)]
+    struct AlwaysMaxU64Rng;
+
+    impl TryRng for AlwaysMaxU64Rng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> std::result::Result<u32, Self::Error> {
+            Ok(u32::MAX)
+        }
+
+        fn try_next_u64(&mut self) -> std::result::Result<u64, Self::Error> {
+            Ok(u64::MAX)
+        }
+
+        fn try_fill_bytes(
+            &mut self,
+            dest: &mut [u8],
+        ) -> std::result::Result<(), Self::Error> {
+            dest.fill(0xff);
+            Ok(())
+        }
+    }
+
+    /// Deterministic `TryRng` for tests. First `try_next_u64` is `0`, so the first jitter
+    /// draw is unjittered (legacy behavior). Values then increase: a constant stream breaks
+    /// `rand`'s `UniformDuration` rejection sampling.
     #[derive(Clone, Default)]
     struct CountingRng(u64);
 
@@ -245,6 +276,14 @@ mod tests {
             }
             Ok(())
         }
+    }
+
+    #[test]
+    fn jittered_sleep_duration_counting_rng_first_draw_is_unjittered_base() {
+        let base = Duration::from_secs(3360);
+        let mut rng = CountingRng::default();
+        let got = jittered_sleep_duration_with_rng(base, REFRESH_JITTER_CAP, &mut rng);
+        assert_eq!(got, base);
     }
 
     #[test]
@@ -331,7 +370,7 @@ mod tests {
         assert!(result.is_err(), "{result:?}");
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn expired_token_success() -> TestResult {
         let now = Instant::now();
 
@@ -376,7 +415,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn expired_token_failure() -> TestResult {
         let now = Instant::now();
 
@@ -481,10 +520,7 @@ mod tests {
 
         tokio::spawn(async move {
             let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
-                jittered_sleep_duration_with_rng(base, cap, &mut rng)
-            })
-            .await;
+            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
         // Give the refresh task a chance to run
@@ -499,7 +535,66 @@ mod tests {
         assert_eq!(actual, token2.clone());
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
+    async fn refresh_task_impl_jitter_shortens_main_refresh_sleep() {
+        let now = Instant::now();
+        let long_expiry = TOKEN_VALID_DURATION;
+        let token1 = Token {
+            token: "token1".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(now + long_expiry),
+            metadata: None,
+        };
+        let token1_clone = token1.clone();
+        let token2 = Token {
+            token: "token2".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_at: Some(now + 2 * long_expiry),
+            metadata: None,
+        };
+        let token2_clone = token2.clone();
+
+        let mut mock = MockTokenProvider::new();
+        mock.expect_token()
+            .times(1)
+            .return_once(|| Ok(token1_clone));
+        mock.expect_token()
+            .times(1)
+            .return_once(|| Ok(token2_clone));
+
+        let (tx, mut rx) = watch::channel::<Option<Result<(Token, EntityTag)>>>(None);
+
+        tokio::spawn(async move {
+            let mut rng = AlwaysMaxU64Rng;
+            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
+        });
+
+        rx.changed().await.unwrap();
+        assert_eq!(
+            rx.borrow().as_ref().unwrap().as_ref().unwrap().0.token,
+            "token1"
+        );
+
+        let base = long_expiry - NORMAL_REFRESH_SLACK;
+        let max_jitter = REFRESH_JITTER_CAP.min(base / 4);
+        assert!(
+            max_jitter > Duration::ZERO,
+            "test requires non-zero jitter cap"
+        );
+
+        tokio::time::advance(base - max_jitter).await;
+        tokio::task::yield_now().await;
+
+        tokio::time::timeout(Duration::from_secs(5), rx.changed())
+            .await
+            .expect("timed out waiting for refresh after jitter-shortened sleep")
+            .unwrap();
+
+        let (actual, ..) = rx.borrow().clone().unwrap().unwrap();
+        assert_eq!(actual.token, "token2");
+    }
+
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn refresh_task_loop() {
         let now = Instant::now();
 
@@ -548,10 +643,7 @@ mod tests {
 
         tokio::spawn(async move {
             let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
-                jittered_sleep_duration_with_rng(base, cap, &mut rng)
-            })
-            .await;
+            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
         rx.changed().await.unwrap();
@@ -584,7 +676,7 @@ mod tests {
         assert_eq!(actual, token3);
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn refresh_task_loop_less_expiry() {
         let now = Instant::now();
 
@@ -626,10 +718,7 @@ mod tests {
 
         tokio::spawn(async move {
             let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
-                jittered_sleep_duration_with_rng(base, cap, &mut rng)
-            })
-            .await;
+            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
         rx.changed().await.unwrap();
@@ -658,7 +747,7 @@ mod tests {
         assert_eq!(actual, token2);
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn refresh_task_loop_long_expiry_waits_long_time_before_refresh() {
         let now = Instant::now();
 
@@ -695,10 +784,7 @@ mod tests {
 
         tokio::spawn(async move {
             let mut rng = CountingRng::default();
-            refresh_task_impl(Arc::new(mock), tx, move |base, cap| {
-                jittered_sleep_duration_with_rng(base, cap, &mut rng)
-            })
-            .await;
+            refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
         rx.changed().await.unwrap();
@@ -717,7 +803,7 @@ mod tests {
         assert_eq!(actual, token2);
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test(start_paused = true, flavor = "current_thread")]
     async fn refresh_task_sleeps_on_transient_error_and_recovers_on_next_loop() -> TestResult {
         let now = Instant::now();
 

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -502,7 +502,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn refresh_task_impl_jitter_shortens_main_refresh_sleep() {
+    async fn refresh_task_impl_jitter_shortens_main_refresh_sleep() -> TestResult {
         let now = Instant::now();
         let long_expiry = TOKEN_VALID_DURATION;
         let token1 = Token {
@@ -545,20 +545,30 @@ mod tests {
             refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
-        rx.changed().await.unwrap();
-        let (actual, ..) = rx.borrow().clone().unwrap().unwrap();
-        assert_eq!(actual.token, "token1");
+        rx.changed()
+            .await
+            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+
+        let actual = rx.borrow().clone();
+        assert!(
+            matches!(&actual, Some(Ok((t, _))) if t.token == "token1"),
+            "{actual:?}"
+        );
 
         tokio::time::advance(base - max_jitter).await;
         tokio::task::yield_now().await;
 
         tokio::time::timeout(Duration::from_secs(5), rx.changed())
             .await
-            .expect("timed out waiting for refresh after jitter-shortened sleep")
-            .unwrap();
+            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?
+            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
 
-        let (actual, ..) = rx.borrow().clone().unwrap().unwrap();
-        assert_eq!(actual.token, "token2");
+        let actual = rx.borrow().clone();
+        assert!(
+            matches!(&actual, Some(Ok((t, _))) if t.token == "token2"),
+            "{actual:?}"
+        );
+        Ok(())
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -551,9 +551,7 @@ mod tests {
             refresh_task_impl(Arc::new(mock), tx, &mut rng).await;
         });
 
-        rx.changed()
-            .await
-            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+        rx.changed().await?;
 
         let actual = rx.borrow().clone();
         assert!(
@@ -564,10 +562,7 @@ mod tests {
         tokio::time::advance(base - max_jitter).await;
         tokio::task::yield_now().await;
 
-        tokio::time::timeout(Duration::from_secs(5), rx.changed())
-            .await
-            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?
-            .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+        tokio::time::timeout(Duration::from_secs(5), rx.changed()).await??;
 
         let actual = rx.borrow().clone();
         assert!(

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -18,6 +18,8 @@ use crate::Result;
 use crate::credentials::{CacheableResource, EntityTag};
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use http::Extensions;
+#[cfg(not(test))]
+use rand::RngExt;
 use std::sync::Arc;
 use tokio::sync::watch;
 use tokio::time::{Duration, Instant, sleep};
@@ -28,6 +30,11 @@ use tokio::time::{Duration, Instant, sleep};
 // expiry. So we are using 4 mins as the staleness limit for our refresh logic.
 const NORMAL_REFRESH_SLACK: Duration = Duration::from_secs(240);
 const SHORT_REFRESH_SLACK: Duration = Duration::from_secs(10);
+/// Upper bound on how much we randomize the scheduled refresh instant. Spreads
+/// load when many independent caches refresh on a similar cadence (#1587).
+const REFRESH_JITTER_CAP: Duration = Duration::from_secs(60);
+/// Jitter cap for the short fixed delays (`SHORT_REFRESH_SLACK`).
+const SHORT_REFRESH_JITTER_CAP: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone)]
 pub(crate) struct TokenCache {
@@ -93,6 +100,33 @@ async fn wait_for_next_token(
     token_result.expect("There should always be a token or error in the channel after changed()")
 }
 
+/// Returns a duration in `[base - max_jitter, base]` (uniformly) so independent
+/// credential caches are less likely to hit the token endpoint at the same
+/// instant. In unit tests the crate is built with `cfg(test)` and jitter is
+/// disabled so timing assertions stay stable.
+fn jittered_sleep_duration(base: Duration, jitter_cap: Duration) -> Duration {
+    if base.is_zero() {
+        return base;
+    }
+
+    #[cfg(test)]
+    {
+        let _ = jitter_cap;
+        base
+    }
+
+    #[cfg(not(test))]
+    {
+        let max_jitter = jitter_cap.min(base / 4);
+        if max_jitter.is_zero() {
+            base
+        } else {
+            let jitter = rand::rng().random_range(Duration::ZERO..=max_jitter);
+            base.saturating_sub(jitter)
+        }
+    }
+}
+
 async fn refresh_task<T>(
     token_provider: Arc<T>,
     tx_token: watch::Sender<Option<Result<(Token, EntityTag)>>>,
@@ -120,11 +154,19 @@ async fn refresh_task<T>(
                     }
                     Some(time_until_expiry) => {
                         if time_until_expiry > NORMAL_REFRESH_SLACK {
-                            sleep(time_until_expiry - NORMAL_REFRESH_SLACK).await;
+                            let wait = jittered_sleep_duration(
+                                time_until_expiry - NORMAL_REFRESH_SLACK,
+                                REFRESH_JITTER_CAP,
+                            );
+                            sleep(wait).await;
                         } else if time_until_expiry > SHORT_REFRESH_SLACK {
                             // If expiry is less than 4 mins, try to refresh every 10 seconds
                             // This is to handle cases where MDS **repeatedly** returns about to expire tokens.
-                            sleep(SHORT_REFRESH_SLACK).await;
+                            let wait = jittered_sleep_duration(
+                                SHORT_REFRESH_SLACK,
+                                SHORT_REFRESH_JITTER_CAP,
+                            );
+                            sleep(wait).await;
                         }
                     }
                 }
@@ -149,7 +191,8 @@ async fn refresh_task<T>(
                 if !err.is_transient() {
                     break;
                 }
-                sleep(SHORT_REFRESH_SLACK).await;
+                let wait = jittered_sleep_duration(SHORT_REFRESH_SLACK, SHORT_REFRESH_JITTER_CAP);
+                sleep(wait).await;
             }
         }
     }


### PR DESCRIPTION
Fixes #1587
## Background
The auth stack wraps many credential types in `TokenCache`, which runs a background loop to refresh access tokens before they expire. Each cache picks its next wake time from the token’s `expires_at`, using fixed slack (4 minutes before expiry for “normal” lifetimes, shorter intervals when the token is almost stale).
When an application creates several caches at roughly the same time—common in workers, pools, or service startup—those tokens often end up with **aligned expiry and refresh schedules**. Every cache then wakes together and issues refresh traffic in a **single spike**. That pattern is hard on token endpoints and on constrained backends
such as the metadata service (connection limits).
## What this PR does
This change **adds bounded jitter** to the sleeps in `refresh_task` so independent caches **spread their refresh attempts over a small time window** instead of a single instant.
Behavior:
- For the usual case (time until expiry is greater than the normal slack), the task still aims to wake **before** expiry using the same slack as before; the sleep length is now **`base − U(0, J)`**, where **`J`** is limited to **at most 60 seconds** and **at most one quarter** of the computed base sleep. That keeps refreshes safely inside
the existing margin.
- For the short fixed sleeps (tight loop near expiry and transient-error backoff), jitter uses the same “**≤ one quarter of base**” idea with a **smaller absolute cap (5 seconds)** so those paths don’t smear unpredictably.
`rand` is added as a normal dependency with the **`thread_rng`** feature (consistent with other crates in the workspace).
## Tests and build
- Jitter is **turned off under `cfg(test)`** so the existing virtual-clock tests in `token_cache` remain deterministic.
- `cargo test -p google-cloud-auth` and `cargo clippy -p google-cloud-auth --all-targets -- -D warnings` were run successfully.
