### PR TITLE
fix(storage): strip projects prefix in cleanup bucket

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -823,8 +823,8 @@ pub async fn cleanup_bucket(
     name: String,
     project_id: String,
 ) -> anyhow::Result<()> {
-    let project_id = clean_project_id(&project_id).to_string();
-    empty_bucket_contents(&client, &name, &project_id).await?;
+    let project_id = clean_project_id(&project_id);
+    empty_bucket_contents(&client, &name, project_id).await?;
     delete_bucket_with_error_backoff(&client, &name).await
 }
 

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -814,11 +814,16 @@ async fn delete_bucket_with_error_backoff(
     Ok(())
 }
 
+fn clean_project_id(project_id: &str) -> &str {
+    project_id.strip_prefix("projects/").unwrap_or(project_id)
+}
+
 pub async fn cleanup_bucket(
     client: StorageControl,
     name: String,
     project_id: String,
 ) -> anyhow::Result<()> {
+    let project_id = clean_project_id(&project_id).to_string();
     empty_bucket_contents(&client, &name, &project_id).await?;
     delete_bucket_with_error_backoff(&client, &name).await
 }
@@ -1021,5 +1026,18 @@ where
 
     fn remaining_time(&self, state: &RetryState) -> Option<Duration> {
         self.inner.remaining_time(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clean_project_id() {
+        assert_eq!(clean_project_id("projects/1234567890"), "1234567890");
+        assert_eq!(clean_project_id("projects/my-project-id"), "my-project-id");
+        assert_eq!(clean_project_id("my-project-id"), "my-project-id");
+        assert_eq!(clean_project_id("1234567890"), "1234567890");
     }
 }


### PR DESCRIPTION
Strip `"projects/"` prefix from `project_id` to ensure the `x-goog-user-project` header contains a valid raw project ID/number.

`x-goog-user-project` header expects only the raw project identifier or number [https://docs.cloud.google.com/storage/docs/json_api/v1/parameters#xgooguserproject](https://docs.cloud.google.com/storage/docs/json_api/v1/parameters#xgooguserproject). 

Therefore, passing `"projects/{project_number}"` causes GCS to return an `INVALID_ARGUMENT` error, causing silent failures for bucket emptying and deletion. 
https://github.com/googleapis/google-cloud-rust/blob/98f06d08cb419d7566d066bf6a1692797b3270c3/src/storage/src/generated/gapic/model.rs#L4803-L4807

For https://github.com/googleapis/google-cloud-rust/issues/3916