### PR TITLE
refactor(lro): move `backoff` to private `SealedPoller` trait

### DIFF
--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -18,7 +18,10 @@
 //! module may be changed or removed without warnings. Applications should not
 //! use any types contained within.
 
-use crate::{Poller, PollingBackoffPolicy, PollingErrorPolicy, PollingResult, Result};
+use crate::{
+    Poller, PollingBackoffPolicy, PollingErrorPolicy, PollingResult, Result,
+    sealed::Poller as SealedPoller,
+};
 use google_cloud_gax::polling_state::PollingState;
 use google_cloud_wkt::Empty;
 use google_cloud_wkt::message::Message;
@@ -123,7 +126,14 @@ impl<P> UnitResponsePoller<P> {
     }
 }
 
-impl<P> crate::sealed::Poller for UnitResponsePoller<P> {}
+impl<P> SealedPoller for UnitResponsePoller<P>
+where
+    P: SealedPoller + Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        self.poller.backoff(state).await
+    }
+}
 
 impl<P, M> Poller<(), M> for UnitResponsePoller<P>
 where
@@ -131,9 +141,6 @@ where
 {
     async fn poll(&mut self) -> Option<PollingResult<(), M>> {
         self.poller.poll().await.map(self::map_polling_result)
-    }
-    async fn backoff(&mut self, state: &PollingState) {
-        self.poller.backoff(state).await
     }
     async fn until_done(self) -> Result<()> {
         self.poller.until_done().await.map(|_| ())
@@ -155,7 +162,14 @@ impl<P> UnitMetadataPoller<P> {
     }
 }
 
-impl<P> crate::sealed::Poller for UnitMetadataPoller<P> {}
+impl<P> SealedPoller for UnitMetadataPoller<P>
+where
+    P: SealedPoller + Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        self.poller.backoff(state).await
+    }
+}
 
 impl<P, R> Poller<R, ()> for UnitMetadataPoller<P>
 where
@@ -163,9 +177,6 @@ where
 {
     async fn poll(&mut self) -> Option<PollingResult<R, ()>> {
         self.poller.poll().await.map(self::map_polling_metadata)
-    }
-    async fn backoff(&mut self, state: &PollingState) {
-        self.poller.backoff(state).await
     }
     async fn until_done(self) -> Result<R> {
         self.poller.until_done().await
@@ -281,10 +292,6 @@ where
         }
         None
     }
-    async fn backoff(&mut self, state: &PollingState) {
-        let backoff = self.backoff_policy.wait_period(state);
-        tokio::time::sleep(backoff).await;
-    }
     async fn until_done(self) -> Result<ResponseType> {
         crate::until_done(self).await
     }
@@ -296,8 +303,16 @@ where
         crate::into_stream(self)
     }
 }
