### PR TITLE
chore(spanner): fix issues with non_exhaustive enums and structs

### DIFF
--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -92,10 +92,9 @@ impl PartitionedDmlTransactionBuilder {
     /// # async fn build_transaction(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     ///     let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     ///     
-    ///     let retry_policy = BasicTransactionRetryPolicy {
-    ///         max_attempts: 5,
-    ///         total_timeout: Duration::from_secs(60),
-    ///     };
+    ///     let retry_policy = BasicTransactionRetryPolicy::new()
+    ///         .with_max_attempts(5)
+    ///         .with_total_timeout(Duration::from_secs(60));
     ///
     ///     let transaction = db_client
     ///         .partitioned_dml_transaction()
@@ -396,10 +395,9 @@ mod tests {
         let mock = create_session_mock();
         let (db_client, _server) = setup_db_client(mock).await;
 
-        let policy = BasicTransactionRetryPolicy {
-            max_attempts: 10,
-            total_timeout: std::time::Duration::from_secs(42),
-        };
+        let policy = BasicTransactionRetryPolicy::new()
+            .with_max_attempts(10)
+            .with_total_timeout(std::time::Duration::from_secs(42));
 
         let _transaction = db_client
             .partitioned_dml_transaction()

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -750,6 +750,7 @@ mod tests {
     use crate::BatchUpdateError;
     use crate::read_only_transaction::tests::{create_session_mock, setup_db_client};
     use crate::result_set::tests::adapt;
+    use crate::transaction_retry_policy::BasicTransactionRetryPolicy;
     use gaxi::grpc::tonic;
     use google_cloud_gax::options::internal::RequestOptionsExt as _;
     use google_cloud_test_macros::tokio_test_no_panics;
@@ -2876,10 +2877,9 @@ mod tests {
         let runner = db_client
             .read_write_transaction()
             .with_retry_policy(
-                crate::transaction_retry_policy::BasicTransactionRetryPolicy {
-                    max_attempts: 3,
-                    total_timeout: std::time::Duration::from_secs(5),
-                },
+                BasicTransactionRetryPolicy::new()
+                    .with_max_attempts(3)
+                    .with_total_timeout(std::time::Duration::from_secs(5)),
             )
             .build()
             .await?;
@@ -2966,10 +2966,9 @@ mod tests {
         let runner = db_client
             .read_write_transaction()
             .with_retry_policy(
-                crate::transaction_retry_policy::BasicTransactionRetryPolicy {
-                    max_attempts: 1,
-                    total_timeout: std::time::Duration::from_secs(5),
-                },
+                BasicTransactionRetryPolicy::new()
+                    .with_max_attempts(1)
+                    .with_total_timeout(std::time::Duration::from_secs(5)),
             )
             .build()
             .await?;
@@ -3066,10 +3065,9 @@ mod tests {
         let runner = db_client
             .read_write_transaction()
             .with_retry_policy(
-                crate::transaction_retry_policy::BasicTransactionRetryPolicy {
-                    max_attempts: 1,
-                    total_timeout: std::time::Duration::from_secs(5),
-                },
+                BasicTransactionRetryPolicy::new()
+                    .with_max_attempts(1)
+                    .with_total_timeout(std::time::Duration::from_secs(5)),
             )
             .build()
             .await?;

--- a/src/spanner/src/transaction_retry_policy.rs
+++ b/src/spanner/src/transaction_retry_policy.rs
@@ -40,9 +40,38 @@ pub trait TransactionRetryPolicy: Send + Sync {
 #[derive(Clone, Debug)]
 pub struct BasicTransactionRetryPolicy {
     /// The maximum number of attempts to make. If 0, this field is ignored.
-    pub max_attempts: u32,
+    max_attempts: u32,
     /// The total maximum time to spend retrying. If 0, this field is ignored.
-    pub total_timeout: Duration,
+    total_timeout: Duration,
+}
+
+impl BasicTransactionRetryPolicy {
+    /// Creates a new basic transaction retry policy with no limits.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the maximum number of attempts to make.
+    pub fn with_max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    /// Sets the total maximum time to spend retrying.
+    pub fn with_total_timeout(mut self, total_timeout: Duration) -> Self {
+        self.total_timeout = total_timeout;
+        self
+    }
+
+    /// Returns the maximum number of attempts configured.
+    pub fn max_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Returns the total maximum time configured.
+    pub fn total_timeout(&self) -> Duration {
+        self.total_timeout
+    }
 }
 
 impl Default for BasicTransactionRetryPolicy {
@@ -251,10 +280,9 @@ pub(crate) mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn retry_aborted_max_attempts_exceeded() {
-        let policy = BasicTransactionRetryPolicy {
-            max_attempts: 2,
-            total_timeout: Duration::from_secs(0),
-        };
+        let policy = BasicTransactionRetryPolicy::new()
+            .with_max_attempts(2)
+            .with_total_timeout(Duration::from_secs(0));
         let attempts = Arc::new(AtomicU32::new(0));
 
         let res = retry_aborted(&policy, || {
@@ -326,10 +354,9 @@ pub(crate) mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn retry_aborted_total_timeout_exceeded() {
-        let policy = BasicTransactionRetryPolicy {
-            max_attempts: 0,
-            total_timeout: Duration::from_secs(1),
-        };
+        let policy = BasicTransactionRetryPolicy::new()
+            .with_max_attempts(0)
+            .with_total_timeout(Duration::from_secs(1));
         let attempts = Arc::new(AtomicU32::new(0));
 
         let res = retry_aborted(&policy, || {

--- a/src/spanner/src/transaction_retry_policy.rs
+++ b/src/spanner/src/transaction_retry_policy.rs
@@ -253,6 +253,15 @@ pub(crate) mod tests {
         );
     }
 
+    #[test]
+    fn basic_retry_policy_getters() {
+        let policy = BasicTransactionRetryPolicy::new()
+            .with_max_attempts(3)
+            .with_total_timeout(Duration::from_secs(10));
+        assert_eq!(policy.max_attempts(), 3);
+        assert_eq!(policy.total_timeout(), Duration::from_secs(10));
+    }
+
     #[tokio::test]
     async fn retry_aborted_success_first_try() {
         let policy = BasicTransactionRetryPolicy::default();

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -309,10 +309,9 @@ impl TransactionRunnerBuilder {
     /// # async fn run(client: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     ///
-    /// let retry_policy = BasicTransactionRetryPolicy {
-    ///     max_attempts: 5,
-    ///     total_timeout: Duration::from_secs(60),
-    /// };
+    /// let retry_policy = BasicTransactionRetryPolicy::new()
+    ///     .with_max_attempts(5)
+    ///     .with_total_timeout(Duration::from_secs(60));
     ///
     /// let runner = db_client
     ///     .read_write_transaction()
@@ -1319,10 +1318,9 @@ mod tests {
         let mock = create_session_mock();
         let (db_client, _server) = setup_db_client(mock).await;
 
-        let retry_policy = BasicTransactionRetryPolicy {
-            max_attempts: 1,
-            total_timeout: std::time::Duration::from_secs(10),
-        };
+        let retry_policy = BasicTransactionRetryPolicy::new()
+            .with_max_attempts(1)
+            .with_total_timeout(std::time::Duration::from_secs(10));
 
         // Validate builder chaining safely accepts and compiles options dynamically
         let _runner = TransactionRunnerBuilder::new(db_client)

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -27,7 +27,7 @@ pub struct Type(pub(crate) crate::generated::gapic_dataplane::model::Type);
 macro_rules! define_type_code {
     ($($variant:ident = $val:expr),* $(,)?) => {
         /// Spanner type code.
-        #[derive(Clone, Debug, PartialEq, Copy, Default)]
+        #[derive(Clone, Debug, PartialEq, Eq, Copy, Hash, Default)]
         #[repr(i32)]
         #[non_exhaustive]
         pub enum TypeCode {
@@ -273,6 +273,7 @@ pub(crate) fn create_type(code: TypeCode) -> Type {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::hash::Hash;
 
     #[test]
     fn test_type_code_round_trip() {
@@ -421,6 +422,15 @@ mod tests {
     #[test]
     fn test_auto_traits() {
         static_assertions::assert_impl_all!(Type: Send, Sync, Clone, std::fmt::Debug);
-        static_assertions::assert_impl_all!(TypeCode: Send, Sync, Clone, std::fmt::Debug);
+        static_assertions::assert_impl_all!(
+            TypeCode: Send,
+            Sync,
+            Clone,
+            Copy,
+            std::fmt::Debug,
+            PartialEq,
+            Eq,
+            Hash
+        );
     }
 }

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -29,6 +29,7 @@ macro_rules! define_type_code {
         /// Spanner type code.
         #[derive(Clone, Debug, PartialEq, Copy, Default)]
         #[repr(i32)]
+        #[non_exhaustive]
         pub enum TypeCode {
             #[default]
             Unspecified = 0,

--- a/src/spanner/src/value.rs
+++ b/src/spanner/src/value.rs
@@ -21,7 +21,11 @@ pub(crate) const SPANNER_DATE_FORMAT: &[time::format_description::FormatItem<'st
 use prost_types::Value as ProtoValue;
 
 /// Kind indicates the type of the value.
+///
+/// This enum maps 1-to-1 with the frozen specification of JSON/Protobuf types
+/// in `google.protobuf.Value`, and is guaranteed not to grow.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::exhaustive_enums, reason = "Value kinds are frozen JSON types")]
 pub enum Kind {
     Null,
     Number,

--- a/src/spanner/src/value.rs
+++ b/src/spanner/src/value.rs
@@ -24,7 +24,7 @@ use prost_types::Value as ProtoValue;
 ///
 /// This enum maps 1-to-1 with the frozen specification of JSON/Protobuf types
 /// in `google.protobuf.Value`, and is guaranteed not to grow.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(clippy::exhaustive_enums, reason = "Value kinds are frozen JSON types")]
 pub enum Kind {
     Null,
@@ -232,6 +232,7 @@ impl List {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::hash::Hash;
 
     #[test]
     fn test_value_kind_and_accessors() {
@@ -300,5 +301,15 @@ mod tests {
         static_assertions::assert_impl_all!(Value: Send, Sync, Clone, std::fmt::Debug);
         static_assertions::assert_impl_all!(Struct: Send, Sync, Clone, std::fmt::Debug);
         static_assertions::assert_impl_all!(List: Send, Sync, Clone, std::fmt::Debug);
+        static_assertions::assert_impl_all!(
+            Kind: Send,
+            Sync,
+            Clone,
+            Copy,
+            std::fmt::Debug,
+            PartialEq,
+            Eq,
+            Hash
+        );
     }
 }

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -181,10 +181,9 @@ impl WriteOnlyTransactionBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     ///
-    /// let retry_policy = BasicTransactionRetryPolicy {
-    ///     max_attempts: 5,
-    ///     total_timeout: Duration::from_secs(60),
-    /// };
+    /// let retry_policy = BasicTransactionRetryPolicy::new()
+    ///     .with_max_attempts(5)
+    ///     .with_total_timeout(Duration::from_secs(60));
     ///
     /// let transaction = db_client.write_only_transaction()
     ///     .with_retry_policy(retry_policy)


### PR DESCRIPTION
- Marks Kind as an exhaustive enum.
- Refactors BasicTransactionRetryPolicy to use setters.
- Marks TypeCode as non-exhaustive

Updates #5566