### PR TITLE
feat(spanner): leader-aware routing

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -557,6 +557,8 @@ impl Client {
         request_params: &str,
         options: &RequestOptions,
     ) -> Result<http::header::HeaderMap> {
+        use google_cloud_gax::options::internal::RequestOptionsExt as _;
+
         let mut headers = HeaderMap::new();
         if let Some(user_agent) = options.user_agent() {
             headers.insert(
@@ -585,6 +587,9 @@ impl Client {
                 http::header::HeaderName::from_static("x-goog-request-params"),
                 http::header::HeaderValue::from_str(request_params).map_err(Error::ser)?,
             );
+        }
+        if let Some(custom_headers) = options.get_extension::<HeaderMap>() {
+            headers.extend(custom_headers.clone());
         }
         Ok(headers)
     }
@@ -716,5 +721,25 @@ mod tests {
             .unwrap();
         // We can't easily assert the internal state without exposing more internals,
         // but this verifies the method exists and runs.
+    }
+
+    #[tokio::test]
+    async fn test_make_headers_with_custom_headers() {
+        use google_cloud_gax::options::internal::RequestOptionsExt as _;
+        let mut custom_headers = http::HeaderMap::new();
+        custom_headers.insert(
+            "x-custom-header",
+            http::HeaderValue::from_static("custom-value"),
+        );
+
+        let options = RequestOptions::default().insert_extension(custom_headers);
+
+        let headers = Client::make_headers("test-client/1.0", "param=1", &options)
+            .await
+            .unwrap();
+
+        assert_eq!(headers.get("x-custom-header").unwrap(), "custom-value");
+        assert_eq!(headers.get("x-goog-api-client").unwrap(), "test-client/1.0");
+        assert_eq!(headers.get("x-goog-request-params").unwrap(), "param=1");
     }
 }

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -20,7 +20,14 @@ use crate::model::{
 };
 use crate::server_streaming::builder;
 use gaxi::options::{ClientConfig, Credentials};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use http::{
+    HeaderMap,
+    header::{HeaderName, HeaderValue},
+};
+use std::sync::{
+    LazyLock,
+    atomic::{AtomicUsize, Ordering},
+};
 
 pub use crate::database_client::DatabaseClient;
 pub use crate::error::SpannerInternalError;
@@ -119,6 +126,15 @@ fn with_default_idempotency(mut options: crate::RequestOptions) -> crate::Reques
     }
     options
 }