-
-impl<S, Q> crate::sealed::Poller for PollerImpl<S, Q> {}
+impl<S, Q> SealedPoller for PollerImpl<S, Q>
+where
+    S: Send,
+    Q: Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        let backoff = self.backoff_policy.wait_period(state);
+        tokio::time::sleep(backoff).await;
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -929,6 +929,77 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_unit_pollers_backoff() {
+        use crate::sealed::Poller as _;
+
+        let start_resp = || async move {
+            Ok::<EmptyResponseOperation, Error>(
+                EmptyResponseOperation::new(OperationAny::default()),
+            )
+        };
+        let query_resp = |_: String| async move {
+            Ok::<EmptyResponseOperation, Error>(
+                EmptyResponseOperation::new(OperationAny::default()),
+            )
+        };
+
+        let mut poller = new_unit_response_poller(
+            Arc::new(AlwaysContinue),
+            Arc::new(
+                ExponentialBackoffBuilder::new()
+                    .with_initial_delay(StdDuration::from_millis(1))
+                    .clamp(),
+            ),
+            start_resp,
+            query_resp,
+        );
+        poller.backoff(&PollingState::default()).await;
+
+        let start_meta = || async move {
+            Ok::<EmptyMetadataOperation, Error>(
+                EmptyMetadataOperation::new(OperationAny::default()),
+            )
+        };
+        let query_meta = |_: String| async move {
+            Ok::<EmptyMetadataOperation, Error>(
+                EmptyMetadataOperation::new(OperationAny::default()),
+            )
+        };
+
+        let mut poller = new_unit_metadata_poller(
+            Arc::new(AlwaysContinue),
+            Arc::new(
+                ExponentialBackoffBuilder::new()
+                    .with_initial_delay(StdDuration::from_millis(1))
+                    .clamp(),
+            ),
+            start_meta,
+            query_meta,
+        );
+        poller.backoff(&PollingState::default()).await;
+
+        type EmptyOperation = Operation<Empty, Empty>;
+        let start_unit = || async move {
+            Ok::<EmptyOperation, Error>(EmptyOperation::new(OperationAny::default()))
+        };
+        let query_unit = |_: String| async move {
+            Ok::<EmptyOperation, Error>(EmptyOperation::new(OperationAny::default()))
+        };
+
+        let mut poller = new_unit_poller(
+            Arc::new(AlwaysContinue),
+            Arc::new(
+                ExponentialBackoffBuilder::new()
+                    .with_initial_delay(StdDuration::from_millis(1))
+                    .clamp(),
+            ),
+            start_unit,
+            query_unit,
+        );
+        poller.backoff(&PollingState::default()).await;
+    }
+
     fn service_error() -> Error {
         Error::service(
             Status::default()

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -23,7 +23,10 @@
 //! we can name directly.
 //!
 
-use crate::{Poller, PollingBackoffPolicy, PollingErrorPolicy, PollingResult, Result};
+use crate::{
+    Poller, PollingBackoffPolicy, PollingErrorPolicy, PollingResult, Result,
+    sealed::Poller as SealedPoller,
+};
 use google_cloud_gax::polling_state::PollingState;
 use google_cloud_gax::retry_result::RetryResult;
 use std::sync::Arc;
@@ -93,7 +96,16 @@ impl<S, Q> DiscoveryPoller<S, Q> {
     }
 }
 
-impl<S, Q> crate::sealed::Poller for DiscoveryPoller<S, Q> {}
+impl<S, Q> SealedPoller for DiscoveryPoller<S, Q>
+where
+    S: Send,
+    Q: Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        let backoff = self.backoff_policy.wait_period(state);
+        tokio::time::sleep(backoff).await;
+    }
+}
 
 impl<O, S, SF, Q, QF> crate::Poller<O, O> for DiscoveryPoller<S, Q>
 where
@@ -119,10 +131,6 @@ where
             return Some(poll);
         }
         None
-    }
-    async fn backoff(&mut self, state: &PollingState) {
-        let backoff = self.backoff_policy.wait_period(state);
-        tokio::time::sleep(backoff).await;
     }
     async fn until_done(self) -> Result<O> {
         crate::until_done(self).await

--- a/src/lro/src/internal/either.rs
+++ b/src/lro/src/internal/either.rs
@@ -25,7 +25,18 @@ pub enum Either<A, B> {
     Right(B),
 }
 
-impl<A, B> sealed::Poller for Either<A, B> {}
+impl<A, B> sealed::Poller for Either<A, B>
+where
+    A: sealed::Poller + Send,
+    B: sealed::Poller + Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        match self {
+            Self::Left(s) => s.backoff(state).await,
+            Self::Right(s) => s.backoff(state).await,
+        }
+    }
+}
 
 impl<A, B, ResponseType, MetadataType> Poller<ResponseType, MetadataType> for Either<A, B>
 where
