### PR TITLE
chore(spanner): use Into<BatchDml> as input argument

### DIFF
--- a/src/spanner/src/batch_dml.rs
+++ b/src/spanner/src/batch_dml.rs
@@ -106,6 +106,22 @@ impl BatchDml {
     }
 }
 
+impl From<BatchDmlBuilder> for BatchDml {
+    fn from(builder: BatchDmlBuilder) -> Self {
+        builder.build()
+    }
+}
+
+impl<T: Into<Statement>> From<Vec<T>> for BatchDml {
+    fn from(statements: Vec<T>) -> Self {
+        BatchDml {
+            statements: statements.into_iter().map(Into::into).collect(),
+            request_options: None,
+            gax_options: GaxRequestOptions::default(),
+        }
+    }
+}
+
 /// Processes an ExecuteBatchDmlResponse and returns the success counts, or an error.
 pub(crate) fn process_response(response: ExecuteBatchDmlResponse) -> crate::Result<Vec<i64>> {
     let mut update_counts = Vec::with_capacity(response.result_sets.len());
@@ -364,5 +380,33 @@ mod tests {
             err.to_string()
                 .contains("invalid or missing row count type")
         );
+    }
+
+    #[test]
+    fn from_vector_of_strings() {
+        let statements = vec!["UPDATE table SET col = 1", "UPDATE table SET col = 2"];
+        let batch: BatchDml = statements.into();
+        assert_eq!(batch.statements.len(), 2);
+        assert_eq!(batch.statements[0].sql, "UPDATE table SET col = 1");
+        assert_eq!(batch.statements[1].sql, "UPDATE table SET col = 2");
+    }
+
+    #[test]
+    fn from_vector_of_statements() {
+        let statement1 = Statement::builder("UPDATE table SET col = 1").build();
+        let statement2 = Statement::builder("UPDATE table SET col = 2").build();
+        let statements = vec![statement1, statement2];
+        let batch: BatchDml = statements.into();
+        assert_eq!(batch.statements.len(), 2);
+        assert_eq!(batch.statements[0].sql, "UPDATE table SET col = 1");
+        assert_eq!(batch.statements[1].sql, "UPDATE table SET col = 2");
+    }
+
+    #[test]
+    fn from_builder() {
+        let builder = BatchDml::builder().add_statement("UPDATE table SET col = 1");
+        let batch: BatchDml = builder.into();
+        assert_eq!(batch.statements.len(), 1);
+        assert_eq!(batch.statements[0].sql, "UPDATE table SET col = 1");
     }
 }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -436,8 +436,11 @@ impl ReadWriteTransaction {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn execute_batch_update(&self, batch: BatchDml) -> crate::Result<Vec<i64>> {
-        let mut batch = batch;
+    pub async fn execute_batch_update<T: Into<BatchDml>>(
+        &self,
+        batch: T,
+    ) -> crate::Result<Vec<i64>> {
+        let mut batch = batch.into();
         self.amend_gax_options(&mut batch.gax_options);
         let seqno = self.seqno.fetch_add(1, Ordering::SeqCst);
 
@@ -1125,6 +1128,86 @@ mod tests {
     #[tokio::test]
     async fn read_write_transaction_execute_batch_update_inline() -> anyhow::Result<()> {
         run_read_write_transaction_execute_batch_update(BeginTransactionOption::InlineBegin).await
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_write_transaction_execute_batch_update_vec() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        mock.expect_execute_batch_dml()
+            .once()
+            .returning(move |req| {
+                let req = req.into_inner();
+                assert_eq!(req.statements.len(), 2);
+                assert_eq!(
+                    req.statements[0].sql,
+                    "UPDATE Users SET Name = 'Alice' WHERE Id = 1"
+                );
+                assert_eq!(
+                    req.statements[1].sql,
+                    "UPDATE Users SET Name = 'Bob' WHERE Id = 2"
+                );
+
+                let selector = req
+                    .transaction
+                    .expect("missing transaction selector")
+                    .selector
+                    .expect("missing selector");
+                assert!(matches!(
+                    selector,
+                    v1::transaction_selector::Selector::Begin(_)
+                ));
+
+                let metadata = v1::ResultSetMetadata {
+                    transaction: Some(v1::Transaction {
+                        id: vec![4, 5, 6],
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                };
+
+                Ok(tonic::Response::new(v1::ExecuteBatchDmlResponse {
+                    result_sets: vec![
+                        v1::ResultSet {
+                            metadata: Some(metadata),
+                            stats: Some(v1::ResultSetStats {
+                                row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        v1::ResultSet {
+                            stats: Some(v1::ResultSetStats {
+                                row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                    ],
+                    status: Some(spanner_grpc_mock::google::rpc::Status {
+                        code: 0,
+                        message: "OK".into(),
+                        details: vec![],
+                    }),
+                    ..Default::default()
+                }))
+            });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = ReadWriteTransactionBuilder::new(db_client)
+            .build(None)
+            .await?;
+
+        let statements = vec![
+            "UPDATE Users SET Name = 'Alice' WHERE Id = 1",
+            "UPDATE Users SET Name = 'Bob' WHERE Id = 2",
+        ];
+
+        let counts = transaction.execute_batch_update(statements).await?;
+
+        assert_eq!(counts, vec![1, 1]);
+        Ok(())
     }
 
     async fn run_read_write_transaction_execute_batch_update(

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -1122,96 +1122,55 @@ mod tests {
 
     #[tokio::test]
     async fn read_write_transaction_execute_batch_update_explicit() -> anyhow::Result<()> {
-        run_read_write_transaction_execute_batch_update(BeginTransactionOption::ExplicitBegin).await
+        let batch = BatchDml::builder()
+            .add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .add_statement("UPDATE Users SET Name = 'Bob' WHERE Id = 2")
+            .build();
+        run_read_write_transaction_execute_batch_update(
+            BeginTransactionOption::ExplicitBegin,
+            batch,
+        )
+        .await
     }
 
     #[tokio::test]
     async fn read_write_transaction_execute_batch_update_inline() -> anyhow::Result<()> {
-        run_read_write_transaction_execute_batch_update(BeginTransactionOption::InlineBegin).await
+        let batch = BatchDml::builder()
+            .add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .add_statement("UPDATE Users SET Name = 'Bob' WHERE Id = 2")
+            .build();
+        run_read_write_transaction_execute_batch_update(BeginTransactionOption::InlineBegin, batch)
+            .await
     }
 
     #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_vec() -> anyhow::Result<()> {
-        let mut mock = create_session_mock();
-
-        mock.expect_execute_batch_dml()
-            .once()
-            .returning(move |req| {
-                let req = req.into_inner();
-                assert_eq!(req.statements.len(), 2);
-                assert_eq!(
-                    req.statements[0].sql,
-                    "UPDATE Users SET Name = 'Alice' WHERE Id = 1"
-                );
-                assert_eq!(
-                    req.statements[1].sql,
-                    "UPDATE Users SET Name = 'Bob' WHERE Id = 2"
-                );
-
-                let selector = req
-                    .transaction
-                    .expect("missing transaction selector")
-                    .selector
-                    .expect("missing selector");
-                assert!(matches!(
-                    selector,
-                    v1::transaction_selector::Selector::Begin(_)
-                ));
-
-                let metadata = v1::ResultSetMetadata {
-                    transaction: Some(v1::Transaction {
-                        id: vec![4, 5, 6],
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                };
-
-                Ok(tonic::Response::new(v1::ExecuteBatchDmlResponse {
-                    result_sets: vec![
-                        v1::ResultSet {
-                            metadata: Some(metadata),
-                            stats: Some(v1::ResultSetStats {
-                                row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        },
-                        v1::ResultSet {
-                            stats: Some(v1::ResultSetStats {
-                                row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
-                                ..Default::default()
-                            }),
-                            ..Default::default()
-                        },
-                    ],
-                    status: Some(spanner_grpc_mock::google::rpc::Status {
-                        code: 0,
-                        message: "OK".into(),
-                        details: vec![],
-                    }),
-                    ..Default::default()
-                }))
-            });
-
-        let (db_client, _server) = setup_db_client(mock).await;
-
-        let transaction = ReadWriteTransactionBuilder::new(db_client)
-            .build(None)
-            .await?;
-
         let statements = vec![
             "UPDATE Users SET Name = 'Alice' WHERE Id = 1",
             "UPDATE Users SET Name = 'Bob' WHERE Id = 2",
         ];
+        run_read_write_transaction_execute_batch_update(
+            BeginTransactionOption::InlineBegin,
+            statements,
+        )
+        .await
+    }
 
-        let counts = transaction.execute_batch_update(statements).await?;
-
-        assert_eq!(counts, vec![1, 1]);
-        Ok(())
+    #[tokio_test_no_panics]
+    async fn read_write_transaction_execute_batch_update_vec_statement() -> anyhow::Result<()> {
+        let statement1 = Statement::builder("UPDATE Users SET Name = 'Alice' WHERE Id = 1").build();
+        let statement2 = Statement::builder("UPDATE Users SET Name = 'Bob' WHERE Id = 2").build();
+        let statements = vec![statement1, statement2];
+        run_read_write_transaction_execute_batch_update(
+            BeginTransactionOption::InlineBegin,
+            statements,
+        )
+        .await
     }
 
     async fn run_read_write_transaction_execute_batch_update(
         begin_transaction_option: BeginTransactionOption,
+        batch: impl Into<BatchDml>,
     ) -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -1289,16 +1248,12 @@ mod tests {
 
         let (db_client, _server) = setup_db_client(mock).await;
 
-        let tx = ReadWriteTransactionBuilder::new(db_client)
+        let transaction = ReadWriteTransactionBuilder::new(db_client)
             .with_begin_transaction_option(begin_transaction_option)
             .build(None)
             .await?;
 
-        let batch = BatchDml::builder()
-            .add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
-            .add_statement("UPDATE Users SET Name = 'Bob' WHERE Id = 2");
-
-        let counts = tx.execute_batch_update(batch.build()).await?;
+        let counts = transaction.execute_batch_update(batch).await?;
 
         assert_eq!(counts, vec![1, 1]);
         Ok(())


### PR DESCRIPTION
Use Into<BatchDml> as the input argument for execute_batch_update. This allows an application to pass in a collection of statements, instead of having to manually construct a BatchDml struct.