### PR TITLE
cleanup: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-iam-v1",
+ "google-cloud-pubsub",
  "google-cloud-rpc",
  "google-cloud-test-macros",
  "google-cloud-wkt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "axum",
- "chrono",
  "clap",
  "google-cloud-aiplatform-v1",
  "google-cloud-auth",
@@ -649,13 +648,10 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "rand 0.10.1",
- "serde",
- "serde_json",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "tracing-serde",
  "tracing-subscriber",
  "uuid",
 ]
@@ -807,7 +803,6 @@ name = "endurance-test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bytes",
  "crc32c",
  "futures",
  "google-cloud-gax",
@@ -853,12 +848,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1998,7 +1987,6 @@ dependencies = [
  "google-cloud-rpc",
  "google-cloud-wkt",
  "http",
- "lazy_static",
  "prost",
  "prost-types",
  "serde",
@@ -2894,7 +2882,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "tokio",
  "tracing",
 ]
 
@@ -2953,7 +2940,6 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "serial_test",
  "static_assertions",
  "test-case",
  "thiserror",
@@ -4218,7 +4204,6 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-iam-v1",
- "google-cloud-pubsub",
  "google-cloud-rpc",
  "google-cloud-test-macros",
  "google-cloud-wkt",
@@ -4686,7 +4671,6 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tokio-stream",
  "tracing",
  "url",
 ]
