### PR TITLE
feat(storage): Support GCS Object Compose - DRAFT

### DIFF
--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -94,6 +94,7 @@ pub mod builder {
     pub mod storage {
         //! Request builders for [Storage][crate::client::Storage].
         pub use crate::storage::client::ClientBuilder;
+        pub use crate::storage::compose_object::ComposeObject;
         pub use crate::storage::open_object::OpenObject;
         pub use crate::storage::read_object::ReadObject;
         pub use crate::storage::signed_url::SignedUrlBuilder;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,6 +18,7 @@ pub(crate) mod bidi;
 pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod common_options;
+pub(crate) mod compose_object;
 pub(crate) mod open_object;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::request_options::RequestOptions;
+use crate::builder::storage::ComposeObject;
 use crate::builder::storage::ReadObject;
 use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
@@ -220,6 +221,34 @@ where
         O: Into<String>,
     {
         ReadObject::new(self.stub.clone(), bucket, object, self.options.clone())
+    }
+
+    /// Concatenates multiple source objects in the same bucket into a single composite object.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .compose_object("projects/_/buckets/my-bucket", "my-composite-object")
+    ///     .add_source("part-1")
+    ///     .add_source("part-2")
+    ///     .send()
+    ///     .await?;
+    /// println!("composite object={response:?}");
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// # Parameters
+    /// * `bucket` - the bucket name containing the source and destination objects. In
+    ///   `projects/_/buckets/{bucket_id}` format.
+    /// * `destination` - the name of the resulting composite object.
+    pub fn compose_object<B, D>(&self, bucket: B, destination: D) -> ComposeObject<S>
+    where
+        B: Into<String>,
+        D: Into<String>,
+    {
+        ComposeObject::new(self.stub.clone(), bucket, destination, self.options.clone())
     }
 
     /// Opens an object to read its contents using concurrent ranged reads.

--- a/src/storage/src/storage/compose_object.rs
+++ b/src/storage/src/storage/compose_object.rs
@@ -1,0 +1,149 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::Object;
+use crate::request_options::RequestOptions;
+use std::sync::Arc;
+
+/// A request builder for [Storage::compose_object][crate::client::Storage::compose_object].
+///
+/// # Example
+/// ```
+/// use google_cloud_storage::client::Storage;
+/// # use google_cloud_storage::builder::storage::ComposeObject;
+/// async fn sample(client: &Storage) -> anyhow::Result<()> {
+///     let response = client
+///         .compose_object("projects/_/buckets/my-bucket", "composite-object")
+///         .add_source("part-1")
+///         .add_source_with_generation("part-2", 123456)
+///         .set_content_type("application/json")
+///         .send()
+///         .await?;
+///     println!("composite object details={response:?}");
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct ComposeObject<S = crate::storage::transport::Storage> {
+    stub: Arc<S>,
+    request: crate::model::ComposeObjectRequest,
+    options: RequestOptions,
+}
+
+impl<S> ComposeObject<S> {
+    pub(crate) fn new<B, D>(
+        stub: Arc<S>,
+        bucket: B,
+        destination: D,
+        options: RequestOptions,
+    ) -> Self
+    where
+        B: Into<String>,
+        D: Into<String>,
+    {
+        let mut request = crate::model::ComposeObjectRequest::default();
+        request.destination = Some(crate::model::Object {
+            bucket: bucket.into(),
+            name: destination.into(),
+            ..Default::default()
+        });
+        Self {
+            stub,
+            request,
+            options,
+        }
+    }
+}
+
+impl<S> ComposeObject<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    /// Appends a source object name to the compose request.
+    pub fn add_source<T: Into<String>>(mut self, name: T) -> Self {
+        let mut source = crate::model::compose_object_request::SourceObject::default();
+        source.name = name.into();
+        self.request.source_objects.push(source);
+        self
+    }
+
+    /// Appends a source object name and its expected generation to the compose request.
+    pub fn add_source_with_generation<T: Into<String>>(mut self, name: T, generation: i64) -> Self {
+        let mut source = crate::model::compose_object_request::SourceObject::default();
+        source.name = name.into();
+        source.generation = generation;
+        self.request.source_objects.push(source);
+        self
+    }
+
+    /// Appends a source object name, generation, and generation match precondition.
+    pub fn add_source_with_preconditions<T: Into<String>>(
+        mut self,
+        name: T,
+        generation: i64,
+        if_generation_match: i64,
+    ) -> Self {
+        let mut source = crate::model::compose_object_request::SourceObject::default();
+        source.name = name.into();
+        source.generation = generation;
+        let mut preconditions = crate::model::compose_object_request::source_object::ObjectPreconditions::default();
+        preconditions.if_generation_match = Some(if_generation_match);
+        source.object_preconditions = Some(preconditions);
+        self.request.source_objects.push(source);
+        self
+    }
+
+    /// Sets the generation match precondition for the destination object.
+    pub fn set_if_generation_match(mut self, v: i64) -> Self {
+        self.request.if_generation_match = Some(v);
+        self
+    }
+
+    /// Sets the metageneration match precondition for the destination object.
+    pub fn set_if_metageneration_match(mut self, v: i64) -> Self {
+        self.request.if_metageneration_match = Some(v);
+        self
+    }
+
+    /// Sets the content type for the destination composite object.
+    pub fn set_content_type<T: Into<String>>(mut self, v: T) -> Self {
+        if let Some(ref mut dest) = self.request.destination {
+            dest.content_type = v.into();
+        }
+        self
+    }
+
+    /// Sets custom metadata attributes for the destination composite object.
+    pub fn set_metadata(mut self, metadata: std::collections::HashMap<String, String>) -> Self {
+        if let Some(ref mut dest) = self.request.destination {
+            dest.metadata = metadata;
+        }
+        self
+    }
+
+    /// Configures a custom retry policy for this compose request.
+    pub fn with_retry_policy<V: Into<google_cloud_gax::retry_policy::RetryPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_policy = v.into().into();
+        self
+    }
+
+    /// Sends the compose request to the GCS service and returns the created composite object.
+    pub async fn send(self) -> Result<Object> {
+        self.stub.compose_object(self.request, self.options).await
+    }
+}

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -81,6 +81,15 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
     {
         unimplemented_stub::<(Descriptor, Vec<ReadObjectResponse>)>()
     }
