### PR TITLE
test(spanner): run the inline-begin-fallback test also on real Spanner

### DIFF
--- a/tests/spanner/src/concurrent_inline_begin.rs
+++ b/tests/spanner/src/concurrent_inline_begin.rs
@@ -19,7 +19,7 @@ use google_cloud_spanner::client::{
     BeginTransactionOption, ResultSet, Row, Spanner, TimestampBound,
 };
 use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
-use http::{Request, Response, StatusCode};
+use http::{Request, Response, StatusCode, Uri};
 use http_body::Frame;
 use http_body_util::Full;
 use http_body_util::StreamBody;
@@ -187,7 +187,17 @@ pub async fn test_concurrent_inline_begin_with_snapshot_consistency() -> anyhow:
         }) as BoxFuture<'static, InterceptionResult>
     };
 
-    let proxy = PassThroughProxy::new(emulator_channel, interceptor);
+    let endpoint_str = format!("http://{}", emulator_host);
+    let uri = endpoint_str.parse::<Uri>()?;
+    let scheme = uri
+        .scheme()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing scheme"))?;
+    let authority = uri
+        .authority()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing authority"))?;
+    let proxy = PassThroughProxy::new(emulator_channel, scheme, authority, interceptor);
     let proxy_server = proxy.start("127.0.0.1:0").await?;
 
     // 5. Build Client pointing to Interceptor

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::client::{get_database_id, get_emulator_host, update_database_ddl};
+use crate::client::{
+    get_database_id, get_emulator_host, get_real_spanner_config, update_database_ddl,
+};
 use crate::test_proxy::{InterceptionResult, PassThroughProxy};
 use futures::future::BoxFuture;
 use google_cloud_spanner::client::{
@@ -23,7 +25,7 @@ use google_cloud_spanner::model::result_set_stats::RowCount;
 use google_cloud_test_utils::resource_names::LowercaseAlphanumeric;
 use std::sync::Arc;
 use tokio::sync::Notify;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, ClientTlsConfig};
 use tracing::info;
 
 pub async fn simple_query(db_client: &DatabaseClient) -> anyhow::Result<()> {
@@ -483,24 +485,26 @@ fn verify_row_2(row: &google_cloud_spanner::client::Row) {
 // transaction could delete the row in the time between the first attempt failed, and the
 // BeginTransaction RPC has been executed.
 pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Result<()> {
-    let emulator_host = match get_emulator_host() {
-        Some(host) => host,
-        None => {
-            // TODO(#5682): enable this on real Spanner
-            info!(
-                "Skipping inline_begin_fallback test on real Spanner as it requires local proxy against emulator"
-            );
-            return Ok(());
-        }
+    let destination_endpoint = match get_emulator_host() {
+        Some(host) => format!("http://{}", host),
+        None => "https://spanner.googleapis.com:443".to_string(),
     };
+
+    let (project_id, instance_id) = match get_real_spanner_config() {
+        Some((project, instance)) => (project, instance),
+        None => ("test-project".to_string(), "test-instance".to_string()),
+    };
+
     let latch = Arc::new(Notify::new());
     let begin_transaction_entered_latch = Arc::new(Notify::new());
 
-    // Create a raw gRPC client that connects to the Spanner Emulator.
-    // This will be used by the proxy server to forward requests to the Emulator.
-    let endpoint = Channel::from_shared(format!("http://{}", emulator_host))?
-        .connect()
-        .await?;
+    // Create a raw gRPC client that connects to the Spanner Emulator or real Spanner.
+    // This will be used by the proxy server to forward requests.
+    let mut endpoint = Channel::from_shared(destination_endpoint.clone())?;
+    if destination_endpoint.starts_with("https") {
+        endpoint = endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
+    }
+    let endpoint = endpoint.connect().await?;
     let latch_clone = Arc::clone(&latch);
     let begin_entered_clone = Arc::clone(&begin_transaction_entered_latch);
 
@@ -519,7 +523,17 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
         }) as BoxFuture<'static, InterceptionResult>
     };
 
-    let proxy = PassThroughProxy::new(endpoint, interceptor);
+    let uri = destination_endpoint.parse::<http::Uri>()?;
+    let scheme = uri
+        .scheme()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing scheme"))?;
+    let authority = uri
+        .authority()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("missing authority"))?;
+
+    let proxy = PassThroughProxy::new(endpoint, scheme, authority, interceptor);
     let proxy_server = proxy.start("127.0.0.1:0").await?;
 
     // We build the Spanner DatabaseClient pointing directly to our proxy address over gRPC.
