### PR TITLE
feat(spanner): support read-only BeginTransaction request options

### DIFF
--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -23,6 +23,7 @@ use crate::statement::Statement;
 use crate::timestamp_bound::TimestampBound;
 use crate::transaction_retry_policy::is_aborted;
 use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::options::internal::RequestOptionsExt as _;
 use google_cloud_gax::retry_policy::RetryPolicyArg;
 use std::mem::replace;
 use std::sync::{Arc, Mutex};
@@ -944,10 +945,10 @@ impl ReadContext {
             return Ok(false);
         }
 
-        let options = self
-            .begin_transaction_request_options
-            .clone()
-            .unwrap_or(fallback_options);
+        let options = merge_request_options(
+            fallback_options,
+            self.begin_transaction_request_options.as_ref(),
+        );
 
         self.transaction_selector
             .begin_explicitly(ExplicitBeginParams {
@@ -962,6 +963,38 @@ impl ReadContext {
             .await?;
         Ok(true)
     }
+}
+
+/// Merges the configured fields from a `source` `RequestOptions` into a `destination` `RequestOptions`.
+/// Configured options in `source` will override those in `destination`.
+fn merge_request_options(
+    mut destination: crate::RequestOptions,
+    source: Option<&crate::RequestOptions>,
+) -> crate::RequestOptions {
+    let Some(source) = source else {
+        return destination;
+    };
+
+    if let Some(timeout) = source.attempt_timeout() {
+        destination.set_attempt_timeout(*timeout);
+    }
+    if let Some(retry) = source.retry_policy() {
+        destination.set_retry_policy(retry.clone());
+    }
+    if let Some(backoff) = source.backoff_policy() {
+        destination.set_backoff_policy(backoff.clone());
+    }
+    if let Some(src_headers) = source.get_extension::<http::HeaderMap>() {
+        let mut dest_headers = destination
+            .get_extension::<http::HeaderMap>()
+            .cloned()
+            .unwrap_or_default();
+        for (name, value) in src_headers.iter() {
+            dest_headers.insert(name.clone(), value.clone());
+        }
+        destination = destination.insert_extension(dest_headers);
+    }
+    destination
 }
 
 /// Helper macro to execute a streaming SQL or streaming read RPC with retry logic.
@@ -1067,6 +1100,7 @@ pub(crate) mod tests {
     use google_cloud_gax::exponential_backoff::ExponentialBackoff;
     use google_cloud_gax::retry_policy::NeverRetry;
     use google_cloud_test_macros::tokio_test_no_panics;
+    use http::{HeaderMap, HeaderName, HeaderValue};
     use mock_v1::transaction_selector::Selector;
     use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
@@ -3036,11 +3070,11 @@ pub(crate) mod tests {
             .with_begin_retry_policy(NeverRetry)
             .with_begin_backoff_policy(ExponentialBackoff::default());
 
-        let gax = builder.begin_gax_options.as_ref().expect("begin_gax_options missing");
-        assert_eq!(
-            *gax.attempt_timeout(),
-            Some(Duration::from_secs(5))
-        );
+        let gax = builder
+            .begin_gax_options
+            .as_ref()
+            .expect("begin_gax_options missing");
+        assert_eq!(*gax.attempt_timeout(), Some(Duration::from_secs(5)));
         assert!(gax.retry_policy().is_some());
         assert!(gax.backoff_policy().is_some());
 
@@ -3066,9 +3100,16 @@ pub(crate) mod tests {
             .in_sequence(&mut sequence)
             .withf(|req| {
                 let timeout_header = req.metadata().get("grpc-timeout");
-                assert!(timeout_header.is_some(), "grpc-timeout header should be present");
+                assert!(
+                    timeout_header.is_some(),
+                    "grpc-timeout header should be present"
+                );
                 let val = timeout_header.unwrap().to_str().unwrap();
-                assert!(val.contains("5000") || val.contains("5"), "timeout header value '{}' should represent 5 seconds", val);
+                assert!(
+                    val.contains("5000") || val.contains("5"),
+                    "timeout header value '{}' should represent 5 seconds",
+                    val
+                );
                 true
             })
             .returning(|_| {
@@ -3076,6 +3117,34 @@ pub(crate) mod tests {
                     id: vec![42],
                     ..Default::default()
                 }))
+            });
+
+        // 3. Query is retried with the successfully obtained transaction ID, succeeding this time
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf(|req| {
+                matches!(
+                    req.get_ref()
+                        .transaction
+                        .as_ref()
+                        .and_then(|t| t.selector.as_ref()),
+                    Some(mock_v1::transaction_selector::Selector::Id(id)) if id == &vec![42]
+                )
+            })
+            .returning(|_| {
+                let mut result_set_partial = setup_select1();
+                result_set_partial
+                    .metadata
+                    .as_mut()
+                    .expect("metadata should be present")
+                    .transaction = Some(mock_v1::Transaction {
+                    id: vec![42],
+                    ..Default::default()
+                });
+                Ok(gaxi::grpc::tonic::Response::from(adapt([Ok(
+                    result_set_partial,
+                )])))
             });
 
         mock.expect_create_session().returning(|_| {
@@ -3096,10 +3165,149 @@ pub(crate) mod tests {
 
         let mut stmt_opts = crate::RequestOptions::default();
         stmt_opts.set_attempt_timeout(Duration::from_secs(5));
-        let stmt = Statement::builder("SELECT 1").build().with_gax_options(stmt_opts);
+        let stmt = Statement::builder("SELECT 1")
+            .build()
+            .with_gax_options(stmt_opts);
 
-        let _res = transaction.execute_query(stmt).await;
+        let mut rs = transaction.execute_query(stmt).await?;
+        let row = rs.next().await.expect("has row")?;
+        assert_eq!(row.raw_values(), [Value(string_val("1"))]);
 
         Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_lazy_begin_fallback_merges_custom_options() -> anyhow::Result<()>
+    {
+        let mut mock = MockSpanner::new();
+        let mut sequence = mockall::Sequence::new();
+
+        // 1. First query execution fails with Unavailable (transient error)
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        // 2. Fallback explicit BeginTransaction must have BOTH:
+        // - attempt_timeout of 5 seconds (inherited from statement's options)
+        // - retry_policy of NeverRetry (inherited from transaction's begin options)
+        // If it did not merge correctly, the timeout header would be missing, or it would retry.
+        mock.expect_begin_transaction()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf(|req| {
+                let timeout_header = req.metadata().get("grpc-timeout");
+                assert!(
+                    timeout_header.is_some(),
+                    "grpc-timeout header should be present"
+                );
+                let val = timeout_header.unwrap().to_str().unwrap();
+                assert!(
+                    val.contains("5000") || val.contains("5"),
+                    "timeout header value '{}' should represent 5 seconds",
+                    val
+                );
+                true
+            })
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
+            .with_begin_retry_policy(NeverRetry)
+            .build()
+            .await?;
+
+        let mut stmt_opts = crate::RequestOptions::default();
+        stmt_opts.set_attempt_timeout(Duration::from_secs(5));
+        let stmt = Statement::builder("SELECT 1")
+            .build()
+            .with_gax_options(stmt_opts);
+
+        let res = transaction.execute_query(stmt).await;
+
+        assert!(
+            res.is_err(),
+            "should fail immediately because of NeverRetry"
+        );
+        let err = res.unwrap_err();
+        assert_eq!(err.status().expect("status").code, GaxCode::Unavailable);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_request_options() {
+        // Case 1: Destination has values, source is empty (Destination preserved)
+        let mut dest = crate::RequestOptions::default();
+        dest.set_attempt_timeout(Duration::from_secs(2));
+        dest.set_retry_policy(NeverRetry);
+
+        // Source is None (Destination preserved)
+        let merged = merge_request_options(dest, None);
+
+        assert_eq!(*merged.attempt_timeout(), Some(Duration::from_secs(2)));
+        assert!(merged.retry_policy().is_some());
+
+        // Case 2: Source has overriding values, destination is empty (Source overrides)
+        let dest = crate::RequestOptions::default();
+
+        let mut source = crate::RequestOptions::default();
+        source.set_attempt_timeout(Duration::from_secs(5));
+        source.set_retry_policy(NeverRetry);
+
+        let merged = merge_request_options(dest, Some(&source));
+
+        assert_eq!(*merged.attempt_timeout(), Some(Duration::from_secs(5)));
+        assert!(merged.retry_policy().is_some());
+
+        // Case 3: Both have distinct custom headers (Headers must merge/combine)
+        let mut dest = crate::RequestOptions::default();
+        let mut dest_headers = HeaderMap::new();
+        dest_headers.insert(
+            HeaderName::from_static("x-goog-spanner-route-to-leader"),
+            HeaderValue::from_static("true"),
+        );
+        dest = dest.insert_extension(dest_headers);
+
+        let mut source = crate::RequestOptions::default();
+        let mut src_headers = HeaderMap::new();
+        src_headers.insert(
+            HeaderName::from_static("x-custom-header"),
+            HeaderValue::from_static("custom-value"),
+        );
+        source = source.insert_extension(src_headers);
+
+        let merged = merge_request_options(dest, Some(&source));
+        let merged_headers = merged
+            .get_extension::<HeaderMap>()
+            .expect("HeaderMap missing");
+
+        assert_eq!(
+            merged_headers
+                .get("x-goog-spanner-route-to-leader")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "true"
+        );
+        assert_eq!(
+            merged_headers
+                .get("x-custom-header")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "custom-value"
+        );
     }
 }

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -234,7 +234,7 @@ pub struct MultiUseReadOnlyTransactionBuilder {
     client: DatabaseClient,
     timestamp_bound: Option<TimestampBound>,
     begin_transaction_option: BeginTransactionOption,
-    begin_gax_options: crate::RequestOptions,
+    begin_gax_options: Option<crate::RequestOptions>,
 }
 
 impl MultiUseReadOnlyTransactionBuilder {
@@ -243,7 +243,7 @@ impl MultiUseReadOnlyTransactionBuilder {
             client,
             timestamp_bound: None,
             begin_transaction_option: BeginTransactionOption::InlineBegin,
-            begin_gax_options: crate::RequestOptions::default(),
+            begin_gax_options: None,
         }
     }
 
@@ -300,7 +300,9 @@ impl MultiUseReadOnlyTransactionBuilder {
     ///
     /// Note: This timeout is only used if the transaction uses the `ExplicitBegin` transaction option.
     pub fn with_begin_attempt_timeout(mut self, timeout: Duration) -> Self {
-        self.begin_gax_options.set_attempt_timeout(timeout);
+        self.begin_gax_options
+            .get_or_insert_with(crate::RequestOptions::default)
+            .set_attempt_timeout(timeout);
         self
     }
 
@@ -322,7 +324,9 @@ impl MultiUseReadOnlyTransactionBuilder {
     ///
     /// Note: This policy is only used if the transaction uses the `ExplicitBegin` transaction option.
     pub fn with_begin_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
-        self.begin_gax_options.set_retry_policy(policy);
+        self.begin_gax_options
+            .get_or_insert_with(crate::RequestOptions::default)
+            .set_retry_policy(policy);
         self
     }
 
@@ -344,7 +348,9 @@ impl MultiUseReadOnlyTransactionBuilder {
     ///
     /// Note: This policy is only used if the transaction uses the `ExplicitBegin` transaction option.
     pub fn with_begin_backoff_policy(mut self, policy: impl Into<BackoffPolicyArg>) -> Self {
-        self.begin_gax_options.set_backoff_policy(policy);
+        self.begin_gax_options
+            .get_or_insert_with(crate::RequestOptions::default)
+            .set_backoff_policy(policy);
         self
     }
 
@@ -418,7 +424,7 @@ impl MultiUseReadOnlyTransactionBuilder {
                     session_name.clone(),
                     options,
                     channel_hint,
-                    self.begin_gax_options.clone(),
+                    self.begin_gax_options.clone().unwrap_or_default(),
                 )
                 .await?
             }
@@ -435,7 +441,7 @@ impl MultiUseReadOnlyTransactionBuilder {
                 precommit_token_tracker: PrecommitTokenTracker::new_noop(),
                 transaction_tag: None,
                 channel_hint,
-                begin_transaction_request_options: Some(self.begin_gax_options.clone()),
+                begin_transaction_request_options: self.begin_gax_options.clone(),
             },
         })
     }
@@ -3030,12 +3036,69 @@ pub(crate) mod tests {
             .with_begin_retry_policy(NeverRetry)
             .with_begin_backoff_policy(ExponentialBackoff::default());
 
+        let gax = builder.begin_gax_options.as_ref().expect("begin_gax_options missing");
         assert_eq!(
-            *builder.begin_gax_options.attempt_timeout(),
+            *gax.attempt_timeout(),
             Some(Duration::from_secs(5))
         );
-        assert!(builder.begin_gax_options.retry_policy().is_some());
-        assert!(builder.begin_gax_options.backoff_policy().is_some());
+        assert!(gax.retry_policy().is_some());
+        assert!(gax.backoff_policy().is_some());
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_lazy_begin_fallback_uses_statement_options_when_unconfigured()
+    -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        let mut sequence = mockall::Sequence::new();
+
+        // 1. First query execution fails with Unavailable (transient error)
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        // 2. Fallback explicit BeginTransaction is executed. Since the transaction itself has no
+        // custom options, it must inherit the statement options, which set attempt_timeout to 5 seconds.
+        mock.expect_begin_transaction()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf(|req| {
+                let timeout_header = req.metadata().get("grpc-timeout");
+                assert!(timeout_header.is_some(), "grpc-timeout header should be present");
+                let val = timeout_header.unwrap().to_str().unwrap();
+                assert!(val.contains("5000") || val.contains("5"), "timeout header value '{}' should represent 5 seconds", val);
+                true
+            })
+            .returning(|_| {
+                Ok(Response::new(mock_v1::Transaction {
+                    id: vec![42],
+                    ..Default::default()
+                }))
+            });
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
+            .build()
+            .await?;
+
+        let mut stmt_opts = crate::RequestOptions::default();
+        stmt_opts.set_attempt_timeout(Duration::from_secs(5));
+        let stmt = Statement::builder("SELECT 1").build().with_gax_options(stmt_opts);
+
+        let _res = transaction.execute_query(stmt).await;
 
         Ok(())
     }

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -22,8 +22,11 @@ use crate::result_set::{ResultSet, ResultSetParams, StreamOperation};
 use crate::statement::Statement;
 use crate::timestamp_bound::TimestampBound;
 use crate::transaction_retry_policy::is_aborted;
+use google_cloud_gax::backoff_policy::BackoffPolicyArg;
+use google_cloud_gax::retry_policy::RetryPolicyArg;
 use std::mem::replace;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::Notify;
 
 /// A builder for [SingleUseReadOnlyTransaction].
@@ -107,6 +110,7 @@ impl SingleUseReadOnlyTransactionBuilder {
                 precommit_token_tracker: PrecommitTokenTracker::new_noop(),
                 transaction_tag: None,
                 channel_hint,
+                begin_transaction_request_options: None,
             },
         }
     }
@@ -230,6 +234,7 @@ pub struct MultiUseReadOnlyTransactionBuilder {
     client: DatabaseClient,
     timestamp_bound: Option<TimestampBound>,
     begin_transaction_option: BeginTransactionOption,
+    begin_gax_options: crate::RequestOptions,
 }
 
 impl MultiUseReadOnlyTransactionBuilder {
@@ -238,6 +243,7 @@ impl MultiUseReadOnlyTransactionBuilder {
             client,
             timestamp_bound: None,
             begin_transaction_option: BeginTransactionOption::InlineBegin,
+            begin_gax_options: crate::RequestOptions::default(),
         }
     }
 
@@ -273,6 +279,72 @@ impl MultiUseReadOnlyTransactionBuilder {
     /// Default is `BeginTransactionOption::InlineBegin`.
     pub fn with_begin_transaction_option(mut self, option: BeginTransactionOption) -> Self {
         self.begin_transaction_option = option;
+        self
+    }
+
+    /// Sets the per-attempt timeout for the BeginTransaction RPC.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use std::time::Duration;
+    /// # async fn sample(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.read_only_transaction()
+    ///     .with_begin_attempt_timeout(Duration::from_secs(10))
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Note: This timeout is only used if the transaction uses the `ExplicitBegin` transaction option.
+    pub fn with_begin_attempt_timeout(mut self, timeout: Duration) -> Self {
+        self.begin_gax_options.set_attempt_timeout(timeout);
+        self
+    }
+
+    /// Sets the retry policy for the BeginTransaction RPC.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_gax::retry_policy::NeverRetry;
+    /// # async fn sample(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.read_only_transaction()
+    ///     .with_begin_retry_policy(NeverRetry)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Note: This policy is only used if the transaction uses the `ExplicitBegin` transaction option.
+    pub fn with_begin_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
+        self.begin_gax_options.set_retry_policy(policy);
+        self
+    }
+
+    /// Sets the backoff policy for the BeginTransaction RPC.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+    /// # async fn sample(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.read_only_transaction()
+    ///     .with_begin_backoff_policy(ExponentialBackoff::default())
+    ///     .build()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Note: This policy is only used if the transaction uses the `ExplicitBegin` transaction option.
+    pub fn with_begin_backoff_policy(mut self, policy: impl Into<BackoffPolicyArg>) -> Self {
+        self.begin_gax_options.set_backoff_policy(policy);
         self
     }
 
@@ -346,7 +418,7 @@ impl MultiUseReadOnlyTransactionBuilder {
                     session_name.clone(),
                     options,
                     channel_hint,
-                    crate::RequestOptions::default(),
+                    self.begin_gax_options.clone(),
                 )
                 .await?
             }