+
+    /// Implements [crate::client::Storage::compose_object].
+    fn compose_object(
+        &self,
+        _req: crate::model::ComposeObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send {
+        unimplemented_stub::<Object>()
+    }
 }
 
 /// Defines the trait used to implement [crate::object_descriptor::ObjectDescriptor].

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::tracing::{TracingObjectDescriptor, TracingResponse};
-use crate::Result;
+use crate::{Error, Result};
 use crate::model::{Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
@@ -262,6 +262,116 @@ impl Storage {
             .collect::<Vec<_>>();
         Ok((descriptor, readers))
     }
+
+    async fn compose_object_plain(
+        &self,
+        req: crate::model::ComposeObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        use gaxi::{
+            grpc::tonic::{Extensions, GrpcMethod},
+            prost::ToProto,
+        };
+        let options = options.gax();
+        let options = google_cloud_gax::options::internal::set_default_idempotency(options, false);
+        let extensions = {
+            let mut e = Extensions::new();
+            e.insert(GrpcMethod::new(
+                "google.storage.v2.Storage",
+                "ComposeObject",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/ComposeObject");
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&req)
+                            .and_then(|m| m.destination.as_ref())
+                            .map(|m| &m.bucket)
+                            .map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
+        };
+        if x_goog_request_params.is_empty() {
+            use gaxi::path_parameter::PathMismatchBuilder;
+            use gaxi::routing_parameter::Segment;
+            use google_cloud_gax::error::binding::BindingError;
+            let mut paths = Vec::new();
+            {
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
+                    Some(&req)
+                        .and_then(|m| m.destination.as_ref())
+                        .map(|m| &m.bucket)
+                        .map(|s| s.as_str()),
+                    &[Segment::MultiWildcard],
+                    "destination.bucket",
+                    "**",
+                );
+                paths.push(builder.build());
+            }
+            return Err(google_cloud_gax::error::Error::binding(BindingError {
+                paths,
+            }));
+        }
+
+        type TR = crate::google::storage::v2::Object;
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/ComposeObject");
+            recorder.on_client_request(attributes);
+        }
+        self.inner
+            .grpc
+            .execute(
+                extensions,
+                path,
+                req.to_proto().map_err(Error::deser)?,
+                options,
+                &super::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(|r| gaxi::grpc::to_gax_response::<TR, crate::model::Object>(r))
+            .map(|r| r.into_body())
+    }
+
+    #[tracing::instrument(name = "compose_object", level = tracing::Level::DEBUG, ret, err(Debug))]
+    async fn compose_object_tracing(
+        &self,
+        request: crate::model::ComposeObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        let bucket_name = request
+            .destination
+            .as_ref()
+            .map(|d| d.bucket.as_str())
+            .unwrap_or_default();
+        let resource_name = format!("//storage.googleapis.com/{}", bucket_name);
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::compose_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_url_template("/storage/v1/b/{bucket}/o/{destinationObject}/compose")
+                            .set_resource_name(resource_name),
+                    );
+                }
+                self.compose_object_plain(request, options).await
+            }
+        );
+        pending.await
+    }
 }
 
 impl super::stub::Storage for Storage {
@@ -324,6 +434,17 @@ impl super::stub::Storage for Storage {
             return self.open_object_tracing(request, options).await;
         }
         self.open_object_plain(request, options).await
+    }
+
+    async fn compose_object(
+        &self,
+        req: crate::model::ComposeObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        if self.tracing {
+            return self.compose_object_tracing(req, options).await;
+        }
+        self.compose_object_plain(req, options).await
     }
 }
 
