### PR TITLE
docs(spanner): setup samples for Spanner and add first sample

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8064,6 +8064,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spanner-samples"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "google-cloud-gax",
+ "google-cloud-spanner",
+ "google-cloud-test-utils",
+ "integration-tests-spanner",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default-members = [
   "src/pubsub",
   "src/pubsub/examples",
   "src/spanner",
+  "src/spanner/examples",
   "src/storage",
   "src/storage/examples",
   "src/wkt",
@@ -296,6 +297,7 @@ members = [
   "src/pubsub/examples",
   "src/pubsub/grpc-mock",
   "src/spanner",
+  "src/spanner/examples",
   "src/spanner/grpc-mock",
   "src/storage",
   "src/storage/benchmarks/random",
@@ -532,7 +534,9 @@ google-cloud-test-macros = { path = "src/test-macros" }
 google-cloud-test-utils  = { default-features = false, path = "src/test-utils" }
 integration-tests        = { path = "tests/integration" }
 integration-tests-o11y   = { default-features = false, path = "tests/o11y" }
+integration-tests-spanner = { path = "tests/spanner" }
 pubsub-samples           = { path = "src/pubsub/examples" }
+spanner-samples          = { path = "src/spanner/examples" }
 storage-samples          = { path = "src/storage/examples" }
 storage-grpc-mock        = { path = "src/storage/grpc-mock" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,15 +530,15 @@ google-cloud-workflows-v1            = { default-features = false, path = "src/g
 google-cloud-workflows-executions-v1 = { default-features = false, path = "src/generated/cloud/workflows/executions/v1" }
 secretmanager-openapi-v1             = { default-features = false, path = "src/generated/openapi-validation" }
 # Local test packages (never add a version)
-google-cloud-test-macros = { path = "src/test-macros" }
-google-cloud-test-utils  = { default-features = false, path = "src/test-utils" }
-integration-tests        = { path = "tests/integration" }
-integration-tests-o11y   = { default-features = false, path = "tests/o11y" }
+google-cloud-test-macros  = { path = "src/test-macros" }
+google-cloud-test-utils   = { default-features = false, path = "src/test-utils" }
+integration-tests         = { path = "tests/integration" }
+integration-tests-o11y    = { default-features = false, path = "tests/o11y" }
 integration-tests-spanner = { path = "tests/spanner" }
-pubsub-samples           = { path = "src/pubsub/examples" }
-spanner-samples          = { path = "src/spanner/examples" }
-storage-samples          = { path = "src/storage/examples" }
-storage-grpc-mock        = { path = "src/storage/grpc-mock" }
+pubsub-samples            = { path = "src/pubsub/examples" }
+spanner-samples           = { path = "src/spanner/examples" }
+storage-samples           = { path = "src/storage/examples" }
+storage-grpc-mock         = { path = "src/storage/grpc-mock" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [

--- a/src/spanner/examples/Cargo.toml
+++ b/src/spanner/examples/Cargo.toml
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name                 = "spanner-samples"
+version              = "0.0.0"
+publish              = false
+edition.workspace    = true
+authors.workspace    = true
+license.workspace    = true
+repository.workspace = true
+keywords.workspace   = true
+categories.workspace = true
+
+[dependencies]
+anyhow.workspace           = true
+futures.workspace          = true
+google-cloud-gax.workspace = true
+google-cloud-spanner       = { workspace = true }
+tokio                      = { workspace = true, features = ["macros"] }
+tracing-subscriber         = { workspace = true, features = ["fmt", "std"] }
+tracing.workspace          = true
+
+[dev-dependencies]
+google-cloud-test-utils   = { workspace = true }
+integration-tests-spanner = { workspace = true }
+
+[features]
+run-integration-tests     = []
+skipped-integration-tests = []

--- a/src/spanner/examples/README.md
+++ b/src/spanner/examples/README.md
@@ -1,0 +1,4 @@
+# Spanner Client Library Examples
+
+This directory contains a number of code examples used in the Spanner
+documentation.

--- a/src/spanner/examples/src/lib.rs
+++ b/src/spanner/examples/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod query;

--- a/src/spanner/examples/src/query/mod.rs
+++ b/src/spanner/examples/src/query/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod query_data;

--- a/src/spanner/examples/src/query/query_data.rs
+++ b/src/spanner/examples/src/query/query_data.rs
@@ -1,0 +1,33 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_query_data]
+use google_cloud_spanner::client::{DatabaseClient, Statement};
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let statement = Statement::builder("SELECT SingerId, AlbumId, AlbumTitle FROM Albums").build();
+    let transaction = client.single_use().build();
+    let mut result_set = transaction.execute_query(statement).await?;
+
+    println!("Listing albums:");
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id = row.get::<i64, _>("SingerId");
+        let album_id = row.get::<i64, _>("AlbumId");
+        let album_title = row.get::<String, _>("AlbumTitle");
+        println!("SingerId: {singer_id}, AlbumId: {album_id}, AlbumTitle: {album_title}");
+    }
+    println!("Done listing albums.");
+    Ok(())
+}
+// [END spanner_query_data]

--- a/src/spanner/examples/tests/integration.rs
+++ b/src/spanner/examples/tests/integration.rs
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(all(test, feature = "run-integration-tests"))]
+mod tests {
+    use google_cloud_spanner::client::{DatabaseClient, Mutation};
+    use google_cloud_test_utils::errors::anydump;
+    use integration_tests_spanner::client::{create_database_client, update_database_ddl_batch};
+    use spanner_samples::query;
+
+    async fn setup_sample_emulator() -> anyhow::Result<Option<DatabaseClient>> {
+        let Some(database_client) = create_database_client().await else {
+            return Ok(None);
+        };
+
+        // Ensure the Singers and Albums tables exist in the provisioned test database.
+        update_database_ddl_batch(vec![
+            "CREATE TABLE IF NOT EXISTS Singers ( \
+                SingerId INT64 NOT NULL, \
+                FirstName STRING(1024), \
+                LastName STRING(1024), \
+                SingerInfo BYTES(MAX), \
+                FullName STRING(2048) AS (ARRAY_TO_STRING([FirstName, LastName], \" \")) STORED \
+             ) PRIMARY KEY (SingerId)"
+                .to_string(),
+            "CREATE TABLE IF NOT EXISTS Albums ( \
+                SingerId INT64 NOT NULL, \
+                AlbumId INT64 NOT NULL, \
+                AlbumTitle STRING(MAX) \
+             ) PRIMARY KEY (SingerId, AlbumId), \
+             INTERLEAVE IN PARENT Singers ON DELETE CASCADE"
+                .to_string(),
+        ])
+        .await?;
+
+        // Populate standard sample data into Singers and Albums tables.
+        let write_transaction = database_client.write_only_transaction().build();
+        let mutations = vec![
+            Mutation::new_insert_or_update_builder("Singers")
+                .set("SingerId")
+                .to(&1)
+                .set("FirstName")
+                .to(&"Marc")
+                .set("LastName")
+                .to(&"Richards")
+                .build(),
+            Mutation::new_insert_or_update_builder("Singers")
+                .set("SingerId")
+                .to(&2)
+                .set("FirstName")
+                .to(&"Catalina")
+                .set("LastName")
+                .to(&"Smith")
+                .build(),
+            Mutation::new_insert_or_update_builder("Singers")
+                .set("SingerId")
+                .to(&3)
+                .set("FirstName")
+                .to(&"Alice")
+                .set("LastName")
+                .to(&"Trentor")
+                .build(),
+            Mutation::new_insert_or_update_builder("Singers")
+                .set("SingerId")
+                .to(&4)
+                .set("FirstName")
+                .to(&"Lea")
+                .set("LastName")
+                .to(&"Martin")
+                .build(),
+            Mutation::new_insert_or_update_builder("Singers")
+                .set("SingerId")
+                .to(&5)
+                .set("FirstName")
+                .to(&"David")
+                .set("LastName")
+                .to(&"Lomond")
+                .build(),
+            Mutation::new_insert_or_update_builder("Albums")
+                .set("SingerId")
+                .to(&1)
+                .set("AlbumId")
+                .to(&1)
+                .set("AlbumTitle")
+                .to(&"Total Junk")
+                .build(),
+            Mutation::new_insert_or_update_builder("Albums")
+                .set("SingerId")
+                .to(&1)
+                .set("AlbumId")
+                .to(&2)
+                .set("AlbumTitle")
+                .to(&"Go, Go, Go")
+                .build(),
+            Mutation::new_insert_or_update_builder("Albums")
+                .set("SingerId")
+                .to(&2)
+                .set("AlbumId")
+                .to(&1)
+                .set("AlbumTitle")
+                .to(&"Green")
+                .build(),
+            Mutation::new_insert_or_update_builder("Albums")
+                .set("SingerId")
+                .to(&2)
+                .set("AlbumId")
+                .to(&2)
+                .set("AlbumTitle")
+                .to(&"Forever Hold Your Peace")
+                .build(),
+            Mutation::new_insert_or_update_builder("Albums")
+                .set("SingerId")
+                .to(&2)
+                .set("AlbumId")
+                .to(&3)
+                .set("AlbumTitle")
+                .to(&"Terrified")
+                .build(),
+        ];
+        write_transaction.write_at_least_once(mutations).await?;
+
+        Ok(Some(database_client))
+    }
+
+    #[tokio::test]
+    async fn query_samples() -> anyhow::Result<()> {
+        let Some(database_client) = setup_sample_emulator().await.inspect_err(anydump)? else {
+            return Ok(());
+        };
+
+        query::query_data::sample(&database_client)
+            .await
+            .inspect_err(anydump)
+    }
+}

--- a/tests/spanner/src/client.rs
+++ b/tests/spanner/src/client.rs
@@ -211,6 +211,16 @@ pub async fn create_database_client() -> Option<google_cloud_spanner::client::Da
 /// if multiple schema changes are executed in parallel, or if schema changes are executed
 /// in parallel with read/write transactions.
 pub async fn update_database_ddl(statement: String) -> anyhow::Result<()> {
+    update_database_ddl_batch(vec![statement]).await
+}
+
+/// Updates the database DDL by executing the given batch of statements on the Spanner Emulator.
+///
+/// This method uses the emulator's REST API directly. It includes a retry loop to handle
+/// transient "Schema change operation rejected" errors that can occur in the emulator
+/// if multiple schema changes are executed in parallel, or if schema changes are executed
+/// in parallel with read/write transactions.
+pub async fn update_database_ddl_batch(statements: Vec<String>) -> anyhow::Result<()> {
     let emulator_host = get_emulator_host().expect("SPANNER_EMULATOR_HOST must be set");
     let rest_endpoint = get_emulator_rest_endpoint(&emulator_host);
     let db_path = format!(
@@ -222,7 +232,7 @@ pub async fn update_database_ddl(statement: String) -> anyhow::Result<()> {
     let url = format!("{}/v1/{}/ddl", rest_endpoint, db_path);
     let client = reqwest::Client::new();
     let payload = serde_json::json!({
-        "statements": [statement]
+        "statements": statements
     });
 
     let mut attempts = 0;


### PR DESCRIPTION
Sets up an examples directory for Spanner, adds the first sample, and sets up integration tests for these samples. The integration tests run against the same Spanner Emulator as the other integration tests.