### PR TITLE
test(spanner): add panic handler to mock Spanner server

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -14,3 +14,7 @@
 
 # We need to support 1.87. Stop clippy from issuing newer warnings.
 msrv = "1.87.0"
+
+disallowed-methods = [
+    "spanner_grpc_mock::start"
+]

--- a/src/spanner/src/batch_read_only_transaction.rs
+++ b/src/spanner/src/batch_read_only_transaction.rs
@@ -448,7 +448,6 @@ pub(crate) mod tests {
     use crate::model::{ExecuteSqlRequest, ReadRequest as GrpcReadRequest, TransactionSelector};
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
     use gaxi::grpc::tonic::Response;
-    use google_cloud_test_macros::tokio_test_no_panics;
     use prost_types::Timestamp;
     use spanner_grpc_mock::google::spanner::v1::{
         Partition as MockPartition, PartitionResponse, Transaction,
@@ -487,7 +486,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn partition_execute_respects_options() -> anyhow::Result<()> {
         use gaxi::grpc::tonic::Response;
         use std::time::Duration;

--- a/src/spanner/src/batch_write_transaction.rs
+++ b/src/spanner/src/batch_write_transaction.rs
@@ -157,9 +157,10 @@ mod tests {
         mock: MockSpanner,
     ) -> (DatabaseClient, tokio::task::JoinHandle<()>) {
         use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-        let (address, server) = spanner_grpc_mock::start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -329,6 +329,7 @@ impl Channel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mock_server::start_panic_safe_spanner_mock as start;
     use crate::model::CreateSessionRequest;
     use crate::result_set::tests::adapt;
     use gaxi::grpc::tonic::MetadataMap;
@@ -337,7 +338,7 @@ mod tests {
     use google_cloud_gax::backoff_policy::BackoffPolicy;
     use google_cloud_gax::error::rpc::Code;
     use google_cloud_gax::retry_state::RetryState;
-    use google_cloud_test_macros::tokio_test_no_panics;
+    use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::rpc as mock_rpc;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
     use spanner_grpc_mock::google::spanner::v1::CommitResponse;
@@ -345,7 +346,6 @@ mod tests {
     use spanner_grpc_mock::google::spanner::v1::ResultSetStats;
     use spanner_grpc_mock::google::spanner::v1::Session;
     use spanner_grpc_mock::google::spanner::v1::result_set_stats::RowCount;
-    use spanner_grpc_mock::{MockSpanner, start};
     use static_assertions::{assert_impl_all, assert_not_impl_any};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1033,7 +1033,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn timeout_respected() -> anyhow::Result<()> {
         use crate::batch_dml::BatchDml;
         use std::time::Duration;
@@ -1198,7 +1198,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn retry_policy_respected() -> anyhow::Result<()> {
         use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
 
@@ -1330,7 +1330,7 @@ mod tests {
         }
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn transaction_timeout_respected() -> anyhow::Result<()> {
         use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
         use spanner_grpc_mock::google::spanner::v1::Transaction;
@@ -1450,7 +1450,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn transaction_timeout_ticks_down() -> anyhow::Result<()> {
         use spanner_grpc_mock::google::spanner::v1::Transaction;
 

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -369,7 +369,7 @@ impl DatabaseClientBuilder {
 mod tests {
     use super::*;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-    use spanner_grpc_mock::{MockSpanner, start};
+    use spanner_grpc_mock::MockSpanner;
 
     #[test]
     fn test_auto_traits() {
@@ -396,9 +396,10 @@ mod tests {
             ))
         });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -452,9 +453,10 @@ mod tests {
                 ))
             });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -495,9 +497,10 @@ mod tests {
             ))
         });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(missing_docs, reason = "docs not yet complete")]
 // TODO(#5566) - stabilize API and remove this.
 #![allow(clippy::exhaustive_enums, reason = "API not yet stable")]
+#![cfg_attr(test, deny(clippy::disallowed_methods))]
 
 pub use batch_dml::BatchDml;
 pub use batch_dml::BatchDmlBuilder;
@@ -76,6 +77,8 @@ pub(crate) mod value;
 pub(crate) mod write_only_transaction;
 
 pub(crate) mod error;
+#[cfg(test)]
+pub(crate) mod mock_server;
 mod status;
 
 #[allow(dead_code)]

--- a/src/spanner/src/mock_server.rs
+++ b/src/spanner/src/mock_server.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use spanner_grpc_mock::MockSpanner;
+
+#[allow(clippy::disallowed_methods)]
+pub async fn start_panic_safe_spanner_mock(
+    address: &str,
+    mock: MockSpanner,
+) -> anyhow::Result<(String, tokio::task::JoinHandle<()>)> {
+    let (address, handle) = spanner_grpc_mock::start(address, mock).await?;
+    let wrapper = tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            if e.is_panic() {
+                std::panic::resume_unwind(e.into_panic());
+            }
+        }
+    });
+    Ok((address, wrapper))
+}

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -452,7 +452,7 @@ mod tests {
         );
     }
 
