### PR TITLE
feat(storage): Support GCS Get Service Account

### DIFF
--- a/src/storage/examples/src/client.rs
+++ b/src/storage/examples/src/client.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 pub mod configure_retries;
+pub mod get_service_account;
 pub mod quota_project;
 pub mod set_client_endpoint;

--- a/src/storage/examples/src/client/get_service_account.rs
+++ b/src/storage/examples/src/client/get_service_account.rs
@@ -20,10 +20,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
 
     // Fetches the email address of the GCS service agent for the given project.
     // If the service agent does not exist yet, the GCS control plane creates it under the hood.
-    let email = client
-        .get_service_account(project_id)
-        .send()
-        .await?;
+    let email = client.get_service_account(project_id).send().await?;
 
     println!("Service account email for project {project_id}: {email}");
 

--- a/src/storage/examples/src/client/get_service_account.rs
+++ b/src/storage/examples/src/client/get_service_account.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_get_service_account]
+use google_cloud_storage::client::Storage;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = Storage::builder().build().await?;
+
+    // Fetches the email address of the GCS service agent for the given project.
+    // If the service agent does not exist yet, the GCS control plane creates it under the hood.
+    let email = client
+        .get_service_account(project_id)
+        .send()
+        .await?;
+
+    println!("Service account email for project {project_id}: {email}");
+
+    Ok(())
+}
+// [END storage_get_service_account]

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -592,6 +592,9 @@ pub async fn run_client_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     tracing::info!("running storage_quota_project example");
     client::quota_project::sample(&id, &project_id).await?;
 
