### PR TITLE
fix(storage): provide user project for requester pays samples

### DIFF
--- a/guide/samples/tests/compute.rs
+++ b/guide/samples/tests/compute.rs
@@ -43,9 +43,14 @@ mod tests {
             .await?;
         let result =
             user_guide_samples::compute::drive_usage_report_samples(&project_id, &bucket_id).await;
-        let _ = storage_samples::cleanup_bucket(control, format!("projects/_/buckets/{bucket_id}"))
-            .await
-            .inspect_err(|e| eprintln!("error cleaning up bucket {bucket_id}: {e:?}"));
+        let project_id = google_cloud_test_utils::runtime_config::project_id()?;
+        let _ = storage_samples::cleanup_bucket(
+            control,
+            format!("projects/_/buckets/{bucket_id}"),
+            project_id,
+        )
+        .await
+        .inspect_err(|e| eprintln!("error cleaning up bucket {bucket_id}: {e:?}"));
         result.inspect_err(anydump)
     }
 }

--- a/guide/samples/tests/storage.rs
+++ b/guide/samples/tests/storage.rs
@@ -88,6 +88,7 @@ pub mod storage {
         let control = google_cloud_storage::client::StorageControl::builder()
             .build()
             .await?;
-        storage_samples::cleanup_bucket(control, bucket_name.to_string()).await
+        let project_id = google_cloud_test_utils::runtime_config::project_id()?;
+        storage_samples::cleanup_bucket(control, bucket_name.to_string(), project_id).await
     }
 }

--- a/src/storage/examples/src/buckets/disable_requester_pays.rs
+++ b/src/storage/examples/src/buckets/disable_requester_pays.rs
@@ -13,14 +13,20 @@
 // limitations under the License.
 
 // [START storage_disable_requester_pays]
+use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_storage::client::StorageControl;
 use google_cloud_storage::model::bucket::Billing;
 use google_cloud_wkt::FieldMask;
 
