### PR TITLE
feat(storage): include custom object metadata in ObjectHighlights

### DIFF
--- a/src/storage/src/model_ext.rs
+++ b/src/storage/src/model_ext.rs
@@ -73,6 +73,12 @@ pub struct ObjectHighlights {
 
     /// The etag of the object.
     pub etag: String,
+
+    /// User-provided metadata, in key/value pairs.
+    ///
+    /// Populated from `x-goog-meta-*` response headers; keys have the
+    /// `x-goog-meta-` prefix stripped and are lowercased by the server.
+    pub metadata: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/storage/src/storage/bidi/range_reader.rs
+++ b/src/storage/src/storage/bidi/range_reader.rs
@@ -63,6 +63,7 @@ impl ReadObjectResponse for RangeReader {
             content_type: self.object.content_type.clone(),
             content_disposition: self.object.content_disposition.clone(),
             etag: self.object.etag.clone(),
+            metadata: self.object.metadata.clone(),
         }
     }
 
@@ -110,6 +111,7 @@ mod tests {
             content_language: "content-language".into(),
             content_type: "content-type".into(),
             content_disposition: "content-disposition".into(),
+            metadata: std::collections::HashMap::new(),
         };
         assert_eq!(got, want);
 

--- a/src/storage/src/storage/read_object/non_resumable.rs
+++ b/src/storage/src/storage/read_object/non_resumable.rs
@@ -127,6 +127,7 @@ mod tests {
             content_disposition: "attachment".to_string(),
             etag: "etag-123".to_string(),
             checksums: None,
+            metadata: std::collections::HashMap::new(),
         };
         assert_eq!(got, want);
 

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -51,7 +51,19 @@ pub fn object_highlights(generation: i64, headers: &HeaderMap) -> Result<ObjectH
                 .set_or_clear_crc32c(headers_to_crc32c(headers))
                 .set_md5_hash(headers_to_md5_hash(headers))
         }),
+        metadata: headers_to_metadata(headers),
     })
+}
+
+fn headers_to_metadata(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            let key = name.as_str().strip_prefix("x-goog-meta-")?;
+            let value = value.to_str().ok()?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect()
 }
 
 pub(crate) fn headers_to_crc32c(headers: &HeaderMap) -> Option<u32> {
@@ -133,7 +145,9 @@ mod tests {
                     .append_header("content-language", "en")
                     .append_header("content-type", "text/plain")
                     .append_header("content-disposition", "inline")
-                    .append_header("etag", "etagval"),
+                    .append_header("etag", "etagval")
+                    .append_header("x-goog-meta-foo", "bar")
+                    .append_header("x-goog-meta-key2", "value2"),
             ),
         );
 
@@ -160,8 +174,41 @@ mod tests {
             object.checksums.as_ref().unwrap().md5_hash,
             base64::prelude::BASE64_STANDARD.decode("d63R1fQSI9VYL8pzalyzNQ==")?
         );
+        assert_eq!(
+            object.metadata,
+            std::collections::HashMap::from([
+                ("foo".to_string(), "bar".to_string()),
+                ("key2".to_string(), "value2".to_string()),
+            ])
+        );
 
         Ok(())