@@ -363,6 +435,7 @@ impl MultiUseReadOnlyTransactionBuilder {
                 precommit_token_tracker: PrecommitTokenTracker::new_noop(),
                 transaction_tag: None,
                 channel_hint,
+                begin_transaction_request_options: Some(self.begin_gax_options.clone()),
             },
         })
     }
@@ -827,6 +900,7 @@ pub(crate) struct ReadContext {
     pub(crate) precommit_token_tracker: PrecommitTokenTracker,
     pub(crate) transaction_tag: Option<String>,
     pub(crate) channel_hint: usize,
+    pub(crate) begin_transaction_request_options: Option<crate::RequestOptions>,
 }
 
 impl ReadContext {
@@ -853,7 +927,7 @@ impl ReadContext {
     /// fallback mechanism when an initial implicit begin attempt failed.
     pub(crate) async fn begin_explicitly_if_not_started(
         &self,
-        request_options: crate::RequestOptions,
+        fallback_options: crate::RequestOptions,
         is_stream_fallback: bool,
     ) -> crate::Result<bool> {
         let ReadContextTransactionSelector::Lazy(lazy) = &self.transaction_selector else {
@@ -864,13 +938,18 @@ impl ReadContext {
             return Ok(false);
         }
 
+        let options = self
+            .begin_transaction_request_options
+            .clone()
+            .unwrap_or(fallback_options);
+
         self.transaction_selector
             .begin_explicitly(ExplicitBeginParams {
                 client: self.client.clone(),
                 session_name: self.session_name.clone(),
                 transaction_tag: self.transaction_tag.clone(),
                 channel_hint: self.channel_hint,
-                request_options,
+                request_options: options,
                 is_stream_fallback,
                 precommit_token_tracker: self.precommit_token_tracker.clone(),
             })
@@ -978,8 +1057,12 @@ pub(crate) mod tests {
     use crate::result_set::tests::string_val;
     use crate::value::Value;
     use gaxi::grpc::tonic::{self, Code, Response, Status};
+    use google_cloud_gax::error::rpc::Code as GaxCode;
+    use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+    use google_cloud_gax::retry_policy::NeverRetry;
     use google_cloud_test_macros::tokio_test_no_panics;
     use mock_v1::transaction_selector::Selector;
+    use spanner_grpc_mock::MockSpanner;
     use spanner_grpc_mock::google::spanner::v1 as mock_v1;
     use std::sync::mpsc::channel as std_channel;
     use std::sync::{Arc, Mutex as StdMutex};
@@ -2795,6 +2878,164 @@ pub(crate) mod tests {
             let next_result = result_set.next().await;
             assert!(next_result.is_none(), "expected None, got {next_result:?}");
         }
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_begin_with_never_retry() -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        let mut sequence = mockall::Sequence::new();
+
+        mock.expect_begin_transaction()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let res = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(BeginTransactionOption::ExplicitBegin)
+            .with_begin_retry_policy(NeverRetry)
+            .build()
+            .await;
+
+        assert!(res.is_err(), "should fail immediately without retry");
+        let err = res.unwrap_err();
+        assert_eq!(err.status().expect("status").code, GaxCode::Unavailable);
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_lazy_begin_fallback_never_retry() -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        let mut sequence = mockall::Sequence::new();
+
+        // 1. First query execution fails with Unavailable (transient error)
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        // 2. Fallback explicit BeginTransaction is executed exactly once and fails
+        mock.expect_begin_transaction()
+            .once()
+            .in_sequence(&mut sequence)
+            .returning(|_| Err(tonic::Status::unavailable("transient error")));
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let transaction = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
+            .with_begin_retry_policy(NeverRetry)
+            .build()
+            .await?;
+
+        let stmt = Statement::builder("SELECT 1").build();
+        let res = transaction.execute_query(stmt).await;
+
+        assert!(
+            res.is_err(),
+            "should fail immediately during fallback without retrying the fallback RPC"
+        );
+        let err = res.unwrap_err();
+        assert_eq!(err.status().expect("status").code, GaxCode::Unavailable);
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_begin_with_attempt_timeout() -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        let mut sequence = mockall::Sequence::new();
+
+        mock.expect_begin_transaction()
+            .once()
+            .in_sequence(&mut sequence)
+            .withf(|req| {
+                let timeout_header = req.metadata().get("grpc-timeout");
+                assert!(
+                    timeout_header.is_some(),
+                    "grpc-timeout header should be present"
+                );
+                let val = timeout_header.unwrap().to_str().unwrap();
+                assert!(
+                    val.contains("5000") || val.contains("5"),
+                    "timeout header value '{}' should represent 5 seconds",
+                    val
+                );
+                true
+            })
+            .returning(|_| {
+                Ok(Response::new(mock_v1::Transaction {
+                    id: vec![42],
+                    ..Default::default()
+                }))
+            });
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let _transaction = db_client
+            .read_only_transaction()
+            .with_begin_transaction_option(BeginTransactionOption::ExplicitBegin)
+            .with_begin_attempt_timeout(std::time::Duration::from_secs(5))
+            .build()
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn read_only_transaction_builder_sets_gax_options() -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let builder = db_client
+            .read_only_transaction()
+            .with_begin_attempt_timeout(Duration::from_secs(5))
+            .with_begin_retry_policy(NeverRetry)
+            .with_begin_backoff_policy(ExponentialBackoff::default());
+
+        assert_eq!(
+            *builder.begin_gax_options.attempt_timeout(),
+            Some(Duration::from_secs(5))
+        );
+        assert!(builder.begin_gax_options.retry_policy().is_some());
+        assert!(builder.begin_gax_options.backoff_policy().is_some());
 
         Ok(())
     }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -198,6 +198,7 @@ impl ReadWriteTransactionBuilder {
                 precommit_token_tracker: PrecommitTokenTracker::new(),
                 transaction_tag: self.transaction_tag.clone(),
                 channel_hint,
+                begin_transaction_request_options: None,
             },
             seqno: Arc::new(AtomicI64::new(1)),
             max_commit_delay: self.max_commit_delay,


### PR DESCRIPTION
Adds support for setting GAX request options for the BeginTransaction RPC call for read-only transactions. These options are only used if the transaction uses the ExplicitBegin transaction option.

Updates #4972