-pub async fn sample(client: &StorageControl, bucket_id: &str) -> anyhow::Result<()> {
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    user_project: &str,
+) -> anyhow::Result<()> {
     let bucket = client
         .get_bucket()
         .set_name(format!("projects/_/buckets/{bucket_id}"))
+        .with_quota_project(user_project)
         .send()
         .await?;
     let metageneration = bucket.metageneration;
@@ -29,6 +35,7 @@ pub async fn sample(client: &StorageControl, bucket_id: &str) -> anyhow::Result<
         .set_bucket(bucket.set_billing(Billing::new().set_requester_pays(false)))
         .set_if_metageneration_match(metageneration)
         .set_update_mask(FieldMask::default().set_paths(["billing.requester_pays"]))
+        .with_quota_project(user_project)
         .send()
         .await?;
     println!(

--- a/src/storage/examples/src/buckets/get_requester_pays_status.rs
+++ b/src/storage/examples/src/buckets/get_requester_pays_status.rs
@@ -13,12 +13,18 @@
 // limitations under the License.
 
 // [START storage_get_requester_pays_status]
+use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_storage::client::StorageControl;
 
-pub async fn sample(client: &StorageControl, bucket_id: &str) -> anyhow::Result<()> {
+pub async fn sample(
+    client: &StorageControl,
+    bucket_id: &str,
+    user_project: &str,
+) -> anyhow::Result<()> {
     let bucket = client
         .get_bucket()
         .set_name(format!("projects/_/buckets/{bucket_id}"))
+        .with_quota_project(user_project)
         .send()
         .await?;
     println!(

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -814,25 +814,6 @@ async fn delete_bucket_with_error_backoff(
     Ok(())
 }
 
-async fn disable_requester_pays_for_cleanup(client: &StorageControl, name: &str, project_id: &str) {
-    use google_cloud_storage::model::bucket::Billing;
-
-    if let Err(e) = client
-        .update_bucket()
-        .set_bucket(
-            Bucket::default()
-                .set_name(name)
-                .set_billing(Billing::default().set_requester_pays(false)),
-        )
-        .set_update_mask(FieldMask::default().set_paths(["billing.requester_pays"]))
-        .with_quota_project(project_id)
-        .send()
-        .await
-    {
-        tracing::error!("error disabling requester_pays for bucket {name}: {e:?}");
-    }
-}
-
 pub async fn cleanup_bucket(
     client: StorageControl,
     name: String,
@@ -862,22 +843,35 @@ async fn empty_bucket_contents(
         .send()
         .await?;
 
-    if current.billing.as_ref().is_some_and(|b| b.requester_pays) {
-        disable_requester_pays_for_cleanup(client, name, project_id).await;
-    }
-    if current
+    let needs_disable_requester_pays = current.billing.as_ref().is_some_and(|b| b.requester_pays);
+    let needs_test_label = current
         .labels
         .get("integration-test")
-        .is_none_or(|v| v != "true")
-    {
+        .is_none_or(|v| v != "true");
+
+    if needs_disable_requester_pays || needs_test_label {
         let mut updated = current.clone();
-        updated
-            .labels
-            .insert("integration-test".to_string(), "true".to_string());
+        let mut paths = vec![];
+
+        if needs_disable_requester_pays {
+            if let Some(billing) = updated.billing.as_mut() {
+                billing.requester_pays = false;
+            }
+            paths.push("billing.requester_pays");
+        }
+
+        if needs_test_label {
+            updated
+                .labels
+                .insert("integration-test".to_string(), "true".to_string());
+            paths.push("labels");
+        }
+
         if let Err(e) = client
             .update_bucket()
             .set_bucket(updated)
-            .set_update_mask(FieldMask::default().set_paths(["labels"]))
+            .set_update_mask(FieldMask::default().set_paths(paths))
+            .with_quota_project(project_id)
             .send()
             .await
         {

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -35,6 +35,7 @@ use google_cloud_storage::model::bucket::{
 use google_cloud_storage::model::{Bucket, Object};
 use google_cloud_storage::retry_policy::RetryableErrors;
 use google_cloud_test_utils::resource_names::random_bucket_id;
+use google_cloud_wkt::FieldMask;
 use std::time::Duration;
 
 pub async fn run_anywhere_cache_examples(buckets: &mut Vec<String>) -> anyhow::Result<()> {
@@ -178,33 +179,12 @@ pub async fn run_bucket_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     tracing::info!("running get_autoclass example");
     buckets::get_autoclass::sample(&client, &id).await?;
 
-    // By capturing the result each call, we ensure that a best-effort
-    // `disable_requester_pays` is always executed before returning any errors,
-    // resetting the bucket so the cleanup routines can delete it.
-    // If the whole test process dies/panics, it will still leak, but this
-    // handles standard runtime or assertion errors much more gracefully.
     tracing::info!("running enable_requester_pays example");
-    let enable_res = buckets::enable_requester_pays::sample(&client, &id).await;
-    if let Err(e) = &enable_res {
-        tracing::error!("Failed to enable requester pays: {:?}", e);
-    }
+    buckets::enable_requester_pays::sample(&client, &id).await?;
     tracing::info!("running get_requester_pays_status example");
-    let status_res = buckets::get_requester_pays_status::sample(&client, &id, &project_id).await;
-    if let Err(e) = &status_res {
-        tracing::error!("Failed to get requester pays status: {:?}", e);
-    }
-    // disable_requester_pays must run last so that the bucket can be cleaned up.
+    buckets::get_requester_pays_status::sample(&client, &id, &project_id).await?;
     tracing::info!("running disable_requester_pays example");
-    let disable_res = buckets::disable_requester_pays::sample(&client, &id, &project_id).await;
-    if let Err(e) = &disable_res {
-        tracing::error!(
-            "Failed to disable requester pays during cleanup (bucket may leak): {:?}",
-            e,
-        );
-    }
-    enable_res?;
-    status_res?;
-    disable_res?;
+    buckets::disable_requester_pays::sample(&client, &id, &project_id).await?;
 
     let id = random_bucket_id();
     buckets.push(id.clone());
@@ -794,9 +774,10 @@ pub async fn cleanup_stale_buckets(
     //    wait is at least 2 seconds. That slows down *every* runner when the API
     //    pushes back, which is the practical mitigation across processes.
     let bucket_names = buckets_to_cleanup;
-    let empty_tasks = bucket_names.iter().cloned().map(|name| {
-        let c = client.clone();
-        async move { empty_bucket_contents(&c, &name).await }
+    let empty_tasks = bucket_names.iter().map(|name| {
+        let client = client.clone();
+        let project_id = project_id.to_string();
+        async move { empty_bucket_contents(&client, name, &project_id).await }
     });
     for result in futures::future::join_all(empty_tasks).await {
         if let Err(e) = result {
@@ -811,11 +792,6 @@ pub async fn cleanup_stale_buckets(
     }
 
     Ok(())
-}
-
-pub async fn cleanup_bucket(client: StorageControl, name: String) -> anyhow::Result<()> {
-    empty_bucket_contents(&client, &name).await?;
-    delete_bucket_with_error_backoff(&client, &name).await
 }
 
 /// Delete one bucket, using the client's retry loop with exponential backoff
@@ -838,17 +814,57 @@ async fn delete_bucket_with_error_backoff(
     Ok(())
 }
 
+async fn disable_requester_pays_for_cleanup(client: &StorageControl, name: &str, project_id: &str) {
+    use google_cloud_storage::model::bucket::Billing;
+
+    if let Err(e) = client
+        .update_bucket()
+        .set_bucket(
+            Bucket::default()
+                .set_name(name)
+                .set_billing(Billing::default().set_requester_pays(false)),
+        )
+        .set_update_mask(FieldMask::default().set_paths(["billing.requester_pays"]))
+        .with_quota_project(project_id)
+        .send()
+        .await
+    {
+        tracing::error!("error disabling requester_pays for bucket {name}: {e:?}");
+    }
+}
+
+pub async fn cleanup_bucket(
+    client: StorageControl,
+    name: String,
+    project_id: String,
+) -> anyhow::Result<()> {
+    empty_bucket_contents(&client, &name, &project_id).await?;
+    delete_bucket_with_error_backoff(&client, &name).await
+}
+
 /// List and remove objects, managed folders, folders, and anywhere caches so
 /// the bucket can be deleted. Per-resource deletes are still parallelized with
 /// `join_all` inside this bucket.
-async fn empty_bucket_contents(client: &StorageControl, name: &str) -> anyhow::Result<()> {
+async fn empty_bucket_contents(
+    client: &StorageControl,
+    name: &str,
+    project_id: &str,
+) -> anyhow::Result<()> {
     use google_cloud_gax::{Result as GaxResult, paginator::ItemPaginator};
-    use google_cloud_wkt::FieldMask;
 
-    let current = client.get_bucket().set_name(name).send().await?;
     // Configure the bucket to be garbage collected. Some buckets are created by
     // sample code, which does not (and should not) include setting labels to
     // automatically garbage collect the bucket.
+    let current = client
+        .get_bucket()
+        .set_name(name)
+        .with_quota_project(project_id)
+        .send()
+        .await?;
+
+    if current.billing.as_ref().is_some_and(|b| b.requester_pays) {
+        disable_requester_pays_for_cleanup(client, name, project_id).await;
+    }
     if current
         .labels
         .get("integration-test")

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -177,17 +177,34 @@ pub async fn run_bucket_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     buckets::set_autoclass::sample(&client, &id).await?;
     tracing::info!("running get_autoclass example");
     buckets::get_autoclass::sample(&client, &id).await?;
-    #[cfg(feature = "skipped-integration-tests")]
-    {
-        // TODO(#3291): cannot cleanup the bucket if this example runs.
-        tracing::info!("running enable_requester_pays example");
-        buckets::enable_requester_pays::sample(&client, &id).await?;
-        // TODO(#3291): fix these samples to provide user project.
-        tracing::info!("running get_requester_pays_status example");
-        buckets::get_requester_pays_status::sample(&client, &id).await?;
-        tracing::info!("running disable_requester_pays example");
-        buckets::disable_requester_pays::sample(&client, &id).await?;
+
+    // By capturing the result each call, we ensure that a best-effort
+    // `disable_requester_pays` is always executed before returning any errors,
+    // resetting the bucket so the cleanup routines can delete it.
+    // If the whole test process dies/panics, it will still leak, but this
+    // handles standard runtime or assertion errors much more gracefully.
+    tracing::info!("running enable_requester_pays example");
+    let enable_res = buckets::enable_requester_pays::sample(&client, &id).await;
+    if let Err(e) = &enable_res {
+        tracing::error!("Failed to enable requester pays: {:?}", e);
     }
+    tracing::info!("running get_requester_pays_status example");
+    let status_res = buckets::get_requester_pays_status::sample(&client, &id, &project_id).await;
+    if let Err(e) = &status_res {
+        tracing::error!("Failed to get requester pays status: {:?}", e);
+    }
+    // disable_requester_pays must run last so that the bucket can be cleaned up.
+    tracing::info!("running disable_requester_pays example");
+    let disable_res = buckets::disable_requester_pays::sample(&client, &id, &project_id).await;
+    if let Err(e) = &disable_res {
+        tracing::error!(
+            "Failed to disable requester pays during cleanup (bucket may leak): {:?}",
+            e,
+        );
+    }
+    enable_res?;
+    status_res?;
+    disable_res?;
 
     let id = random_bucket_id();
     buckets.push(id.clone());

--- a/src/storage/examples/tests/integration.rs
+++ b/src/storage/examples/tests/integration.rs
@@ -19,12 +19,17 @@ mod tests {
     use storage_samples::*;
 
     async fn cleanup_all_buckets(client: StorageControl, buckets: Vec<String>) {
+        let project_id = std::env::var("GOOGLE_CLOUD_PROJECT").unwrap_or_default();
         // Report, but do not cause a build failure on cleanup errors.
         for id in buckets.into_iter() {
-            let _ = cleanup_bucket(client.clone(), format!("projects/_/buckets/{id}"))
-                .await
-                .inspect_err(|e| eprintln!("error cleaning up bucket {id}: {e:?}"))
-                .inspect_err(anydump);
+            let _ = cleanup_bucket(
+                client.clone(),
+                format!("projects/_/buckets/{id}"),
+                project_id.clone(),
+            )
+            .await
+            .inspect_err(|e| eprintln!("error cleaning up bucket {id}: {e:?}"))
+            .inspect_err(anydump);
         }
     }
 

--- a/tests/o11y/src/e2e/storage.rs
+++ b/tests/o11y/src/e2e/storage.rs
@@ -110,7 +110,9 @@ async fn send_trace(project_id: &str) -> anyhow::Result<String> {
 async fn client_library_operations() -> anyhow::Result<()> {
     let (control, bucket) = storage_samples::create_test_bucket().await?;
     let _ = storage_data_operations(&bucket.name).await;
-    if let Err(e) = storage_samples::cleanup_bucket(control, bucket.name.clone()).await {
+    if let Err(e) =
+        storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone()).await
+    {
         tracing::error!("error cleaning up test bucket {}: {e:?}", bucket.name);
     };
     Ok(())

--- a/tests/storage/tests/driver.rs
+++ b/tests/storage/tests/driver.rs
@@ -62,10 +62,11 @@ mod storage {
             Ok(())
         };
         let result = variants().await.inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 
@@ -98,10 +99,11 @@ mod storage {
         )
         .await
         .inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 
@@ -114,10 +116,11 @@ mod storage {
         let result = integration_tests_storage::read_object::run(&bucket.name)
             .await
             .inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 
@@ -130,10 +133,11 @@ mod storage {
         let result = integration_tests_storage::write_object::run(&bucket.name)
             .await
             .inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 
@@ -148,10 +152,11 @@ mod storage {
             integration_tests_storage::object_names(builder, control.clone(), &bucket.name)
                 .await
                 .inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 
@@ -164,10 +169,11 @@ mod storage {
         let result = integration_tests_storage::bidi_read::run(&bucket.name)
             .await
             .inspect_err(anydump);
-        let _ = storage_samples::cleanup_bucket(control, bucket.name.clone())
-            .await
-            .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-            .inspect_err(anydump);
+        let _ =
+            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+                .await
+                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
+                .inspect_err(anydump);
         result
     }
 }


### PR DESCRIPTION
Fix the  `get_requester_pays_status` and `disable_requester_pays` samples by adding a user project identifier. This allows the samples to successfully execute against a requester-pays bucket.

Fixes #3291.