### PR TITLE
chore: update librarian version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.12.2-0.20260508011052-ac66121ddb28
+version: v0.13.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
```
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
go: github.com/googleapis/librarian@v0.13.0 requires go >= 1.26.1; switching to go1.26.3
2026/05/12 19:58:49 WARN mismatched body in additional binding (see AIP-127) message=.google.devtools.cloudbuild.v1.RunBuildTriggerRequest topLevelBody=source additionalBindingBody=*
```