-    #[google_cloud_test_macros::tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_enabled_by_default() {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().once().returning(|req| {

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -958,7 +958,6 @@ pub(crate) mod tests {
     use crate::result_set::tests::string_val;
     use crate::value::Value;
     use gaxi::grpc::tonic::{self, Code, Response, Status};
-    use google_cloud_test_macros::tokio_test_no_panics;
     use mock_v1::transaction_selector::Selector;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
     use std::sync::mpsc::channel as std_channel;
@@ -1007,9 +1006,10 @@ pub(crate) mod tests {
     ) -> (DatabaseClient, tokio::task::JoinHandle<()>) {
         use crate::client::Spanner;
         use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-        let (address, server) = spanner_grpc_mock::start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
 
         let spanner = Spanner::builder()
             .with_endpoint(address)
@@ -1752,7 +1752,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_concurrent_queries_inline_begin() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().never();
@@ -1894,7 +1894,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_concurrent_queries_inline_begin_failed_cascade() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         let mut seq = mockall::Sequence::new();
@@ -2025,7 +2025,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_concurrent_queries_inline_begin_stream_restart_deadlock_prevention()
     -> crate::Result<()> {
         let mut mock = create_session_mock();
@@ -2196,7 +2196,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_concurrent_queries_late_arrival_failure() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         let mut seq = mockall::Sequence::new();
@@ -2259,7 +2259,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_concurrent_reads_inline_begin() -> anyhow::Result<()> {
         use crate::client::{KeySet, ReadRequest};
         let mut mock = create_session_mock();
@@ -2391,7 +2391,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_inline_begin_idempotent_update() -> anyhow::Result<()> {
         let (db_client, _server) = setup_db_client(create_session_mock()).await;
         // Access internal state for unit testing.
@@ -2436,7 +2436,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_inline_begin_with_transient_failure() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         let mut seq = mockall::Sequence::new();
@@ -2485,7 +2485,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_query_in_read_only() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         mock.expect_execute_streaming_sql().once().returning(|req| {

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -643,7 +643,6 @@ mod tests {
     use crate::result_set::tests::adapt;
     use gaxi::grpc::tonic;
     use google_cloud_gax::options::internal::RequestOptionsExt as _;
-    use google_cloud_test_macros::tokio_test_no_panics;
     use spanner_grpc_mock::google::spanner::v1;
     use std::fmt::Debug;
     use std::sync::Mutex;
@@ -1999,7 +1998,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_enabled_by_default() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().once().returning(|req| {
@@ -2062,7 +2061,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_disabled() -> anyhow::Result<()> {
         use crate::client::Spanner;
         use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
@@ -2108,7 +2107,10 @@ mod tests {
             }))
         });
 
-        let (address, _server) = spanner_grpc_mock::start("0.0.0.0:0", mock).await.unwrap();
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .unwrap();
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -2130,7 +2132,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_query_in_read_write() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().once().returning(|req| {
@@ -2177,7 +2179,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_merges_custom_headers() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
         mock.expect_begin_transaction().once().returning(|req| {
@@ -2241,7 +2243,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_implicit_begin_fallback() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -2307,7 +2309,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn read_write_transaction_fallback_forwards_transaction_tag() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 
@@ -2373,7 +2375,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn read_write_transaction_mutation_only_inline_begin_commit() -> anyhow::Result<()> {
         let mut mock = create_session_mock();
 

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -748,13 +748,13 @@ pub(crate) mod tests {
     use crate::client::Spanner;
     use crate::client::Statement;
     use crate::key::KeySet;
+    use crate::mock_server::start_panic_safe_spanner_mock as start;
     use crate::read::ReadRequest;
     use gaxi::grpc::tonic::{Code as GrpcCode, Response, Status};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::backoff_policy::BackoffPolicy;
     use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_gax::retry_state::RetryState;
-    use google_cloud_test_macros::tokio_test_no_panics;
     use prost_types::Value;
     use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::spanner::v1 as spanner_v1;
@@ -762,7 +762,6 @@ pub(crate) mod tests {
     use spanner_grpc_mock::google::spanner::v1::{
         MultiplexedSessionPrecommitToken, PartialResultSet, ResultSetMetadata, Session, StructType,
     };
-    use spanner_grpc_mock::start;
     use std::time::Duration;
 
     mockall::mock! {
@@ -1908,7 +1907,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn test_result_set_retry_under_limit_no_resume_token() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -2047,7 +2046,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn result_set_inline_begin_stream_error_fallback() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -2136,7 +2135,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn result_set_retry_inline_begin_transient_error() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();
@@ -2215,7 +2214,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn result_set_retry_inline_begin_id_recovered() -> anyhow::Result<()> {
         let mut mock = MockSpanner::new();
         let mut seq = mockall::Sequence::new();

--- a/src/spanner/src/session_maintainer.rs
+++ b/src/spanner/src/session_maintainer.rs
@@ -168,9 +168,8 @@ mod tests {
     use super::*;
     use gaxi::grpc::tonic::Response;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-    use google_cloud_test_macros::tokio_test_no_panics;
+    use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::spanner::v1::Session as GrpcSession;
-    use spanner_grpc_mock::{MockSpanner, start};
 
     #[tokio::test]
     async fn session_maintenance() {
@@ -203,9 +202,10 @@ mod tests {
                 }))
             });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -273,9 +273,10 @@ mod tests {
             }))
         });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -315,9 +316,10 @@ mod tests {
             }))
         });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -379,9 +381,10 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(|_| Err(gaxi::grpc::tonic::Status::internal("mock failure")));
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -421,7 +424,7 @@ mod tests {
         );
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn transaction_session_consistency_across_retries() {
         use crate::database_client::DatabaseClient;
         use crate::transaction_retry_policy::tests::create_aborted_status;
@@ -527,9 +530,10 @@ mod tests {
             }))
         });
 
-        let (address, _server) = start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, _server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
 
         let spanner = Spanner::builder()
             .with_endpoint(address)

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -479,7 +479,6 @@ mod tests {
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
     use crate::transaction_retry_policy::tests::create_aborted_status;
     use gaxi::grpc::tonic;
-    use google_cloud_test_macros::tokio_test_no_panics;
     use prost_types::value::Kind;
     use spanner_grpc_mock::google::spanner::v1;
     use spanner_grpc_mock::google::spanner::v1::CommitResponse;
@@ -1301,6 +1300,9 @@ mod tests {
                 .returning(|_req| Err(tonic::Status::new(tonic::Code::Internal, "internal error")));
         }
 
+        mock.expect_rollback()
+            .returning(|_| Ok(tonic::Response::new(())));
+
         let res = execute_test_runner(mock, begin_transaction_option).await;
 
         assert!(res.is_err());
@@ -1821,7 +1823,7 @@ mod tests {
         );
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_run_with_mutations_happy_flow() {
         let mut mock = create_session_mock();
 
@@ -1884,7 +1886,7 @@ mod tests {
         assert_eq!(res.result, 1);
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_run_with_mutations_aborted_retry() {
         let mut mock = create_session_mock();
         let mut sequence = mockall::Sequence::new();
@@ -2030,7 +2032,7 @@ mod tests {
         assert_eq!(res.result, 1);
     }
 
-    #[tokio_test_no_panics]
+    #[tokio::test]
     async fn execute_run_mutation_only_explicit_begin_fallback() {
         let mut mock = create_session_mock();
 

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -447,9 +447,10 @@ mod tests {
         mock: spanner_grpc_mock::MockSpanner,
     ) -> (DatabaseClient, tokio::task::JoinHandle<()>) {
         use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-        let (address, server) = spanner_grpc_mock::start("0.0.0.0:0", mock)
-            .await
-            .expect("Failed to start mock server");
+        let (address, server) =
+            crate::mock_server::start_panic_safe_spanner_mock("0.0.0.0:0", mock)
+                .await
+                .expect("Failed to start mock server");
         let spanner = Spanner::builder()
             .with_endpoint(address)
             .with_credentials(Anonymous::new().build())
@@ -1043,7 +1044,7 @@ mod tests {
         assert!(res.is_ok());
     }
 
-    #[google_cloud_test_macros::tokio_test_no_panics]
+    #[tokio::test]
     async fn leader_aware_routing_enabled_by_default() {
         let mut mock = spanner_grpc_mock::MockSpanner::new();
         mock.expect_create_session().returning(|_| {


### PR DESCRIPTION
Adds a panic handler to the Spanner mock server that is used in tests. This removes the requirement to add the `tokio_test_no_panics` attribute to tests that use this server.

This is an alternative for #5718

Fixes #5523