### PR TITLE
ci(workspace): add spanner to strict clippy checks

### DIFF
--- a/.gcb/scripts/lint-unstable.sh
+++ b/.gcb/scripts/lint-unstable.sh
@@ -25,7 +25,7 @@ echo "==== cargo clippy ===="
 cargo clippy --all-features --all-targets --profile=test --workspace -- --deny warnings
 
 echo "==== cargo clippy strict (handwritten crates non-test mode) ===="
-cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
+cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-spanner -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
 
 echo "==== DONE ===="
 /workspace/.bin/sccache --show-stats

--- a/.gcb/scripts/lint.sh
+++ b/.gcb/scripts/lint.sh
@@ -25,7 +25,7 @@ echo "==== cargo clippy ===="
 cargo clippy --all-features --all-targets --profile=test --workspace -- --deny warnings
 
 echo "==== cargo clippy strict (handwritten crates non-test mode) ===="
-cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
+cargo clippy --all-features --no-deps -p google-cloud-auth -p google-cloud-bigquery -p google-cloud-bigtable -p google-cloud-datastore -p google-cloud-firestore -p google-cloud-gax -p google-cloud-lro -p google-cloud-pubsub -p google-cloud-spanner -p google-cloud-storage -p google-cloud-wkt -- -D missing_docs -D clippy::exhaustive_enums
 
 echo "==== DONE ===="
 /workspace/.bin/sccache --show-stats

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -18,7 +18,11 @@
 //! breaking changes in the upcoming releases. Testing is also incomplete, we do
 //! **not** recommend that you use this crate in production. We welcome feedback
 //! about the APIs, documentation, missing features, bugs, etc.
-//!
+
+// TODO(#5537) - fix missing docs and remove this.
+#![allow(missing_docs, reason = "docs not yet complete")]
+// TODO(#5566) - stabilize API and remove this.
+#![allow(clippy::exhaustive_enums, reason = "API not yet stable")]
 
 pub use batch_dml::BatchDml;
 pub use batch_dml::BatchDmlBuilder;


### PR DESCRIPTION
This change adds the `google-cloud-spanner` crate to the list of handwritten crates checked with strict clippy flags (`-D missing_docs -D clippy::exhaustive_enums`) in the CI linting scripts.

To allow the checks to pass for the spanner crate, temporary `#![allow]` attributes are added to the crate root to suppress warnings for missing documentation and exhaustive enums, with TODOs referencing tracking issues for their future resolution. For specific items that don't need documentation or are intentionally exhaustive, these can be `#[allow]`ed at a more fine grained level upon resolution.

For #5537
For #5566