### PR TITLE
docs: update dev and agents docs to include stricter lint checks

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -123,6 +123,31 @@ For example:
 cargo clippy -p google-cloud-storage --profile test -- -D warnings
 ```
 
+We have a more comprehensive strict check as part of our CI (see
+`.gcb/scripts/lint.sh`) that enforces stricter lints on all handwritten crates.
+
+To run this strict check for a specific crate, copy the exact lint flags defined
+in `.gcb/scripts/lint.sh` and run:
+
+```bash
+cargo clippy --all-features --no-deps -p ${crate_name} -- <flags from lint.sh>
+```
+
+For example, with flags like `-D missing_docs -D clippy::exhaustive_enums`:
+
+```bash
+cargo clippy --all-features --no-deps -p ${crate_name} -- -D missing_docs -D clippy::exhaustive_enums
+```
+
+Please refer to `.gcb/scripts/lint.sh` for the authoritative list of crates and
+exact set of lint flags currently subject to these checks.
+
+> [!IMPORTANT]
+> When editing or adding code within any of the handwritten crates, you MUST
+> check `.gcb/scripts/lint.sh` to find the list of covered crates and the exact
+> strict lint flags currently enforced, and run the strict clippy command for
+> the modified crate to ensure no new warnings are introduced.
+
 ### Code Formatter
 
 To format the code for the entire workspace, use the following command:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -136,7 +136,7 @@ cargo clippy --all-features --no-deps -p ${crate_name} -- <flags from lint.sh>
 For example, with flags like `-D missing_docs -D clippy::exhaustive_enums`:
 
 ```bash
-cargo clippy --all-features --no-deps -p ${crate_name} -- -D missing_docs -D clippy::exhaustive_enums
+cargo clippy --all-features --no-deps -p google-cloud-storage -- -D missing_docs -D clippy::exhaustive_enums
 ```
 
 Please refer to `.gcb/scripts/lint.sh` for the authoritative list of crates and

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -87,6 +87,13 @@ cargo fmt && cargo clippy --profile=test -- --deny warnings && cargo test
 git status # Shows any diffs created by `cargo fmt`
 ```
 
+> [!NOTE]
+> If you are modifying handwritten crates, note that our CI runs stricter lints
+> (such as missing documentation checks and exhaustive enums). Please refer to
+> the **Linter** section in [GEMINI.md](../../GEMINI.md) or check
+> [.gcb/scripts/lint.sh](../../.gcb/scripts/lint.sh) for the exact commands and
+> targeted crates to verify locally before submitting a PR.
+
 If you are seeing errors when running locally that are not present in the CI,
 you may need to update your local rust version.
 


### PR DESCRIPTION
We now run some stricter checks on our handwritten crates. To try to help devs catch this earlier in the developer cycle (ie before sending a PR for review), the documentation for AI Agents and human devs has been updated to make this more clear. 