@@ -4801,7 +4785,6 @@ dependencies = [
  "multer",
  "pastey",
  "percent-encoding",
- "pin-project",
  "pretty_assertions",
  "prost",
  "prost-types",
@@ -4972,8 +4955,6 @@ name = "google-cloud-test-utils"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "once_cell",
- "opentelemetry-semantic-conventions",
  "pretty_assertions",
  "rand 0.10.1",
  "scoped-env",
@@ -5431,13 +5412,10 @@ dependencies = [
  "google-cloud-gax-internal",
  "http",
  "prost",
- "prost-build",
- "serde_json",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
 ]
 
 [[package]]
@@ -5872,8 +5850,6 @@ name = "integration-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bytes",
- "futures",
  "google-cloud-aiplatform-v1",
  "google-cloud-auth",
  "google-cloud-gax",
@@ -5881,21 +5857,13 @@ dependencies = [
  "google-cloud-storage",
  "google-cloud-telcoautomation-v1",
  "google-cloud-test-utils",
- "google-cloud-wkt",
  "google-cloud-workflows-v1",
- "http",
  "httptest",
- "mockall",
- "rand 0.10.1",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
- "serde_with",
- "static_assertions",
  "tokio",
  "tracing",
- "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
@@ -5903,7 +5871,6 @@ name = "integration-tests-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
  "bytes",
  "google-cloud-auth",
  "google-cloud-bigquery-v2",
@@ -5939,14 +5906,12 @@ name = "integration-tests-bigquery"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "chrono",
  "futures",
  "google-cloud-bigquery-v2",
  "google-cloud-gax",
  "google-cloud-test-utils",
  "rand 0.10.1",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -5967,9 +5932,6 @@ name = "integration-tests-discovery"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bytes",
- "chrono",
- "futures",
  "google-cloud-auth",
  "google-cloud-compute-v1",
  "google-cloud-gax",
@@ -5992,7 +5954,6 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-lro",
  "google-cloud-test-utils",
- "rand 0.10.1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -6003,8 +5964,6 @@ name = "integration-tests-enums-query-parameters"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "chrono",
- "futures",
  "google-cloud-gax",
  "google-cloud-lro",
  "google-cloud-test-utils",
@@ -6012,7 +5971,6 @@ dependencies = [
  "google-cloud-workflows-v1",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6020,9 +5978,6 @@ name = "integration-tests-grpc-mock"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "google-cloud-gax",
- "google-cloud-storage",
- "mockall",
  "pastey",
  "storage-grpc-mock",
  "test-case",
@@ -6036,13 +5991,10 @@ name = "integration-tests-locational-endpoints"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "chrono",
- "futures",
  "google-cloud-aiplatform-v1",
  "google-cloud-test-utils",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6050,7 +6002,6 @@ name = "integration-tests-lro"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "chrono",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
@@ -6061,11 +6012,8 @@ dependencies = [
  "google-cloud-wkt",
  "google-cloud-workflows-v1",
  "httptest",
- "rand 0.10.1",
  "serde_json",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6073,13 +6021,11 @@ name = "integration-tests-o11y"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bytes",
  "chrono",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
- "google-cloud-lro",
  "google-cloud-monitoring-v3",
  "google-cloud-showcase-v1beta1",
  "google-cloud-storage",
@@ -6107,7 +6053,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-serde",
@@ -6121,11 +6066,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "chrono",
  "crc32c",
  "futures",
  "google-cloud-gax",
- "google-cloud-lro",
  "google-cloud-test-utils",
  "google-cloud-wkt",
  "secretmanager-openapi-v1",
@@ -6133,8 +6076,6 @@ dependencies = [
  "static_assertions",
  "test-case",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6143,7 +6084,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "chrono",
  "crc32c",
  "futures",
  "google-cloud-gax",
@@ -6153,7 +6093,6 @@ dependencies = [
  "google-cloud-wkt",
  "mockall",
  "serde_json",
- "static_assertions",
  "test-case",
  "tokio",
 ]
@@ -6164,16 +6103,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "chrono",
  "futures",
- "google-cloud-gax",
- "google-cloud-lro",
  "google-cloud-pubsub",
  "google-cloud-test-utils",
  "pubsub-samples",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6182,17 +6117,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "chrono",
- "futures",
  "google-cloud-auth",
  "google-cloud-gax",
- "google-cloud-lro",
  "google-cloud-showcase-v1beta1",
  "google-cloud-test-utils",
  "google-cloud-wkt",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid",
 ]
 
@@ -6203,12 +6134,9 @@ dependencies = [
  "anyhow",
  "base64",
  "futures",
- "google-cloud-auth",
  "google-cloud-gax",
- "google-cloud-lro",
  "google-cloud-spanner",
  "google-cloud-test-utils",
- "google-cloud-wkt",
  "http",
  "http-body",
  "http-body-util",
@@ -6223,7 +6151,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tower",
- "tracing",
 ]
 
 [[package]]
@@ -6232,7 +6159,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "chrono",
  "crc32c",
  "flate2",
  "futures",
@@ -6249,7 +6175,6 @@ dependencies = [
  "test-case",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6558,12 +6483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "mutants"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6842,17 +6761,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7013,25 +6921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
-dependencies = [
- "heck",
- "itertools",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 2.0.117",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7059,16 +6948,12 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bytes",
- "crc32c",
- "futures",
  "google-cloud-gax-internal",
  "google-cloud-wkt",
  "prost",
- "prost-types",
  "serde",
  "serde_json",
  "serde_with",
- "tokio",
 ]
 
 [[package]]
@@ -7122,7 +7007,6 @@ dependencies = [
  "rand 0.10.1",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -7132,13 +7016,9 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
- "futures",
  "google-cloud-pubsub",
  "humantime",
- "rand 0.10.1",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -8121,14 +8001,10 @@ dependencies = [
  "google-cloud-storage",
  "humantime",
  "parse-size",
- "pin-project",
  "rand 0.10.1",
- "regex",
  "test-case",
  "tokio",
- "tokio-metrics",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -8137,9 +8013,7 @@ name = "storage-samples"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64",
  "bytes",
- "clap",
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
@@ -8170,15 +8044,10 @@ dependencies = [
  "google-cloud-storage",
  "http",
  "humantime",
- "parse-size",
- "pin-project",
  "rand 0.10.1",
- "regex",
  "test-case",
  "tokio",
- "tokio-metrics",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -8195,7 +8064,6 @@ dependencies = [
  "google-cloud-storage",
  "humantime",
  "integration-tests-o11y",
- "opentelemetry",
  "opentelemetry_sdk",
  "parse-size",
  "pin-project",
@@ -8640,18 +8508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "tonic-prost"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8660,22 +8516,6 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
-]
-
-[[package]]
-name = "tonic-prost-build"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types",
- "quote",
- "syn 2.0.117",
- "tempfile",
- "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5412,10 +5418,12 @@ dependencies = [
  "google-cloud-gax-internal",
  "http",
  "prost",
+ "prost-build",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -6483,6 +6491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "mutants"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6761,6 +6775,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6918,6 +6943,25 @@ checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]
@@ -8508,6 +8552,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tonic-prost"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8516,6 +8572,22 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -549,4 +549,4 @@ unexpected_cfgs = { level = "deny", check-cfg = [
 ] }
 
 [workspace.metadata.cargo-machete]
-ignored = ["h2", "lazy_static", "rustc_version", "pin-project"]
+ignored = ["h2", "lazy_static", "pin-project", "rustc_version"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -547,3 +547,6 @@ unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_generate_protos)',
   'cfg(tokio_unstable)',
 ] }
+
+[workspace.metadata.cargo-machete]
+ignored = ["h2", "lazy_static", "rustc_version", "pin-project"]

--- a/demos/cloud-run-o11y/Cargo.toml
+++ b/demos/cloud-run-o11y/Cargo.toml
@@ -28,7 +28,6 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace           = true
 axum                       = { workspace = true, features = ["http1", "tokio"] }
-chrono                     = { workspace = true, features = ["std"] }
 clap                       = { workspace = true, features = ["env", "std"] }
 google-cloud-aiplatform-v1 = { workspace = true, features = ["default-rustls-provider", "prediction-service"] }
 google-cloud-auth          = { workspace = true, features = ["default", "idtoken"] }
@@ -40,12 +39,9 @@ opentelemetry              = { workspace = true, features = ["trace"] }
 opentelemetry-http         = { workspace = true }
 opentelemetry_sdk          = { workspace = true }
 rand.workspace             = true
-serde                      = { workspace = true }
-serde_json.workspace       = true
 thiserror.workspace        = true
 tokio                      = { workspace = true, features = ["full", "macros"] }
 tracing-opentelemetry      = { workspace = true, default-features = true }
-tracing-serde              = { workspace = true }
 tracing-subscriber         = { workspace = true, features = ["json", "std"] }
 tracing.workspace          = true
 uuid                       = { workspace = true, features = ["v4"] }

--- a/src/bigquery-write/Cargo.toml
+++ b/src/bigquery-write/Cargo.toml
@@ -30,7 +30,6 @@ rust-version.workspace = true
 async-trait.workspace      = true
 bytes.workspace            = true
 http.workspace             = true
-lazy_static.workspace      = true
 prost.workspace            = true
 prost-types.workspace      = true
 serde.workspace            = true

--- a/src/firestore/Cargo.toml
+++ b/src/firestore/Cargo.toml
@@ -35,7 +35,6 @@ prost-types.workspace = true
 serde.workspace       = true
 serde_json.workspace  = true
 serde_with.workspace  = true
-tokio                 = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace     = true
 # Local crates
 google-cloud-gax  = { workspace = true }
@@ -54,7 +53,6 @@ default-rustls-provider = ["gaxi/_default-rustls-provider"]
 
 [dev-dependencies]
 anyhow.workspace = true
-tokio            = { workspace = true, features = ["full", "macros"] }
 
 [lints]
 workspace = true

--- a/src/gax-internal/grpc-server/Cargo.toml
+++ b/src/gax-internal/grpc-server/Cargo.toml
@@ -39,3 +39,5 @@ google-cloud-gax.workspace  = true
 gaxi                        = { workspace = true, features = ["_internal-grpc-client"] }
 
 [build-dependencies]
+prost-build       = { workspace = true }
+tonic-prost-build = { workspace = true }

--- a/src/gax-internal/grpc-server/Cargo.toml
+++ b/src/gax-internal/grpc-server/Cargo.toml
@@ -29,7 +29,6 @@ async-trait.workspace = true
 anyhow.workspace      = true
 http.workspace        = true
 prost                 = { workspace = true, default-features = true }
-serde_json.workspace  = true
 tokio                 = { workspace = true, features = ["macros"] }
 tokio-stream          = { workspace = true }
 tonic                 = { workspace = true, default-features = true }
@@ -40,5 +39,3 @@ google-cloud-gax.workspace  = true
 gaxi                        = { workspace = true, features = ["_internal-grpc-client"] }
 
 [build-dependencies]
-prost-build       = { workspace = true }
-tonic-prost-build = { workspace = true }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -54,7 +54,6 @@ wkt.workspace    = true
 anyhow.workspace      = true
 mockall.workspace     = true
 serde.workspace       = true
-serial_test.workspace = true
 static_assertions     = { workspace = true }
 test-case.workspace   = true
 tokio                 = { workspace = true, features = ["test-util"] }

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -51,12 +51,12 @@ google-cloud-rpc = { workspace = true }
 wkt.workspace    = true
 
 [dev-dependencies]
-anyhow.workspace      = true
-mockall.workspace     = true
-serde.workspace       = true
-static_assertions     = { workspace = true }
-test-case.workspace   = true
-tokio                 = { workspace = true, features = ["test-util"] }
+anyhow.workspace    = true
+mockall.workspace   = true
+serde.workspace     = true
+static_assertions   = { workspace = true }
+test-case.workspace = true
+tokio               = { workspace = true, features = ["test-util"] }
 
 [features]
 # Enable functionality that depends on the [futures::stream::Stream] trait. This

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -70,3 +70,6 @@ tokio                = { workspace = true, features = ["test-util"] }
 # Local dependencies
 google-cloud-auth.workspace = true
 google-cloud-lro            = { path = ".", features = ["unstable-stream"] }
+
+[package.metadata.cargo-machete]
+ignored = ["anyhow", "httptest", "serde_json", "google-cloud-auth", "google-cloud-lro"]

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -72,4 +72,4 @@ google-cloud-auth.workspace = true
 google-cloud-lro            = { path = ".", features = ["unstable-stream"] }
 
 [package.metadata.cargo-machete]
-ignored = ["anyhow", "httptest", "serde_json", "google-cloud-auth", "google-cloud-lro"]
+ignored = ["anyhow", "google-cloud-auth", "google-cloud-lro", "httptest", "serde_json"]

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -67,6 +67,7 @@ test-case.workspace                = true
 tokio                              = { workspace = true, features = ["rt", "sync", "test-util", "time"] }
 google-cloud-test-macros.workspace = true
 pubsub-grpc-mock                   = { path = "grpc-mock" }
+google-cloud-pubsub                = { path = ".", features = ["default-rustls-provider"] }
 google-cloud-rpc                   = { workspace = true }
 
 [lints]

--- a/src/pubsub/Cargo.toml
+++ b/src/pubsub/Cargo.toml
@@ -67,7 +67,6 @@ test-case.workspace                = true
 tokio                              = { workspace = true, features = ["rt", "sync", "test-util", "time"] }
 google-cloud-test-macros.workspace = true
 pubsub-grpc-mock                   = { path = "grpc-mock" }
-google-cloud-pubsub                = { path = ".", features = ["default-rustls-provider"] }
 google-cloud-rpc                   = { workspace = true }
 
 [lints]

--- a/src/pubsub/benchmarks/throughput/Cargo.toml
+++ b/src/pubsub/benchmarks/throughput/Cargo.toml
@@ -30,9 +30,5 @@ anyhow.workspace    = true
 bytes.workspace     = true
 clap                = { workspace = true, features = ["derive", "env", "help", "std"] }
 google-cloud-pubsub = { workspace = true, features = ["default-rustls-provider"] }
-futures.workspace   = true
 humantime.workspace = true
-rand.workspace      = true
 tokio               = { workspace = true, features = ["full"] }
-tracing.workspace   = true
-tracing-subscriber  = { workspace = true, features = ["fmt", "std"] }

--- a/src/pubsub/examples/Cargo.toml
+++ b/src/pubsub/examples/Cargo.toml
@@ -33,7 +33,6 @@ google-cloud-test-utils    = { workspace = true }
 google-cloud-wkt.workspace = true
 rand.workspace             = true
 tokio.workspace            = true
-tracing-subscriber         = { workspace = true, features = ["fmt", "std"] }
 tracing.workspace          = true
 
 [features]

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -59,7 +59,6 @@ mockall.workspace                  = true
 spanner-grpc-mock                  = { path = "grpc-mock" }
 static_assertions.workspace        = true
 tokio                              = { workspace = true, features = ["test-util"] }
-tokio-stream.workspace             = true
 
 [lints]
 workspace = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -42,7 +42,6 @@ futures.workspace          = true
 http-body.workspace        = true
 md5.workspace              = true
 percent-encoding.workspace = true
-pin-project.workspace      = true
 prost.workspace            = true
 prost-types.workspace      = true
 serde.workspace            = true
@@ -103,3 +102,6 @@ pretty_assertions.workspace = true
 google-cloud-storage    = { path = ".", features = ["unstable-stream"] }
 google-cloud-test-utils = { workspace = true }
 storage-grpc-mock       = { path = "grpc-mock" }
+
+[package.metadata.cargo-machete]
+ignored = ["flate2"]

--- a/src/storage/benchmarks/random/Cargo.toml
+++ b/src/storage/benchmarks/random/Cargo.toml
@@ -36,13 +36,9 @@ google-cloud-gax.workspace  = true
 google-cloud-storage        = { workspace = true, features = ["default-rustls-provider"] }
 humantime.workspace         = true
 parse-size.workspace        = true
-pin-project.workspace       = true
 rand.workspace              = true
-regex.workspace             = true
 tokio                       = { workspace = true, features = ["macros"] }
-tokio-metrics               = { workspace = true, features = ["rt"] }
 tracing.workspace           = true
-tracing-log                 = { workspace = true, features = ["log-tracer", "std"] }
 tracing-subscriber          = { workspace = true, features = ["fmt", "std"] }
 
 [dev-dependencies]

--- a/src/storage/benchmarks/w1r3/Cargo.toml
+++ b/src/storage/benchmarks/w1r3/Cargo.toml
@@ -33,7 +33,6 @@ google-cloud-gax.workspace       = true
 google-cloud-storage             = { workspace = true, features = ["default-rustls-provider"] }
 humantime.workspace              = true
 integration-tests-o11y.workspace = true
-opentelemetry                    = { workspace = true, features = ["trace"] }
 opentelemetry_sdk                = { workspace = true, features = ["rt-tokio", "trace"] }
 parse-size.workspace             = true
 pin-project.workspace            = true

--- a/src/storage/examples/Cargo.toml
+++ b/src/storage/examples/Cargo.toml
@@ -25,9 +25,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace              = true
-base64.workspace              = true
 bytes.workspace               = true
-clap                          = { workspace = true, features = ["derive", "std"] }
 futures.workspace             = true
 google-cloud-auth.workspace   = true
 google-cloud-gax.workspace    = true

--- a/src/storage/tests/scenarios/Cargo.toml
+++ b/src/storage/tests/scenarios/Cargo.toml
@@ -36,14 +36,9 @@ google-cloud-gax.workspace     = true
 google-cloud-storage.workspace = true
 http.workspace                 = true
 humantime.workspace            = true
-parse-size.workspace           = true
-pin-project.workspace          = true
 rand.workspace                 = true
-regex.workspace                = true
 tokio                          = { workspace = true, features = ["macros"] }
-tokio-metrics                  = { workspace = true, features = ["rt"] }
 tracing.workspace              = true
-tracing-log                    = { workspace = true, features = ["log-tracer", "std"] }
 tracing-subscriber             = { workspace = true, features = ["fmt", "std"] }
 
 [dev-dependencies]

--- a/src/test-utils/Cargo.toml
+++ b/src/test-utils/Cargo.toml
@@ -22,8 +22,6 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace                   = true
-once_cell.workspace                = true
-opentelemetry-semantic-conventions = { workspace = true }
 rand                               = { workspace = true, features = ["thread_rng"] }
 tracing                            = { workspace = true, features = ["std"] }
 tracing-subscriber                 = { workspace = true, features = ["env-filter", "fmt", "std"] }

--- a/src/test-utils/Cargo.toml
+++ b/src/test-utils/Cargo.toml
@@ -21,11 +21,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow.workspace                   = true
-rand                               = { workspace = true, features = ["thread_rng"] }
-tracing                            = { workspace = true, features = ["std"] }
-tracing-subscriber                 = { workspace = true, features = ["env-filter", "fmt", "std"] }
-uuid                               = { workspace = true, features = ["std", "v4"] }
+anyhow.workspace   = true
+rand               = { workspace = true, features = ["thread_rng"] }
+tracing            = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "std"] }
+uuid               = { workspace = true, features = ["std", "v4"] }
 
 [dev-dependencies]
 pretty_assertions     = { workspace = true }

--- a/tests/bigquery/Cargo.toml
+++ b/tests/bigquery/Cargo.toml
@@ -28,11 +28,9 @@ log-integration-tests = []
 
 [dependencies]
 anyhow.workspace         = true
-chrono                   = { workspace = true, features = ["now"] }
 futures.workspace        = true
 google-cloud-bigquery-v2 = { workspace = true, features = ["default"] }
 google-cloud-gax         = { workspace = true, features = ["unstable-stream"] }
 google-cloud-test-utils  = { workspace = true }
 rand.workspace           = true
 tokio.workspace          = true
-tracing.workspace        = true

--- a/tests/discovery/Cargo.toml
+++ b/tests/discovery/Cargo.toml
@@ -28,9 +28,6 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 
 [dependencies]
 anyhow.workspace            = true
-bytes.workspace             = true
-chrono                      = { workspace = true, features = ["now"] }
-futures.workspace           = true
 google-cloud-auth.workspace = true
 google-cloud-gax.workspace  = true
 google-cloud-lro.workspace  = true

--- a/tests/dns/Cargo.toml
+++ b/tests/dns/Cargo.toml
@@ -34,7 +34,6 @@ google-cloud-dns-v1.workspace = true
 google-cloud-gax.workspace    = true
 google-cloud-test-utils       = { workspace = true }
 google-cloud-lro.workspace    = true
-rand.workspace                = true
 tokio.workspace               = true
 tracing.workspace             = true
 tracing-subscriber            = { workspace = true, features = ["fmt"] }

--- a/tests/endurance/Cargo.toml
+++ b/tests/endurance/Cargo.toml
@@ -22,7 +22,6 @@ license.workspace = true
 
 [dependencies]
 anyhow.workspace     = true
-bytes.workspace      = true
 crc32c.workspace     = true
 futures.workspace    = true
 serde_json.workspace = true

--- a/tests/enums-query-parameters/Cargo.toml
+++ b/tests/enums-query-parameters/Cargo.toml
@@ -28,8 +28,6 @@ log-integration-tests = []
 
 [dependencies]
 anyhow.workspace                     = true
-chrono                               = { workspace = true, features = ["now"] }
-futures.workspace                    = true
 google-cloud-workflows-v1            = { workspace = true, features = ["default"] }
 google-cloud-workflows-executions-v1 = { workspace = true, features = ["default"] }
 google-cloud-gax.workspace           = true
@@ -37,4 +35,3 @@ google-cloud-test-utils              = { workspace = true }
 google-cloud-lro.workspace           = true
 tokio.workspace                      = true
 tracing.workspace                    = true
-tracing-subscriber                   = { workspace = true, features = ["fmt"] }

--- a/tests/grpc-mock/Cargo.toml
+++ b/tests/grpc-mock/Cargo.toml
@@ -24,14 +24,11 @@ license.workspace = true
 
 [dev-dependencies]
 anyhow.workspace               = true
-mockall.workspace              = true
 pastey.workspace               = true
 test-case.workspace            = true
 tokio.workspace                = true
 tokio-stream.workspace         = true
 tonic.workspace                = true
-google-cloud-gax.workspace     = true
-google-cloud-storage.workspace = true
 storage-grpc-mock.workspace    = true
 
 [lints]

--- a/tests/grpc-mock/Cargo.toml
+++ b/tests/grpc-mock/Cargo.toml
@@ -23,13 +23,13 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-anyhow.workspace               = true
-pastey.workspace               = true
-test-case.workspace            = true
-tokio.workspace                = true
-tokio-stream.workspace         = true
-tonic.workspace                = true
-storage-grpc-mock.workspace    = true
+anyhow.workspace            = true
+pastey.workspace            = true
+test-case.workspace         = true
+tokio.workspace             = true
+tokio-stream.workspace      = true
+tonic.workspace             = true
+storage-grpc-mock.workspace = true
 
 [lints]
 workspace = true

--- a/tests/integration-auth/Cargo.toml
+++ b/tests/integration-auth/Cargo.toml
@@ -32,7 +32,6 @@ tempfile.workspace   = true
 serde_json.workspace = true
 httptest.workspace   = true
 test-case.workspace  = true
-base64.workspace     = true
 reqwest.workspace    = true
 # Local dependencies
 google-cloud-gax.workspace      = true

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -28,8 +28,6 @@ run-integration-tests = []
 
 [dependencies]
 anyhow.workspace                = true
-bytes.workspace                 = true
-futures.workspace               = true
 google-cloud-auth               = { workspace = true, features = ["default"] }
 google-cloud-gax                = { workspace = true, features = ["unstable-stream"] }
 gaxi                            = { workspace = true, features = ["_internal-http-client"] }
@@ -38,23 +36,15 @@ google-cloud-aiplatform-v1      = { workspace = true, features = ["default-rustl
 google-cloud-storage            = { workspace = true, features = ["default"] }
 google-cloud-telcoautomation-v1 = { workspace = true, features = ["default"] }
 google-cloud-workflows-v1       = { workspace = true, features = ["default"] }
-http.workspace                  = true
-rand                            = { workspace = true, features = ["thread_rng"] }
 reqwest.workspace               = true
 serde_json.workspace            = true
 tokio                           = { workspace = true, features = ["process", "test-util"] }
 tracing.workspace               = true
-tracing-subscriber              = { workspace = true, features = ["env-filter", "fmt", "std"] }
-uuid                            = { workspace = true, features = ["std", "v4"] }
-wkt.workspace                   = true
 
 [dev-dependencies]
 anyhow.workspace            = true
 httptest.workspace          = true
-mockall.workspace           = true
 serde.workspace             = true
-serde_with.workspace        = true
-static_assertions.workspace = true
 tokio.workspace             = true
 
 [lints]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -42,10 +42,10 @@ tokio                           = { workspace = true, features = ["process", "te
 tracing.workspace               = true
 
 [dev-dependencies]
-anyhow.workspace            = true
-httptest.workspace          = true
-serde.workspace             = true
-tokio.workspace             = true
+anyhow.workspace   = true
+httptest.workspace = true
+serde.workspace    = true
+tokio.workspace    = true
 
 [lints]
 workspace = true

--- a/tests/locational-endpoints/Cargo.toml
+++ b/tests/locational-endpoints/Cargo.toml
@@ -28,13 +28,10 @@ log-integration-tests = []
 
 [dependencies]
 anyhow.workspace           = true
-chrono                     = { workspace = true, features = ["now"] }
-futures.workspace          = true
 google-cloud-aiplatform-v1 = { workspace = true, features = ["default-rustls-provider", "model-service"] }
 google-cloud-test-utils    = { workspace = true }
 tokio.workspace            = true
 tracing.workspace          = true
-tracing-subscriber         = { workspace = true, features = ["fmt"] }
 
 [lints]
 workspace = true

--- a/tests/lro/Cargo.toml
+++ b/tests/lro/Cargo.toml
@@ -28,7 +28,6 @@ log-integration-tests = []
 
 [dependencies]
 anyhow.workspace            = true
-chrono                      = { workspace = true, features = ["now"] }
 futures.workspace           = true
 google-cloud-auth.workspace = true
 google-cloud-gax.workspace  = true
@@ -39,8 +38,5 @@ google-cloud-rpc.workspace  = true
 google-cloud-workflows-v1   = { workspace = true, features = ["default"] }
 google-cloud-wkt.workspace  = true
 httptest.workspace          = true
-rand.workspace              = true
 serde_json.workspace        = true
 tokio.workspace             = true
-tracing.workspace           = true
-tracing-subscriber          = { workspace = true, features = ["fmt"] }

--- a/tests/o11y/Cargo.toml
+++ b/tests/o11y/Cargo.toml
@@ -28,13 +28,11 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 
 [dependencies]
 anyhow.workspace              = true
-bytes.workspace               = true
 chrono                        = { workspace = true, features = ["now"] }
 futures.workspace             = true
 google-cloud-auth.workspace   = true
 google-cloud-gax.workspace    = true
 gaxi                          = { workspace = true, features = ["_internal-grpc-client"] }
-google-cloud-lro.workspace    = true
 google-cloud-test-utils       = { workspace = true }
 google-cloud-showcase-v1beta1 = { workspace = true, features = ["default"] }
 google-cloud-storage          = { workspace = true, features = ["default"] }
@@ -76,7 +74,6 @@ opentelemetry_sdk = { workspace = true, features = ["testing"] }
 serial_test       = { workspace = true }
 scoped-env        = { workspace = true }
 test-case         = { workspace = true }
-tower             = { workspace = true, features = ["util"] }
 storage-grpc-mock = { workspace = true }
 
 [dependencies.opentelemetry-appender-tracing]

--- a/tests/openapi/Cargo.toml
+++ b/tests/openapi/Cargo.toml
@@ -29,18 +29,14 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 [dependencies]
 anyhow.workspace           = true
 bytes.workspace            = true
-chrono                     = { workspace = true, features = ["now"] }
 crc32c.workspace           = true
 futures.workspace          = true
 google-cloud-gax.workspace = true
-google-cloud-lro.workspace = true
 google-cloud-test-utils    = { workspace = true }
 google-cloud-wkt.workspace = true
 secretmanager-openapi-v1   = { workspace = true, features = ["default"] }
 serde.workspace            = true
 tokio.workspace            = true
-tracing.workspace          = true
-tracing-subscriber         = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
 static_assertions.workspace = true

--- a/tests/protobuf/Cargo.toml
+++ b/tests/protobuf/Cargo.toml
@@ -29,7 +29,6 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 [dependencies]
 anyhow.workspace              = true
 bytes.workspace               = true
-chrono                        = { workspace = true, features = ["now"] }
 crc32c.workspace              = true
 futures.workspace             = true
 google-cloud-gax              = { workspace = true, features = ["unstable-stream"] }
@@ -42,7 +41,6 @@ tokio.workspace               = true
 [dev-dependencies]
 mockall.workspace           = true
 serde_json.workspace        = true
-static_assertions.workspace = true
 test-case.workspace         = true
 
 [lints]

--- a/tests/protobuf/Cargo.toml
+++ b/tests/protobuf/Cargo.toml
@@ -39,9 +39,9 @@ google-cloud-wkt.workspace    = true
 tokio.workspace               = true
 
 [dev-dependencies]
-mockall.workspace           = true
-serde_json.workspace        = true
-test-case.workspace         = true
+mockall.workspace    = true
+serde_json.workspace = true
+test-case.workspace  = true
 
 [lints]
 workspace = true

--- a/tests/protojson-conformance/Cargo.toml
+++ b/tests/protojson-conformance/Cargo.toml
@@ -23,14 +23,10 @@ license.workspace = true
 [dependencies]
 anyhow.workspace      = true
 bytes.workspace       = true
-crc32c.workspace      = true
-futures.workspace     = true
 prost.workspace       = true
-prost-types.workspace = true
 serde.workspace       = true
 serde_json            = { workspace = true, features = ["float_roundtrip"] }
 serde_with.workspace  = true
-tokio.workspace       = true
 # Local dependencies
 wkt.workspace = true
 gaxi          = { workspace = true, features = ["_internal-grpc-client"] }

--- a/tests/protojson-conformance/Cargo.toml
+++ b/tests/protojson-conformance/Cargo.toml
@@ -21,12 +21,12 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow.workspace      = true
-bytes.workspace       = true
-prost.workspace       = true
-serde.workspace       = true
-serde_json            = { workspace = true, features = ["float_roundtrip"] }
-serde_with.workspace  = true
+anyhow.workspace     = true
+bytes.workspace      = true
+prost.workspace      = true
+serde.workspace      = true
+serde_json           = { workspace = true, features = ["float_roundtrip"] }
+serde_with.workspace = true
 # Local dependencies
 wkt.workspace = true
 gaxi          = { workspace = true, features = ["_internal-grpc-client"] }

--- a/tests/pubsub/Cargo.toml
+++ b/tests/pubsub/Cargo.toml
@@ -27,14 +27,14 @@ run-integration-tests = []
 log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 
 [dependencies]
-anyhow.workspace           = true
-bytes.workspace            = true
-futures.workspace          = true
-google-cloud-test-utils    = { workspace = true }
-google-cloud-pubsub        = { workspace = true, features = ["default"] }
-pubsub-samples.workspace   = true
-tokio.workspace            = true
-tracing.workspace          = true
+anyhow.workspace         = true
+bytes.workspace          = true
+futures.workspace        = true
+google-cloud-test-utils  = { workspace = true }
+google-cloud-pubsub      = { workspace = true, features = ["default"] }
+pubsub-samples.workspace = true
+tokio.workspace          = true
+tracing.workspace        = true
 
 [lints]
 workspace = true

--- a/tests/pubsub/Cargo.toml
+++ b/tests/pubsub/Cargo.toml
@@ -29,16 +29,12 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 [dependencies]
 anyhow.workspace           = true
 bytes.workspace            = true
-chrono                     = { workspace = true, features = ["now"] }
 futures.workspace          = true
-google-cloud-gax.workspace = true
-google-cloud-lro.workspace = true
 google-cloud-test-utils    = { workspace = true }
 google-cloud-pubsub        = { workspace = true, features = ["default"] }
 pubsub-samples.workspace   = true
 tokio.workspace            = true
 tracing.workspace          = true
-tracing-subscriber         = { workspace = true, features = ["fmt"] }
 
 [lints]
 workspace = true

--- a/tests/showcase/Cargo.toml
+++ b/tests/showcase/Cargo.toml
@@ -29,17 +29,13 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 [dependencies]
 anyhow.workspace              = true
 bytes.workspace               = true
-chrono                        = { workspace = true, features = ["now"] }
-futures.workspace             = true
 google-cloud-auth.workspace   = true
 google-cloud-gax.workspace    = true
-google-cloud-lro.workspace    = true
 google-cloud-test-utils       = { workspace = true }
 google-cloud-showcase-v1beta1 = { workspace = true, features = ["default"] }
 google-cloud-wkt.workspace    = true
 tokio.workspace               = true
 tracing.workspace             = true
-tracing-subscriber            = { workspace = true, features = ["fmt"] }
 uuid                          = { workspace = true, features = ["v4"] }
 
 [lints]

--- a/tests/spanner/Cargo.toml
+++ b/tests/spanner/Cargo.toml
@@ -28,12 +28,9 @@ run-integration-tests = []
 anyhow.workspace        = true
 base64.workspace        = true
 futures.workspace       = true
-google-cloud-auth       = { workspace = true, features = ["default"] }
 google-cloud-gax        = { workspace = true }
-google-cloud-lro        = { workspace = true }
 google-cloud-spanner    = { workspace = true, features = ["unstable-stream"] }
 google-cloud-test-utils = { workspace = true }
-google-cloud-wkt        = { workspace = true }
 http                    = { workspace = true }
 http-body               = { workspace = true }
 http-body-util          = { workspace = true }
@@ -48,7 +45,6 @@ tokio                   = { workspace = true, features = ["sync"] }
 tokio-stream            = { workspace = true }
 tonic                   = { workspace = true }
 tower                   = { workspace = true }
-tracing.workspace       = true
 
 [lints]
 workspace = true

--- a/tests/storage/Cargo.toml
+++ b/tests/storage/Cargo.toml
@@ -29,7 +29,6 @@ log-integration-tests = ["google-cloud-test-utils/log-integration-tests"]
 [dependencies]
 anyhow.workspace            = true
 bytes.workspace             = true
-chrono                      = { workspace = true, features = ["now"] }
 crc32c.workspace            = true
 flate2                      = { workspace = true, features = ["zlib-rs"] }
 futures.workspace           = true
@@ -45,7 +44,6 @@ reqwest.workspace           = true
 storage-samples.workspace   = true
 tokio.workspace             = true
 tracing.workspace           = true
-tracing-subscriber          = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
 test-case.workspace = true


### PR DESCRIPTION
Used `cargo machete` tool to detect unused deps and manually resolved some false positives.

Command use:  `cargo machete --with-metadata --fix .`