### PR TITLE
perf(spanner): inline-begin for read/write transactions (step 6)

### DIFF
--- a/src/spanner/src/batch_write_transaction.rs
+++ b/src/spanner/src/batch_write_transaction.rs
@@ -35,9 +35,11 @@ impl BatchWriteTransactionBuilder {
     /// Builds the [BatchWriteTransaction].
     pub fn build(self) -> BatchWriteTransaction {
         let session_name = self.client.session_name();
+        let channel_hint = self.client.spanner.next_channel_hint();
         BatchWriteTransaction {
             session_name,
             client: self.client,
+            channel_hint,
         }
     }
 }
@@ -49,6 +51,7 @@ impl BatchWriteTransactionBuilder {
 pub struct BatchWriteTransaction {
     session_name: String,
     client: DatabaseClient,
+    channel_hint: usize,
 }
 
 impl BatchWriteTransaction {
@@ -100,7 +103,7 @@ impl BatchWriteTransaction {
         let stream = self
             .client
             .spanner
-            .batch_write(req, crate::RequestOptions::default())
+            .batch_write(req, crate::RequestOptions::default(), self.channel_hint)
             .send()
             .await?;
         Ok(BatchWriteResponseStream { inner: stream })

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -20,6 +20,7 @@ use crate::precommit::PrecommitTokenTracker;
 use crate::result_set::{ResultSet, ResultSetParams, StreamOperation};
 use crate::statement::Statement;
 use crate::timestamp_bound::TimestampBound;
+use crate::transaction_retry_policy::is_aborted;
 use std::mem::replace;
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
@@ -652,6 +653,32 @@ impl ReadContextTransactionSelector {
         }
     }
 
+    /// Returns the transaction ID if it is already available, without waiting.
+    ///
+    /// This method inspects the selector and returns the transaction ID if the
+    /// transaction has already started. It returns `None` if the transaction
+    /// has not yet started or is in a state without an ID.
+    #[allow(dead_code)]
+    pub(crate) fn get_id_no_wait(&self) -> Option<bytes::Bytes> {
+        use crate::model::transaction_selector::Selector;
+        match self {
+            Self::Fixed(selector, _) => {
+                if let Some(Selector::Id(id)) = &selector.selector {
+                    return Some(id.clone());
+                }
+            }
+            Self::Lazy(lazy) => {
+                let guard = lazy.lock().expect("transaction state mutex poisoned");
+                if let TransactionState::Started(selector, _) = &*guard {
+                    if let Some(Selector::Id(id)) = &selector.selector {
+                        return Some(id.clone());
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Resets the selector state from `Starting` back to `NotStarted`.
     ///
     /// This is used during stream resume fallbacks when the first query stream
@@ -754,6 +781,9 @@ macro_rules! execute_stream_with_retry {
         {
             Ok(s) => s,
             Err(e) => {
+                if is_aborted(&e) {
+                    return Err(e);
+                }
                 if $self.begin_explicitly_if_not_started().await? {
                     $request.transaction = Some($self.transaction_selector.selector().await?);
                     $self

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -284,9 +284,16 @@ impl MultiUseReadOnlyTransactionBuilder {
         session_name: String,
         options: TransactionOptions,
         channel_hint: usize,
+        request_options: crate::RequestOptions,
     ) -> crate::Result<ReadContextTransactionSelector> {
-        let response =
-            execute_begin_transaction(&self.client, session_name, options, channel_hint).await?;
+        let response = execute_begin_transaction(
+            &self.client,
+            session_name,
+            options,
+            channel_hint,
+            request_options,
+        )
+        .await?;
 
         let transaction_selector = crate::model::TransactionSelector::default().set_id(response.id);
 
@@ -319,8 +326,13 @@ impl MultiUseReadOnlyTransactionBuilder {
         let session_name = self.client.session_name();
         let channel_hint = self.client.spanner.next_channel_hint();
         let selector = if self.explicit_begin {
-            self.begin(session_name.clone(), options, channel_hint)
-                .await?
+            self.begin(
+                session_name.clone(),
+                options,
+                channel_hint,
+                crate::RequestOptions::default(),
+            )
+            .await?
         } else {
             ReadContextTransactionSelector::Lazy(Arc::new(Mutex::new(
                 TransactionState::NotStarted(options),
@@ -442,15 +454,15 @@ async fn execute_begin_transaction(
     session_name: String,
     options: crate::model::TransactionOptions,
     channel_hint: usize,
+    request_options: crate::RequestOptions,
 ) -> crate::Result<crate::model::Transaction> {
     let request = crate::model::BeginTransactionRequest::default()
         .set_session(session_name)
         .set_options(options);
 
-    // TODO(#4972): make request options configurable
     client
         .spanner
-        .begin_transaction(request, crate::RequestOptions::default(), channel_hint)
+        .begin_transaction(request, request_options, channel_hint)
         .await
 }
 
@@ -544,6 +556,7 @@ impl ReadContextTransactionSelector {
         client: &crate::database_client::DatabaseClient,
         session_name: String,
         channel_hint: usize,
+        request_options: crate::RequestOptions,
     ) -> crate::Result<()> {
         let Self::Lazy(lazy) = self else {
             return Ok(());
@@ -576,33 +589,35 @@ impl ReadContextTransactionSelector {
         // Only the leader thread will reach this point to perform the explicit begin.
         // Waiters are blocked in `poll_selector_status` waiting for the result,
         // and already completed states return early above.
-        let response =
-            match execute_begin_transaction(client, session_name.clone(), options, channel_hint)
-                .await
-            {
-                Ok(r) => r,
-                Err(e) => {
-                    let mut guard = lazy.lock().expect("transaction state mutex poisoned");
-                    let error = Arc::new(e);
-                    *guard = TransactionState::Failed(Arc::clone(&error));
-                    // Release the lock and notify all the waiting queries that
-                    // the transaction has failed.
-                    drop(guard);
-                    if let Some(notify) = notify_opt {
-                        notify.notify_waiters();
-                    }
-
-                    let return_error = if let Some(status) = error.status() {
-                        crate::Error::service(status.clone())
-                    } else {
-                        crate::error::internal_error(format!(
-                            "Transaction failed to start: {}",
-                            error
-                        ))
-                    };
-                    return Err(return_error);
+        let response = match execute_begin_transaction(
+            client,
+            session_name.clone(),
+            options,
+            channel_hint,
+            request_options,
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let mut guard = lazy.lock().expect("transaction state mutex poisoned");
+                let error = Arc::new(e);
+                *guard = TransactionState::Failed(Arc::clone(&error));
+                // Release the lock and notify all the waiting queries that
+                // the transaction has failed.
+                drop(guard);
+                if let Some(notify) = notify_opt {
+                    notify.notify_waiters();
                 }
-            };
+
+                let return_error = if let Some(status) = error.status() {
+                    crate::Error::service(status.clone())
+                } else {
+                    crate::error::internal_error(format!("Transaction failed to start: {}", error))
+                };
+                return Err(return_error);
+            }
+        };
 
         self.update(response.id, response.read_timestamp)?;
 
@@ -651,32 +666,6 @@ impl ReadContextTransactionSelector {
                 "got a transaction id for an already Started or Failed transaction",
             ))
         }
-    }
-
-    /// Returns the transaction ID if it is already available, without waiting.
-    ///
-    /// This method inspects the selector and returns the transaction ID if the
-    /// transaction has already started. It returns `None` if the transaction
-    /// has not yet started or is in a state without an ID.
-    #[allow(dead_code)]
-    pub(crate) fn get_id_no_wait(&self) -> Option<bytes::Bytes> {
-        use crate::model::transaction_selector::Selector;
-        match self {
-            Self::Fixed(selector, _) => {
-                if let Some(Selector::Id(id)) = &selector.selector {
-                    return Some(id.clone());
-                }
-            }
-            Self::Lazy(lazy) => {
-                let guard = lazy.lock().expect("transaction state mutex poisoned");
-                if let TransactionState::Started(selector, _) = &*guard {
-                    if let Some(Selector::Id(id)) = &selector.selector {
-                        return Some(id.clone());
-                    }
-                }
-            }
-        }
-        None
     }
 
     /// Resets the selector state from `Starting` back to `NotStarted`.
@@ -753,7 +742,10 @@ impl ReadContext {
     /// Attempts to execute an explicit `begin_transaction` RPC if the current transaction
     /// selector is still in the `Lazy(NotStarted)` state. This is used as a
     /// fallback mechanism when an initial implicit begin attempt failed.
-    async fn begin_explicitly_if_not_started(&self) -> crate::Result<bool> {
+    async fn begin_explicitly_if_not_started(
+        &self,
+        request_options: crate::RequestOptions,
+    ) -> crate::Result<bool> {
         let ReadContextTransactionSelector::Lazy(lazy) = &self.transaction_selector else {
             return Ok(false);
         };
@@ -763,7 +755,12 @@ impl ReadContext {
         }
 
         self.transaction_selector
-            .begin_explicitly(&self.client, self.session_name.clone(), self.channel_hint)
+            .begin_explicitly(
+                &self.client,
+                self.session_name.clone(),
+                self.channel_hint,
+                request_options,
+            )
             .await?;
         Ok(true)
     }
@@ -784,7 +781,10 @@ macro_rules! execute_stream_with_retry {
                 if is_aborted(&e) {
                     return Err(e);
                 }
-                if $self.begin_explicitly_if_not_started().await? {
+                if $self
+                    .begin_explicitly_if_not_started($gax_options.clone())
+                    .await?
+                {
                     $request.transaction = Some($self.transaction_selector.selector().await?);
                     $self
                         .client

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -230,6 +230,12 @@ macro_rules! execute_with_retry {
                     return Err(error);
                 }
 
+                let mut begin_options = crate::RequestOptions::default();
+                if let Some(d) = $self.deadline {
+                    let remaining = d.saturating_duration_since(tokio::time::Instant::now());
+                    begin_options.set_attempt_timeout(remaining);
+                }
+
                 $self
                     .context
                     .transaction_selector
@@ -237,6 +243,7 @@ macro_rules! execute_with_retry {
                         &$self.context.client,
                         $self.context.session_name.clone(),
                         $self.context.channel_hint,
+                        begin_options,
                     )
                     .await?;
 

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -35,6 +35,7 @@ use crate::precommit::PrecommitTokenTracker;
 use crate::read_only_transaction::ReadContext;
 use crate::result_set::ResultSet;
 use crate::statement::Statement;
+use crate::transaction_retry_policy::is_aborted;
 use google_cloud_gax::error::Error as GaxError;
 use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
 use google_cloud_gax::retry_policy::RetryPolicy;
@@ -56,6 +57,7 @@ pub(crate) struct ReadWriteTransactionBuilder {
     pub(crate) session_name: String,
     return_commit_stats: bool,
     commit_priority: Priority,
+    explicit_begin: bool,
 }
 
 impl ReadWriteTransactionBuilder {
@@ -69,6 +71,7 @@ impl ReadWriteTransactionBuilder {
             session_name,
             return_commit_stats: false,
             commit_priority: Priority::Unspecified,
+            explicit_begin: false,
         }
     }
 
@@ -122,39 +125,62 @@ impl ReadWriteTransactionBuilder {
         self
     }
 
+    pub fn with_explicit_begin_transaction(mut self, explicit: bool) -> Self {
+        self.explicit_begin = explicit;
+        self
+    }
+
     pub(crate) async fn begin_transaction(
         &self,
         deadline: Option<Instant>,
     ) -> crate::Result<ReadWriteTransaction> {
+        self.clone()
+            .with_explicit_begin_transaction(true)
+            .build(deadline)
+            .await
+    }
+
+    pub(crate) async fn build(
+        &self,
+        deadline: Option<Instant>,
+    ) -> crate::Result<ReadWriteTransaction> {
         let session_name = self.session_name.clone();
-        let mut request = BeginTransactionRequest::default()
-            .set_session(session_name.clone())
-            .set_options(self.options.clone());
-        if let Some(tag) = &self.transaction_tag {
-            request = request.set_request_options(
-                crate::model::RequestOptions::default().set_transaction_tag(tag.clone()),
-            );
-        }
-
-        // TODO(#4972): make request options configurable
         let channel_hint = self.client.spanner.next_channel_hint();
-        let mut options = RequestOptions::default();
-        if let Some(d) = deadline {
-            let remaining = d.saturating_duration_since(Instant::now());
-            options.set_attempt_timeout(remaining);
-        }
+        let transaction_selector = if self.explicit_begin {
+            let mut request = BeginTransactionRequest::default()
+                .set_session(session_name.clone())
+                .set_options(self.options.clone());
+            if let Some(tag) = &self.transaction_tag {
+                request = request.set_request_options(
+                    crate::model::RequestOptions::default().set_transaction_tag(tag.clone()),
+                );
+            }
 
-        let response = self
-            .client
-            .spanner
-            .begin_transaction(request, options, channel_hint)
-            .await?;
+            // TODO(#4972): make request options configurable
+            let mut options = RequestOptions::default();
+            if let Some(d) = deadline {
+                let remaining = d.saturating_duration_since(Instant::now());
+                options.set_attempt_timeout(remaining);
+            }
 
-        let transaction_selector =
+            let response = self
+                .client
+                .spanner
+                .begin_transaction(request, options, channel_hint)
+                .await?;
+
             crate::read_only_transaction::ReadContextTransactionSelector::Fixed(
                 TransactionSelector::default().set_id(response.id),
                 None,
-            );
+            )
+        } else {
+            crate::read_only_transaction::ReadContextTransactionSelector::Lazy(Arc::new(
+                std::sync::Mutex::new(crate::read_only_transaction::TransactionState::NotStarted(
+                    self.options.clone(),
+                )),
+            ))
+        };
+
         Ok(ReadWriteTransaction {
             context: ReadContext {
                 session_name,
@@ -171,6 +197,72 @@ impl ReadWriteTransactionBuilder {
             commit_priority: self.commit_priority.clone(),
         })
     }
+}
+
+/// Helper macro to execute a DML or BatchDML RPC with retry logic if the
+/// request included a BeginTransaction option.
+macro_rules! execute_with_retry {
+    ($self:expr, $request:ident, $gax_options:expr, $rpc_method:ident, $extract_id:expr) => {{
+        let is_starting = matches!(
+            $request
+                .transaction
+                .as_ref()
+                .and_then(|t| t.selector.as_ref()),
+            Some(Selector::Begin(_))
+        );
+
+        let response_result = $self
+            .context
+            .client
+            .spanner
+            .$rpc_method(
+                $request.clone(),
+                $gax_options.clone(),
+                $self.context.channel_hint,
+            )
+            .await;
+
+        let response = match response_result {
+            Ok(response) => {
+                if is_starting {
+                    let id = $extract_id(&response).ok_or_else(|| {
+                        crate::error::internal_error("Transaction ID was not returned by Spanner")
+                    })?;
+                    $self.context.transaction_selector.update(id, None)?;
+                }
+                response
+            }
+            Err(error) => {
+                if !is_starting {
+                    return Err(error);
+                }
+                if is_aborted(&error) {
+                    return Err(error);
+                }
+
+                $self
+                    .context
+                    .transaction_selector
+                    .begin_explicitly(
+                        &$self.context.client,
+                        $self.context.session_name.clone(),
+                        $self.context.channel_hint,
+                    )
+                    .await?;
+
+                $request.transaction = Some($self.context.transaction_selector.selector().await?);
+
+                $self
+                    .context
+                    .client
+                    .spanner
+                    .$rpc_method($request.clone(), $gax_options, $self.context.channel_hint)
+                    .await?
+            }
+        };
+
+        response
+    }};
 }
 
 /// A read-write transaction.
@@ -228,12 +320,20 @@ impl ReadWriteTransaction {
             .set_seqno(seqno);
         request.request_options = self.context.amend_request_options(request.request_options);
 
-        let response = self
-            .context
-            .client
-            .spanner
-            .execute_sql(request, gax_options, self.context.channel_hint)
-            .await?;
+        let response = execute_with_retry!(
+            self,
+            request,
+            gax_options,
+            execute_sql,
+            |response: &crate::model::ResultSet| {
+                response
+                    .metadata
+                    .as_ref()
+                    .and_then(|md| md.transaction.as_ref())
+                    .map(|t| t.id.clone())
+            }
+        );
+
         self.context
             .precommit_token_tracker
             .update(response.precommit_token);
@@ -327,7 +427,7 @@ impl ReadWriteTransaction {
             .map(|stmt: crate::statement::Statement| stmt.into_batch_statement())
             .collect();
 
-        let request = ExecuteBatchDmlRequest::default()
+        let mut request = ExecuteBatchDmlRequest::default()
             .set_session(self.context.session_name.clone())
             .set_transaction(self.context.transaction_selector.selector().await?)
             .set_seqno(seqno)
@@ -336,22 +436,25 @@ impl ReadWriteTransaction {
                 self.context.amend_request_options(batch.request_options),
             );
 
-        let response_result = self
-            .context
-            .client
-            .spanner
-            .execute_batch_dml(request, batch.gax_options, self.context.channel_hint)
-            .await;
-
-        match response_result {
-            Ok(response) => {
-                self.context
-                    .precommit_token_tracker
-                    .update(response.precommit_token.clone());
-                crate::batch_dml::process_response(response)
+        let response = execute_with_retry!(
+            self,
+            request,
+            batch.gax_options,
+            execute_batch_dml,
+            |response: &crate::model::ExecuteBatchDmlResponse| {
+                response
+                    .result_sets
+                    .first()
+                    .and_then(|rs| rs.metadata.as_ref())
+                    .and_then(|md| md.transaction.as_ref())
+                    .map(|t| t.id.clone())
             }
-            Err(e) => Err(e),
-        }
+        );
+
+        self.context
+            .precommit_token_tracker
+            .update(response.precommit_token.clone());
+        crate::batch_dml::process_response(response)
     }
 
     pub(crate) async fn transaction_id(&self) -> crate::Result<bytes::Bytes> {
@@ -1251,5 +1354,151 @@ mod tests {
                 .seconds(),
             123456789
         );
+    }
+
+    #[tokio::test]
+    async fn read_write_transaction_execute_update_fallback() {
+        let mut mock = create_session_mock();
+
+        // 1. First DML attempt fails!
+        mock.expect_execute_sql().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.sql, "UPDATE Users SET Name = 'Alice' WHERE Id = 1");
+
+            let selector = req
+                .transaction
+                .expect("missing transaction selector")
+                .selector
+                .expect("missing selector");
+            match selector {
+                v1::transaction_selector::Selector::Begin(_) => {}
+                _ => panic!("Expected Selector::Begin"),
+            }
+
+            Err(tonic::Status::new(tonic::Code::Internal, "internal error"))
+        });
+
+        // 2. Client falls back to explicit BeginTransaction!
+        mock.expect_begin_transaction().once().returning(|_| {
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![7, 8, 9],
+                ..Default::default()
+            }))
+        });
+
+        // 3. Client retries DML with new ID!
+        mock.expect_execute_sql().once().returning(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.sql, "UPDATE Users SET Name = 'Alice' WHERE Id = 1");
+
+            let selector = req
+                .transaction
+                .expect("missing transaction selector")
+                .selector
+                .expect("missing selector");
+            match selector {
+                v1::transaction_selector::Selector::Id(id) => {
+                    assert_eq!(id, vec![7, 8, 9]);
+                }
+                _ => panic!("Expected Selector::Id"),
+            }
+
+            Ok(tonic::Response::new(v1::ResultSet {
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let tx = ReadWriteTransactionBuilder::new(db_client.clone())
+            .build(None)
+            .await
+            .expect("Failed to build transaction");
+
+        let count = tx
+            .execute_update("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .await
+            .expect("Failed to execute update after fallback");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn read_write_transaction_execute_batch_update_fallback() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        // 1. First Batch DML attempt fails!
+        mock.expect_execute_batch_dml().once().returning(|req| {
+            let req = req.into_inner();
+            let selector = req
+                .transaction
+                .expect("missing transaction selector")
+                .selector
+                .expect("missing selector");
+            match selector {
+                v1::transaction_selector::Selector::Begin(_) => {}
+                _ => panic!("Expected Selector::Begin"),
+            }
+
+            Err(tonic::Status::new(tonic::Code::Internal, "internal error"))
+        });
+
+        // 2. Client falls back to explicit BeginTransaction!
+        mock.expect_begin_transaction().once().returning(|_| {
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![4, 5, 6],
+                ..Default::default()
+            }))
+        });
+
+        // 3. Client retries Batch DML with new ID!
+        mock.expect_execute_batch_dml().once().returning(|req| {
+            let req = req.into_inner();
+            let selector = req
+                .transaction
+                .expect("missing transaction selector")
+                .selector
+                .expect("missing selector");
+            match selector {
+                v1::transaction_selector::Selector::Id(id) => {
+                    assert_eq!(id, vec![4, 5, 6]);
+                }
+                _ => panic!("Expected Selector::Id"),
+            }
+
+            Ok(tonic::Response::new(v1::ExecuteBatchDmlResponse {
+                result_sets: vec![v1::ResultSet {
+                    stats: Some(v1::ResultSetStats {
+                        row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }],
+                status: Some(spanner_grpc_mock::google::rpc::Status {
+                    code: 0,
+                    message: "OK".into(),
+                    details: vec![],
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let tx = ReadWriteTransactionBuilder::new(db_client)
+            .build(None)
+            .await?;
+
+        let batch =
+            BatchDml::builder().add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1");
+
+        let counts = tx.execute_batch_update(batch.build()).await?;
+
+        assert_eq!(counts, vec![1]);
+
+        Ok(())
     }
 }

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -465,7 +465,12 @@ impl ResultSetWorker {
         self.transaction_selector
             .as_ref()
             .unwrap()
-            .begin_explicitly(&self.client, self.session_name.clone(), self.channel_hint)
+            .begin_explicitly(
+                &self.client,
+                self.session_name.clone(),
+                self.channel_hint,
+                self.gax_options.clone(),
+            )
             .await?;
 
         self.partial_result_sets_buffer.clear();

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -372,7 +372,12 @@ impl TransactionRunner {
 
             let mut current_tx_id = None;
             let attempt_result = async {
-                let transaction = self.builder.begin_transaction(deadline).await?;
+                let transaction = self
+                    .builder
+                    .clone()
+                    .with_explicit_begin_transaction(true)
+                    .build(deadline)
+                    .await?;
                 current_tx_id = transaction.transaction_id().await.ok();
 
                 let result = match work(transaction.clone()).await {


### PR DESCRIPTION
Adds support for inline-begin for read/write transactions. This reduces the
number of round-trips to Spanner by one for read/write transactions.

Replaces #5325