### PR TITLE
fix(spanner): accept receiving transaction ID multiple times

### DIFF
--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -711,6 +711,17 @@ impl ReadContextTransactionSelector {
                 notify.notify_waiters();
             }
             Ok(())
+        } else if let TransactionState::Started(existing_selector, _) = &*guard {
+            // Spanner returns the transaction ID on all statements executed within that transaction
+            // when using multiplexed sessions.If the transaction has already started with the same ID,
+            // this is expected behavior and can be ignored.
+            if existing_selector.id() == Some(&id) {
+                Ok(())
+            } else {
+                Err(crate::error::internal_error(
+                    "got a transaction id for an already Started or Failed transaction",
+                ))
+            }
         } else {
             // This should never happen.
             Err(crate::error::internal_error(
@@ -2416,16 +2427,12 @@ pub(crate) mod tests {
             &id1
         );
 
-        // 2. Redundant update with same ID should result in an error.
-        // The implementation explicitly prevents redundant updates to ensure state consistency.
-        let err1 = tx
-            .context
-            .transaction_selector
-            .update(id1.clone(), None)
-            .expect_err("Redundant update should fail");
-        assert!(err1.to_string().contains("already Started or Failed"));
+        // 2. Redundant update with same ID should succeed, as Spanner returns the
+        // transaction ID on all statements executed within that transaction when
+        // using multiplexed sessions.
+        tx.context.transaction_selector.update(id1.clone(), None)?;
 
-        // 3. Update with DIFFERENT ID after already Started should also fail.
+        // 3. Update with DIFFERENT ID after already Started should fail.
         let err2 = tx
             .context
             .transaction_selector
@@ -2600,6 +2607,176 @@ pub(crate) mod tests {
 
         handle_leader.await.expect("Task 1 panicked")?;
         handle_follower.await.expect("Task 2 panicked")?;
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn execute_multi_query_redundant_transaction_id_explicit() -> anyhow::Result<()> {
+        run_execute_multi_query_redundant_transaction_id(BeginTransactionOption::ExplicitBegin)
+            .await
+    }
+
+    #[tokio_test_no_panics]
+    async fn execute_multi_query_redundant_transaction_id_inline() -> anyhow::Result<()> {
+        run_execute_multi_query_redundant_transaction_id(BeginTransactionOption::InlineBegin).await
+    }
+
+    async fn run_execute_multi_query_redundant_transaction_id(
+        option: BeginTransactionOption,
+    ) -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+        let mut sequence = mockall::Sequence::new();
+
+        if option == BeginTransactionOption::ExplicitBegin {
+            mock.expect_begin_transaction()
+                .once()
+                .in_sequence(&mut sequence)
+                .returning(|req| {
+                    let req = req.into_inner();
+                    assert_eq!(
+                        req.session,
+                        "projects/p/instances/i/databases/d/sessions/123"
+                    );
+                    Ok(tonic::Response::new(mock_v1::Transaction {
+                        id: vec![4, 5, 6],
+                        read_timestamp: Some(prost_types::Timestamp {
+                            seconds: 123456789,
+                            nanos: 0,
+                        }),
+                        ..Default::default()
+                    }))
+                });
+
+            mock.expect_execute_streaming_sql()
+                .times(2)
+                .returning(|req| {
+                    let req = req.into_inner();
+                    assert_eq!(
+                        req.transaction
+                            .expect("transaction should be present")
+                            .selector
+                            .expect("selector should be present"),
+                        mock_v1::transaction_selector::Selector::Id(vec![4, 5, 6])
+                    );
+
+                    let mut result_set_partial = setup_select1();
+                    result_set_partial
+                        .metadata
+                        .as_mut()
+                        .expect("metadata should be present")
+                        .transaction = Some(mock_v1::Transaction {
+                        id: vec![4, 5, 6],
+                        read_timestamp: Some(prost_types::Timestamp {
+                            seconds: 123456789,
+                            nanos: 0,
+                        }),
+                        ..Default::default()
+                    });
+                    Ok(gaxi::grpc::tonic::Response::from(adapt([Ok(
+                        result_set_partial,
+                    )])))
+                });
+        } else {
+            mock.expect_begin_transaction().never();
+
+            mock.expect_execute_streaming_sql()
+                .times(1)
+                .in_sequence(&mut sequence)
+                .returning(|req| {
+                    let req = req.into_inner();
+                    assert_eq!(
+                        req.session,
+                        "projects/p/instances/i/databases/d/sessions/123"
+                    );
+
+                    match req
+                        .transaction
+                        .expect("transaction should be present")
+                        .selector
+                        .expect("selector should be present")
+                    {
+                        mock_v1::transaction_selector::Selector::Begin(_) => {}
+                        _ => panic!("Expected Selector::Begin"),
+                    }
+                    let mut result_set_partial = setup_select1();
+                    result_set_partial
+                        .metadata
+                        .as_mut()
+                        .expect("metadata should be present")
+                        .transaction = Some(mock_v1::Transaction {
+                        id: vec![4, 5, 6],
+                        read_timestamp: Some(prost_types::Timestamp {
+                            seconds: 987654321,
+                            nanos: 0,
+                        }),
+                        ..Default::default()
+                    });
+                    Ok(gaxi::grpc::tonic::Response::from(adapt([Ok(
+                        result_set_partial,
+                    )])))
+                });
+
+            mock.expect_execute_streaming_sql()
+                .times(1)
+                .in_sequence(&mut sequence)
+                .returning(|req| {
+                    let req = req.into_inner();
+                    match req
+                        .transaction
+                        .expect("transaction should be present")
+                        .selector
+                        .expect("selector should be present")
+                    {
+                        mock_v1::transaction_selector::Selector::Id(id) => {
+                            assert_eq!(id, vec![4, 5, 6]);
+                        }
+                        _ => panic!("Expected Selector::Id"),
+                    }
+                    let mut result_set_partial = setup_select1();
+                    result_set_partial
+                        .metadata
+                        .as_mut()
+                        .expect("metadata should be present")
+                        .transaction = Some(mock_v1::Transaction {
+                        id: vec![4, 5, 6],
+                        read_timestamp: Some(prost_types::Timestamp {
+                            seconds: 987654321,
+                            nanos: 0,
+                        }),
+                        ..Default::default()
+                    });
+                    Ok(gaxi::grpc::tonic::Response::from(adapt([Ok(
+                        result_set_partial,
+                    )])))
+                });
+        }
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(option)
+            .build()
+            .await
+            .expect("Failed to start transaction");
+
+        for _ in 0..2 {
+            let mut result_set = transaction
+                .execute_query(Statement::builder("SELECT 1").build())
+                .await
+                .expect("Failed to execute query");
+
+            let row = result_set
+                .next()
+                .await
+                .expect("has row")
+                .expect("has valid row");
+            assert_eq!(row.raw_values(), [Value(string_val("1"))]);
+
+            let next_result = result_set.next().await;
+            assert!(next_result.is_none(), "expected None, got {next_result:?}");
+        }
 
         Ok(())
     }

--- a/tests/spanner/src/read_write_transaction.rs
+++ b/tests/spanner/src/read_write_transaction.rs
@@ -394,3 +394,96 @@ pub async fn read_write_transaction_mutation_only(
 
     Ok(())
 }
+
+pub async fn read_write_transaction_multiple_queries_and_dml(
+    db_client: &DatabaseClient,
+) -> anyhow::Result<()> {
+    let first_id = format!("rw-multi-1-{}", LowercaseAlphanumeric.random_string(10));
+    let second_id = format!("rw-multi-2-{}", LowercaseAlphanumeric.random_string(10));
+
+    // Insert two rows
+    let first_mutation = Mutation::new_insert_builder("AllTypes")
+        .set("Id")
+        .to(&first_id)
+        .set("ColInt64")
+        .to(&100_i64)
+        .build();
+    let second_mutation = Mutation::new_insert_builder("AllTypes")
+        .set("Id")
+        .to(&second_id)
+        .set("ColInt64")
+        .to(&200_i64)
+        .build();
+    db_client
+        .write_only_transaction()
+        .build()
+        .write(vec![first_mutation, second_mutation])
+        .await?;
+
+    let runner = db_client
+        .read_write_transaction()
+        .with_transaction_tag("multi-query-tag")
+        .build()
+        .await?;
+    runner
+        .run(async |transaction| {
+            // First query
+            let first_statement =
+                Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+                    .add_param("id", &first_id)
+                    .build();
+            let mut first_result_set = transaction.execute_query(first_statement).await?;
+            let first_row = first_result_set
+                .next()
+                .await
+                .transpose()?
+                .expect("First row exists for multiple queries transaction test");
+            let first_value: i64 = first_row.get("ColInt64");
+
+            // Second query
+            let second_statement =
+                Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+                    .add_param("id", &second_id)
+                    .build();
+            let mut second_result_set = transaction.execute_query(second_statement).await?;
+            let second_row = second_result_set
+                .next()
+                .await
+                .transpose()?
+                .expect("Second row exists for multiple queries transaction test");
+            let second_value: i64 = second_row.get("ColInt64");
+
+            // DML statement
+            let update_statement =
+                Statement::builder("UPDATE AllTypes SET ColInt64 = @new_val WHERE Id = @id")
+                    .add_param("new_val", &(first_value + second_value))
+                    .add_param("id", &first_id)
+                    .build();
+            transaction.execute_update(update_statement).await?;
+
+            Ok(())
+        })
+        .await?;
+
+    // Verify update
+    let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+        .add_param("id", &first_id)
+        .build();
+    let mut result_set = db_client
+        .single_use()
+        .build()
+        .execute_query(statement)
+        .await?;
+    let row = result_set
+        .next()
+        .await
+        .transpose()?
+        .expect("Row exists for verification");
+    let final_value: i64 = row.get("ColInt64");
+    assert_eq!(
+        final_value, 300,
+        "Update from multiple queries and DML transaction should have been committed"
+    );
+
+    Ok(())
+}

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -99,6 +99,11 @@ mod spanner {
         )
         .await?;
 
+        integration_tests_spanner::read_write_transaction::read_write_transaction_multiple_queries_and_dml(
+            &db_client,
+        )
+        .await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Spanner returns the ID of a transaction in the ResultSetMetadata for each query in a transaction, when the transaction is executed using a multiplexed session. The client library should accept and ignore these transaction IDs as long as they are consistent with the transaction ID that was returned by the first query.