### PR TITLE
chore: align google-cloud-lro versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,7 +482,7 @@ google-cloud-api         = { default-features = false, version = "1.6.0", path =
 google-cloud-iam-v1      = { default-features = false, version = "1.9.0", path = "src/generated/iam/v1" }
 google-cloud-location    = { default-features = false, version = "1.9.0", path = "src/generated/cloud/location" }
 google-cloud-longrunning = { default-features = false, version = "1.10.0", path = "src/generated/longrunning" }
-google-cloud-lro         = { default-features = false, version = "1.6.0", path = "src/lro" }
+google-cloud-lro         = { default-features = false, version = "1.7.0", path = "src/lro" }
 google-cloud-rpc         = { default-features = false, version = "1.5.0", path = "src/generated/rpc/types", package = "google-cloud-rpc" }
 google-cloud-type        = { default-features = false, version = "1.5.0", path = "src/generated/type" }
 # These are used by specific generated libraries.

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1032,7 +1032,7 @@ libraries:
           ignore: true
           package: ""
   - name: google-cloud-lro
-    version: 1.6.0
+    version: 1.7.0
     copyright_year: "2025"
     output: src/lro
   - name: google-cloud-lustre-v1


### PR DESCRIPTION
Fixes google-cloud-lro version in librarian.yaml & root Cargo.toml.

The Cargo.toml files were all manually updated in https://github.com/googleapis/google-cloud-rust/commit/c3f781435ac5223df920da2bba42b4da0dc183be, but not with `librarian bump` and so forth. 