### PR TITLE
chore(spanner): add default TLS provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,6 +4691,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-rpc",
+ "google-cloud-spanner",
  "google-cloud-test-macros",
  "google-cloud-wkt",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,7 +4691,6 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-rpc",
- "google-cloud-spanner",
  "google-cloud-test-macros",
  "google-cloud-wkt",
  "http",

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -60,7 +60,6 @@ wkt                   = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 anyhow.workspace                   = true
-google-cloud-spanner               = { path = ".", features = ["default-rustls-provider"] }
 google-cloud-test-macros.workspace = true
 mockall.workspace                  = true
 spanner-grpc-mock                  = { path = "grpc-mock" }

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -27,7 +27,13 @@ categories.workspace   = true
 rust-version.workspace = true
 
 [features]
-unstable-stream = ["dep:futures"]
+default = ["default-rustls-provider"]
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
+default-rustls-provider = ["gaxi/_default-rustls-provider"]
+unstable-stream         = ["dep:futures"]
 
 [dependencies]
 async-trait.workspace = true
@@ -54,6 +60,7 @@ wkt                   = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 anyhow.workspace                   = true
+google-cloud-spanner               = { path = ".", features = ["default-rustls-provider"] }
 google-cloud-test-macros.workspace = true
 mockall.workspace                  = true
 spanner-grpc-mock                  = { path = "grpc-mock" }

--- a/tests/spanner/Cargo.toml
+++ b/tests/spanner/Cargo.toml
@@ -32,7 +32,7 @@ google-cloud-auth                      = { workspace = true, features = ["defaul
 google-cloud-gax                       = { workspace = true }
 google-cloud-longrunning               = { workspace = true }
 google-cloud-lro                       = { workspace = true }
-google-cloud-spanner                   = { workspace = true, features = ["unstable-stream"] }
+google-cloud-spanner                   = { workspace = true, features = ["default", "unstable-stream"] }
 google-cloud-spanner-admin-database-v1 = { path = "../../src/generated/spanner/admin/database/v1" }
 google-cloud-test-utils                = { workspace = true }
 google-cloud-wkt                       = { workspace = true }


### PR DESCRIPTION
Adds a default TLS provider to Spanner in the same way as the other clients.