### PR TITLE
impl(o11y): add operation name support to `Poller` interface

### DIFF
--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -132,6 +132,9 @@ where
     async fn poll(&mut self) -> Option<PollingResult<(), M>> {
         self.poller.poll().await.map(self::map_polling_result)
     }
+    fn operation_name(&self) -> Option<&str> {
+        self.poller.operation_name()
+    }
     async fn backoff(&mut self, state: &PollingState) {
         self.poller.backoff(state).await
     }
@@ -163,6 +166,9 @@ where
 {
     async fn poll(&mut self) -> Option<PollingResult<R, ()>> {
         self.poller.poll().await.map(self::map_polling_metadata)
+    }
+    fn operation_name(&self) -> Option<&str> {
+        self.poller.operation_name()
     }
     async fn backoff(&mut self, state: &PollingState) {
         self.poller.backoff(state).await
@@ -281,6 +287,9 @@ where
         }
         None
     }
+    fn operation_name(&self) -> Option<&str> {
+        self.operation.as_deref()
+    }
     async fn backoff(&mut self, state: &PollingState) {
         let backoff = self.backoff_policy.wait_period(state);
         tokio::time::sleep(backoff).await;
@@ -347,7 +356,9 @@ mod tests {
             start,
             query,
         );
+        assert_eq!(poller.operation_name(), None);
         let p0 = poller.poll().await;
+        assert_eq!(poller.operation_name(), Some("test-only-name"));
         match p0.unwrap() {
             PollingResult::InProgress(m) => {
                 assert_eq!(m, Some(Timestamp::clamp(123, 0)));

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -120,6 +120,9 @@ where
         }
         None
     }
+    fn operation_name(&self) -> Option<&str> {
+        self.operation.as_deref()
+    }
     async fn backoff(&mut self, state: &PollingState) {
         let backoff = self.backoff_policy.wait_period(state);
         tokio::time::sleep(backoff).await;
@@ -230,6 +233,33 @@ mod tests {
             ),
             "{got:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn poller_operation_name() {
+        let start = || async move {
+            let op = TestOperation {
+                name: Some("test-operation-abc".into()),
+                ..TestOperation::default()
+            };
+            Ok(op)
+        };
+        let query = |_name| async move {
+            let op = TestOperation {
+                done: true,
+                ..TestOperation::default()
+            };
+            Ok(op)
+        };
+        let mut poller = new_discovery_poller(
+            Arc::new(AlwaysContinue),
+            Arc::new(test_backoff()),
+            start,
+            query,
+        );
+        assert_eq!(poller.operation_name(), None);
+        let _ = poller.poll().await;
+        assert_eq!(poller.operation_name(), Some("test-operation-abc"));
     }
 
     #[tokio::test]

--- a/src/lro/src/internal/either.rs
+++ b/src/lro/src/internal/either.rs
@@ -40,6 +40,12 @@ where
             Self::Right(s) => s.poll().await,
         }
     }
+    fn operation_name(&self) -> Option<&str> {
+        match self {
+            Self::Left(s) => s.operation_name(),
+            Self::Right(s) => s.operation_name(),
+        }
+    }
     async fn backoff(&mut self, state: &PollingState) {
         match self {
             Self::Left(s) => s.backoff(state).await,
@@ -79,6 +85,7 @@ mod tests {
         impl sealed::Poller for PollerA {}
         impl Poller<ResponseType, MetadataType> for PollerA {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
+            fn operation_name<'a>(&'a self) -> Option<&'a str>;
             async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]
@@ -92,6 +99,7 @@ mod tests {
         impl sealed::Poller for PollerB {}
         impl Poller<ResponseType, MetadataType> for PollerB {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
+            fn operation_name<'a>(&'a self) -> Option<&'a str>;
             async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]

--- a/src/lro/src/internal/ext.rs
+++ b/src/lro/src/internal/ext.rs
@@ -70,6 +70,7 @@ mod tests {
         impl sealed::Poller for PollerA {}
         impl Poller<ResponseType, MetadataType> for PollerA {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
+            fn operation_name<'a>(&'a self) -> Option<&'a str>;
             async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -41,6 +41,9 @@ where
         let span = info_span!("LRO Poll");
         self.inner.poll().instrument(span).await
     }
+    fn operation_name(&self) -> Option<&str> {
+        self.inner.operation_name()
+    }
     async fn backoff(&mut self, state: &PollingState) {
         let span = info_span!("LRO Sleep");
         self.inner.backoff(state).instrument(span).await

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -149,6 +149,9 @@ pub trait Poller<ResponseType, MetadataType>: Send + sealed::Poller {
         &mut self,
     ) -> impl Future<Output = Option<PollingResult<ResponseType, MetadataType>>> + Send;
 
+    /// Returns the name of the operation, if known.
+    fn operation_name(&self) -> Option<&str>;
+
     /// Sleep until the backoff time has elapsed.
     fn backoff(&mut self, state: &PollingState) -> impl Future<Output = ()> + Send;
 


### PR DESCRIPTION
Allow tracing decorators to dynamically query LRO operation IDs from underlying poller for telemetry recording.

Because `PollerImpl` is encapsulated as a generic inside the telemetry decorator, we can't do direct field access (like `self.inner.operation`) on the generic type. Declaring this standard method on the `Poller` trait supports LRO tracing attribute propagation without contaminating public structs.