### PR TITLE
docs(spanner): add missing documentation

### DIFF
--- a/src/spanner/src/batch_dml.rs
+++ b/src/spanner/src/batch_dml.rs
@@ -101,6 +101,7 @@ pub struct BatchDml {
 }
 
 impl BatchDml {
+    /// Creates a new builder for constructing a [`BatchDml`] request.
     pub fn builder() -> BatchDmlBuilder {
         BatchDmlBuilder::new()
     }

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -73,6 +73,9 @@ pub struct Spanner {
     pub(crate) config: ClientConfig,
 }
 
+/// A factory for constructing `Spanner` clients.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub struct Factory;
 
 impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
@@ -168,6 +171,9 @@ fn map_emulator_admin_endpoint(endpoint: &str, is_emulator: bool) -> String {
 
 #[allow(dead_code)]
 impl Spanner {
+    /// Returns a builder for the `Spanner` client.
+    ///
+    /// TODO(#5430) - entire module exports and structure needs a review.
     pub fn builder() -> ClientBuilder {
         let builder = google_cloud_gax::client_builder::internal::new_builder(Factory);
         // The Spanner client should automatically use the Spanner emulator if the

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -74,8 +74,6 @@ pub struct Spanner {
 }
 
 /// A factory for constructing `Spanner` clients.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub struct Factory;
 
 impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
@@ -173,7 +171,32 @@ fn map_emulator_admin_endpoint(endpoint: &str, is_emulator: bool) -> String {
 impl Spanner {
     /// Returns a builder for the `Spanner` client.
     ///
-    /// TODO(#5430) - entire module exports and structure needs a review.
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let spanner = Spanner::builder().build().await?;
+    ///
+    /// let db_client = spanner
+    ///     .database_client("projects/my-project/instances/my-instance/databases/my-db")
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let tx = db_client.single_use().build();
+    /// let mut rs = tx.execute_query("SELECT 1").await?;
+    ///
+    /// while let Some(row) = rs.next().await {
+    ///     let row = row?;
+    ///     let val: i64 = row.get(0);
+    ///     assert_eq!(val, 1);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The returned builder is pre-configured with standard defaults. It automatically
+    /// detects and connects to the Spanner emulator if the `SPANNER_EMULATOR_HOST`
+    /// environment variable is set.
     pub fn builder() -> ClientBuilder {
         let builder = google_cloud_gax::client_builder::internal::new_builder(Factory);
         // The Spanner client should automatically use the Spanner emulator if the

--- a/src/spanner/src/error.rs
+++ b/src/spanner/src/error.rs
@@ -28,7 +28,7 @@ use std::error::Error;
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SpannerInternalError {
-    /// Indicates that Spanner returned data in an unexpected or unparseable format.
+    /// Indicates that Spanner returned data in an unexpected or unparsable format.
     ///
     /// This represents an unexpected state and is an indication of an internal bug.
     #[error("unexpected data received from Spanner: {0}")]

--- a/src/spanner/src/error.rs
+++ b/src/spanner/src/error.rs
@@ -28,6 +28,9 @@ use std::error::Error;
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SpannerInternalError {
+    /// Indicates that Spanner returned data in an unexpected or unparseable format.
+    ///
+    /// This represents an unexpected state and is an indication of an internal bug.
     #[error("unexpected data received from Spanner: {0}")]
     UnexpectedData(String),
 }

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -56,7 +56,7 @@ pub trait FromValue: Sized {
     /// # Errors
     ///
     /// Returns a [`ConvertError`] if the kind of the value does not match the expected kind,
-    /// if the value is null but the target type is not optional (e.g., `Option<T>`), or if 
+    /// if the value is null but the target type is not optional (e.g., `Option<T>`), or if
     /// parsing or decoding the inner value format fails.
     fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError>;
 }

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -25,9 +25,14 @@ use time::{Date, OffsetDateTime};
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum ConvertError {
-    /// The value kind is not what we expected.
+    /// The value kind is not as expected.
     #[error("expected {want:?}, got {got:?}")]
-    KindMismatch { want: Kind, got: Kind },
+    KindMismatch {
+        /// The expected Spanner value kind.
+        want: Kind,
+        /// The actual Spanner value kind.
+        got: Kind,
+    },
 
     /// The value is null, but the target type does not support nulls.
     #[error("expected non-null value, got null")]
@@ -40,8 +45,19 @@ pub enum ConvertError {
 
 type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
-/// Converts Spanner [Value] to Rust types.
+/// Converts a Spanner [Value] into a Rust type.
+///
+/// Implementations are provided for all standard types like `String`, primitive integer
+/// and float types, decimals, timestamps, dates, vectors, and options for nullable fields.
 pub trait FromValue: Sized {
+    /// Converts a Spanner value into the target Rust type, using the provided
+    /// Spanner `Type` metadata for compatibility checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ConvertError`] if the kind of the value does not match the expected kind,
+    /// if the value is null but the target type is not optional (e.g., `Option<T>`), or if 
+    /// parsing or decoding the inner value format fails.
     fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError>;
 }
 

--- a/src/spanner/src/key.rs
+++ b/src/spanner/src/key.rs
@@ -33,6 +33,13 @@ macro_rules! key {
     };
 }
 
+/// A primary key or index key in Spanner.
+///
+/// A `Key` consists of an ordered collection of one or more Spanner [`Value`]s.
+/// The elements must match the correct column order as defined by the table or
+/// index schema.
+///
+/// For a simpler way to construct a `Key` instance, use the [`key!`] macro.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Key {
     pub(crate) values: Vec<Value>,

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -19,8 +19,6 @@
 //! **not** recommend that you use this crate in production. We welcome feedback
 //! about the APIs, documentation, missing features, bugs, etc.
 
-// TODO(#5537) - fix missing docs and remove this.
-#![allow(missing_docs, reason = "docs not yet complete")]
 // TODO(#5566) - stabilize API and remove this.
 #![allow(clippy::exhaustive_enums, reason = "API not yet stable")]
 
@@ -42,12 +40,31 @@ pub(crate) use google_cloud_gax::options::RequestOptions;
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
+/// Batch DML support.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod batch_dml;
+
+/// Spanner client implementation.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod client;
+
+/// Client builder utility.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod builder {
     pub use crate::database_client::DatabaseClientBuilder;
 }
+
+/// Batch read-only transaction support.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod batch_read_only_transaction;
+
+/// Spanner data models.
+///
+/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod model {
     pub use crate::generated::gapic_dataplane::model::*;
 }

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -38,30 +38,20 @@ pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
 /// Batch DML support.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod batch_dml;
 
 /// Spanner client implementation.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod client;
 
 /// Client builder utility.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod builder {
     pub use crate::database_client::DatabaseClientBuilder;
 }
 
 /// Batch read-only transaction support.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod batch_read_only_transaction;
 
 /// Spanner data models.
-///
-/// TODO(#5430) - entire module exports and structure needs a review.
 pub mod model {
     pub use crate::generated::gapic_dataplane::model::*;
 }

--- a/src/spanner/src/mutation.rs
+++ b/src/spanner/src/mutation.rs
@@ -285,13 +285,18 @@ impl ValueBinder {
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct MutationGroup {
-    pub mutations: Vec<Mutation>,
+    mutations: Vec<Mutation>,
 }
 
 impl MutationGroup {
     /// Creates a new mutation group from a list of mutations.
     pub fn new(mutations: Vec<Mutation>) -> Self {
         Self { mutations }
+    }
+
+    /// Returns a reference to the collection of mutations in this group.
+    pub fn mutations(&self) -> &[Mutation] {
+        &self.mutations
     }
 
     #[allow(dead_code)]

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -231,7 +231,7 @@ impl StatementBuilder {
 /// ```
 #[derive(Clone, Debug)]
 pub struct Statement {
-    pub sql: String,
+    pub(crate) sql: String,
     pub(crate) params: BTreeMap<String, Value>,
     pub(crate) param_types: BTreeMap<String, Type>,
     pub(crate) request_options: Option<crate::model::RequestOptions>,
@@ -245,6 +245,11 @@ impl Statement {
     /// Creates a new statement builder.
     pub fn builder(sql: impl Into<String>) -> StatementBuilder {
         StatementBuilder::new(sql)
+    }
+
+    /// Returns the SQL query string of this statement.
+    pub fn sql(&self) -> &str {
+        &self.sql
     }
 
     pub(crate) fn gax_options(&self) -> &GaxRequestOptions {

--- a/src/spanner/src/to_value.rs
+++ b/src/spanner/src/to_value.rs
@@ -22,7 +22,18 @@ use std::time::SystemTime;
 use time::{Date, OffsetDateTime};
 
 /// Converts Rust types to Spanner [Value].
+///
+/// This trait is used to encode native Rust types into the generic `Value`
+/// representation suitable for transmission to Cloud Spanner (such as in query parameters
+/// or mutation values).
+///
+/// Implementations are provided for standard Rust types, mapping them to their appropriate
+/// Spanner values. For example, optional types naturally map to `Value::Null` when they are `None`.
 pub trait ToValue {
+    /// Encodes this Rust type as a Spanner `Value`.
+    ///
+    /// Implementations are responsible for using the correct value kind for the
+    /// corresponding data type in Spanner.
     fn to_value(&self) -> Value;
 }
 

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -27,13 +27,21 @@ pub struct Type(pub(crate) crate::generated::gapic_dataplane::model::Type);
 macro_rules! define_type_code {
     ($($variant:ident = $val:expr),* $(,)?) => {
         /// Spanner type code.
+        ///
+        /// Maps directly to the gRPC type codes defined in
+        /// [`crate::generated::gapic_dataplane::model::TypeCode`].
         #[derive(Clone, Debug, PartialEq, Eq, Copy, Hash, Default)]
         #[repr(i32)]
         #[non_exhaustive]
         pub enum TypeCode {
+            /// Not specified.
             #[default]
             Unspecified = 0,
-            $($variant = $val),*,
+            $(
+                #[doc = concat!("Spanner `", stringify!($variant), "` data type.")]
+                $variant = $val
+            ),*,
+            /// An unknown or unsupported type code value.
             Unknown(i32),
         }
 

--- a/src/spanner/src/value.rs
+++ b/src/spanner/src/value.rs
@@ -27,11 +27,18 @@ use prost_types::Value as ProtoValue;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[allow(clippy::exhaustive_enums, reason = "Value kinds are frozen JSON types")]
 pub enum Kind {
+    /// Represents a null value of any data type.
     Null,
+    /// Represents a floating point value.
     Number,
+    /// Represents a UTF-8 string value or encoded representations of other data types,
+    /// such as base64-encoded bytes, decimals, dates, timestamps, and integers.
     String,
+    /// Represents a boolean value.
     Bool,
+    /// Represents a structured object containing a collection of key-value pairs.
     Struct,
+    /// Represents an ordered list of values.
     List,
 }
 


### PR DESCRIPTION
Adds missing documentation for public methods and types.

The documentation for the module exports is a stop-gap to be able to remove the
allow(missing_docs) annotation. The module exports need a general audit, but this
ensures that we can remove the annotation and prevent further slippage in missing
documentation.

Fixes https://github.com/googleapis/google-cloud-rust/issues/5537