### PR TITLE
test(spanner): add tokio_test_no_panics where needed

### DIFF
--- a/src/spanner/src/batch_read_only_transaction.rs
+++ b/src/spanner/src/batch_read_only_transaction.rs
@@ -591,7 +591,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_query() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -633,7 +633,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_read() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -676,7 +676,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn partition_query() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -747,7 +747,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn partition_read() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -805,7 +805,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_query_with_data_boost() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -837,7 +837,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_read_with_data_boost() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 

--- a/src/spanner/src/batch_write_transaction.rs
+++ b/src/spanner/src/batch_write_transaction.rs
@@ -150,6 +150,7 @@ mod tests {
     use crate::result_set::tests::adapt;
     use anyhow::Result;
     use gaxi::grpc::tonic::Response;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 
@@ -176,7 +177,7 @@ mod tests {
         (db_client, server)
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_streaming() -> Result<()> {
         let mut mock = MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -228,7 +229,7 @@ mod tests {
     }
 
     #[cfg(feature = "unstable-stream")]
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_streaming_into_stream() -> Result<()> {
         use futures::StreamExt;
 

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -365,7 +365,7 @@ mod tests {
         assert_not_impl_any!(Spanner: std::panic::RefUnwindSafe, std::panic::UnwindSafe);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn channel_pool_default_size() {
         let mock = MockSpanner::new();
         let (address, _server) = start("0.0.0.0:0", mock)
@@ -382,7 +382,7 @@ mod tests {
         assert_eq!(client.channels.len(), 4);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn channel_selection() {
         let mock = MockSpanner::new();
         let (address, _server) = start("0.0.0.0:0", mock)
@@ -409,7 +409,7 @@ mod tests {
         assert_eq!(hint4 % 4, 0);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_create_session() {
         // 1. Setup Mock Server
         let mut mock = MockSpanner::new();
@@ -456,7 +456,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_create_session_retry() {
         use google_cloud_gax::options::RequestOptionsBuilder;
         use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
@@ -516,7 +516,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_execute_sql() {
         use crate::model::ExecuteSqlRequest;
 
@@ -559,7 +559,7 @@ mod tests {
         assert!(result_set.metadata.is_some());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_execute_batch_dml() {
         use crate::model::ExecuteBatchDmlRequest;
 
@@ -602,7 +602,7 @@ mod tests {
         assert!(response.status.is_some());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_read() {
         use crate::model::ReadRequest;
 
@@ -641,7 +641,7 @@ mod tests {
         assert!(result_set.metadata.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_begin_transaction() {
         use crate::model::BeginTransactionRequest;
 
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(tx.id, vec![1, 2, 3]);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_commit() {
         use crate::model::CommitRequest;
 
@@ -721,7 +721,7 @@ mod tests {
         assert!(response.commit_timestamp.is_some());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_rollback() {
         use crate::model::RollbackRequest;
 
@@ -753,7 +753,7 @@ mod tests {
             .expect("Failed to call rollback");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_execute_streaming_sql() {
         use crate::model::ExecuteSqlRequest;
 
@@ -804,7 +804,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_streaming_read() {
         use crate::model::ReadRequest;
 
@@ -856,7 +856,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_batch_write() {
         use crate::model::BatchWriteRequest;
 
@@ -898,7 +898,7 @@ mod tests {
         assert!(result.unwrap().is_ok());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_execute_streaming_sql_error() {
         use crate::model::ExecuteSqlRequest;
 
@@ -942,7 +942,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn default_retry_respected() -> anyhow::Result<()> {
         use crate::model::CreateSessionRequest;
 
@@ -993,7 +993,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn override_idempotency_to_false() -> anyhow::Result<()> {
         use crate::model::CreateSessionRequest;
 

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -369,6 +369,7 @@ impl DatabaseClientBuilder {
 mod tests {
     use super::*;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::{MockSpanner, start};
 
     #[test]
@@ -377,7 +378,7 @@ mod tests {
         assert_impl_all!(DatabaseClient: Send, Sync, Clone, std::fmt::Debug);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_database_client_builder() {
         let mut mock = MockSpanner::new();
         mock.expect_create_session().once().returning(|req| {
@@ -428,7 +429,7 @@ mod tests {
         assert_eq!(session.creator_role, "test-role");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_database_client_builder_with_options() {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -486,7 +487,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_database_client_builder_error() {
         let mut mock = MockSpanner::new();
         mock.expect_create_session().once().returning(|_| {

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -252,6 +252,7 @@ mod tests {
     use crate::result_set::tests::adapt;
     use crate::transaction_retry_policy::tests::create_aborted_status;
     use gaxi::grpc::tonic;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::google::spanner::v1;
 
     #[test]
@@ -260,7 +261,7 @@ mod tests {
         static_assertions::assert_impl_all!(PartitionedDmlTransaction: Send, Sync);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_update_success() {
         let mut mock = create_session_mock();
 
@@ -301,7 +302,7 @@ mod tests {
         assert_eq!(res, 500);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_update_with_exclude_txn_from_change_streams() {
         let mut mock = create_session_mock();
 
@@ -341,7 +342,7 @@ mod tests {
         assert_eq!(res, 500);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_update_with_aborted_retry() {
         let mut mock = create_session_mock();
 
@@ -390,7 +391,7 @@ mod tests {
         assert_eq!(res, 100);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn builder_with_retry_settings() {
         let mock = create_session_mock();
         let (db_client, _server) = setup_db_client(mock).await;
@@ -408,7 +409,7 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_update_missing_lower_bound() {
         let mut mock = create_session_mock();
 
@@ -452,7 +453,7 @@ mod tests {
         );
     }
 
-    #[google_cloud_test_macros::tokio_test_no_panics]
+    #[tokio_test_no_panics]
     async fn leader_aware_routing_enabled_by_default() {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().once().returning(|req| {

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -1027,7 +1027,7 @@ pub(crate) mod tests {
         (db_client, server)
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn single_use_builder() {
         let mock = create_session_mock();
 
@@ -1077,7 +1077,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_single_query() {
         use super::super::result_set::tests::string_val;
         use crate::client::Statement;
@@ -1112,7 +1112,7 @@ pub(crate) mod tests {
         assert!(result.is_none(), "expected None, got {result:?}");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_multi_query() {
         use super::super::result_set::tests::string_val;
         use crate::client::Statement;
@@ -1188,7 +1188,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_multi_query_inline_begin() -> anyhow::Result<()> {
         use super::super::result_set::tests::string_val;
         use crate::client::Statement;
@@ -1282,7 +1282,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_single_read() {
         use super::super::result_set::tests::string_val;
         use crate::client::{KeySet, ReadRequest};
@@ -1318,7 +1318,7 @@ pub(crate) mod tests {
         assert!(result.is_none(), "expected None, got {result:?}");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_multi_read() -> anyhow::Result<()> {
         use super::super::result_set::tests::string_val;
         use crate::client::{KeySet, ReadRequest};
@@ -1413,7 +1413,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn inline_begin_failure_retry_success() -> anyhow::Result<()> {
         use crate::value::Value;
         use gaxi::grpc::tonic::Status;
@@ -1491,7 +1491,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn inline_begin_failure_retry_failure() -> anyhow::Result<()> {
         use gaxi::grpc::tonic::Status;
         use tonic::Response;
@@ -1551,7 +1551,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn inline_begin_failure_fallback_rpc_fails() -> anyhow::Result<()> {
         use gaxi::grpc::tonic::Status;
 
@@ -1595,7 +1595,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn inline_begin_read_failure_retry_success() -> anyhow::Result<()> {
         use crate::client::{KeySet, ReadRequest};
         use crate::value::Value;
@@ -1666,7 +1666,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn single_use_query_send_error_returns_immediately() -> anyhow::Result<()> {
         use crate::client::Statement;
         use gaxi::grpc::tonic::Status;
@@ -1694,7 +1694,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn inline_begin_already_started_query_send_error_returns_immediately()
     -> anyhow::Result<()> {
         use crate::client::Statement;

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -654,12 +654,12 @@ mod tests {
         static_assertions::assert_impl_all!(ReadWriteTransaction: Send, Sync, Debug);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_retry_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_commit_retry(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_retry_inline() -> anyhow::Result<()> {
         run_read_write_transaction_commit_retry(BeginTransactionOption::InlineBegin).await
     }
@@ -840,12 +840,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_explicit() {
         run_read_write_transaction_execute_update(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_inline() {
         run_read_write_transaction_execute_update(BeginTransactionOption::InlineBegin).await;
     }
@@ -950,7 +950,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_invalid_stats_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_execute_update_invalid_stats(
             BeginTransactionOption::ExplicitBegin,
@@ -958,7 +958,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_invalid_stats_inline() -> anyhow::Result<()> {
         run_read_write_transaction_execute_update_invalid_stats(BeginTransactionOption::InlineBegin)
             .await
@@ -1034,12 +1034,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_rollback_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_rollback(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_rollback_inline() -> anyhow::Result<()> {
         run_read_write_transaction_rollback(BeginTransactionOption::InlineBegin).await
     }
@@ -1117,12 +1117,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_execute_batch_update(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_inline() -> anyhow::Result<()> {
         run_read_write_transaction_execute_batch_update(BeginTransactionOption::InlineBegin).await
     }
@@ -1221,7 +1221,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_partial_failure_explicit()
     -> anyhow::Result<()> {
         run_read_write_transaction_execute_batch_update_partial_failure(
@@ -1230,7 +1230,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_partial_failure_inline()
     -> anyhow::Result<()> {
         run_read_write_transaction_execute_batch_update_partial_failure(
@@ -1324,13 +1324,13 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_multiple_updates_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_execute_multiple_updates(BeginTransactionOption::ExplicitBegin)
             .await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_multiple_updates_inline() -> anyhow::Result<()> {
         run_read_write_transaction_execute_multiple_updates(BeginTransactionOption::InlineBegin)
             .await
@@ -1424,7 +1424,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_query() {
         use crate::client::Statement;
         let mut mock = create_session_mock();
@@ -1475,7 +1475,7 @@ mod tests {
         assert!(result.is_none(), "expected None, got empty stream");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_with_options() {
         let mut mock = create_session_mock();
 
@@ -1520,7 +1520,7 @@ mod tests {
             .expect("Failed to build transaction");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_with_exclude_txn_from_change_streams() {
         let mut mock = create_session_mock();
 
@@ -1545,7 +1545,7 @@ mod tests {
             .expect("Failed to build transaction");
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_tracks_highest_precommit_token() {
         let mut mock = create_session_mock();
 
@@ -1619,13 +1619,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_retry_exactly_once_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_commit_retry_exactly_once(BeginTransactionOption::ExplicitBegin)
             .await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_retry_exactly_once_inline() -> anyhow::Result<()> {
         run_read_write_transaction_commit_retry_exactly_once(BeginTransactionOption::InlineBegin)
             .await
@@ -1755,7 +1755,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_with_max_commit_delay_explicit() -> anyhow::Result<()> {
         run_read_write_transaction_commit_with_max_commit_delay(
             BeginTransactionOption::ExplicitBegin,
@@ -1763,7 +1763,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_commit_with_max_commit_delay_inline() -> anyhow::Result<()> {
         run_read_write_transaction_commit_with_max_commit_delay(BeginTransactionOption::InlineBegin)
             .await
@@ -1853,7 +1853,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_fallback() {
         let mut mock = create_session_mock();
 
@@ -1923,7 +1923,7 @@ mod tests {
         assert_eq!(count, 1);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_fallback() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -854,7 +854,7 @@ pub(crate) mod tests {
         static_assertions::assert_impl_all!(ResultSet: std::fmt::Debug, Send, Sync);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_zero_rows() {
         let mut rs = run_mock_query(vec![PartialResultSet {
             metadata: metadata(2),
@@ -872,7 +872,7 @@ pub(crate) mod tests {
         assert!(next.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_metadata() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![PartialResultSet {
             metadata: metadata(2),
@@ -906,7 +906,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_handle_partial_result_set_error() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![PartialResultSet {
             values: vec![string_val("row1")],
@@ -928,7 +928,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_handle_partial_result_set_error_immediate() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![
             PartialResultSet {
@@ -956,7 +956,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_stream_ended_with_chunked_value() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![PartialResultSet {
             metadata: metadata(2),
@@ -980,7 +980,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_duplicate_metadata() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![
             PartialResultSet {
@@ -1013,7 +1013,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_empty_column_metadata() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![PartialResultSet {
             metadata: Some(ResultSetMetadata {
@@ -1040,7 +1040,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_default_policies_applied() -> anyhow::Result<()> {
         let rs = run_mock_query(vec![PartialResultSet {
             metadata: metadata(2),
@@ -1061,7 +1061,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_retry_read_stream() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -1135,7 +1135,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_custom_retry_policy() -> anyhow::Result<()> {
         // Extend the default retry policy to also retry on ResourceExhausted.
         let retry_policy = Aip194Strict.continue_on_too_many_requests();
@@ -1219,7 +1219,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_one_row() {
         let mut rs = run_mock_query(vec![PartialResultSet {
             metadata: metadata(2),
@@ -1241,7 +1241,7 @@ pub(crate) mod tests {
         assert!(rs.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn result_set_last_flag() -> anyhow::Result<()> {
         let mut rs = run_mock_query(vec![
             PartialResultSet {
@@ -1269,7 +1269,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn result_set_early_termination_not_cancelled() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let (tx, rx) = tokio::sync::mpsc::channel(10);
@@ -1333,7 +1333,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_chunked_values_string() {
         let mut rs = run_mock_query(vec![
             PartialResultSet {
@@ -1369,7 +1369,7 @@ pub(crate) mod tests {
         assert!(rs.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_chunked_values_list() {
         let mut rs = run_mock_query(vec![
             PartialResultSet {
@@ -1410,7 +1410,7 @@ pub(crate) mod tests {
         assert!(rs.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_multi_response_chunking_bool_array() {
         fn bool_val(b: bool) -> Value {
             Value {
@@ -1487,7 +1487,7 @@ pub(crate) mod tests {
         assert!(rs.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_multi_response_chunking_int64_array() {
         fn null_val() -> Value {
             Value {
@@ -1559,7 +1559,7 @@ pub(crate) mod tests {
         assert!(rs.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_precommit_token_tracked() -> anyhow::Result<()> {
         let token = MultiplexedSessionPrecommitToken {
             precommit_token: b"test_token".to_vec(),
@@ -1640,7 +1640,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_retry_simple() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -1713,7 +1713,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_retry_non_retriable_error() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         mock.expect_execute_streaming_sql()
@@ -1768,7 +1768,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_buffer_overflow() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         mock.expect_execute_streaming_sql()
@@ -1840,7 +1840,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_retry_missing_resume_token_safe() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -1993,7 +1993,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_retry_limit_exceeded() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
 
@@ -2310,7 +2310,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn result_set_inline_begin_metadata_missing_transaction_fails() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -2373,7 +2373,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn result_set_stats() -> anyhow::Result<()> {
         let mock_stats = spanner_v1::ResultSetStats {
             query_plan: Some(spanner_v1::QueryPlan::default()),
@@ -2397,7 +2397,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn result_set_duplicate_stats() -> anyhow::Result<()> {
         let mock_stats = spanner_v1::ResultSetStats {
             query_plan: Some(spanner_v1::QueryPlan::default()),
@@ -2438,7 +2438,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_lazy_begin_deadlock_fixed() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -2535,7 +2535,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_metadata_not_available() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
 
@@ -2577,7 +2577,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn test_result_set_metadata_available_before_next() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
 

--- a/src/spanner/src/session_maintainer.rs
+++ b/src/spanner/src/session_maintainer.rs
@@ -172,7 +172,7 @@ mod tests {
     use spanner_grpc_mock::google::spanner::v1::Session as GrpcSession;
     use spanner_grpc_mock::{MockSpanner, start};
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn session_maintenance() {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -261,7 +261,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn maintain_success() {
         let mut mock = MockSpanner::new();
         mock.expect_create_session().once().returning(|_| {
@@ -297,13 +297,13 @@ mod tests {
         ManagedSessionMaintainer::maintain(m, SESSION_MAINTENANCE_AGE).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn maintain_dropped() {
         let weak = Weak::<ManagedSessionMaintainer>::new();
         assert!(weak.upgrade().is_none());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn check_and_replace_session_no_op() {
         let mut mock = MockSpanner::new();
         mock.expect_create_session().once().returning(|_| {
@@ -354,7 +354,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn maintain_creation_fails() {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -560,12 +560,12 @@ mod tests {
         static_assertions::assert_impl_all!(TransactionRunner: Send, Sync);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_success_explicit() {
         run_success(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_success_inline() {
         run_success(BeginTransactionOption::InlineBegin).await;
     }
@@ -631,12 +631,12 @@ mod tests {
         assert_eq!(res, 1);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_success_with_commit_stats_explicit() {
         run_success_with_commit_stats(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_success_with_commit_stats_inline() {
         run_success_with_commit_stats(BeginTransactionOption::InlineBegin).await;
     }
@@ -724,12 +724,12 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_aborted_retry_explicit() -> anyhow::Result<()> {
         run_with_aborted_retry(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_aborted_retry_inline() -> anyhow::Result<()> {
         run_with_aborted_retry(BeginTransactionOption::InlineBegin).await
     }
@@ -870,12 +870,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_query_stream_with_aborted_retry_explicit() -> anyhow::Result<()> {
         run_query_stream_with_aborted_retry(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_query_stream_with_aborted_retry_inline() -> anyhow::Result<()> {
         run_query_stream_with_aborted_retry(BeginTransactionOption::InlineBegin).await
     }
@@ -1062,12 +1062,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_non_aborted_error_explicit() {
         run_with_non_aborted_error(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_non_aborted_error_inline() {
         run_with_non_aborted_error(BeginTransactionOption::InlineBegin).await;
     }
@@ -1116,12 +1116,12 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_non_aborted_error_and_rollback_fails_explicit() {
         run_with_non_aborted_error_and_rollback_fails(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_non_aborted_error_and_rollback_fails_inline() {
         run_with_non_aborted_error_and_rollback_fails(BeginTransactionOption::InlineBegin).await;
     }
@@ -1173,12 +1173,12 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_commit_aborted_retry_explicit() {
         run_commit_aborted_retry(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_commit_aborted_retry_inline() {
         run_commit_aborted_retry(BeginTransactionOption::InlineBegin).await;
     }
@@ -1258,12 +1258,12 @@ mod tests {
         assert_eq!(res, 5);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_begin_transaction_fails_explicit() {
         run_begin_transaction_fails(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_begin_transaction_fails_inline() {
         run_begin_transaction_fails(BeginTransactionOption::InlineBegin).await;
     }
@@ -1312,7 +1312,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn builder_options() {
         use crate::transaction_retry_policy::BasicTransactionRetryPolicy;
 
@@ -1334,12 +1334,12 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_batch_dml_aborted_retry_explicit() {
         run_batch_dml_aborted_retry(BeginTransactionOption::ExplicitBegin).await;
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_batch_dml_aborted_retry_inline() {
         run_batch_dml_aborted_retry(BeginTransactionOption::InlineBegin).await;
     }
@@ -1475,12 +1475,12 @@ mod tests {
         assert_eq!(attempt_counter, 2);
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_transaction_tag_explicit() -> anyhow::Result<()> {
         run_with_transaction_tag(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_transaction_tag_inline() -> anyhow::Result<()> {
         run_with_transaction_tag(BeginTransactionOption::InlineBegin).await
     }
@@ -1580,12 +1580,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_exclude_txn_from_change_streams_explicit() -> anyhow::Result<()> {
         run_with_exclude_txn_from_change_streams(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_exclude_txn_from_change_streams_inline() -> anyhow::Result<()> {
         run_with_exclude_txn_from_change_streams(BeginTransactionOption::InlineBegin).await
     }
@@ -1666,12 +1666,12 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_max_commit_delay_explicit() -> anyhow::Result<()> {
         run_with_max_commit_delay(BeginTransactionOption::ExplicitBegin).await
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_with_max_commit_delay_inline() -> anyhow::Result<()> {
         run_with_max_commit_delay(BeginTransactionOption::InlineBegin).await
     }
@@ -1748,7 +1748,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn execute_run_empty_closure_inline() {
         let mut mock = create_session_mock();
         expect_begin_transaction(&mut mock, 1, vec![1, 2, 3]);

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -434,6 +434,7 @@ mod tests {
     use crate::client::Spanner;
     use crate::transaction_retry_policy::tests::create_aborted_status;
     use gaxi::grpc::tonic::Response;
+    use google_cloud_test_macros::tokio_test_no_panics;
     use prost_types::Duration as ProstDuration;
     use prost_types::Timestamp;
     use spanner_grpc_mock::google::spanner::v1::CommitResponse;
@@ -466,7 +467,7 @@ mod tests {
         (db_client, server)
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_at_least_once() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -535,7 +536,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -621,7 +622,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_at_least_once_with_commit_stats() -> anyhow::Result<()> {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -664,7 +665,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_with_commit_stats() -> anyhow::Result<()> {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -714,7 +715,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_at_least_once_with_exclude_txn_from_change_streams() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -763,7 +764,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_with_exclude_txn_from_change_streams() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -817,7 +818,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_with_commit_retry() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -904,7 +905,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_with_commit_aborted_retry() -> anyhow::Result<()> {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -993,7 +994,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio_test_no_panics]
     async fn write_at_least_once_with_max_commit_delay() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {
@@ -1043,7 +1044,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[google_cloud_test_macros::tokio_test_no_panics]
+    #[tokio_test_no_panics]
     async fn leader_aware_routing_enabled_by_default() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {

--- a/src/spanner/tests/execute_query.rs
+++ b/src/spanner/tests/execute_query.rs
@@ -14,10 +14,10 @@
 
 use google_cloud_spanner::client::Spanner;
 use google_cloud_spanner::client::Statement;
+use google_cloud_test_macros::tokio_test_no_panics;
 use spanner_grpc_mock::MockSpanner;
 use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 use spanner_grpc_mock::start;
-use google_cloud_test_macros::tokio_test_no_panics;
 
 #[tokio_test_no_panics]
 async fn test_execute_query() -> anyhow::Result<()> {

--- a/src/spanner/tests/execute_query.rs
+++ b/src/spanner/tests/execute_query.rs
@@ -17,8 +17,9 @@ use google_cloud_spanner::client::Statement;
 use spanner_grpc_mock::MockSpanner;
 use spanner_grpc_mock::google::spanner::v1 as mock_v1;
 use spanner_grpc_mock::start;
+use google_cloud_test_macros::tokio_test_no_panics;
 
-#[tokio::test]
+#[tokio_test_no_panics]
 async fn test_execute_query() -> anyhow::Result<()> {
     // Set up a MockSpanner server
     let mut mock = MockSpanner::new();


### PR DESCRIPTION
Adds the `#[tokio_test_no_panics]` to all tests that could potentially cause a panic in a background task.

Fixes #5523