### PR TITLE
chore: update librarian.yaml pubsub version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1189,7 +1189,7 @@ libraries:
     rust:
       package_name_override: google-cloud-profiler-v2
   - name: google-cloud-pubsub
-    version: 0.33.2
+    version: 1.0.0
     copyright_year: "2025"
     output: src/pubsub
     rust:


### PR DESCRIPTION
Fixes `google-cloud-pubsub` version in `librarian.yaml`.

The `Cargo.toml` files were all manually updated in https://github.com/googleapis/google-cloud-rust/commit/4ef2464d0bb81ce0eea6fe2a89f8cb30a6a01fca to `1.0.0` and released, but not with `librarian bump google-cloud-pubsub -version=1.0.0`, so the `librarian.yaml` was missed.

This PR was created by doing the bump and regen to ensure all required diffs are met.