@@ -675,6 +796,87 @@ mod tests {
             "missing = {missing:?}\ngot  = {:?}\nwant = {want:?}\nfull = {got:#?}",
             got.keys().collect::<Vec<_>>(),
         );
+    }
+
+    #[tokio::test]
+    async fn compose_object_failure() -> anyhow::Result<()> {
+        use gaxi::grpc::tonic::Status as TonicStatus;
+        use google_cloud_gax::error::rpc::Code;
+        use storage_grpc_mock::{MockStorage, start};
+
+        let guard = TestLayer::initialize();
+
+        let mut mock = MockStorage::new();
+        mock.expect_compose_object()
+            .return_once(|_| Err(TonicStatus::not_found("not here")));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+
+        let client = crate::client::Storage::builder()
+            .with_credentials(Anonymous::new().build())
+            .with_endpoint(endpoint.clone())
+            .with_tracing()
+            .build()
+            .await?;
+        let response = client
+            .compose_object("projects/_/buckets/test-bucket", "test-composite")
+            .add_source("part-1")
+            .send()
+            .await;
+        assert!(
+            matches!(response, Err(ref e) if e.status().is_some_and(|s| s.code == Code::NotFound)),
+            "{response:?}"
+        );
+
+        let captured = TestLayer::capture(&guard);
+        check_debug_log(&captured, "compose_object");
+
+        client_request_span(&captured, "compose_object", "NOT_FOUND", "grpc");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn compose_object_success() -> anyhow::Result<()> {
+        use gaxi::grpc::tonic::Response as TonicResponse;
+        use storage_grpc_mock::google::storage::v2::Object as ProtoObject;
+        use storage_grpc_mock::{MockStorage, start};
+
+        let guard = TestLayer::initialize();
+
+        let mut mock = MockStorage::new();
+        mock.expect_compose_object().return_once(|req| {
+            let req = req.get_ref();
+            assert_eq!(req.destination.as_ref().unwrap().name, "test-composite");
+            Ok(TonicResponse::new(ProtoObject {
+                bucket: "projects/_/buckets/test-bucket".to_string(),
+                name: "test-composite".to_string(),
+                generation: 7890,
+                ..ProtoObject::default()
+            }))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+
+        let client = crate::client::Storage::builder()
+            .with_credentials(Anonymous::new().build())
+            .with_endpoint(endpoint.clone())
+            .with_tracing()
+            .build()
+            .await?;
+        let got = client
+            .compose_object("projects/_/buckets/test-bucket", "test-composite")
+            .add_source("part-1")
+            .send()
+            .await?;
+
+        assert_eq!(got.generation, 7890);
+        assert_eq!(got.name, "test-composite");
+
+        let captured = TestLayer::capture(&guard);
+        let _span = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| panic!("missing `client_request` span in capture: {captured:#?}"));
+
+        Ok(())
     }
 
     #[track_caller]

--- a/src/storage/tests/mocking.rs
+++ b/src/storage/tests/mocking.rs
@@ -54,6 +54,11 @@ mod tests {
                 _request: OpenObjectRequest,
                 _options: RequestOptions,
             ) -> Result<(ObjectDescriptor, Vec<ReadObjectResponse>)>;
+            async fn compose_object(
+                &self,
+                _req: gcs::model::ComposeObjectRequest,
+                _options: RequestOptions,
+            ) -> Result<Object>;
         }
     }
 
