### PR TITLE
chore(deps): consolidate otel update PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     {
       "description": "Group all OpenTelemetry crates into a single PR",
       "matchPackagePatterns": ["opentelemetry"],
+      "matchManagers": ["cargo"],
       "groupName": "OpenTelemetry"
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Group all OpenTelemetry crates into a single PR",
+      "matchPackagePatterns": ["opentelemetry"],
+      "groupName": "OpenTelemetry"
+    }
+  ]
+}


### PR DESCRIPTION
Try to get renovate-bot to update all opentelemetry dependencies in a single PR. This gives us a chance at updating the dep without manual intervention (beyond approving, merging the PR).

Motivated by #5656 