+    tracing::info!("running storage_get_service_account example");
+    client::get_service_account::sample(&project_id).await?;
+
     Ok(())
 }
 

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -94,7 +94,9 @@ pub mod builder {
     pub mod storage {
         //! Request builders for [Storage][crate::client::Storage].
         pub use crate::storage::client::ClientBuilder;
-        pub use crate::storage::get_service_account::GetServiceAccount;
+        pub use crate::storage::get_service_account::{
+            GetServiceAccount, GetServiceAccountRequest,
+        };
         pub use crate::storage::open_object::OpenObject;
         pub use crate::storage::read_object::ReadObject;
         pub use crate::storage::signed_url::SignedUrlBuilder;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -94,6 +94,7 @@ pub mod builder {
     pub mod storage {
         //! Request builders for [Storage][crate::client::Storage].
         pub use crate::storage::client::ClientBuilder;
+        pub use crate::storage::get_service_account::GetServiceAccount;
         pub use crate::storage::open_object::OpenObject;
         pub use crate::storage::read_object::ReadObject;
         pub use crate::storage::signed_url::SignedUrlBuilder;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,7 +18,7 @@ pub(crate) mod bidi;
 pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod common_options;
-pub mod get_service_account;
+pub(crate) mod get_service_account;
 pub(crate) mod open_object;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,6 +18,7 @@ pub(crate) mod bidi;
 pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod common_options;
+pub mod get_service_account;
 pub(crate) mod open_object;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -225,13 +225,11 @@ where
 
     /// Fetches the email address of the GCS service account for the given project.
     ///
-    /// # Design Note (Architectural Exception):
-    /// Logically, this administrative operation belongs to the control plane (`StorageControl`).
-    /// However, since the GCS gRPC control plane does not support project service account retrieval,
-    /// we place it here in the handwritten REST client to avoid altering machine-generated code.
-    ///
     /// # Parameters
-    /// * `project` - the Project ID or project number.
+    /// * `project` - the project name, either `projects/{projectId}` or `projects/{projectNumber}`.
+    ///     See [The project resource] for more information about projects and their identifiers.
+    ///
+    /// [The project resource]: https://docs.cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy#projects
     pub fn get_service_account<P>(&self, project: P) -> GetServiceAccount<S>
     where
         P: Into<String>,

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -18,6 +18,7 @@ use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
 use crate::storage::bidi::OpenObject;
 use crate::storage::common_options::CommonOptions;
+use crate::storage::get_service_account::GetServiceAccount;
 use crate::streaming_source::Payload;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
@@ -220,6 +221,22 @@ where
         O: Into<String>,
     {
         ReadObject::new(self.stub.clone(), bucket, object, self.options.clone())
+    }
+
+    /// Fetches the email address of the GCS service account for the given project.
+    ///
+    /// # Design Note (Architectural Exception):
+    /// Logically, this administrative operation belongs to the control plane (`StorageControl`).
+    /// However, since the GCS gRPC control plane does not support project service account retrieval,
+    /// we place it here in the handwritten REST client to avoid altering machine-generated code.
+    ///
+    /// # Parameters
+    /// * `project` - the Project ID or project number.
+    pub fn get_service_account<P>(&self, project: P) -> GetServiceAccount<S>
+    where
+        P: Into<String>,
+    {
+        GetServiceAccount::new(self.stub.clone(), project.into(), self.options.clone())
     }
 
     /// Opens an object to read its contents using concurrent ranged reads.

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -95,7 +95,7 @@ pub(crate) struct ServiceAccountLookup {
 
 impl ServiceAccountLookup {
     async fn http_request_builder(&self) -> Result<RequestBuilder> {
-        let project_id = &self.project;
+        let project_id = super::client::enc(&self.project);
         let builder = self
             .inner
             .client
@@ -212,6 +212,34 @@ mod tests {
 
         let err = client.get_service_account("non-existent").send().await.expect_err("should fail with 404");
         assert_eq!(err.http_status_code(), Some(404));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_service_account_with_domain_prefix() -> anyhow::Result<()> {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("GET", "/storage/v1/projects/example.com%3Amy-project-123/serviceAccount"),
+                request::headers(contains(("x-goog-api-client", super::X_GOOG_API_CLIENT_HEADER.as_str()))),
+            ])
+            .respond_with(
+                status_code(200).body(serde_json::json!({
+                    "kind": "storage#serviceAccount",
+                    "email_address": "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+                }).to_string()),
+            ),
+        );
+
+        let client = Storage::builder()
+            .with_endpoint(format!("http://{}", server.addr()))
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let email = client.get_service_account("example.com:my-project-123").send().await?;
+        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
 
         Ok(())
     }

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -82,7 +82,9 @@ where
 
     /// Sends the request and returns the GCS service account email address.
     pub async fn send(self) -> Result<String> {
-        self.stub.get_service_account(self.project, self.options).await
+        self.stub
+            .get_service_account(self.project, self.options)
+            .await
     }
 }
 
@@ -130,12 +132,7 @@ impl ServiceAccountLookup {
 mod tests {
     use crate::client::Storage;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
-    use httptest::{
-        Expectation,
-        Server,
-        matchers::*,
-        responders::*,
-    };
+    use httptest::{Expectation, Server, matchers::*, responders::*};
 
     #[tokio::test]
     async fn test_get_service_account_success() -> anyhow::Result<()> {
@@ -161,7 +158,10 @@ mod tests {
             .await?;
 
         let email = client.get_service_account("my-project-123").send().await?;
-        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+        assert_eq!(
+            email,
+            "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+        );
 
         Ok(())
     }
@@ -187,8 +187,14 @@ mod tests {
             .build()
             .await?;
 
-        let email = client.get_service_account("projects/my-project-123").send().await?;
-        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+        let email = client
+            .get_service_account("projects/my-project-123")
+            .send()
+            .await?;
+        assert_eq!(
+            email,
+            "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+        );
 
         Ok(())
     }
@@ -197,9 +203,10 @@ mod tests {
     async fn test_get_service_account_not_found() -> anyhow::Result<()> {
         let server = Server::run();
         server.expect(
-            Expectation::matching(all_of![
-                request::method_path("GET", "/storage/v1/projects/non-existent/serviceAccount"),
-            ])
+            Expectation::matching(all_of![request::method_path(
+                "GET",
+                "/storage/v1/projects/non-existent/serviceAccount"
+            ),])
             .respond_with(status_code(404).body("Not Found")),
         );
 
@@ -209,7 +216,11 @@ mod tests {
             .build()
             .await?;
 
-        let err = client.get_service_account("non-existent").send().await.expect_err("should fail with 404");
+        let err = client
+            .get_service_account("non-existent")
+            .send()
+            .await
+            .expect_err("should fail with 404");
         assert_eq!(err.http_status_code(), Some(404));
 
         Ok(())
@@ -237,10 +248,15 @@ mod tests {
             .build()
             .await?;
 
-        let email = client.get_service_account("example.com:my-project-123").send().await?;
-        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+        let email = client
+            .get_service_account("example.com:my-project-123")
+            .send()
+            .await?;
+        assert_eq!(
+            email,
+            "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+        );
 
         Ok(())
     }
 }
-

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -20,6 +20,22 @@ use gaxi::http::NoBody;
 use gaxi::http::reqwest::{HeaderValue, Method, RequestBuilder};
 use std::sync::Arc;
 
+/// Request message for [Storage::get_service_account][crate::client::Storage::get_service_account].
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GetServiceAccountRequest {
+    /// The project name, either `projects/{projectId}` or `projects/{projectNumber}`.
+    pub project: String,
+}
+
+impl GetServiceAccountRequest {
+    /// Creates a new request with the given project.
+    pub fn new(project: impl Into<String>) -> Self {
+        Self {
+            project: project.into(),
+        }
+    }
+}
+
 /// The request builder for [Storage::get_service_account][crate::client::Storage::get_service_account] calls.
 #[derive(Clone, Debug)]
 pub struct GetServiceAccount<S>
@@ -36,10 +52,6 @@ where
     S: crate::storage::stub::Storage + 'static,
 {
     pub(crate) fn new(stub: Arc<S>, project: String, options: RequestOptions) -> Self {
-        let project = project
-            .strip_prefix("projects/")
-            .unwrap_or(&project)
-            .to_string();
         Self {
             stub,
             project,
@@ -82,9 +94,10 @@ where
 
     /// Sends the request and returns the GCS service account email address.
     pub async fn send(self) -> Result<String> {
-        self.stub
-            .get_service_account(self.project, self.options)
-            .await
+        let request = GetServiceAccountRequest {
+            project: self.project,
+        };
+        self.stub.get_service_account(request, self.options).await
     }
 }
 
@@ -97,7 +110,11 @@ pub(crate) struct ServiceAccountLookup {
 
 impl ServiceAccountLookup {
     async fn http_request_builder(&self) -> Result<RequestBuilder> {
-        let project_id = super::client::enc(&self.project);
+        let project_id = self
+            .project
+            .strip_prefix("projects/")
+            .unwrap_or(&self.project);
+        let project_id = super::client::enc(project_id);
         let builder = self
             .inner
             .client
@@ -118,14 +135,19 @@ impl ServiceAccountLookup {
         let response = self
             .inner
             .client
-            .execute::<NoBody, crate::storage::v1::ProjectServiceAccount>(
-                builder,
-                None,
-                self.options.gax().clone(),
-            )
+            .execute::<NoBody, ProjectServiceAccount>(builder, None, self.options.gax().clone())
             .await?;
         Ok(response.into_body().email_address)
     }
+}
+
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
+#[serde(default)]
+struct ProjectServiceAccount {
+    kind: String,
+    email_address: String,
+    #[serde(flatten)]
+    unknown_fields: std::collections::HashMap<String, serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -128,7 +128,6 @@ impl ServiceAccountLookup {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::client::Storage;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use httptest::{

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -1,0 +1,214 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::client::StorageInner;
+use crate::Result;
+use crate::storage::request_options::RequestOptions;
+use gaxi::http::NoBody;
+use gaxi::http::reqwest::{HeaderValue, Method, RequestBuilder};
+use std::sync::Arc;
+
+/// The request builder for [Storage::get_service_account][crate::client::Storage::get_service_account] calls.
+#[derive(Clone, Debug)]
+pub struct GetServiceAccount<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    stub: Arc<S>,
+    project: String,
+    options: RequestOptions,
+}
+
+impl<S> GetServiceAccount<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    pub(crate) fn new(stub: Arc<S>, project: String, options: RequestOptions) -> Self {
+        Self {
+            stub,
+            project,
+            options,
+        }
+    }
+
+    /// The retry policy used for this request.
+    pub fn with_retry_policy<V: Into<google_cloud_gax::retry_policy::RetryPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_policy = v.into().into();
+        self
+    }
+
+    /// The backoff policy used for this request.
+    pub fn with_backoff_policy<V: Into<google_cloud_gax::backoff_policy::BackoffPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.backoff_policy = v.into().into();
+        self
+    }
+
+    /// The retry throttler used for this request.
+    pub fn with_retry_throttler<V: Into<google_cloud_gax::retry_throttler::RetryThrottlerArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_throttler = v.into().into();
+        self
+    }
+
+    /// Sets the project that will be billed for this request.
+    pub fn with_quota_project(mut self, project: impl Into<String>) -> Self {
+        self.options.set_quota_project(project);
+        self
+    }
+
+    /// Sends the request and returns the GCS service account email address.
+    pub async fn send(self) -> Result<String> {
+        self.stub.get_service_account(self.project, self.options).await
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ServiceAccountLookup {
+    pub inner: Arc<StorageInner>,
+    pub project: String,
+    pub options: RequestOptions,
+}
+
+impl ServiceAccountLookup {
+    async fn http_request_builder(&self) -> Result<RequestBuilder> {
+        let project_id = self.project.strip_prefix("projects/").unwrap_or(&self.project);
+        let builder = self
+            .inner
+            .client
+            .builder(
+                Method::GET,
+                format!("/storage/v1/projects/{project_id}/serviceAccount"),
+            )
+            .header(
+                "x-goog-api-client",
+                HeaderValue::from_static(&super::info::X_GOOG_API_CLIENT_HEADER),
+            );
+
+        Ok(builder)
+    }
+
+    pub(crate) async fn response(self) -> Result<String> {
+        let builder = self.http_request_builder().await?;
+        let response = self
+            .inner
+            .client
+            .execute::<NoBody, crate::storage::v1::ProjectServiceAccount>(
+                builder,
+                None,
+                self.options.gax().clone(),
+            )
+            .await?;
+        Ok(response.into_body().email_address)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::Storage;
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use httptest::{
+        Expectation,
+        Server,
+        matchers::*,
+        responders::*,
+    };
+
+    #[tokio::test]
+    async fn test_get_service_account_success() -> anyhow::Result<()> {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("GET", "/storage/v1/projects/my-project-123/serviceAccount"),
+                request::headers(contains(("x-goog-api-client", super::super::info::X_GOOG_API_CLIENT_HEADER.as_str()))),
+            ])
+            .respond_with(
+                status_code(200).body(serde_json::json!({
+                    "kind": "storage#serviceAccount",
+                    "email_address": "service-123456@gs-project-accounts.iam.gserviceaccount.com",
+                    "extra_field": "test-value"
+                }).to_string()),
+            ),
+        );
+
+        let client = Storage::builder()
+            .with_endpoint(format!("http://{}", server.addr()))
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let email = client.get_service_account("my-project-123").send().await?;
+        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_service_account_with_projects_prefix() -> anyhow::Result<()> {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("GET", "/storage/v1/projects/my-project-123/serviceAccount"),
+            ])
+            .respond_with(
+                status_code(200).body(serde_json::json!({
+                    "kind": "storage#serviceAccount",
+                    "email_address": "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+                }).to_string()),
+            ),
+        );
+
+        let client = Storage::builder()
+            .with_endpoint(format!("http://{}", server.addr()))
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let email = client.get_service_account("projects/my-project-123").send().await?;
+        assert_eq!(email, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_service_account_not_found() -> anyhow::Result<()> {
+        let server = Server::run();
+        server.expect(
+            Expectation::matching(all_of![
+                request::method_path("GET", "/storage/v1/projects/non-existent/serviceAccount"),
+            ])
+            .respond_with(status_code(404).body("Not Found")),
+        );
+
+        let client = Storage::builder()
+            .with_endpoint(format!("http://{}", server.addr()))
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let err = client.get_service_account("non-existent").send().await.expect_err("should fail with 404");
+        assert_eq!(err.http_status_code(), Some(404));
+
+        Ok(())
+    }
+}
+

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -14,6 +14,7 @@
 
 use super::client::StorageInner;
 use crate::Result;
+use crate::storage::info::X_GOOG_API_CLIENT_HEADER;
 use crate::storage::request_options::RequestOptions;
 use gaxi::http::NoBody;
 use gaxi::http::reqwest::{HeaderValue, Method, RequestBuilder};
@@ -100,7 +101,7 @@ impl ServiceAccountLookup {
             )
             .header(
                 "x-goog-api-client",
-                HeaderValue::from_static(&super::info::X_GOOG_API_CLIENT_HEADER),
+                HeaderValue::from_static(&X_GOOG_API_CLIENT_HEADER),
             );
 
         Ok(builder)

--- a/src/storage/src/storage/get_service_account.rs
+++ b/src/storage/src/storage/get_service_account.rs
@@ -36,6 +36,10 @@ where
     S: crate::storage::stub::Storage + 'static,
 {
     pub(crate) fn new(stub: Arc<S>, project: String, options: RequestOptions) -> Self {
+        let project = project
+            .strip_prefix("projects/")
+            .unwrap_or(&project)
+            .to_string();
         Self {
             stub,
             project,
@@ -91,7 +95,7 @@ pub(crate) struct ServiceAccountLookup {
 
 impl ServiceAccountLookup {
     async fn http_request_builder(&self) -> Result<RequestBuilder> {
-        let project_id = self.project.strip_prefix("projects/").unwrap_or(&self.project);
+        let project_id = &self.project;
         let builder = self
             .inner
             .client

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -25,6 +25,8 @@ use crate::{
 };
 use gaxi::unimplemented::UNIMPLEMENTED;
 
+use crate::storage::get_service_account::GetServiceAccountRequest;
+
 /// Defines the trait used to implement [crate::client::Storage].
 ///
 /// Application developers may need to implement this trait to mock
@@ -40,7 +42,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
     /// Implements [crate::client::Storage::get_service_account].
     fn get_service_account(
         &self,
-        _project: String,
+        _request: GetServiceAccountRequest,
         _options: RequestOptions,
     ) -> impl std::future::Future<Output = Result<String>> + Send {
         unimplemented_stub::<String>()

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -37,6 +37,15 @@ use gaxi::unimplemented::UNIMPLEMENTED;
 /// implementation of each method. Most of these implementations just return an
 /// error.
 pub trait Storage: std::fmt::Debug + Send + Sync {
+    /// Implements [crate::client::Storage::get_service_account].
+    fn get_service_account(
+        &self,
+        _project: String,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<String>> + Send {
+        unimplemented_stub::<String>()
+    }
+
     /// Implements [crate::client::Storage::read_object].
     fn read_object(
         &self,

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -18,7 +18,7 @@ use crate::model::{Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
-use crate::storage::get_service_account::ServiceAccountLookup;
+use crate::storage::get_service_account::{GetServiceAccountRequest, ServiceAccountLookup};
 use crate::storage::info::INSTRUMENTATION;
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;
@@ -65,12 +65,12 @@ impl Storage {
 
     async fn get_service_account_plain(
         &self,
-        project: String,
+        request: GetServiceAccountRequest,
         options: RequestOptions,
     ) -> Result<String> {
         let service_account = ServiceAccountLookup {
             inner: self.inner.clone(),
-            project,
+            project: request.project,
             options,
         };
         service_account.response().await
@@ -80,14 +80,19 @@ impl Storage {
         name = "get_service_account",
         level = tracing::Level::DEBUG,
         ret,
-        err(Debug)
+        err(Debug),
+        skip(request)
     )]
     async fn get_service_account_tracing(
         &self,
-        project: String,
+        request: GetServiceAccountRequest,
         options: RequestOptions,
     ) -> Result<String> {
-        let resource_name = format!("//storage.googleapis.com/projects/{}", project);
+        let project_id = request
+            .project
+            .strip_prefix("projects/")
+            .unwrap_or(&request.project);
+        let resource_name = format!("//storage.googleapis.com/projects/{}", project_id);
         let (_span, pending) = gaxi::client_request_signals!(
             metric: self.metric.clone(),
             info: *INSTRUMENTATION,
@@ -100,7 +105,7 @@ impl Storage {
                             .set_resource_name(resource_name),
                     );
                 }
-                self.get_service_account_plain(project, options).await
+                self.get_service_account_plain(request, options).await
             }
         );
         pending.await
@@ -312,13 +317,13 @@ impl super::stub::Storage for Storage {
     /// Implements [crate::client::Storage::get_service_account].
     async fn get_service_account(
         &self,
-        project: String,
+        request: GetServiceAccountRequest,
         options: RequestOptions,
     ) -> Result<String> {
         if self.tracing {
-            self.get_service_account_tracing(project, options).await
+            self.get_service_account_tracing(request, options).await
         } else {
-            self.get_service_account_plain(project, options).await
+            self.get_service_account_plain(request, options).await
         }
     }
 

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -18,6 +18,7 @@ use crate::model::{Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
+use crate::storage::get_service_account::ServiceAccountLookup;
 use crate::storage::info::INSTRUMENTATION;
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;
@@ -60,6 +61,49 @@ impl Storage {
             tracing,
             metric,
         })
+    }
+
+    async fn get_service_account_plain(
+        &self,
+        project: String,
+        options: RequestOptions,
+    ) -> Result<String> {
+        let service_account = ServiceAccountLookup {
+            inner: self.inner.clone(),
+            project,
+            options,
+        };
+        service_account.response().await
+    }
+
+    #[tracing::instrument(
+        name = "get_service_account",
+        level = tracing::Level::DEBUG,
+        ret,
+        err(Debug)
+    )]
+    async fn get_service_account_tracing(
+        &self,
+        project: String,
+        options: RequestOptions,
+    ) -> Result<String> {
+        let resource_name = format!("//storage.googleapis.com/projects/{}", project);
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::get_service_account",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_url_template("/storage/v1/projects/{project}/serviceAccount")
+                            .set_resource_name(resource_name),
+                    );
+                }
+                self.get_service_account_plain(project, options).await
+            }
+        );
+        pending.await
     }
 
     async fn read_object_plain(
@@ -265,6 +309,19 @@ impl Storage {
 }
 
 impl super::stub::Storage for Storage {
+    /// Implements [crate::client::Storage::get_service_account].
+    async fn get_service_account(
+        &self,
+        project: String,
+        options: RequestOptions,
+    ) -> Result<String> {
+        if self.tracing {
+            self.get_service_account_tracing(project, options).await
+        } else {
+            self.get_service_account_plain(project, options).await
+        }
+    }
+
     /// Implements [crate::client::Storage::read_object].
     async fn read_object(
         &self,

--- a/src/storage/src/storage/v1.rs
+++ b/src/storage/src/storage/v1.rs
@@ -358,16 +358,6 @@ pub(crate) fn insert_body(resource: &crate::model::Object) -> serde_json::Value 
     )
 }
 
-#[derive(Debug, Default, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
-#[serde(default, rename_all = "camelCase")]
-pub(crate) struct ProjectServiceAccount {
-    pub kind: String,
-    #[serde(rename = "email_address")]
-    pub email_address: String,
-    #[serde(flatten)]
-    pub unknown_fields: std::collections::HashMap<String, serde_json::Value>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/storage/src/storage/v1.rs
+++ b/src/storage/src/storage/v1.rs
@@ -358,6 +358,16 @@ pub(crate) fn insert_body(resource: &crate::model::Object) -> serde_json::Value 
     )
 }
 
+#[derive(Debug, Default, serde::Deserialize, serde::Serialize, PartialEq, Clone)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct ProjectServiceAccount {
+    pub kind: String,
+    #[serde(rename = "email_address")]
+    pub email_address: String,
+    #[serde(flatten)]
+    pub unknown_fields: std::collections::HashMap<String, serde_json::Value>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -901,5 +911,25 @@ mod tests {
     fn insert_body(input: crate::model::Object, want: serde_json::Value) {
         let got = super::insert_body(&input);
         assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_deserialize_project_service_account() {
+        let json = serde_json::json!({
+            "kind": "storage#serviceAccount",
+            "email_address": "service-123456@gs-project-accounts.iam.gserviceaccount.com",
+            "extra_field_1": "value_1",
+            "extra_field_2": 12345
+        });
+        let got: ProjectServiceAccount = serde_json::from_value(json)
+            .expect("should deserialize ProjectServiceAccount successfully");
+        
+        let mut want_unknown = std::collections::HashMap::new();
+        want_unknown.insert("extra_field_1".to_string(), serde_json::json!("value_1"));
+        want_unknown.insert("extra_field_2".to_string(), serde_json::json!(12345));
+
+        assert_eq!(got.kind, "storage#serviceAccount");
+        assert_eq!(got.email_address, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+        assert_eq!(got.unknown_fields, want_unknown);
     }
 }

--- a/src/storage/src/storage/v1.rs
+++ b/src/storage/src/storage/v1.rs
@@ -923,13 +923,16 @@ mod tests {
         });
         let got: ProjectServiceAccount = serde_json::from_value(json)
             .expect("should deserialize ProjectServiceAccount successfully");
-        
+
         let mut want_unknown = std::collections::HashMap::new();
         want_unknown.insert("extra_field_1".to_string(), serde_json::json!("value_1"));
         want_unknown.insert("extra_field_2".to_string(), serde_json::json!(12345));
 
         assert_eq!(got.kind, "storage#serviceAccount");
-        assert_eq!(got.email_address, "service-123456@gs-project-accounts.iam.gserviceaccount.com");
+        assert_eq!(
+            got.email_address,
+            "service-123456@gs-project-accounts.iam.gserviceaccount.com"
+        );
         assert_eq!(got.unknown_fields, want_unknown);
     }
 }

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -453,7 +453,7 @@ pub fn retry_policy() -> impl google_cloud_gax::retry_policy::RetryPolicy {
 pub async fn service_account(builder: StorageBuilder) -> Result<()> {
     let client = builder.build().await?;
     let project = project_id()?;
-    
+
     tracing::info!("testing get_service_account() for project: {project}");
     let email = client.get_service_account(project).send().await?;
     tracing::info!("success with get_service_account, email={email}");
@@ -461,4 +461,3 @@ pub async fn service_account(builder: StorageBuilder) -> Result<()> {
     assert!(email.contains('@'));
     Ok(())
 }
-

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -449,3 +449,16 @@ pub fn retry_policy() -> impl google_cloud_gax::retry_policy::RetryPolicy {
         .with_time_limit(Duration::from_secs(15))
         .with_attempt_limit(5)
 }
+
+pub async fn service_account(builder: StorageBuilder) -> Result<()> {
+    let client = builder.build().await?;
+    let project = project_id()?;
+    
+    tracing::info!("testing get_service_account() for project: {project}");
+    let email = client.get_service_account(project).send().await?;
+    tracing::info!("success with get_service_account, email={email}");
+    assert!(!email.is_empty());
+    assert!(email.contains('@'));
+    Ok(())
+}
+

--- a/tests/storage/tests/driver.rs
+++ b/tests/storage/tests/driver.rs
@@ -85,6 +85,11 @@ mod storage {
                 .inspect_err(anydump)?;
 
             let builder = Storage::builder();
+            integration_tests_storage::service_account(builder)
+                .await
+                .inspect_err(anydump)?;
+
+            let builder = Storage::builder();
             integration_tests_storage::object_names(builder, control.clone(), &bucket.name)
                 .await
                 .inspect_err(anydump)?;


### PR DESCRIPTION
feat(storage): Support GCS Get Service Account REST endpoint

Closes a GCS feature gap by implementing the  control plane feature. This retrieves the email address of the Google Cloud Storage service agent for a given project, creating it under the hood if it does not yet exist.

### Main changes:
1. **Data Modeling**: Created  JSON deserializer in  using  for robust unknown fields preservation (forward compatibility).
2. **Request Builder**: Added a public fluent request builder  and runner  in  utilizing standard GAX execution pipelines.
3. **Client Integration**: Wired the API cleanly into the mockable  trait (), handwritten REST client (), and  (plain and traced paths).
4. **Unit & E2E Tests**: Added mock HTTP REST server unit tests, deserialization unit tests, and wired up a live end-to-end integration test in  hitting the live GCS control plane.