@@ -230,6 +235,54 @@ mod tests {
         }
         let contents = bytes::Bytes::from_owner(contents);
         assert_eq!(contents, LAZY);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mock_compose_object() -> anyhow::Result<()> {
+        let want_object = Object::new()
+            .set_bucket("projects/_/buckets/my-bucket")
+            .set_name("my-composite")
+            .set_generation(45678);
+
+        let mut mock = MockStorage::new();
+        mock.expect_compose_object().return_once({
+            let want = want_object.clone();
+            move |req, _opt| {
+                assert_eq!(req.destination.as_ref().map(|d| d.bucket.as_str()), Some("projects/_/buckets/my-bucket"));
+                assert_eq!(req.destination.as_ref().map(|d| d.name.as_str()), Some("my-composite"));
+                let sources = req.source_objects;
+                assert_eq!(sources.len(), 3);
+                assert_eq!(sources[0].name, "part-1");
+                assert_eq!(sources[0].generation, 0);
+                assert_eq!(sources[1].name, "part-2");
+                assert_eq!(sources[1].generation, 123);
+                assert_eq!(sources[2].name, "part-3");
+                assert_eq!(sources[2].generation, 456);
+                
+                let preconditions = sources[2].object_preconditions.as_ref().unwrap();
+                assert_eq!(preconditions.if_generation_match, Some(789));
+
+                assert_eq!(req.if_generation_match, Some(999));
+                assert_eq!(req.if_metageneration_match, Some(888));
+                assert_eq!(req.destination.as_ref().unwrap().content_type, "text/plain");
+                Ok(want)
+            }
+        });
+
+        let client = gcs::client::Storage::from_stub(mock);
+        let got = client
+            .compose_object("projects/_/buckets/my-bucket", "my-composite")
+            .add_source("part-1")
+            .add_source_with_generation("part-2", 123)
+            .add_source_with_preconditions("part-3", 456, 789)
+            .set_if_generation_match(999)
+            .set_if_metageneration_match(888)
+            .set_content_type("text/plain")
+            .send()
+            .await?;
+
+        assert_eq!(got, want_object);
         Ok(())
     }
 


### PR DESCRIPTION
DRAFT, DO NOT REVIEW YET

This PR introduces the GCS Object Compose feature into the developer-facing handwritten Storage client of the google-cloud-rust SDK. 

### Key Additions
1. **Handwritten Veneer API**: Exposes a fluent, premium request builder ComposeObject via Storage::compose_object(bucket, destination).
2. **Rich Fluent Builder**: Supports source names, optional expected generations, individual source preconditions, destination object metadata overrides (e.g., content type, custom metadata), destination preconditions, and custom retry policies.
3. **Extended Mocking Support**: Extends stub::Storage trait with compose_object so developers can mock composition in tests.
4. **gRPC Transport Implementation**: Integrates the gRPC call via self.inner.grpc.execute in transport.rs, with full routing rules, GCP headers, tracing, and observability.
5. **Comprehensive Testing**: Adds mock unit tests (tests/mocking.rs) and transport layer integration tests (transport.rs) covering success and failure cases.