+
+pub(crate) static LAR_HEADER_MAP: LazyLock<HeaderMap> = LazyLock::new(|| {
+    let mut map = HeaderMap::new();
+    map.insert(
+        HeaderName::from_static("x-goog-spanner-route-to-leader"),
+        HeaderValue::from_static("true"),
+    );
+    map
+});
 
 #[allow(dead_code)]
 impl Spanner {

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -20,6 +20,9 @@ use crate::model::{
 };
 use crate::server_streaming::builder;
 use gaxi::options::{ClientConfig, Credentials};
+use google_cloud_gax::options::{
+    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
+};
 use http::{
     HeaderMap,
     header::{HeaderName, HeaderValue},
@@ -135,6 +138,21 @@ pub(crate) static LAR_HEADER_MAP: LazyLock<HeaderMap> = LazyLock::new(|| {
     );
     map
 });
+
+pub(crate) fn amend_request_options_for_lar(
+    leader_aware_routing_enabled: bool,
+    mut options: GaxRequestOptions,
+) -> GaxRequestOptions {
+    if leader_aware_routing_enabled {
+        let mut headers = options
+            .get_extension::<HeaderMap>()
+            .cloned()
+            .unwrap_or_default();
+        headers.extend((*LAR_HEADER_MAP).clone());
+        options = options.insert_extension(headers);
+    }
+    options
+}
 
 #[allow(dead_code)]
 impl Spanner {

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 pub struct DatabaseClient {
     pub(crate) spanner: Spanner,
     pub(crate) session_maintainer: Arc<ManagedSessionMaintainer>,
+    pub(crate) leader_aware_routing_enabled: bool,
 }
 
 impl DatabaseClient {
@@ -253,6 +254,7 @@ pub struct DatabaseClientBuilder {
     database_name: String,
     database_role: Option<String>,
     options: Option<crate::RequestOptions>,
+    leader_aware_routing_enabled: bool,
 }
 
 impl DatabaseClientBuilder {
@@ -262,6 +264,7 @@ impl DatabaseClientBuilder {
             database_name,
             database_role: None,
             options: None,
+            leader_aware_routing_enabled: true,
         }
     }
 
@@ -314,6 +317,34 @@ impl DatabaseClientBuilder {
         self
     }
 
+    /// Sets whether Leader-Aware Routing (LAR) is enabled for read/write transactions.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn sample() -> anyhow::Result<()> {
+    ///     let spanner = Spanner::builder().build().await?;
+    ///     let database_client = spanner
+    ///         .database_client("projects/my-project/instances/my-instance/databases/my-db")
+    ///         .with_leader_aware_routing(true)
+    ///         .build()
+    ///         .await?;
+    ///     # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// When LAR is enabled, modifying operations (Read-Write, Write-Only, and Partitioned DML
+    /// transactions) automatically route requests directly to the Spanner leader replica. This
+    /// eliminates internal forwarding hops between replicas and reduces overall transaction latency.
+    ///
+    /// Enabled by default.
+    ///
+    /// See also: <https://docs.cloud.google.com/spanner/docs/leader-aware-routing>
+    pub fn with_leader_aware_routing(mut self, enabled: bool) -> Self {
+        self.leader_aware_routing_enabled = enabled;
+        self
+    }
+
     /// Builds the [DatabaseClient] and creates a single multiplexed session that
     /// will be used for all operations on the database.
     pub async fn build(self) -> crate::Result<DatabaseClient> {
@@ -329,6 +360,7 @@ impl DatabaseClientBuilder {
         Ok(DatabaseClient {
             spanner: spanner_clone,
             session_maintainer,
+            leader_aware_routing_enabled: self.leader_aware_routing_enabled,
         })
     }
 }

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::client::LAR_HEADER_MAP;
 use crate::database_client::DatabaseClient;
 use crate::google::spanner::v1::result_set_stats::RowCount::RowCountLowerBound;
 use crate::model::transaction_options::PartitionedDml;
@@ -22,6 +23,9 @@ use crate::server_streaming::stream::PartialResultSetStream;
 use crate::statement::Statement;
 use crate::transaction_retry_policy::{
     BasicTransactionRetryPolicy, TransactionRetryPolicy, retry_aborted,
+};
+use google_cloud_gax::options::{
+    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
 };
 
 /// A builder for [PartitionedDmlTransaction].
@@ -174,37 +178,52 @@ impl PartitionedDmlTransaction {
         };
         let base_request = statement.into_request();
         let channel_hint = self.client.spanner.next_channel_hint();
+        let gax_options = self.gax_options();
+        let client = self.client;
 
         // Execute the statement and retry if the transaction is aborted by Spanner.
-        retry_aborted(&*self.retry_policy, || async {
-            let transaction = self
-                .client
-                .spanner
-                .begin_transaction(
-                    begin_request.clone(),
-                    crate::RequestOptions::default(),
+        retry_aborted(&*self.retry_policy, || {
+            let begin_request = begin_request.clone();
+            let base_request = base_request.clone();
+            let session_name = session_name.clone();
+            let gax_options = gax_options.clone();
+            let client = client.clone();
+
+            async move {
+                let transaction = client
+                    .spanner
+                    .begin_transaction(begin_request, gax_options.clone(), channel_hint)
+                    .await?;
+
+                let execute_request =
+                    base_request
+                        .set_session(session_name)
+                        .set_transaction(TransactionSelector {
+                            selector: Some(transaction_selector::Selector::Id(
+                                transaction.id.clone(),
+                            )),
+                            ..Default::default()
+                        });
+
+                let stream_builder = client.spanner.execute_streaming_sql(
+                    execute_request,
+                    gax_options,
                     channel_hint,
-                )
-                .await?;
+                );
+                let stream = stream_builder.send().await?;
 
-            let execute_request = base_request
-                .clone()
-                .set_session(session_name.clone())
-                .set_transaction(TransactionSelector {
-                    selector: Some(transaction_selector::Selector::Id(transaction.id.clone())),
-                    ..Default::default()
-                });
-
-            let stream_builder = self.client.spanner.execute_streaming_sql(
-                execute_request.clone(),
-                crate::RequestOptions::default(),
-                channel_hint,
-            );
-            let stream = stream_builder.send().await?;
-
-            extract_lower_bound_update_count_from_stream(stream).await
+                extract_lower_bound_update_count_from_stream(stream).await
+            }
         })
         .await
+    }
+
+    fn gax_options(&self) -> GaxRequestOptions {
+        let mut options = GaxRequestOptions::default();
+        if self.client.leader_aware_routing_enabled {
+            options = options.insert_extension((*LAR_HEADER_MAP).clone());
+        }
+        options
     }
 }
 
@@ -433,5 +452,53 @@ mod tests {
             err.to_string()
                 .contains("no row_count_lower_bound was returned")
         );
+    }
+
+    #[google_cloud_test_macros::tokio_test_no_panics]
+    async fn leader_aware_routing_enabled_by_default() {
+        let mut mock = create_session_mock();
+        mock.expect_begin_transaction().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![0, 1, 2],
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_execute_streaming_sql().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            let stream = adapt([Ok(v1::PartialResultSet {
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountLowerBound(500)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })]);
+            Ok(tonic::Response::from(stream))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let transaction = db_client
+            .partitioned_dml_transaction()
+            .build()
+            .await
+            .unwrap();
+        let statement = Statement::builder("UPDATE Users SET active = true").build();
+        let res: i64 = transaction.execute_update(statement).await.unwrap();
+        assert_eq!(res, 500);
     }
 }

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::LAR_HEADER_MAP;
+use crate::client::amend_request_options_for_lar;
 use crate::database_client::DatabaseClient;
 use crate::google::spanner::v1::result_set_stats::RowCount::RowCountLowerBound;
 use crate::model::transaction_options::PartitionedDml;
@@ -24,9 +24,7 @@ use crate::statement::Statement;
 use crate::transaction_retry_policy::{
     BasicTransactionRetryPolicy, TransactionRetryPolicy, retry_aborted,
 };
-use google_cloud_gax::options::{
-    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
-};
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
 
 /// A builder for [PartitionedDmlTransaction].
 ///
@@ -166,6 +164,8 @@ impl PartitionedDmlTransaction {
     /// See also: <https://docs.cloud.google.com/spanner/docs/dml-partitioned>
     pub async fn execute_update<T: Into<Statement>>(self, statement: T) -> crate::Result<i64> {
         let statement = statement.into();
+        let mut gax_options = statement.gax_options().clone();
+        self.amend_gax_options(&mut gax_options);
 
         let session_name = self.client.session_name();
         let transaction_options = TransactionOptions::default()
@@ -178,7 +178,6 @@ impl PartitionedDmlTransaction {
         };
         let base_request = statement.into_request();
         let channel_hint = self.client.spanner.next_channel_hint();
-        let gax_options = self.gax_options();
         let client = self.client;
 
         // Execute the statement and retry if the transaction is aborted by Spanner.
@@ -218,12 +217,11 @@ impl PartitionedDmlTransaction {
         .await
     }
 
-    fn gax_options(&self) -> GaxRequestOptions {
-        let mut options = GaxRequestOptions::default();
-        if self.client.leader_aware_routing_enabled {
-            options = options.insert_extension((*LAR_HEADER_MAP).clone());
-        }
-        options
+    fn amend_gax_options(&self, options: &mut GaxRequestOptions) {
+        *options = amend_request_options_for_lar(
+            self.client.leader_aware_routing_enabled,
+            options.clone(),
+        );
     }
 }
 

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -2387,4 +2387,31 @@ pub(crate) mod tests {
 
         Ok(())
     }
+
+    #[tokio_test_no_panics]
+    async fn leader_aware_routing_query_in_read_only() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+        mock.expect_execute_streaming_sql().once().returning(|req| {
+            assert!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .is_none()
+            );
+            let stream = adapt([Ok(mock_v1::PartialResultSet {
+                metadata: Some(mock_v1::ResultSetMetadata {
+                    row_type: Some(mock_v1::StructType { fields: vec![] }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })]);
+            Ok(tonic::Response::from(stream))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let tx = db_client.single_use().build();
+        let _rs = tx
+            .execute_query(Statement::builder("SELECT 1").build())
+            .await?;
+        Ok(())
+    }
 }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -14,6 +14,7 @@
 
 use crate::BatchDml;
 use crate::RequestOptions;
+use crate::client::LAR_HEADER_MAP;
 use crate::database_client::DatabaseClient;
 use crate::error::internal_error;
 use crate::model::BeginTransactionRequest;
@@ -37,7 +38,9 @@ use crate::result_set::ResultSet;
 use crate::statement::Statement;
 use crate::transaction_retry_policy::is_aborted;
 use google_cloud_gax::error::Error as GaxError;
-use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
+use google_cloud_gax::options::{
+    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
+};
 use google_cloud_gax::retry_policy::RetryPolicy;
 use google_cloud_gax::retry_result::RetryResult;
 use google_cloud_gax::retry_state::RetryState;
@@ -152,6 +155,9 @@ impl ReadWriteTransactionBuilder {
                 let remaining = d.saturating_duration_since(Instant::now());
                 options.set_attempt_timeout(remaining);
             }
+            if self.client.leader_aware_routing_enabled {
+                options = options.insert_extension((*LAR_HEADER_MAP).clone());
+            }
 
             let response = self
                 .client
@@ -235,6 +241,9 @@ macro_rules! execute_with_retry {
                     let remaining = d.saturating_duration_since(tokio::time::Instant::now());
                     begin_options.set_attempt_timeout(remaining);
                 }
+                if $self.context.client.leader_aware_routing_enabled {
+                    begin_options = begin_options.insert_extension((*LAR_HEADER_MAP).clone());
+                }
 
                 $self
                     .context
@@ -279,12 +288,9 @@ impl ReadWriteTransaction {
         &self,
         statement: T,
     ) -> crate::Result<ResultSet> {
-        if self.deadline.is_none() {
-            return self.context.execute_query(statement).await;
-        }
         let stmt = statement.into();
         let mut gax_options = stmt.gax_options().clone();
-        self.apply_transaction_timeout(&mut gax_options);
+        self.amend_gax_options(&mut gax_options);
         let stmt = stmt.with_gax_options(gax_options);
         self.context.execute_query(stmt).await
     }
@@ -294,11 +300,8 @@ impl ReadWriteTransaction {
         &self,
         read: T,
     ) -> crate::Result<ResultSet> {
-        if self.deadline.is_none() {
-            return self.context.execute_read(read).await;
-        }
         let mut req = read.into();
-        self.apply_transaction_timeout(&mut req.gax_options);
+        self.amend_gax_options(&mut req.gax_options);
         self.context.execute_read(req).await
     }
 
@@ -306,9 +309,7 @@ impl ReadWriteTransaction {
     pub async fn execute_update<T: Into<Statement>>(&self, statement: T) -> crate::Result<i64> {
         let statement = statement.into();
         let mut gax_options = statement.gax_options().clone();
-        if self.deadline.is_some() {
-            self.apply_transaction_timeout(&mut gax_options);
-        }
+        self.amend_gax_options(&mut gax_options);
         let seqno = self.seqno.fetch_add(1, Ordering::SeqCst);
         let mut request = statement
             .into_request()
@@ -413,9 +414,7 @@ impl ReadWriteTransaction {
     /// ```
     pub async fn execute_batch_update(&self, batch: BatchDml) -> crate::Result<Vec<i64>> {
         let mut batch = batch;
-        if self.deadline.is_some() {
-            self.apply_transaction_timeout(&mut batch.gax_options);
-        }
+        self.amend_gax_options(&mut batch.gax_options);
         let seqno = self.seqno.fetch_add(1, Ordering::SeqCst);
 
         let statements: Vec<ExecuteBatchDmlStatement> = batch
@@ -485,7 +484,7 @@ impl ReadWriteTransaction {
 
         // TODO(#4972): make request options configurable
         let mut gax_options = GaxRequestOptions::default();
-        self.apply_transaction_timeout(&mut gax_options);
+        self.amend_gax_options(&mut gax_options);
 
         let response = self
             .context
@@ -504,7 +503,7 @@ impl ReadWriteTransaction {
 
                 // TODO(#4972): make request options configurable
                 let mut gax_options = GaxRequestOptions::default();
-                self.apply_transaction_timeout(&mut gax_options);
+                self.amend_gax_options(&mut gax_options);
 
                 self.context
                     .client
@@ -526,20 +525,19 @@ impl ReadWriteTransaction {
             .set_session(self.context.session_name.clone())
             .set_transaction_id(transaction_id);
 
+        let mut gax_options = RequestOptions::default();
+        self.amend_gax_options(&mut gax_options);
+
         self.context
             .client
             .spanner
-            .rollback(
-                request,
-                RequestOptions::default(),
-                self.context.channel_hint,
-            )
+            .rollback(request, gax_options, self.context.channel_hint)
             .await?;
 
         Ok(())
     }
 
-    fn apply_transaction_timeout(&self, options: &mut GaxRequestOptions) {
+    fn amend_gax_options(&self, options: &mut GaxRequestOptions) {
         if let Some(deadline) = self.deadline {
             let inner_policy = options
                 .retry_policy()
@@ -550,6 +548,9 @@ impl ReadWriteTransaction {
                 deadline,
             };
             options.set_retry_policy(bounded_policy);
+        }
+        if self.context.client.leader_aware_routing_enabled {
+            *options = options.clone().insert_extension((*LAR_HEADER_MAP).clone());
         }
     }
 }
@@ -579,7 +580,9 @@ mod tests {
     use super::*;
     use crate::BatchUpdateError;
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
+    use crate::result_set::tests::adapt;
     use gaxi::grpc::tonic;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::google::spanner::v1;
     use std::fmt::Debug;
     use std::sync::Mutex;
@@ -1904,6 +1907,184 @@ mod tests {
 
         assert_eq!(counts, vec![1]);
 
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn leader_aware_routing_enabled_by_default() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+        mock.expect_begin_transaction().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![1, 2, 3],
+                ..Default::default()
+            }))
+        });
+        mock.expect_execute_sql().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::ResultSet {
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+        mock.expect_commit().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let tx = ReadWriteTransactionBuilder::new(db_client)
+            .with_explicit_begin_transaction(true)
+            .build(None)
+            .await?;
+        let count = tx.execute_update("UPDATE Users SET active = true").await?;
+        assert_eq!(count, 1);
+        let _ = tx.commit().await?;
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn leader_aware_routing_disabled() -> anyhow::Result<()> {
+        use crate::client::Spanner;
+        use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+
+        let mut mock = create_session_mock();
+        mock.expect_begin_transaction().once().returning(|req| {
+            assert!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .is_none()
+            );
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![1, 2, 3],
+                ..Default::default()
+            }))
+        });
+        mock.expect_execute_sql().once().returning(|req| {
+            assert!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .is_none()
+            );
+            Ok(tonic::Response::new(v1::ResultSet {
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+        mock.expect_commit().once().returning(|req| {
+            assert!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .is_none()
+            );
+            Ok(tonic::Response::new(v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (address, _server) = spanner_grpc_mock::start("0.0.0.0:0", mock).await.unwrap();
+        let spanner = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let db_client = spanner
+            .database_client("projects/p/instances/i/databases/d")
+            .with_leader_aware_routing(false)
+            .build()
+            .await?;
+
+        let tx = ReadWriteTransactionBuilder::new(db_client)
+            .with_explicit_begin_transaction(true)
+            .build(None)
+            .await?;
+        let count = tx.execute_update("UPDATE Users SET active = true").await?;
+        assert_eq!(count, 1);
+        let _ = tx.commit().await?;
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn leader_aware_routing_query_in_read_write() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+        mock.expect_begin_transaction().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![1, 2, 3],
+                ..Default::default()
+            }))
+        });
+        mock.expect_execute_streaming_sql().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            let stream = adapt([Ok(v1::PartialResultSet {
+                metadata: Some(v1::ResultSetMetadata {
+                    row_type: Some(v1::StructType { fields: vec![] }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })]);
+            Ok(tonic::Response::from(stream))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let tx = ReadWriteTransactionBuilder::new(db_client)
+            .with_explicit_begin_transaction(true)
+            .build(None)
+            .await?;
+        let _rs = tx
+            .execute_query(Statement::builder("SELECT 1").build())
+            .await?;
         Ok(())
     }
 }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -14,7 +14,7 @@
 
 use crate::BatchDml;
 use crate::RequestOptions;
-use crate::client::LAR_HEADER_MAP;
+use crate::client::amend_request_options_for_lar;
 use crate::database_client::DatabaseClient;
 use crate::error::internal_error;
 use crate::model::BeginTransactionRequest;
@@ -38,9 +38,7 @@ use crate::result_set::ResultSet;
 use crate::statement::Statement;
 use crate::transaction_retry_policy::is_aborted;
 use google_cloud_gax::error::Error as GaxError;
-use google_cloud_gax::options::{
-    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
-};
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
 use google_cloud_gax::retry_policy::RetryPolicy;
 use google_cloud_gax::retry_result::RetryResult;
 use google_cloud_gax::retry_state::RetryState;
@@ -155,9 +153,8 @@ impl ReadWriteTransactionBuilder {
                 let remaining = d.saturating_duration_since(Instant::now());
                 options.set_attempt_timeout(remaining);
             }
-            if self.client.leader_aware_routing_enabled {
-                options = options.insert_extension((*LAR_HEADER_MAP).clone());
-            }
+            options =
+                amend_request_options_for_lar(self.client.leader_aware_routing_enabled, options);
 
             let response = self
                 .client
@@ -241,9 +238,10 @@ macro_rules! execute_with_retry {
                     let remaining = d.saturating_duration_since(tokio::time::Instant::now());
                     begin_options.set_attempt_timeout(remaining);
                 }
-                if $self.context.client.leader_aware_routing_enabled {
-                    begin_options = begin_options.insert_extension((*LAR_HEADER_MAP).clone());
-                }
+                begin_options = amend_request_options_for_lar(
+                    $self.context.client.leader_aware_routing_enabled,
+                    begin_options,
+                );
 
                 $self
                     .context
@@ -549,9 +547,10 @@ impl ReadWriteTransaction {
             };
             options.set_retry_policy(bounded_policy);
         }
-        if self.context.client.leader_aware_routing_enabled {
-            *options = options.clone().insert_extension((*LAR_HEADER_MAP).clone());
-        }
+        *options = amend_request_options_for_lar(
+            self.context.client.leader_aware_routing_enabled,
+            options.clone(),
+        );
     }
 }
 
@@ -582,6 +581,7 @@ mod tests {
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
     use crate::result_set::tests::adapt;
     use gaxi::grpc::tonic;
+    use google_cloud_gax::options::internal::RequestOptionsExt as _;
     use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::google::spanner::v1;
     use std::fmt::Debug;
@@ -2085,6 +2085,70 @@ mod tests {
         let _rs = tx
             .execute_query(Statement::builder("SELECT 1").build())
             .await?;
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn leader_aware_routing_merges_custom_headers() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+        mock.expect_begin_transaction().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(tonic::Response::new(v1::Transaction {
+                id: vec![1, 2, 3],
+                ..Default::default()
+            }))
+        });
+        mock.expect_execute_sql().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            assert_eq!(
+                req.metadata()
+                    .get("x-custom-user-header")
+                    .expect("custom header required")
+                    .to_str()
+                    .unwrap(),
+                "custom-value"
+            );
+            Ok(tonic::Response::new(v1::ResultSet {
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let tx = ReadWriteTransactionBuilder::new(db_client)
+            .with_explicit_begin_transaction(true)
+            .build(None)
+            .await?;
+
+        let mut custom_headers = http::HeaderMap::new();
+        custom_headers.insert(
+            "x-custom-user-header",
+            http::HeaderValue::from_static("custom-value"),
+        );
+
+        let mut stmt = Statement::builder("UPDATE Users SET active = true").build();
+        let opts = stmt.gax_options().clone().insert_extension(custom_headers);
+        stmt = stmt.with_gax_options(opts);
+
+        let count = tx.execute_update(stmt).await?;
+        assert_eq!(count, 1);
         Ok(())
     }
 }

--- a/src/spanner/src/session_maintainer.rs
+++ b/src/spanner/src/session_maintainer.rs
@@ -535,6 +535,7 @@ mod tests {
         let db_client = DatabaseClient {
             spanner,
             session_maintainer: maintainer.clone(),
+            leader_aware_routing_enabled: true,
         };
 
         // 1. Create builder (captures session 1)

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::{DatabaseClient, LAR_HEADER_MAP, Mutation};
+use crate::client::{DatabaseClient, Mutation, amend_request_options_for_lar};
 use crate::model::request_options::Priority;
 use crate::model::transaction_options::ReadWrite;
 use crate::model::{
@@ -22,9 +22,7 @@ use crate::transaction_retry_policy::{
     BasicTransactionRetryPolicy, TransactionRetryPolicy, retry_aborted,
 };
 use bytes::Bytes;
-use google_cloud_gax::options::{
-    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
-};
+use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
 use std::sync::{Arc, Mutex};
 use wkt::Duration;
 
@@ -423,11 +421,10 @@ impl WriteOnlyTransaction {
     }
 
     fn gax_options(&self) -> GaxRequestOptions {
-        let mut options = GaxRequestOptions::default();
-        if self.client.leader_aware_routing_enabled {
-            options = options.insert_extension((*LAR_HEADER_MAP).clone());
-        }
-        options
+        amend_request_options_for_lar(
+            self.client.leader_aware_routing_enabled,
+            GaxRequestOptions::default(),
+        )
     }
 }
 

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::{DatabaseClient, Mutation};
+use crate::client::{DatabaseClient, LAR_HEADER_MAP, Mutation};
 use crate::model::request_options::Priority;
 use crate::model::transaction_options::ReadWrite;
 use crate::model::{
@@ -22,6 +22,9 @@ use crate::transaction_retry_policy::{
     BasicTransactionRetryPolicy, TransactionRetryPolicy, retry_aborted,
 };
 use bytes::Bytes;
+use google_cloud_gax::options::{
+    RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
+};
 use std::sync::{Arc, Mutex};
 use wkt::Duration;
 
@@ -272,6 +275,7 @@ impl WriteOnlyTransaction {
     where
         I: IntoIterator<Item = Mutation>,
     {
+        let gax_options = self.gax_options();
         let req_options = RequestOptions::default()
             .set_transaction_tag(self.transaction_tag.unwrap_or_default())
             .set_priority(self.commit_priority.clone());
@@ -290,6 +294,7 @@ impl WriteOnlyTransaction {
             let mutations_proto = mutations_proto.clone();
             let mutation_key = mutation_key.clone();
             let previous_transaction_id = previous_transaction_id.clone();
+            let gax_options = gax_options.clone();
 
             async move {
                 let previous_id: Bytes = previous_transaction_id.lock().unwrap().clone();
@@ -311,7 +316,7 @@ impl WriteOnlyTransaction {
 
                 let tx = client
                     .spanner
-                    .begin_transaction(begin_req, crate::RequestOptions::default(), channel_hint)
+                    .begin_transaction(begin_req, gax_options.clone(), channel_hint)
                     .await?;
                 *previous_transaction_id.lock().unwrap() = tx.id.clone();
 
@@ -326,7 +331,7 @@ impl WriteOnlyTransaction {
 
                 let response = client
                     .spanner
-                    .commit(commit_req, crate::RequestOptions::default(), channel_hint)
+                    .commit(commit_req, gax_options.clone(), channel_hint)
                     .await?;
 
                 // If a commit_response with a precommit_token is returned, then we need to
@@ -339,11 +344,7 @@ impl WriteOnlyTransaction {
                         .set_precommit_token(new_token);
                     client
                         .spanner
-                        .commit(
-                            retry_commit_req,
-                            crate::RequestOptions::default(),
-                            channel_hint,
-                        )
+                        .commit(retry_commit_req, gax_options, channel_hint)
                         .await
                 } else {
                     Ok(response)
@@ -389,6 +390,7 @@ impl WriteOnlyTransaction {
     where
         I: IntoIterator<Item = Mutation>,
     {
+        let gax_options = self.gax_options();
         let single_use = TransactionOptions::new()
             .set_read_write(Box::new(ReadWrite::new()))
             .set_exclude_txn_from_change_streams(self.exclude_txn_from_change_streams);
@@ -408,15 +410,24 @@ impl WriteOnlyTransaction {
         retry_aborted(&*self.retry_policy, || {
             let client = client.clone();
             let request = request.clone();
+            let gax_options = gax_options.clone();
 
             async move {
                 client
                     .spanner
-                    .commit(request, crate::RequestOptions::default(), channel_hint)
+                    .commit(request, gax_options, channel_hint)
                     .await
             }
         })
         .await
+    }
+
+    fn gax_options(&self) -> GaxRequestOptions {
+        let mut options = GaxRequestOptions::default();
+        if self.client.leader_aware_routing_enabled {
+            options = options.insert_extension((*LAR_HEADER_MAP).clone());
+        }
+        options
     }
 }
 
@@ -1032,6 +1043,47 @@ mod tests {
             .write_at_least_once(vec![mutation])
             .await;
 
+        assert!(res.is_ok());
+    }
+
+    #[google_cloud_test_macros::tokio_test_no_panics]
+    async fn leader_aware_routing_enabled_by_default() {
+        let mut mock = spanner_grpc_mock::MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(Session {
+                name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_commit().once().returning(|req| {
+            assert_eq!(
+                req.metadata()
+                    .get("x-goog-spanner-route-to-leader")
+                    .expect("header required")
+                    .to_str()
+                    .unwrap(),
+                "true"
+            );
+            Ok(Response::new(CommitResponse {
+                commit_timestamp: Some(Timestamp {
+                    seconds: 1234,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+        let mutation = Mutation::new_insert_or_update_builder("Users")
+            .set("UserId")
+            .to(&1)
+            .build();
+        let res = db_client
+            .write_only_transaction()
+            .build()
+            .write_at_least_once(vec![mutation])
+            .await;
         assert!(res.is_ok());
     }
 }


### PR DESCRIPTION
Adds support for leader-aware routing to the Spanner client. This requires a custom header to be included in the requests that should be routed to the leader.

This change also includes a small change to gaxi to support setting custom headers.