### PR TITLE
chore: add librarian team to librarian.yaml CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 *           @googleapis/cloud-sdk-rust-team
-/librarian.yaml @googleapis/cloud-sdk-rust-team  @googleapis/cloud-sdk-librarian-team
+/librarian.yaml @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-librarian-team
 /src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-auth-team
 
 /src/spanner/ @googleapis/spanner-team @googleapis/cloud-sdk-rust-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 *           @googleapis/cloud-sdk-rust-team
+/librarian.yaml @googleapis/cloud-sdk-rust-team  @googleapis/cloud-sdk-librarian-team
 /src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-auth-team
 
 /src/spanner/ @googleapis/spanner-team @googleapis/cloud-sdk-rust-team


### PR DESCRIPTION
Give Librarian team CODEOWNERS on `librarian.yaml`. This will both notify the team of changes to this file and expedite review of `librarian.yaml` only changes that do not produce a diff e.g. config refactor or version update without a regen diff.

Fixes https://github.com/googleapis/librarian/issues/5451