### PR TITLE
feat(spanner): ToValue and FromValue implementation for wkt::Timestamp

### DIFF
--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -173,6 +173,13 @@ impl FromValue for OffsetDateTime {
     }
 }
 
+impl FromValue for wkt::Timestamp {
+    fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError> {
+        let dt = OffsetDateTime::from_value(value, type_)?;
+        wkt::Timestamp::try_from(dt).map_err(|e| ConvertError::Convert(Box::new(e)))
+    }
+}
+
 impl FromValue for Date {
     fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError> {
         if type_.code() != TypeCode::Date {
@@ -490,6 +497,24 @@ mod tests {
 
         let v = "invalid timestamp".to_string().to_value();
         let err = SystemTime::from_value(&v, &types::timestamp()).unwrap_err();
+        assert!(format!("{}", err).contains("cannot convert value"));
+    }
+
+    #[test]
+    fn test_from_value_wkt_timestamp() {
+        let dt = OffsetDateTime::parse(
+            "2023-10-27T10:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .expect("valid date time parsing");
+        let wkt_ts = wkt::Timestamp::try_from(dt).expect("valid wkt timestamp conversion");
+        let v = dt.to_value();
+        let res = wkt::Timestamp::from_value(&v, &types::timestamp())
+            .expect("valid wkt timestamp decoding");
+        assert_eq!(res, wkt_ts);
+
+        let v = "invalid timestamp".to_string().to_value();
+        let err = wkt::Timestamp::from_value(&v, &types::timestamp()).unwrap_err();
         assert!(format!("{}", err).contains("cannot convert value"));
     }
 

--- a/src/spanner/src/timestamp_bound.rs
+++ b/src/spanner/src/timestamp_bound.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use crate::model::transaction_options::read_only::TimestampBound as ReadOnlyTimestampBound;
-use std::time::Duration;
-use time::OffsetDateTime;
+use std::fmt::Debug;
 
 /// Use a timestamp bound to specify how to choose a timestamp at which a query should read data.
 ///
@@ -51,8 +50,13 @@ impl TimestampBound {
     /// See [timestamp_bound_exact_staleness] for more information.
     ///
     /// [timestamp_bound_exact_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#exact_staleness
-    pub fn read_timestamp(timestamp: OffsetDateTime) -> Self {
-        Self::try_read_timestamp(timestamp).expect("timestamp out of range")
+    pub fn read_timestamp<T>(timestamp: T) -> Self
+    where
+        T: TryInto<wkt::Timestamp>,
+        T::Error: Debug,
+    {
+        let timestamp = timestamp.try_into().expect("timestamp out of range");
+        Self(ReadOnlyTimestampBound::ReadTimestamp(Box::new(timestamp)))
     }
 
     /// Returns a timestamp bound for an exact timestamp, returning an error if the timestamp is out of range.
@@ -60,10 +64,11 @@ impl TimestampBound {
     /// See [timestamp_bound_exact_staleness] for more information.
     ///
     /// [timestamp_bound_exact_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#exact_staleness
-    pub fn try_read_timestamp(
-        timestamp: OffsetDateTime,
-    ) -> Result<Self, crate::client::TimestampError> {
-        let timestamp = wkt::Timestamp::try_from(timestamp)?;
+    pub fn try_read_timestamp<T>(timestamp: T) -> Result<Self, T::Error>
+    where
+        T: TryInto<wkt::Timestamp>,
+    {
+        let timestamp = timestamp.try_into()?;
         Ok(Self(ReadOnlyTimestampBound::ReadTimestamp(Box::new(
             timestamp,
         ))))
@@ -75,8 +80,15 @@ impl TimestampBound {
     /// See [timestamp_bound_bounded_staleness] for more information.
     ///
     /// [timestamp_bound_bounded_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#bounded_staleness
-    pub fn min_read_timestamp(timestamp: OffsetDateTime) -> Self {
-        Self::try_min_read_timestamp(timestamp).expect("timestamp out of range")
+    pub fn min_read_timestamp<T>(timestamp: T) -> Self
+    where
+        T: TryInto<wkt::Timestamp>,
+        T::Error: Debug,
+    {
+        let timestamp = timestamp.try_into().expect("timestamp out of range");
+        Self(ReadOnlyTimestampBound::MinReadTimestamp(Box::new(
+            timestamp,
+        )))
     }
 
     /// Returns a timestamp bound for a minimum read timestamp, returning an error if the timestamp is out of range.
@@ -84,10 +96,11 @@ impl TimestampBound {
     /// See [timestamp_bound_bounded_staleness] for more information.
     ///
     /// [timestamp_bound_bounded_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#bounded_staleness
-    pub fn try_min_read_timestamp(
-        timestamp: OffsetDateTime,
-    ) -> Result<Self, crate::client::TimestampError> {
-        let timestamp = wkt::Timestamp::try_from(timestamp)?;
+    pub fn try_min_read_timestamp<T>(timestamp: T) -> Result<Self, T::Error>
+    where
+        T: TryInto<wkt::Timestamp>,
+    {
+        let timestamp = timestamp.try_into()?;
         Ok(Self(ReadOnlyTimestampBound::MinReadTimestamp(Box::new(
             timestamp,
         ))))
@@ -99,7 +112,11 @@ impl TimestampBound {
     /// See [timestamp_bound_exact_staleness] for more information.
     ///
     /// [timestamp_bound_exact_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#exact_staleness
-    pub fn exact_staleness(duration: Duration) -> Self {
+    pub fn exact_staleness<T>(duration: T) -> Self
+    where
+        T: TryInto<wkt::Duration>,
+        T::Error: Debug,
+    {
         Self::try_exact_staleness(duration).expect("duration out of range")
     }
 
@@ -108,8 +125,11 @@ impl TimestampBound {
     /// See [timestamp_bound_exact_staleness] for more information.
     ///
     /// [timestamp_bound_exact_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#exact_staleness
-    pub fn try_exact_staleness(duration: Duration) -> Result<Self, crate::client::DurationError> {
-        let duration = wkt::Duration::try_from(duration)?;
+    pub fn try_exact_staleness<T>(duration: T) -> Result<Self, T::Error>
+    where
+        T: TryInto<wkt::Duration>,
+    {
+        let duration = duration.try_into()?;
         Ok(Self(ReadOnlyTimestampBound::ExactStaleness(Box::new(
             duration,
         ))))
@@ -121,7 +141,11 @@ impl TimestampBound {
     /// See [timestamp_bound_bounded_staleness] for more information.
     ///
     /// [timestamp_bound_bounded_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#bounded_staleness
-    pub fn max_staleness(duration: Duration) -> Self {
+    pub fn max_staleness<T>(duration: T) -> Self
+    where
+        T: TryInto<wkt::Duration>,
+        T::Error: Debug,
+    {
         Self::try_max_staleness(duration).expect("duration out of range")
     }
 
@@ -130,8 +154,11 @@ impl TimestampBound {
     /// See [timestamp_bound_bounded_staleness] for more information.
     ///
     /// [timestamp_bound_bounded_staleness]: https://docs.cloud.google.com/spanner/docs/timestamp-bounds#bounded_staleness
-    pub fn try_max_staleness(duration: Duration) -> Result<Self, crate::client::DurationError> {
-        let duration = wkt::Duration::try_from(duration)?;
+    pub fn try_max_staleness<T>(duration: T) -> Result<Self, T::Error>
+    where
+        T: TryInto<wkt::Duration>,
+    {
+        let duration = duration.try_into()?;
         Ok(Self(ReadOnlyTimestampBound::MaxStaleness(Box::new(
             duration,
         ))))
@@ -141,11 +168,12 @@ impl TimestampBound {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
     use time::macros::datetime;
 
     #[test]
     fn test_auto_traits() {
-        static_assertions::assert_impl_all!(TimestampBound: Clone, std::fmt::Debug, Send, Sync);
+        static_assertions::assert_impl_all!(TimestampBound: Clone, Debug, Send, Sync);
     }
 
     #[test]
@@ -158,13 +186,42 @@ mod tests {
     fn test_read_timestamp_methods() {
         let ts = datetime!(2026-03-09 18:00:00 UTC);
 
+        // 1. OffsetDateTime
         let read = TimestampBound::read_timestamp(ts);
         assert!(matches!(
             read.0,
             ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
         ));
 
-        let try_read = TimestampBound::try_read_timestamp(ts).unwrap();
+        let try_read = TimestampBound::try_read_timestamp(ts).expect("valid OffsetDateTime");
+        assert!(matches!(
+            try_read.0,
+            ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        // 2. wkt::Timestamp
+        let wkt_ts = wkt::Timestamp::try_from(ts).expect("valid wkt timestamp");
+        let read = TimestampBound::read_timestamp(wkt_ts);
+        assert!(matches!(
+            read.0,
+            ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        let try_read = TimestampBound::try_read_timestamp(wkt_ts).expect("valid wkt timestamp");
+        assert!(matches!(
+            try_read.0,
+            ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        // 3. SystemTime
+        let system_time = std::time::SystemTime::from(ts);
+        let read = TimestampBound::read_timestamp(system_time);
+        assert!(matches!(
+            read.0,
+            ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        let try_read = TimestampBound::try_read_timestamp(system_time).expect("valid SystemTime");
         assert!(matches!(
             try_read.0,
             ReadOnlyTimestampBound::ReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
@@ -175,13 +232,45 @@ mod tests {
     fn test_min_read_timestamp_methods() {
         let ts = datetime!(2026-03-09 18:00:00 UTC);
 
+        // 1. OffsetDateTime
         let min_read = TimestampBound::min_read_timestamp(ts);
         assert!(matches!(
             min_read.0,
             ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
         ));
 
-        let try_min_read = TimestampBound::try_min_read_timestamp(ts).unwrap();
+        let try_min_read =
+            TimestampBound::try_min_read_timestamp(ts).expect("valid OffsetDateTime");
+        assert!(matches!(
+            try_min_read.0,
+            ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        // 2. wkt::Timestamp
+        let wkt_ts = wkt::Timestamp::try_from(ts).expect("valid wkt timestamp");
+        let min_read = TimestampBound::min_read_timestamp(wkt_ts);
+        assert!(matches!(
+            min_read.0,
+            ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        let try_min_read =
+            TimestampBound::try_min_read_timestamp(wkt_ts).expect("valid wkt timestamp");
+        assert!(matches!(
+            try_min_read.0,
+            ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        // 3. SystemTime
+        let system_time = std::time::SystemTime::from(ts);
+        let min_read = TimestampBound::min_read_timestamp(system_time);
+        assert!(matches!(
+            min_read.0,
+            ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
+        ));
+
+        let try_min_read =
+            TimestampBound::try_min_read_timestamp(system_time).expect("valid SystemTime");
         assert!(matches!(
             try_min_read.0,
             ReadOnlyTimestampBound::MinReadTimestamp(ref t) if t.seconds() == ts.unix_timestamp() && t.nanos() == ts.nanosecond() as i32
@@ -192,13 +281,28 @@ mod tests {
     fn test_exact_staleness_methods() {
         let d = Duration::from_secs(60);
 
+        // 1. std::time::Duration
         let exact = TimestampBound::exact_staleness(d);
         assert!(matches!(
             exact.0,
             ReadOnlyTimestampBound::ExactStaleness(ref t) if t.seconds() == 60 && t.nanos() == 0
         ));
 
-        let try_exact = TimestampBound::try_exact_staleness(d).unwrap();
+        let try_exact = TimestampBound::try_exact_staleness(d).expect("valid std::time::Duration");
+        assert!(matches!(
+            try_exact.0,
+            ReadOnlyTimestampBound::ExactStaleness(ref t) if t.seconds() == 60 && t.nanos() == 0
+        ));
+
+        // 2. wkt::Duration
+        let wkt_d = wkt::Duration::try_from(d).expect("valid wkt duration");
+        let exact = TimestampBound::exact_staleness(wkt_d);
+        assert!(matches!(
+            exact.0,
+            ReadOnlyTimestampBound::ExactStaleness(ref t) if t.seconds() == 60 && t.nanos() == 0
+        ));
+
+        let try_exact = TimestampBound::try_exact_staleness(wkt_d).expect("valid wkt::Duration");
         assert!(matches!(
             try_exact.0,
             ReadOnlyTimestampBound::ExactStaleness(ref t) if t.seconds() == 60 && t.nanos() == 0
@@ -209,13 +313,28 @@ mod tests {
     fn test_max_staleness_methods() {
         let d = Duration::from_secs(120);
 
+        // 1. std::time::Duration
         let max = TimestampBound::max_staleness(d);
         assert!(matches!(
             max.0,
             ReadOnlyTimestampBound::MaxStaleness(ref t) if t.seconds() == 120 && t.nanos() == 0
         ));
 
-        let try_max = TimestampBound::try_max_staleness(d).unwrap();
+        let try_max = TimestampBound::try_max_staleness(d).expect("valid std::time::Duration");
+        assert!(matches!(
+            try_max.0,
+            ReadOnlyTimestampBound::MaxStaleness(ref t) if t.seconds() == 120 && t.nanos() == 0
+        ));
+
+        // 2. wkt::Duration
+        let wkt_d = wkt::Duration::try_from(d).expect("valid wkt duration");
+        let max = TimestampBound::max_staleness(wkt_d);
+        assert!(matches!(
+            max.0,
+            ReadOnlyTimestampBound::MaxStaleness(ref t) if t.seconds() == 120 && t.nanos() == 0
+        ));
+
+        let try_max = TimestampBound::try_max_staleness(wkt_d).expect("valid wkt::Duration");
         assert!(matches!(
             try_max.0,
             ReadOnlyTimestampBound::MaxStaleness(ref t) if t.seconds() == 120 && t.nanos() == 0

--- a/src/spanner/src/timestamp_bound.rs
+++ b/src/spanner/src/timestamp_bound.rs
@@ -55,8 +55,7 @@ impl TimestampBound {
         T: TryInto<wkt::Timestamp>,
         T::Error: Debug,
     {
-        let timestamp = timestamp.try_into().expect("timestamp out of range");
-        Self(ReadOnlyTimestampBound::ReadTimestamp(Box::new(timestamp)))
+        Self::try_read_timestamp(timestamp).expect("timestamp out of range")
     }
 
     /// Returns a timestamp bound for an exact timestamp, returning an error if the timestamp is out of range.
@@ -85,10 +84,7 @@ impl TimestampBound {
         T: TryInto<wkt::Timestamp>,
         T::Error: Debug,
     {
-        let timestamp = timestamp.try_into().expect("timestamp out of range");
-        Self(ReadOnlyTimestampBound::MinReadTimestamp(Box::new(
-            timestamp,
-        )))
+        Self::try_min_read_timestamp(timestamp).expect("timestamp out of range")
     }
 
     /// Returns a timestamp bound for a minimum read timestamp, returning an error if the timestamp is out of range.

--- a/src/spanner/src/to_value.rs
+++ b/src/spanner/src/to_value.rs
@@ -115,6 +115,14 @@ impl ToValue for OffsetDateTime {
     }
 }
 
+impl ToValue for wkt::Timestamp {
+    fn to_value(&self) -> Value {
+        let dt = OffsetDateTime::try_from(*self)
+            .expect("valid wkt timestamp conversion to OffsetDateTime");
+        dt.to_value()
+    }
+}
+
 impl ToValue for Date {
     fn to_value(&self) -> Value {
         Value(ProtoValue {
@@ -262,6 +270,19 @@ mod tests {
 
         let system_time: SystemTime = dt.into();
         let v = system_time.to_value();
+        assert_eq!(v.kind(), Kind::String);
+        assert_eq!(v.as_string(), "2023-10-27T10:00:00.000000000Z");
+    }
+
+    #[test]
+    fn test_to_value_wkt_timestamp() {
+        let dt = OffsetDateTime::parse(
+            "2023-10-27T10:00:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .expect("valid date time parsing");
+        let wkt_ts = wkt::Timestamp::try_from(dt).expect("valid wkt timestamp conversion");
+        let v = wkt_ts.to_value();
         assert_eq!(v.kind(), Kind::String);
         assert_eq!(v.as_string(), "2023-10-27T10:00:00.000000000Z");
     }


### PR DESCRIPTION
Adds implementations for ToValue and FromValue for wkt::Timestamp. Also changes the input arguments for creating timestamp bounds so wkt::Timestamp can be used directly.