### PR TITLE
cleanup: remove warn missing_docs attributes from handwritten crates

### DIFF
--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -52,8 +52,6 @@
 //! [Tokens]: https://cloud.google.com/docs/authentication#token
 //! [Credentials]: https://cloud.google.com/docs/authentication#credentials
 
-#![warn(missing_docs)]
-
 pub(crate) mod access_boundary;
 pub mod build_errors;
 pub(crate) mod constants;

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(missing_docs)]
-
 //! Google Cloud Client Libraries for Rust - BigQuery
 //!
 //! **WARNING:** this crate is under active development. We expect multiple

--- a/src/bigtable/src/lib.rs
+++ b/src/bigtable/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(missing_docs)]
-
 //! Google Cloud Client Libraries for Rust - Bigtable
 //!
 //! **WARNING:** this crate is under active development. We expect multiple

--- a/src/datastore/src/lib.rs
+++ b/src/datastore/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(missing_docs)]
-
 //! Google Cloud Client Libraries for Rust - Datastore
 //!
 //! **WARNING:** this crate is under active development. We expect multiple

--- a/src/firestore/src/lib.rs
+++ b/src/firestore/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![warn(missing_docs)]
-
 //! Google Cloud Client Libraries for Rust - Cloud Firestore API
 //!
 //! **WARNING:** this crate is under active development. We expect multiple

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -26,7 +26,6 @@
 //! </div>
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
 
 /// An alias of [std::result::Result] where the error is always [Error][crate::error::Error].
 ///

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -86,7 +86,6 @@
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
 
 use google_cloud_gax::Result;
 use google_cloud_gax::error::Error;

--- a/src/pubsub/src/lib.rs
+++ b/src/pubsub/src/lib.rs
@@ -50,7 +50,6 @@
 //! [ring]: https://crates.io/crates/ring
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
 
 #[allow(rustdoc::broken_intra_doc_links)]
 pub(crate) mod generated;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -43,7 +43,6 @@
 //! [ring]: https://crates.io/crates/ring
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
 
 pub use google_cloud_gax::Result;
 pub use google_cloud_gax::error::Error;

--- a/src/wkt/src/lib.rs
+++ b/src/wkt/src/lib.rs
@@ -19,7 +19,6 @@
 //! native or commonly used Rust types.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs)]
 
 mod any;
 pub use crate::any::*;


### PR DESCRIPTION
This is now covered via ci.

For #5459 