### PR TITLE
feat(lro): introduce `PollerOptions` and bump 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3524,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-lro"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -478,7 +478,7 @@ google-cloud-api         = { default-features = false, version = "1.6.0", path =
 google-cloud-iam-v1      = { default-features = false, version = "1.9.0", path = "src/generated/iam/v1" }
 google-cloud-location    = { default-features = false, version = "1.9.0", path = "src/generated/cloud/location" }
 google-cloud-longrunning = { default-features = false, version = "1.10.0", path = "src/generated/longrunning" }
-google-cloud-lro         = { default-features = false, version = "1.6.0", path = "src/lro" }
+google-cloud-lro         = { default-features = false, version = "1.7.0", path = "src/lro" }
 google-cloud-rpc         = { default-features = false, version = "1.5.0", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
 google-cloud-type        = { default-features = false, version = "1.5.0", path = "src/generated/type" }
 # These are used by specific generated libraries.

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -19,7 +19,7 @@ name        = "google-cloud-lro"
 #     version of all downstream dependencies. For details see:
 #         https://github.com/googleapis/google-cloud-rust/issues/3237
 #         https://github.com/googleapis/google-cloud-rust/issues/3265
-version = "1.6.0"
+version = "1.7.0"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -22,9 +22,14 @@ mod aip151;
 mod discovery;
 #[allow(deprecated)]
 pub use aip151::{
-    Operation, PollerOptions, TracingDetails, new_poller, new_poller_with_options,
-    new_unit_metadata_poller, new_unit_metadata_poller_with_options, new_unit_poller,
-    new_unit_poller_with_options, new_unit_response_poller, new_unit_response_poller_with_options,
+    Operation, new_poller, new_unit_metadata_poller, new_unit_poller, new_unit_response_poller,
+};
+
+#[cfg(google_cloud_unstable_tracing)]
+#[allow(deprecated)]
+pub use aip151::{
+    PollerOptions, TracingDetails, new_poller_with_options, new_unit_metadata_poller_with_options,
+    new_unit_poller_with_options, new_unit_response_poller_with_options,
 };
 
 pub use discovery::{DiscoveryOperation, new_discovery_poller};

--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -22,8 +22,9 @@ mod aip151;
 mod discovery;
 #[allow(deprecated)]
 pub use aip151::{
-    Operation, PollerOptions, new_poller, new_poller_with_options, new_unit_metadata_poller,
-    new_unit_poller, new_unit_response_poller,
+    Operation, PollerOptions, TracingDetails, new_poller, new_poller_with_options,
+    new_unit_metadata_poller, new_unit_metadata_poller_with_options, new_unit_poller,
+    new_unit_poller_with_options, new_unit_response_poller, new_unit_response_poller_with_options,
 };
 
 pub use discovery::{DiscoveryOperation, new_discovery_poller};

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -61,6 +61,7 @@ where
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct TracingDetails {
+    /// The fully qualified RPC method name.
     pub method_name: &'static str,
 }
 
@@ -68,6 +69,7 @@ pub struct TracingDetails {
 #[derive(Default)]
 #[non_exhaustive]
 pub struct PollerOptions {
+    /// Telemetry tracing details, if active.
     pub tracing: Option<TracingDetails>,
 }
 

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -133,12 +133,35 @@ where
     Q: Fn(String) -> QF + Send + Sync + Clone,
     QF: std::future::Future<Output = Result<Operation<Empty, MetadataType>>> + Send + 'static,
 {
-    let poller = new_poller_with_options(
+    new_unit_response_poller_with_options(
         polling_error_policy,
         polling_backoff_policy,
         start,
         query,
         PollerOptions::default(),
+    )
+}
+
+pub fn new_unit_response_poller_with_options<MetadataType, S, SF, Q, QF>(
+    polling_error_policy: Arc<dyn PollingErrorPolicy>,
+    polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
+    start: S,
+    query: Q,
+    options: PollerOptions,
+) -> impl Poller<(), MetadataType>
+where
+    MetadataType: Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<Operation<Empty, MetadataType>>> + Send + 'static,
+    Q: Fn(String) -> QF + Send + Sync + Clone,
+    QF: std::future::Future<Output = Result<Operation<Empty, MetadataType>>> + Send + 'static,
+{
+    let poller = new_poller_with_options(
+        polling_error_policy,
+        polling_backoff_policy,
+        start,
+        query,
+        options,
     );
     UnitResponsePoller::new(poller)
 }
@@ -160,12 +183,35 @@ where
     Q: Fn(String) -> QF + Send + Sync + Clone,
     QF: std::future::Future<Output = Result<Operation<ResponseType, Empty>>> + Send + 'static,
 {
-    let poller = new_poller_with_options(
+    new_unit_metadata_poller_with_options(
         polling_error_policy,
         polling_backoff_policy,
         start,
         query,
         PollerOptions::default(),
+    )
+}
+
+pub fn new_unit_metadata_poller_with_options<ResponseType, S, SF, Q, QF>(
+    polling_error_policy: Arc<dyn PollingErrorPolicy>,
+    polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
+    start: S,
+    query: Q,
+    options: PollerOptions,
+) -> impl Poller<ResponseType, ()>
+where
+    ResponseType: Message + serde::ser::Serialize + serde::de::DeserializeOwned + Send,
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<Operation<ResponseType, Empty>>> + Send + 'static,
+    Q: Fn(String) -> QF + Send + Sync + Clone,
+    QF: std::future::Future<Output = Result<Operation<ResponseType, Empty>>> + Send + 'static,
+{
+    let poller = new_poller_with_options(
+        polling_error_policy,
+        polling_backoff_policy,
+        start,
+        query,
+        options,
     );
     UnitMetadataPoller::new(poller)
 }
@@ -186,12 +232,34 @@ where
     Q: Fn(String) -> QF + Send + Sync + Clone,
     QF: std::future::Future<Output = Result<Operation<Empty, Empty>>> + Send + 'static,
 {
-    let poller = new_poller_with_options(
+    new_unit_poller_with_options(
         polling_error_policy,
         polling_backoff_policy,
         start,
         query,
         PollerOptions::default(),
+    )
+}
+
+pub fn new_unit_poller_with_options<S, SF, Q, QF>(
+    polling_error_policy: Arc<dyn PollingErrorPolicy>,
+    polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
+    start: S,
+    query: Q,
+    options: PollerOptions,
+) -> impl Poller<(), ()>
+where
+    S: FnOnce() -> SF + Send + Sync,
+    SF: std::future::Future<Output = Result<Operation<Empty, Empty>>> + Send + 'static,
+    Q: Fn(String) -> QF + Send + Sync + Clone,
+    QF: std::future::Future<Output = Result<Operation<Empty, Empty>>> + Send + 'static,
+{
+    let poller = new_poller_with_options(
+        polling_error_policy,
+        polling_backoff_policy,
+        start,
+        query,
+        options,
     );
     UnitResponsePoller::new(UnitMetadataPoller::new(poller))
 }

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -58,6 +58,7 @@ where
 }
 
 /// Details for tracing a poller.
+#[allow(dead_code)]
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct TracingDetails {
@@ -66,6 +67,7 @@ pub struct TracingDetails {
 }
 
 /// Options for creating a new poller.
+#[allow(dead_code)]
 #[derive(Default)]
 #[non_exhaustive]
 pub struct PollerOptions {

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -142,6 +142,10 @@ where
     )
 }
 
+/// Creates a new `impl Poller<(), M>` with options.
+///
+/// This is intended as an implementation detail of the generated clients.
+/// Applications should have no need to use this function directly.
 pub fn new_unit_response_poller_with_options<MetadataType, S, SF, Q, QF>(
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
@@ -192,6 +196,10 @@ where
     )
 }
 
+/// Creates a new `impl Poller<R, ()>` with options.
+///
+/// This is intended as an implementation detail of the generated clients.
+/// Applications should have no need to use this function directly.
 pub fn new_unit_metadata_poller_with_options<ResponseType, S, SF, Q, QF>(
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,
@@ -241,6 +249,10 @@ where
     )
 }
 
+/// Creates a new `impl Poller<(), ()>` with options.
+///
+/// This is intended as an implementation detail of the generated clients.
+/// Applications should have no need to use this function directly.
 pub fn new_unit_poller_with_options<S, SF, Q, QF>(
     polling_error_policy: Arc<dyn PollingErrorPolicy>,
     polling_backoff_policy: Arc<dyn PollingBackoffPolicy>,

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -128,6 +128,7 @@ pub enum PollingResult<ResponseType, MetadataType> {
 #[allow(missing_docs)]
 pub mod internal;
 
+#[cfg(google_cloud_unstable_tracing)]
 pub use internal::{PollerOptions, TracingDetails};
 
 pub(crate) mod sealed {

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -128,6 +128,8 @@ pub enum PollingResult<ResponseType, MetadataType> {
 #[allow(missing_docs)]
 pub mod internal;
 
+pub use internal::{PollerOptions, TracingDetails};
+
 pub(crate) mod sealed {
     pub trait Poller {}
 }


### PR DESCRIPTION
Add new polling option helper functions to support instrumentation and telemetry tracing.

The minor version bump to `1.7.0` reflects the backwards-compatible addition of these new public APIs.

For https://github.com/googleapis/google-cloud-rust/issues/5623