+    }
+
+    #[test]
+    fn test_headers_to_metadata() -> Result {
+        let mut headers = http::HeaderMap::new();
+        headers.insert("x-goog-meta-foo", http::HeaderValue::from_static("bar"));
+        headers.insert("X-Goog-Meta-Mixed", http::HeaderValue::from_static("case"));
+        headers.insert("content-type", http::HeaderValue::from_static("text/plain"));
+        headers.insert("x-goog-generation", http::HeaderValue::from_static("1"));
+
+        let got = headers_to_metadata(&headers);
+        assert_eq!(
+            got,
+            std::collections::HashMap::from([
+                ("foo".to_string(), "bar".to_string()),
+                ("mixed".to_string(), "case".to_string()),
+            ])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_headers_to_metadata_empty() {
+        let headers = http::HeaderMap::new();
+        let got = headers_to_metadata(&headers);
+        assert!(got.is_empty(), "{got:?}");
     }
 
     #[test]

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -58,12 +58,10 @@ pub fn object_highlights(generation: i64, headers: &HeaderMap) -> Result<ObjectH
 fn headers_to_metadata(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
     let mut metadata = std::collections::HashMap::new();
     for (name, value) in headers.iter() {
-        if let Some(key) = name.as_str().strip_prefix("x-goog-meta-") {
-            if let Ok(val_str) = value.to_str() {
-                metadata
-                    .entry(key.to_string())
-                    .or_insert_with(|| val_str.to_string());
-            }
+        if let (Some(key), Ok(val)) = (name.as_str().strip_prefix("x-goog-meta-"), value.to_str()) {
+            metadata
+                .entry(key.to_string())
+                .or_insert_with(|| val.to_string());
         }
     }
     metadata

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -56,14 +56,17 @@ pub fn object_highlights(generation: i64, headers: &HeaderMap) -> Result<ObjectH
 }
 
 fn headers_to_metadata(headers: &HeaderMap) -> std::collections::HashMap<String, String> {
-    headers
-        .iter()
-        .filter_map(|(name, value)| {
-            let key = name.as_str().strip_prefix("x-goog-meta-")?;
-            let value = value.to_str().ok()?;
-            Some((key.to_string(), value.to_string()))
-        })
-        .collect()
+    let mut metadata = std::collections::HashMap::new();
+    for (name, value) in headers.iter() {
+        if let Some(key) = name.as_str().strip_prefix("x-goog-meta-") {
+            if !metadata.contains_key(key) {
+                if let Ok(val_str) = value.to_str() {
+                    metadata.insert(key.to_string(), val_str.to_string());
+                }
+            }
+        }
+    }
+    metadata
 }
 
 pub(crate) fn headers_to_crc32c(headers: &HeaderMap) -> Option<u32> {
@@ -209,6 +212,15 @@ mod tests {
         let headers = http::HeaderMap::new();
         let got = headers_to_metadata(&headers);
         assert!(got.is_empty(), "{got:?}");
+    }
+
+    #[test]
+    fn test_headers_to_metadata_duplicate_keeps_first() {
+        let mut headers = http::HeaderMap::new();
+        headers.append("x-goog-meta-foo", http::HeaderValue::from_static("first"));
+        headers.append("x-goog-meta-foo", http::HeaderValue::from_static("second"));
+        let got = headers_to_metadata(&headers);
+        assert_eq!(got.get("foo"), Some(&"first".to_string()));
     }
 
     #[test]

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -59,10 +59,10 @@ fn headers_to_metadata(headers: &HeaderMap) -> std::collections::HashMap<String,
     let mut metadata = std::collections::HashMap::new();
     for (name, value) in headers.iter() {
         if let Some(key) = name.as_str().strip_prefix("x-goog-meta-") {
-            if !metadata.contains_key(key) {
-                if let Ok(val_str) = value.to_str() {
-                    metadata.insert(key.to_string(), val_str.to_string());
-                }
+            if let Ok(val_str) = value.to_str() {
+                metadata
+                    .entry(key.to_string())
+                    .or_insert_with(|| val_str.to_string());
             }
         }
     }


### PR DESCRIPTION
Adds `metadata: HashMap<String, String>` to `ObjectHighlights`,
populated from the `x-goog-meta-*` HTTP response headers on
`read_object()`. The metadata is already on the wire alongside the
object body, so no additional `StorageControl::get_object` RPC is
needed.

`ObjectHighlights` is `#[non_exhaustive]`, so this is additive — no
public API break.

## Changes

- `model_ext.rs`: new `metadata` field on `ObjectHighlights`.
- `parse_http_response.rs`: extract `x-goog-meta-*` headers into the
  field, via a small private helper.
- `bidi/range_reader.rs`: propagate `metadata` from the source
  `Object` (the bidi path already has it in memory; no extra cost).
- Test fixtures in `non_resumable.rs` and `bidi/range_reader.rs`
  updated for the new field.

## Out of scope

The issue mentions optionally also surfacing `event_based_hold`,
`temporary_hold`, and `retention`. The two hold flags are not exposed
as HTTP headers on the download response — surfacing them from
`read_object()` would require an additional metadata GET, defeating
the purpose. Per-object retention may map to
`x-goog-object-lock-mode` / `x-goog-object-lock-retain-until-date`
headers, but this needs empirical confirmation against a real GCS
endpoint with a retention-locked object. Both can be follow-up PRs if
the maintainers want them.

## Test plan

- `cargo test -p google-cloud-storage` — 215 passed, 0 failed.
- `cargo clippy --all-features --no-deps -p google-cloud-storage -- -D missing_docs -D clippy::exhaustive_enums` (the `clippy-strict` content) — clean.
- `cargo clippy --profile=test -p google-cloud-storage --all-targets -- -D warnings` — clean.
- Extended the existing `read_object_metadata` integration-style test to round-trip two `x-goog-meta-*` headers.
- Added two focused unit tests for the new `headers_to_metadata` helper covering case-insensitive header names, non-meta header filtering, and the empty-headers case.

For #5644