### PR TITLE
cleanup(lro): clippy with all cfgs

### DIFF
--- a/src/lro/src/internal/ext.rs
+++ b/src/lro/src/internal/ext.rs
@@ -67,10 +67,11 @@ mod tests {
 
     mock! {
         PollerA {}
-        impl sealed::Poller for PollerA {}
+        impl sealed::Poller for PollerA {
+            async fn backoff(&mut self, state: &PollingState);
+        }
         impl Poller<ResponseType, MetadataType> for PollerA {
             async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>>;
-            async fn backoff(&mut self, state: &PollingState);
             async fn until_done(self) -> google_cloud_gax::Result<ResponseType>;
             #[cfg(feature = "unstable-stream")]
             fn into_stream(

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -56,8 +56,7 @@ where
     #[cfg(feature = "unstable-stream")]
     fn into_stream(
         self,
-    ) -> impl futures::Stream<Item = PollingResult<ResponseType, MetadataType>> + Unpin {
-        let span = self.span.clone();
-        crate::into_stream(self).instrument(span)
+    ) -> impl futures::Stream<Item = crate::PollingResult<ResponseType, MetadataType>> + Unpin {
+        crate::into_stream(self)
     }
 }


### PR DESCRIPTION
The code was not compiling with `--cfg google_cloud_unstable_tracing` and with `--all-features` at the same time.