@@ -528,7 +542,9 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
         .build()
         .await?
         .database_client(format!(
-            "projects/test-project/instances/test-instance/databases/{}",
+            "projects/{}/instances/{}/databases/{}",
+            project_id,
+            instance_id,
             get_database_id().await
         ))
         .build()

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -500,10 +500,12 @@ pub async fn inline_begin_fallback(_db_client: &DatabaseClient) -> anyhow::Resul
 
     // Create a raw gRPC client that connects to the Spanner Emulator or real Spanner.
     // This will be used by the proxy server to forward requests.
-    let mut endpoint = Channel::from_shared(destination_endpoint.clone())?;
-    if destination_endpoint.starts_with("https") {
-        endpoint = endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?;
-    }
+    let endpoint = Channel::from_shared(destination_endpoint.clone())?;
+    let endpoint = if destination_endpoint.starts_with("https") {
+        endpoint.tls_config(ClientTlsConfig::new().with_enabled_roots())?
+    } else {
+        endpoint
+    };
     let endpoint = endpoint.connect().await?;
     let latch_clone = Arc::clone(&latch);
     let begin_entered_clone = Arc::clone(&begin_transaction_entered_latch);

--- a/tests/spanner/src/test_proxy.rs
+++ b/tests/spanner/src/test_proxy.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use futures::future::BoxFuture;
-use http::{Request, Response, StatusCode};
+use http::{
+    Request, Response, StatusCode, Uri,
+    uri::{Authority, Scheme},
+};
 use spanner_grpc_mock::to_uri;
 use std::convert::Infallible;
 use tokio::net::TcpListener;
@@ -42,14 +45,23 @@ pub(crate) enum InterceptionResult {
 /// an interceptor closure to inspect and potentially handle specific requests.
 #[derive(Clone)]
 pub(crate) struct PassThroughProxy<F> {
-    emulator_channel: Channel,
+    destination_channel: Channel,
+    scheme: Scheme,
+    authority: Authority,
     interceptor: F,
 }
 
 impl<F> PassThroughProxy<F> {
-    pub(crate) fn new(emulator_channel: Channel, interceptor: F) -> Self {
+    pub(crate) fn new(
+        destination_channel: Channel,
+        scheme: Scheme,
+        authority: Authority,
+        interceptor: F,
+    ) -> Self {
         Self {
-            emulator_channel,
+            destination_channel,
+            scheme,
+            authority,
             interceptor,
         }
     }
@@ -77,18 +89,25 @@ where
     }
 
     fn call(&mut self, req: Request<Body>) -> Self::Future {
-        let channel = self.emulator_channel.clone();
+        let channel = self.destination_channel.clone();
+        let scheme = self.scheme.clone();
+        let authority = self.authority.clone();
         let interceptor = self.interceptor.clone();
 
         Box::pin(async move {
-            let req = match interceptor(req).await {
+            let mut req = match interceptor(req).await {
                 InterceptionResult::Continue(r) => r,
                 InterceptionResult::Complete(resp) => return Ok(resp),
             };
 
+            let mut parts = req.uri().clone().into_parts();
+            parts.scheme = Some(scheme);
+            parts.authority = Some(authority);
+            *req.uri_mut() = Uri::from_parts(parts).expect("Invalid URI parts");
+
             let response = match channel.oneshot(req).await {
                 Ok(resp) => resp,
-                // gRPC errors from the emulator are returned as successful HTTP responses
+                // gRPC errors from the emulator/real Spanner are returned as successful HTTP responses
                 // with `grpc-status` headers and are handled by the `Ok` branch above.
                 // This `Err` branch only handles transport-level errors. We must convert
                 // them to a valid gRPC response because Tonic requires `Error = Infallible`.


### PR DESCRIPTION
Enable the integration test inline-begin-fallback to also run on real Spanner, instead of only the emulator.

Fixes #5682