### PR TITLE
ci: add checks for google_cloud_unstable_tracing and lro crate

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -37,7 +37,8 @@ locals {
   unstable_flags = join(" ", [
     "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
-    "--cfg google_cloud_unstable_grpc_server_streaming"
+    "--cfg google_cloud_unstable_grpc_server_streaming",
+    "--cfg google_cloud_unstable_tracing"
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"

--- a/.gcb/scripts/test-unstable-cfg.sh
+++ b/.gcb/scripts/test-unstable-cfg.sh
@@ -27,6 +27,7 @@ echo "RUSTDOCFLAGS in test-unstable-cfg: ${RUSTDOCFLAGS:-}"
 crates=(
     "google-cloud-gax"
     "google-cloud-gax-internal"
+    "google-cloud-lro"
     "google-cloud-test-utils"
 )
 for crate in "${crates[@]}"; do

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.95" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
 
 jobs:
   build:


### PR DESCRIPTION
It seems like we are not capturing errors on some of the tracing features and also LRO is not being compiled to check for errors.