@@ -38,12 +49,6 @@ where
         match self {
             Self::Left(s) => s.poll().await,
             Self::Right(s) => s.poll().await,
-        }
-    }
-    async fn backoff(&mut self, state: &PollingState) {
-        match self {
-            Self::Left(s) => s.backoff(state).await,
-            Self::Right(s) => s.backoff(state).await,
         }
     }
     async fn until_done(self) -> Result<ResponseType> {
@@ -68,6 +73,7 @@ where
 mod tests {
     use super::*;
     use crate::PollingResult;
+    use crate::sealed::Poller as _;
     use google_cloud_wkt::{Duration, Timestamp};
     use mockall::mock;
 
@@ -76,10 +82,11 @@ mod tests {
 
     mock! {
         PollerA {}
-        impl sealed::Poller for PollerA {}
+        impl sealed::Poller for PollerA {
+            async fn backoff(&mut self, state: &PollingState);
+        }
         impl Poller<ResponseType, MetadataType> for PollerA {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
-            async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]
             fn into_stream(
@@ -89,10 +96,11 @@ mod tests {
     }
     mock! {
         PollerB {}
-        impl sealed::Poller for PollerB {}
+        impl sealed::Poller for PollerB {
+            async fn backoff(&mut self, state: &PollingState);
+        }
         impl Poller<ResponseType, MetadataType> for PollerB {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
-            async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]
             fn into_stream(

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -29,7 +29,15 @@ impl<P> Tracing<P> {
     }
 }
 
-impl<P> sealed::Poller for Tracing<P> {}
+impl<P> sealed::Poller for Tracing<P>
+where
+    P: sealed::Poller + Send,
+{
+    async fn backoff(&mut self, state: &PollingState) {
+        let span = info_span!("LRO Sleep");
+        self.inner.backoff(state).instrument(span).await
+    }
+}
 
 impl<P, ResponseType, MetadataType> Poller<ResponseType, MetadataType> for Tracing<P>
 where
@@ -40,10 +48,6 @@ where
     async fn poll(&mut self) -> Option<crate::PollingResult<ResponseType, MetadataType>> {
         let span = info_span!("LRO Poll");
         self.inner.poll().instrument(span).await
-    }
-    async fn backoff(&mut self, state: &PollingState) {
-        let span = info_span!("LRO Sleep");
-        self.inner.backoff(state).instrument(span).await
     }
     async fn until_done(self) -> Result<ResponseType> {
         let span = self.span.clone();

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -133,7 +133,12 @@ pub mod internal;
 pub use internal::{PollerOptions, TracingDetails};
 
 pub(crate) mod sealed {
-    pub trait Poller {}
+    use google_cloud_gax::polling_state::PollingState;
+    use std::future::Future;
+
+    pub trait Poller {
+        fn backoff(&mut self, state: &PollingState) -> impl Future<Output = ()> + Send;
+    }
 }
 
 /// Automatically polls long-running operations.
@@ -148,9 +153,6 @@ pub trait Poller<ResponseType, MetadataType>: Send + sealed::Poller {
     fn poll(
         &mut self,
     ) -> impl Future<Output = Option<PollingResult<ResponseType, MetadataType>>> + Send;
-
-    /// Sleep until the backoff time has elapsed.
-    fn backoff(&mut self, state: &PollingState) -> impl Future<Output = ()> + Send;
 
     /// Poll the long-running operation until it completes.
     fn until_done(self) -> impl Future<Output = Result<ResponseType>> + Send;

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -137,6 +137,7 @@ pub(crate) mod sealed {
     use std::future::Future;
 
     pub trait Poller {
+        /// Sleep until the backoff time has elapsed.
         fn backoff(&mut self, state: &PollingState) -> impl Future<Output = ()> + Send;
     }
 }


### PR DESCRIPTION
Change the visibility of `Poller::backoff()`.

`backoff()` is part of the internal `until_done()` polling loop. We don't want application developers to call it directly.

Now that we moved `backoff()` out of public `Poller` and put it inside the private `sealed::Poller` supertrait:
Because `sealed::Poller` trait is crate-private, external consumers of `impl Poller` cannot see or call `backoff()`.
Crate-internal loops (e.g., `until_done()` and `into_stream()`) can import and call `poller.backoff(&state)` as they reside within the same crate.