### PR TITLE
refactor(storage): use single bucket for integration tests

### DIFF
--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -259,50 +259,60 @@ pub async fn buckets() -> Result<()> {
     println!("SUCCESS on create_bucket: {create:?}");
     assert_eq!(create.name, bucket_name);
 
-    let client_tracing = StorageControl::builder()
-        .with_tracing()
-        .with_retry_policy(retry_policy())
-        .build()
-        .await?;
+    let result: Result<()> = async {
+        let client_tracing = StorageControl::builder()
+            .with_tracing()
+            .with_retry_policy(retry_policy())
+            .build()
+            .await?;
 
-    let client_global = StorageControl::builder()
-        .with_endpoint("https://www.googleapis.com")
-        .build()
-        .await?;
+        let client_global = StorageControl::builder()
+            .with_endpoint("https://www.googleapis.com")
+            .build()
+            .await?;
 
-    for client in [&client_tracing, &client_global] {
-        println!("\nTesting get_bucket()");
-        let get = client.get_bucket().set_name(&bucket_name).send().await?;
-        println!("SUCCESS on get_bucket: {get:?}");
-        assert_eq!(get.name, bucket_name);
+        for client in [&client_tracing, &client_global] {
+            println!("\nTesting get_bucket()");
+            let get = client.get_bucket().set_name(&bucket_name).send().await?;
+            println!("SUCCESS on get_bucket: {get:?}");
+            assert_eq!(get.name, bucket_name);
 
-        println!("\nTesting list_buckets()");
-        let mut buckets = client
-            .list_buckets()
-            .set_parent(format!("projects/{project_id}"))
-            .by_item();
-        let mut bucket_names = Vec::new();
-        while let Some(bucket) = buckets.next().await {
-            bucket_names.push(bucket?.name);
+            println!("\nTesting list_buckets()");
+            let mut buckets = client
+                .list_buckets()
+                .set_parent(format!("projects/{project_id}"))
+                .by_item();
+            let mut bucket_names = Vec::new();
+            while let Some(bucket) = buckets.next().await {
+                bucket_names.push(bucket?.name);
+            }
+            println!("SUCCESS on list_buckets");
+            assert!(
+                bucket_names.iter().any(|name| name == &bucket_name),
+                "missing bucket name {bucket_name} in {bucket_names:?}"
+            );
+
+            buckets_iam(client, &bucket_name).await?;
+            folders(client, &bucket_name).await?;
         }
-        println!("SUCCESS on list_buckets");
-        assert!(
-            bucket_names.iter().any(|name| name == &bucket_name),
-            "missing bucket name {bucket_name} in {bucket_names:?}"
-        );
-
-        buckets_iam(client, &bucket_name).await?;
-        folders(client, &bucket_name).await?;
+        Ok(())
     }
+    .await;
 
     println!("\nTesting delete_bucket()");
-    control
+    let delete_result = control
         .delete_bucket()
         .set_name(bucket_name)
         .with_idempotency(true)
         .send()
-        .await?;
-    println!("SUCCESS on delete_bucket");
+        .await;
+
+    if let Err(ref e) = delete_result {
+        println!("ERROR on delete_bucket: {e:?}");
+    }
+
+    result?;
+    delete_result?;
 
     Ok(())
 }

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -271,27 +271,15 @@ pub async fn buckets() -> Result<()> {
             .build()
             .await?;
 
-        for client in [&client_tracing, &client_global] {
-            println!("\nTesting get_bucket()");
-            let get = client.get_bucket().set_name(&bucket_name).send().await?;
-            println!("SUCCESS on get_bucket: {get:?}");
-            assert_eq!(get.name, bucket_name);
+        for (label, client) in [
+            ("with tracing and retry", &client_tracing),
+            ("with global endpoint", &client_global),
+        ] {
+            tracing::info!("running bucket control tests with config: {label}");
+            println!("\nRunning tests with configuration: {label}");
 
-            println!("\nTesting list_buckets()");
-            let mut buckets = client
-                .list_buckets()
-                .set_parent(format!("projects/{project_id}"))
-                .by_item();
-            let mut bucket_names = Vec::new();
-            while let Some(bucket) = buckets.next().await {
-                bucket_names.push(bucket?.name);
-            }
-            println!("SUCCESS on list_buckets");
-            assert!(
-                bucket_names.iter().any(|name| name == &bucket_name),
-                "missing bucket name {bucket_name} in {bucket_names:?}"
-            );
-
+            get_bucket(client, &bucket_name).await?;
+            list_buckets(client, &project_id, &bucket_name).await?;
             buckets_iam(client, &bucket_name).await?;
             folders(client, &bucket_name).await?;
         }
@@ -314,6 +302,32 @@ pub async fn buckets() -> Result<()> {
     result?;
     delete_result?;
 
+    Ok(())
+}
+
+async fn get_bucket(client: &StorageControl, bucket_name: &str) -> Result<()> {
+    println!("\nTesting get_bucket()");
+    let get = client.get_bucket().set_name(bucket_name).send().await?;
+    println!("SUCCESS on get_bucket: {get:?}");
+    assert_eq!(get.name, bucket_name);
+    Ok(())
+}
+
+async fn list_buckets(client: &StorageControl, project_id: &str, bucket_name: &str) -> Result<()> {
+    println!("\nTesting list_buckets()");
+    let mut buckets = client
+        .list_buckets()
+        .set_parent(format!("projects/{project_id}"))
+        .by_item();
+    let mut bucket_names = Vec::new();
+    while let Some(bucket) = buckets.next().await {
+        bucket_names.push(bucket?.name);
+    }
+    println!("SUCCESS on list_buckets");
+    assert!(
+        bucket_names.iter().any(|name| name == bucket_name),
+        "missing bucket name {bucket_name} in {bucket_names:?}"
+    );
     Ok(())
 }
 

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -227,17 +227,17 @@ pub async fn object_names(
     Ok(())
 }
 
-pub async fn buckets(builder: StorageControlBuilder) -> Result<()> {
+pub async fn buckets() -> Result<()> {
     let project_id = project_id()?;
-    let client = builder.build().await?;
 
-    cleanup_stale_buckets(&client, &project_id).await?;
+    let control = StorageControl::builder().build().await?;
+    cleanup_stale_buckets(&control, &project_id).await?;
 
     let bucket_id = random_bucket_id();
     let bucket_name = format!("projects/_/buckets/{bucket_id}");
 
     println!("\nTesting create_bucket()");
-    let create = client
+    let create = control
         .create_bucket()
         .set_parent("projects/_")
         .set_bucket_id(bucket_id)
@@ -259,31 +259,44 @@ pub async fn buckets(builder: StorageControlBuilder) -> Result<()> {
     println!("SUCCESS on create_bucket: {create:?}");
     assert_eq!(create.name, bucket_name);
 
-    println!("\nTesting get_bucket()");
-    let get = client.get_bucket().set_name(&bucket_name).send().await?;
-    println!("SUCCESS on get_bucket: {get:?}");
-    assert_eq!(get.name, bucket_name);
+    let client_tracing = StorageControl::builder()
+        .with_tracing()
+        .with_retry_policy(retry_policy())
+        .build()
+        .await?;
 
-    println!("\nTesting list_buckets()");
-    let mut buckets = client
-        .list_buckets()
-        .set_parent(format!("projects/{project_id}"))
-        .by_item();
-    let mut bucket_names = Vec::new();
-    while let Some(bucket) = buckets.next().await {
-        bucket_names.push(bucket?.name);
+    let client_global = StorageControl::builder()
+        .with_endpoint("https://www.googleapis.com")
+        .build()
+        .await?;
+
+    for client in [&client_tracing, &client_global] {
+        println!("\nTesting get_bucket()");
+        let get = client.get_bucket().set_name(&bucket_name).send().await?;
+        println!("SUCCESS on get_bucket: {get:?}");
+        assert_eq!(get.name, bucket_name);
+
+        println!("\nTesting list_buckets()");
+        let mut buckets = client
+            .list_buckets()
+            .set_parent(format!("projects/{project_id}"))
+            .by_item();
+        let mut bucket_names = Vec::new();
+        while let Some(bucket) = buckets.next().await {
+            bucket_names.push(bucket?.name);
+        }
+        println!("SUCCESS on list_buckets");
+        assert!(
+            bucket_names.iter().any(|name| name == &bucket_name),
+            "missing bucket name {bucket_name} in {bucket_names:?}"
+        );
+
+        buckets_iam(client, &bucket_name).await?;
+        folders(client, &bucket_name).await?;
     }
-    println!("SUCCESS on list_buckets");
-    assert!(
-        bucket_names.iter().any(|name| name == &bucket_name),
-        "missing bucket name {bucket_name} in {bucket_names:?}"
-    );
-
-    buckets_iam(&client, &bucket_name).await?;
-    folders(&client, &bucket_name).await?;
 
     println!("\nTesting delete_bucket()");
-    client
+    control
         .delete_bucket()
         .set_name(bucket_name)
         .with_idempotency(true)

--- a/tests/storage/tests/driver.rs
+++ b/tests/storage/tests/driver.rs
@@ -14,21 +14,16 @@
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod storage {
-    use google_cloud_storage::client::{Storage, StorageControl};
+    use google_cloud_storage::client::Storage;
     use google_cloud_test_utils::errors::anydump;
     use google_cloud_test_utils::tracing::enable_tracing;
     use integration_tests_storage::StorageBuilder;
-    use integration_tests_storage::StorageControlBuilder;
-    use integration_tests_storage::retry_policy;
     use test_case::test_case;
 
-    #[test_case(StorageControl::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
-    #[test_case(StorageControl::builder().with_endpoint("https://www.googleapis.com"); "with global endpoint")]
     #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "flaky test, see #3916"]
-    async fn run_storage_control_buckets(builder: StorageControlBuilder) -> anyhow::Result<()> {
+    async fn run_storage_control_buckets() -> anyhow::Result<()> {
         let _guard = enable_tracing();
-        integration_tests_storage::buckets(builder)
+        integration_tests_storage::buckets()
             .await
             .inspect_err(anydump)
     }

--- a/tests/storage/tests/driver.rs
+++ b/tests/storage/tests/driver.rs
@@ -17,8 +17,6 @@ mod storage {
     use google_cloud_storage::client::Storage;
     use google_cloud_test_utils::errors::anydump;
     use google_cloud_test_utils::tracing::enable_tracing;
-    use integration_tests_storage::StorageBuilder;
-    use test_case::test_case;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn run_storage_control_buckets() -> anyhow::Result<()> {
@@ -34,16 +32,17 @@ mod storage {
         let (control, bucket) = integration_tests_storage::create_test_bucket()
             .await
             .inspect_err(anydump)?;
-        let variants = || async {
+
+        let run_all = || async {
             tracing::info!("default builder");
             let builder = Storage::builder();
             integration_tests_storage::objects(builder, &bucket.name, "default-endpoint")
                 .await
                 .inspect_err(anydump)?;
-            tracing::info!("with global endpoint");
 
+            tracing::info!("with global endpoint");
             let builder = Storage::builder().with_endpoint("https://www.googleapis.com");
-            integration_tests_storage::objects(builder, &bucket.name, "global endpoint")
+            integration_tests_storage::objects(builder, &bucket.name, "global-endpoint")
                 .await
                 .inspect_err(anydump)?;
 
@@ -55,99 +54,45 @@ mod storage {
                     .await
                     .inspect_err(anydump)?;
             }
-            Ok(())
-        };
-        let result = variants().await.inspect_err(anydump);
-        let _ =
-            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
-                .await
-                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-                .inspect_err(anydump);
-        result
-    }
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn run_storage_signed_urls() -> anyhow::Result<()> {
-        let _guard = enable_tracing();
-
-        let signer = google_cloud_auth::credentials::Builder::default().build_signer();
-        let signer = match signer {
-            Ok(s) => s,
-            Err(err) if err.is_not_supported() => {
-                tracing::warn!("skipping run_storage_signed_urls: {err:?}");
-                return Ok(());
+            let signer = google_cloud_auth::credentials::Builder::default().build_signer();
+            match signer {
+                Ok(s) => {
+                    let builder = Storage::builder();
+                    integration_tests_storage::signed_urls(
+                        builder,
+                        &s,
+                        &bucket.name,
+                        "default-endpoint",
+                    )
+                    .await
+                    .inspect_err(anydump)?;
+                }
+                Err(err) if err.is_not_supported() => {
+                    tracing::warn!("skipping run_storage_signed_urls: {err:?}");
+                }
+                Err(err) => {
+                    anyhow::bail!("error creating signer: {err:?}");
+                }
             }
-            Err(err) => {
-                anyhow::bail!("error creating signer: {err:?}")
-            }
-        };
 
-        let (control, bucket) = integration_tests_storage::create_test_bucket()
-            .await
-            .inspect_err(anydump)?;
-
-        let builder = Storage::builder();
-        let result = integration_tests_storage::signed_urls(
-            builder,
-            &signer,
-            &bucket.name,
-            "default-endpoint",
-        )
-        .await
-        .inspect_err(anydump);
-        let _ =
-            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+            integration_tests_storage::read_object::run(&bucket.name)
                 .await
-                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-                .inspect_err(anydump);
-        result
-    }
+                .inspect_err(anydump)?;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn run_storage_read_object() -> anyhow::Result<()> {
-        let _guard = enable_tracing();
-        let (control, bucket) = integration_tests_storage::create_test_bucket()
-            .await
-            .inspect_err(anydump)?;
-        let result = integration_tests_storage::read_object::run(&bucket.name)
-            .await
-            .inspect_err(anydump);
-        let _ =
-            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
+            integration_tests_storage::write_object::run(&bucket.name)
                 .await
-                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-                .inspect_err(anydump);
-        result
-    }
+                .inspect_err(anydump)?;
 
-    #[tokio::test(flavor = "multi_thread")]
-    async fn run_storage_write_object() -> anyhow::Result<()> {
-        let _guard = enable_tracing();
-        let (control, bucket) = integration_tests_storage::create_test_bucket()
-            .await
-            .inspect_err(anydump)?;
-        let result = integration_tests_storage::write_object::run(&bucket.name)
-            .await
-            .inspect_err(anydump);
-        let _ =
-            storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
-                .await
-                .inspect_err(|e| tracing::error!("error cleaning up bucket {}: {e:?}", bucket.name))
-                .inspect_err(anydump);
-        result
-    }
-
-    #[test_case(Storage::builder(); "default")]
-    #[tokio::test]
-    async fn run_storage_object_names(builder: StorageBuilder) -> anyhow::Result<()> {
-        let _guard = enable_tracing();
-        let (control, bucket) = integration_tests_storage::create_test_bucket()
-            .await
-            .inspect_err(anydump)?;
-        let result =
+            let builder = Storage::builder();
             integration_tests_storage::object_names(builder, control.clone(), &bucket.name)
                 .await
-                .inspect_err(anydump);
+                .inspect_err(anydump)?;
+
+            Ok(())
+        };
+
+        let result = run_all().await.inspect_err(anydump);
         let _ =
             storage_samples::cleanup_bucket(control, bucket.name.clone(), bucket.project.clone())
                 .await


### PR DESCRIPTION
Reduce GCS bucket creation/deletion operations to resolve `RESOURCE_EXHAUSTED` errors.
https://github.com/googleapis/google-cloud-rust/pull/5713#discussion_r3277316384

Before: 7 bucket created (for 14+ GCS bucket creation/deletion RPCs).
After: Reduced to 2 bucket created (4 RPCs).

Fixes https://github.com/googleapis/google-cloud-rust/issues/3916
