### PR TITLE
test(spanner): add more integration tests for read/write transactions

### DIFF
--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -519,6 +519,22 @@ impl ReadWriteTransaction {
         options
     }
 
+    fn build_commit_request(
+        &self,
+        transaction_id: bytes::Bytes,
+        mutations: Vec<ProtoMutation>,
+        precommit_token: Option<crate::model::MultiplexedSessionPrecommitToken>,
+    ) -> CommitRequest {
+        CommitRequest::default()
+            .set_session(self.context.session_name.clone())
+            .set_transaction_id(transaction_id)
+            .set_mutations(mutations)
+            .set_or_clear_precommit_token(precommit_token)
+            .set_or_clear_request_options(self.commit_request_options())
+            .set_or_clear_max_commit_delay(self.max_commit_delay)
+            .set_return_commit_stats(self.return_commit_stats)
+    }
+
     /// Commits the transaction.
     pub(crate) async fn commit(self) -> crate::Result<CommitResponse> {
         let mutations = take(&mut *self.mutations.lock().unwrap());
@@ -549,14 +565,8 @@ impl ReadWriteTransaction {
         }
         let transaction_id = id.ok_or_else(|| internal_error("Transaction ID is missing"))?;
         let precommit_token = self.context.precommit_token_tracker.get();
-        let request = CommitRequest::default()
-            .set_session(self.context.session_name.clone())
-            .set_transaction_id(transaction_id.clone())
-            .set_mutations(mutations)
-            .set_or_clear_precommit_token(precommit_token)
-            .set_or_clear_request_options(self.context.amend_request_options(None))
-            .set_or_clear_max_commit_delay(self.max_commit_delay)
-            .set_return_commit_stats(self.return_commit_stats);
+
+        let request = self.build_commit_request(transaction_id.clone(), mutations, precommit_token);
 
         // TODO(#4972): make request options configurable
         let mut gax_options = GaxRequestOptions::default();
@@ -571,11 +581,11 @@ impl ReadWriteTransaction {
 
         let response =
             if let Some(new_precommit_token) = response.precommit_token().map(|b| (*b).clone()) {
-                let retry_commit_req = CommitRequest::default()
-                    .set_session(self.context.session_name.clone())
-                    .set_transaction_id(transaction_id)
-                    .set_precommit_token(*new_precommit_token)
-                    .set_or_clear_request_options(self.commit_request_options());
+                let retry_commit_req = self.build_commit_request(
+                    transaction_id,
+                    Vec::new(), // mutations are never re-sent in retry requests
+                    Some(*new_precommit_token),
+                );
 
                 // TODO(#4972): make request options configurable
                 let mut gax_options = GaxRequestOptions::default();
@@ -804,6 +814,10 @@ mod tests {
                     seq_num: 2,
                 })
             );
+            assert!(
+                req.mutations.is_empty(),
+                "Expected mutations to be empty in retried CommitRequest"
+            );
             Ok(tonic::Response::new(v1::CommitResponse {
                 commit_timestamp: Some(prost_types::Timestamp {
                     seconds: 1001,
@@ -853,6 +867,208 @@ mod tests {
         for addr in remotes.iter() {
             assert_eq!(*addr, first, "All RPCs should use the same gRPC channel");
         }
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_write_transaction_commit_retry_preserves_options() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        // execute_update returns a precommit token.
+        mock.expect_execute_sql().once().returning(move |req| {
+            let req = req.into_inner();
+            assert_eq!(req.sql, "UPDATE Users SET Name = 'Bob' WHERE Id = 1");
+
+            let mut metadata = v1::ResultSetMetadata {
+                row_type: Some(v1::StructType { fields: vec![] }),
+                ..Default::default()
+            };
+            metadata.transaction = Some(v1::Transaction {
+                id: vec![0, 0, 7],
+                ..Default::default()
+            });
+
+            Ok(tonic::Response::new(v1::ResultSet {
+                metadata: Some(metadata),
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                precommit_token: Some(v1::MultiplexedSessionPrecommitToken {
+                    precommit_token: vec![101],
+                    seq_num: 1,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        // Simulate that commit returns a precommit token in the response.
+        // This would normally not happen, but we test it here to verify
+        // that the commit is retried and the options are preserved.
+        let expected_delay = prost_types::Duration {
+            seconds: 0,
+            nanos: 200_000_000,
+        };
+
+        let expected_delay_clone = expected_delay;
+        mock.expect_commit().once().returning(move |req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.precommit_token,
+                Some(v1::MultiplexedSessionPrecommitToken {
+                    precommit_token: vec![101],
+                    seq_num: 1,
+                })
+            );
+            // Assert original options are present
+            assert!(
+                req.return_commit_stats,
+                "Expected return_commit_stats to be true in first commit"
+            );
+            assert_eq!(
+                req.max_commit_delay.as_ref(),
+                Some(&expected_delay_clone),
+                "Expected max_commit_delay to be set in first commit"
+            );
+
+            Ok(tonic::Response::new(v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1000,
+                    nanos: 0,
+                }),
+                multiplexed_session_retry: Some(
+                    v1::commit_response::MultiplexedSessionRetry::PrecommitToken(
+                        v1::MultiplexedSessionPrecommitToken {
+                            precommit_token: vec![202],
+                            seq_num: 2,
+                        },
+                    ),
+                ),
+                ..Default::default()
+            }))
+        });
+
+        // Second commit retry is automatically issued with the new token and MUST preserve original options
+        mock.expect_commit().once().returning(move |req| {
+            let req = req.into_inner();
+            assert_eq!(
+                req.precommit_token,
+                Some(v1::MultiplexedSessionPrecommitToken {
+                    precommit_token: vec![202],
+                    seq_num: 2,
+                })
+            );
+            assert!(
+                req.return_commit_stats,
+                "Expected return_commit_stats to be preserved in retried commit request"
+            );
+            assert_eq!(
+                req.max_commit_delay.as_ref(),
+                Some(&expected_delay),
+                "Expected max_commit_delay to be preserved in retried commit request"
+            );
+            assert!(
+                req.mutations.is_empty(),
+                "Expected mutations to be empty in retried CommitRequest"
+            );
+
+            Ok(tonic::Response::new(v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 1001,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let tx = ReadWriteTransactionBuilder::new(db_client.clone())
+            .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
+            .with_return_commit_stats(true)
+            .with_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
+            .build(None)
+            .await
+            .expect("Failed to build transaction");
+
+        let count = tx
+            .execute_update("UPDATE Users SET Name = 'Bob' WHERE Id = 1")
+            .await?;
+        assert_eq!(count, 1);
+
+        let timestamp = tx.commit().await?;
+        assert_eq!(
+            timestamp
+                .commit_timestamp
+                .as_ref()
+                .expect("timestamp should be present")
+                .seconds(),
+            1001
+        );
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_write_transaction_commit_carries_commit_priority() -> anyhow::Result<()> {
+        let mut mock = create_session_mock();
+
+        mock.expect_execute_sql().once().returning(move |_req| {
+            let mut metadata = v1::ResultSetMetadata {
+                row_type: Some(v1::StructType { fields: vec![] }),
+                ..Default::default()
+            };
+            metadata.transaction = Some(v1::Transaction {
+                id: vec![1, 2, 3],
+                ..Default::default()
+            });
+
+            Ok(tonic::Response::new(v1::ResultSet {
+                metadata: Some(metadata),
+                stats: Some(v1::ResultSetStats {
+                    row_count: Some(v1::result_set_stats::RowCount::RowCountExact(1)),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_commit().once().returning(|req| {
+            let req = req.into_inner();
+            let request_options = req
+                .request_options
+                .expect("Expected request_options in CommitRequest");
+            assert_eq!(
+                request_options.priority,
+                v1::request_options::Priority::Low as i32,
+                "Expected priority to be Priority::Low in CommitRequest"
+            );
+
+            Ok(tonic::Response::new(v1::CommitResponse {
+                commit_timestamp: Some(prost_types::Timestamp {
+                    seconds: 123456789,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let tx = ReadWriteTransactionBuilder::new(db_client.clone())
+            .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
+            .with_commit_priority(Priority::Low)
+            .build(None)
+            .await
+            .expect("Failed to build transaction");
+
+        let count = tx
+            .execute_update("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .await?;
+        assert_eq!(count, 1);
+
+        let _ = tx.commit().await?;
 
         Ok(())
     }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -39,6 +39,7 @@ use crate::read_only_transaction::{
 use crate::result_set::ResultSet;
 use crate::statement::Statement;
 use crate::transaction_retry_policy::is_aborted;
+use crate::write_only_transaction::create_commit_request;
 use google_cloud_gax::error::Error as GaxError;
 use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
 use google_cloud_gax::retry_policy::Aip194Strict;
@@ -525,14 +526,15 @@ impl ReadWriteTransaction {
         mutations: Vec<ProtoMutation>,
         precommit_token: Option<crate::model::MultiplexedSessionPrecommitToken>,
     ) -> CommitRequest {
-        CommitRequest::default()
-            .set_session(self.context.session_name.clone())
-            .set_transaction_id(transaction_id)
-            .set_mutations(mutations)
-            .set_or_clear_precommit_token(precommit_token)
-            .set_or_clear_request_options(self.commit_request_options())
-            .set_or_clear_max_commit_delay(self.max_commit_delay)
-            .set_return_commit_stats(self.return_commit_stats)
+        create_commit_request(
+            self.context.session_name.clone(),
+            transaction_id,
+            mutations,
+            precommit_token,
+            self.commit_request_options(),
+            self.max_commit_delay,
+            self.return_commit_stats,
+        )
     }
 
     /// Commits the transaction.

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -16,7 +16,8 @@ use crate::client::{DatabaseClient, Mutation, amend_request_options_for_lar};
 use crate::model::request_options::Priority;
 use crate::model::transaction_options::ReadWrite;
 use crate::model::{
-    BeginTransactionRequest, CommitRequest, CommitResponse, RequestOptions, TransactionOptions,
+    BeginTransactionRequest, CommitRequest, CommitResponse, MultiplexedSessionPrecommitToken,
+    Mutation as ProtoMutation, RequestOptions, TransactionOptions,
 };
 use crate::transaction_retry_policy::{
     BasicTransactionRetryPolicy, TransactionRetryPolicy, retry_aborted,
@@ -285,6 +286,9 @@ impl WriteOnlyTransaction {
         let previous_transaction_id = Arc::new(Mutex::new(Bytes::new()));
         let channel_hint = client.spanner.next_channel_hint();
 
+        let max_commit_delay = self.max_commit_delay;
+        let return_commit_stats = self.return_commit_stats;
+
         retry_aborted(&*self.retry_policy, || {
             let client = client.clone();
             let session_name = session_name.clone();
@@ -318,14 +322,15 @@ impl WriteOnlyTransaction {
                     .await?;
                 *previous_transaction_id.lock().unwrap() = tx.id.clone();
 
-                let commit_req = CommitRequest::default()
-                    .set_session(session_name.clone())
-                    .set_mutations(mutations_proto)
-                    .set_transaction_id(tx.id.clone())
-                    .set_request_options(req_options.clone())
-                    .set_or_clear_precommit_token(tx.precommit_token)
-                    .set_or_clear_max_commit_delay(self.max_commit_delay)
-                    .set_return_commit_stats(self.return_commit_stats);
+                let commit_req = build_commit_request(
+                    session_name.clone(),
+                    tx.id.clone(),
+                    mutations_proto,
+                    tx.precommit_token,
+                    req_options.clone(),
+                    max_commit_delay,
+                    return_commit_stats,
+                );
 
                 let response = client
                     .spanner
@@ -335,11 +340,15 @@ impl WriteOnlyTransaction {
                 // If a commit_response with a precommit_token is returned, then we need to
                 // retry the commit with the new precommit_token and without any mutations.
                 if let Some(new_token) = response.precommit_token().map(|b| *b.clone()) {
-                    let retry_commit_req = CommitRequest::default()
-                        .set_session(session_name.clone())
-                        .set_transaction_id(tx.id)
-                        .set_request_options(req_options)
-                        .set_precommit_token(new_token);
+                    let retry_commit_req = build_commit_request(
+                        session_name.clone(),
+                        tx.id,
+                        Vec::new(),
+                        Some(new_token),
+                        req_options,
+                        max_commit_delay,
+                        return_commit_stats,
+                    );
                     client
                         .spanner
                         .commit(retry_commit_req, gax_options, channel_hint)
@@ -426,6 +435,25 @@ impl WriteOnlyTransaction {
             GaxRequestOptions::default(),
         )
     }
+}
+
+fn build_commit_request(
+    session_name: String,
+    transaction_id: bytes::Bytes,
+    mutations: Vec<ProtoMutation>,
+    precommit_token: Option<MultiplexedSessionPrecommitToken>,
+    req_options: RequestOptions,
+    max_commit_delay: Option<Duration>,
+    return_commit_stats: bool,
+) -> CommitRequest {
+    CommitRequest::default()
+        .set_session(session_name)
+        .set_transaction_id(transaction_id)
+        .set_mutations(mutations)
+        .set_or_clear_precommit_token(precommit_token)
+        .set_request_options(req_options)
+        .set_or_clear_max_commit_delay(max_commit_delay)
+        .set_return_commit_stats(return_commit_stats)
 }
 
 #[cfg(test)]
@@ -903,6 +931,107 @@ mod tests {
                 .seconds(),
             9999
         );
+    }
+
+    #[tokio_test_no_panics]
+    async fn write_with_commit_retry_preserves_options() -> anyhow::Result<()> {
+        let mut mock = spanner_grpc_mock::MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                    ..Default::default()
+                },
+            ))
+        });
+
+        mock.expect_begin_transaction().once().returning(|req| {
+            let req = req.into_inner();
+            assert!(req.mutation_key.is_some());
+
+            Ok(gaxi::grpc::tonic::Response::new(
+                spanner_grpc_mock::google::spanner::v1::Transaction {
+                    id: vec![42],
+                    ..Default::default()
+                },
+            ))
+        });
+
+        let expected_delay = prost_types::Duration {
+            seconds: 0,
+            nanos: 200_000_000,
+        };
+
+        let expected_delay_clone = expected_delay;
+        let commit_call_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        mock.expect_commit().times(2).returning(move |req| {
+            let count = commit_call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let req = req.into_inner();
+            assert_eq!(req.session, "projects/p/instances/i/databases/d/sessions/123");
+
+            // Verify options are present in both attempts
+            assert!(req.return_commit_stats, "Expected return_commit_stats to be true");
+            assert_eq!(req.max_commit_delay.as_ref(), Some(&expected_delay_clone), "Expected max_commit_delay to be 200ms");
+
+            if count == 0 {
+                assert!(!req.mutations.is_empty());
+                Ok(gaxi::grpc::tonic::Response::new(
+                    spanner_grpc_mock::google::spanner::v1::CommitResponse {
+                        multiplexed_session_retry: Some(
+                            spanner_grpc_mock::google::spanner::v1::commit_response::MultiplexedSessionRetry::PrecommitToken(
+                                spanner_grpc_mock::google::spanner::v1::MultiplexedSessionPrecommitToken {
+                                    precommit_token: vec![4, 5, 6],
+                                    seq_num: 2,
+                                }
+                            )
+                        ),
+                        ..Default::default()
+                    },
+                ))
+            } else {
+                assert!(req.mutations.is_empty(), "Expected mutations to be empty on retry");
+                assert_eq!(
+                    req.precommit_token.expect("precommit_token required").precommit_token,
+                    vec![4, 5, 6]
+                );
+                Ok(gaxi::grpc::tonic::Response::new(
+                    spanner_grpc_mock::google::spanner::v1::CommitResponse {
+                        commit_timestamp: Some(prost_types::Timestamp {
+                            seconds: 9999,
+                            nanos: 0,
+                        }),
+                        commit_stats: Some(CommitStats { mutation_count: 12 }),
+                        ..Default::default()
+                    },
+                ))
+            }
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let mutation = Mutation::new_insert_or_update_builder("Users")
+            .set("UserId")
+            .to(&1)
+            .build();
+
+        let res = db_client
+            .write_only_transaction()
+            .with_return_commit_stats(true)
+            .with_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
+            .build()
+            .write(vec![mutation])
+            .await?;
+
+        let stats = res.commit_stats.expect("Expected commit stats in response");
+        assert_eq!(stats.mutation_count, 12);
+        assert_eq!(
+            res.commit_timestamp
+                .expect("timestamp should be present")
+                .seconds(),
+            9999
+        );
+
+        Ok(())
     }
 
     #[tokio_test_no_panics]

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -322,12 +322,12 @@ impl WriteOnlyTransaction {
                     .await?;
                 *previous_transaction_id.lock().unwrap() = tx.id.clone();
 
-                let commit_req = build_commit_request(
+                let commit_req = create_commit_request(
                     session_name.clone(),
                     tx.id.clone(),
                     mutations_proto,
                     tx.precommit_token,
-                    req_options.clone(),
+                    Some(req_options.clone()),
                     max_commit_delay,
                     return_commit_stats,
                 );
@@ -340,12 +340,12 @@ impl WriteOnlyTransaction {
                 // If a commit_response with a precommit_token is returned, then we need to
                 // retry the commit with the new precommit_token and without any mutations.
                 if let Some(new_token) = response.precommit_token().map(|b| *b.clone()) {
-                    let retry_commit_req = build_commit_request(
+                    let retry_commit_req = create_commit_request(
                         session_name.clone(),
                         tx.id,
                         Vec::new(),
                         Some(new_token),
-                        req_options,
+                        Some(req_options),
                         max_commit_delay,
                         return_commit_stats,
                     );
@@ -437,12 +437,12 @@ impl WriteOnlyTransaction {
     }
 }
 
-fn build_commit_request(
+pub(crate) fn create_commit_request(
     session_name: String,
     transaction_id: bytes::Bytes,
     mutations: Vec<ProtoMutation>,
     precommit_token: Option<MultiplexedSessionPrecommitToken>,
-    req_options: RequestOptions,
+    request_options: Option<RequestOptions>,
     max_commit_delay: Option<Duration>,
     return_commit_stats: bool,
 ) -> CommitRequest {
@@ -451,7 +451,7 @@ fn build_commit_request(
         .set_transaction_id(transaction_id)
         .set_mutations(mutations)
         .set_or_clear_precommit_token(precommit_token)
-        .set_request_options(req_options)
+        .set_or_clear_request_options(request_options)
         .set_or_clear_max_commit_delay(max_commit_delay)
         .set_return_commit_stats(return_commit_stats)
 }

--- a/tests/spanner/src/lib.rs
+++ b/tests/spanner/src/lib.rs
@@ -21,5 +21,7 @@ pub mod partitioned_dml;
 pub mod query;
 pub mod read;
 pub mod read_write_transaction;
+pub mod read_write_transaction_options;
 pub mod test_proxy;
 pub mod write;
+pub mod write_only_transaction_options;

--- a/tests/spanner/src/read_write_transaction_options.rs
+++ b/tests/spanner/src/read_write_transaction_options.rs
@@ -1,0 +1,206 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::client::{get_database_id, get_emulator_host, get_real_spanner_config};
+use google_cloud_spanner::Result as SpannerResult;
+use google_cloud_spanner::client::{DatabaseClient, Mutation, Spanner, Statement};
+use google_cloud_spanner::model::request_options::Priority;
+use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
+use google_cloud_wkt::Duration as WktDuration;
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::info;
+
+async fn get_database_path() -> String {
+    if get_emulator_host().is_some() {
+        format!(
+            "projects/{}/instances/{}/databases/{}",
+            "test-project",
+            "test-instance",
+            get_database_id().await
+        )
+    } else {
+        let (project, instance) =
+            get_real_spanner_config().expect("Real Spanner config must be present if not emulator");
+        format!(
+            "projects/{}/instances/{}/databases/{}",
+            project,
+            instance,
+            get_database_id().await
+        )
+    }
+}
+
+pub async fn runner_commit_configurations(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    let id = format!("adv-conf-{}", LowercaseAlphanumeric.random_string(10));
+
+    let runner = db_client
+        .read_write_transaction()
+        .with_commit_priority(Priority::Low)
+        .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+        .with_exclude_txn_from_change_streams(true)
+        .with_return_commit_stats(true)
+        .build()
+        .await?;
+
+    let result = runner
+        .run(async |transaction| {
+            let mutation = Mutation::new_insert_builder("AllTypes")
+                .set("Id")
+                .to(&id)
+                .set("ColInt64")
+                .to(&99_i64)
+                .build();
+            transaction.buffer(vec![mutation])?;
+            Ok(())
+        })
+        .await?;
+
+    if get_emulator_host().is_none() {
+        let stats = result.commit_response.commit_stats.expect(
+            "Expected commit_stats to be returned when with_return_commit_stats is enabled",
+        );
+
+        assert_eq!(
+            stats.mutation_count, 3,
+            "Expected exactly 3 mutations (base row + secondary index updates) in commit stats"
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn client_routing_success(_db_client: &DatabaseClient) -> anyhow::Result<()> {
+    let database_path = get_database_path().await;
+
+    // Build a new Spanner client using the builder to customize routing
+    let spanner = Spanner::builder().build().await?;
+    let custom_client = spanner
+        .database_client(database_path)
+        .with_leader_aware_routing(false)
+        .build()
+        .await?;
+
+    let id = format!("adv-routing-{}", LowercaseAlphanumeric.random_string(10));
+    let runner = custom_client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |transaction| {
+            let statement =
+                Statement::builder("INSERT INTO AllTypes (Id, ColInt64) VALUES (@id, 42)")
+                    .add_param("id", &id)
+                    .build();
+            transaction.execute_update(statement).await?;
+            Ok(())
+        })
+        .await?;
+
+    // Verify that the row was actually inserted
+    let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+        .add_param("id", &id)
+        .build();
+    let mut result_set = custom_client
+        .single_use()
+        .build()
+        .execute_query(statement)
+        .await?;
+    let row = result_set
+        .next()
+        .await
+        .transpose()?
+        .expect("Expected row to be inserted and readable");
+    let value: i64 = row.get("ColInt64");
+    assert_eq!(value, 42, "Expected inserted value to be 42");
+
+    Ok(())
+}
+
+pub async fn unauthorized_database_role_rejection(
+    _db_client: &DatabaseClient,
+) -> anyhow::Result<()> {
+    if get_emulator_host().is_some() {
+        info!(
+            "Skipping unauthorized_database_role_rejection test on Spanner Emulator as it does not support FGAC."
+        );
+        return Ok(());
+    }
+
+    let database_path = get_database_path().await;
+
+    // Build a new Spanner client using the builder to customize database role
+    let spanner = Spanner::builder().build().await?;
+    let custom_client_res = spanner
+        .database_client(database_path)
+        .with_database_role("invalid-unauthorized-role")
+        .build()
+        .await;
+
+    assert!(
+        custom_client_res.is_err(),
+        "Expected client creation to fail with PermissionDenied due to unauthorized database role"
+    );
+
+    let err = custom_client_res.unwrap_err();
+    let err_str = format!("{:?}", err);
+    assert!(
+        err_str.contains("PermissionDenied") || err_str.contains("Role not found"),
+        "Expected PermissionDenied error, got: {}",
+        err_str
+    );
+
+    Ok(())
+}
+
+pub async fn timeout_exceeded_transaction_abort(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    // Configure a tight transaction timeout (2ms)
+    let runner = db_client
+        .read_write_transaction()
+        .with_transaction_timeout(Duration::from_millis(2))
+        .build()
+        .await?;
+
+    let result: SpannerResult<()> = runner
+        .run(async |transaction| {
+            // Execute multiple statements with delay to guarantee timeout exceeding
+            for _ in 0..5 {
+                let statement = Statement::builder("SELECT * FROM AllTypes").build();
+                let mut result_set = transaction.execute_query(statement).await?;
+                while let Some(row) = result_set.next().await.transpose()? {
+                    let _: String = row.get("Id");
+                }
+                sleep(Duration::from_millis(1)).await;
+            }
+            Ok(())
+        })
+        .await
+        .map(|res| res.result);
+
+    assert!(
+        result.is_err(),
+        "Expected transaction to fail with a DeadlineExceeded error"
+    );
+
+    let err = result.unwrap_err();
+    let err_str = format!("{:?}", err);
+    let err_str_lower = err_str.to_lowercase();
+    assert!(
+        err_str_lower.contains("deadlineexceeded")
+            || err_str_lower.contains("timeout")
+            || err_str_lower.contains("cancel"),
+        "Expected DeadlineExceeded / timeout error, got: {}",
+        err_str
+    );
+
+    Ok(())
+}

--- a/tests/spanner/src/write_only_transaction_options.rs
+++ b/tests/spanner/src/write_only_transaction_options.rs
@@ -1,0 +1,102 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::client::get_emulator_host;
+use google_cloud_spanner::client::{DatabaseClient, Mutation, Statement};
+use google_cloud_spanner::model::CommitResponse;
+use google_cloud_spanner::model::request_options::Priority;
+use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
+use google_cloud_wkt::Duration as WktDuration;
+
+async fn run_write_only_options_test<F, Fut>(
+    db_client: &DatabaseClient,
+    id_prefix: &str,
+    val: i64,
+    execute_write: F,
+) -> anyhow::Result<()>
+where
+    F: FnOnce(&DatabaseClient, Vec<Mutation>) -> Fut,
+    Fut: std::future::Future<Output = google_cloud_spanner::Result<CommitResponse>>,
+{
+    let id = format!("{}-{}", id_prefix, LowercaseAlphanumeric.random_string(10));
+
+    let mutation = Mutation::new_insert_builder("AllTypes")
+        .set("Id")
+        .to(&id)
+        .set("ColInt64")
+        .to(&val)
+        .build();
+
+    let result = execute_write(db_client, vec![mutation]).await?;
+
+    if get_emulator_host().is_none() {
+        let stats = result.commit_stats.expect(
+            "Expected commit_stats to be returned when with_return_commit_stats is enabled in write_only_transaction",
+        );
+
+        assert_eq!(
+            stats.mutation_count, 3,
+            "Expected exactly 3 mutations (base row + secondary index updates) in commit stats"
+        );
+    }
+
+    // Verify that the row was actually inserted using a separate read context
+    let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+        .add_param("id", &id)
+        .build();
+    let mut result_set = db_client
+        .single_use()
+        .build()
+        .execute_query(statement)
+        .await?;
+    let row = result_set
+        .next()
+        .await
+        .transpose()?
+        .expect("Expected row to be inserted and readable");
+    let value: i64 = row.get("ColInt64");
+    assert_eq!(value, val, "Expected inserted value to match");
+
+    Ok(())
+}
+
+pub async fn write_only_commit_configurations(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    run_write_only_options_test(db_client, "wo-conf", 101, |client, mutations| {
+        client
+            .write_only_transaction()
+            .with_commit_priority(Priority::Low)
+            .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+            .with_exclude_txn_from_change_streams(true)
+            .with_return_commit_stats(true)
+            .build()
+            .write(mutations)
+    })
+    .await
+}
+
+pub async fn write_only_at_least_once_commit_configurations(
+    db_client: &DatabaseClient,
+) -> anyhow::Result<()> {
+    run_write_only_options_test(db_client, "wo-least-once", 202, |client, mutations| {
+        client
+            .write_only_transaction()
+            .with_commit_priority(Priority::Low)
+            .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+            .with_exclude_txn_from_change_streams(true)
+            .with_return_commit_stats(true)
+            .build()
+            .write_at_least_once(mutations)
+    })
+    .await
+}

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -131,6 +131,20 @@ mod spanner {
             Ok(())
         }
 
+        async fn run_read_write_transaction_options_tests(db_client: &DatabaseClient) -> anyhow::Result<()> {
+            integration_tests_spanner::read_write_transaction_options::runner_commit_configurations(db_client).await?;
+            integration_tests_spanner::read_write_transaction_options::client_routing_success(db_client).await?;
+            integration_tests_spanner::read_write_transaction_options::unauthorized_database_role_rejection(db_client).await?;
+            integration_tests_spanner::read_write_transaction_options::timeout_exceeded_transaction_abort(db_client).await?;
+            Ok(())
+        }
+
+        async fn run_write_only_transaction_options_tests(db_client: &DatabaseClient) -> anyhow::Result<()> {
+            integration_tests_spanner::write_only_transaction_options::write_only_commit_configurations(db_client).await?;
+            integration_tests_spanner::write_only_transaction_options::write_only_at_least_once_commit_configurations(db_client).await?;
+            Ok(())
+        }
+
         async fn run_batch_read_only_transaction_tests(db_client: &DatabaseClient) -> anyhow::Result<()> {
             integration_tests_spanner::batch_read_only_transaction::partitioned_query(db_client)
                 .await?;


### PR DESCRIPTION
Adds more integration tests for read/write transactions, and fixes a bug where some commit options were not applied to the retry request if the original commit attempt returned a CommitResponse with a new precommit_token.