### PR TITLE
chore(deps): update `http` to 1.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5532,9 +5532,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",

--- a/src/auth/src/access_boundary.rs
+++ b/src/auth/src/access_boundary.rs
@@ -799,7 +799,11 @@ pub(crate) mod tests {
         });
         mock.expect_universe_domain().returning(|| None);
 
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
         let mds_client = MDSClient::new(Some(endpoint.clone()));
 
         let creds = CredentialsWithAccessBoundary::new_for_mds(mock, mds_client, Some(endpoint));

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -2529,7 +2529,11 @@ mod tests {
             }
         });
 
-        let iam_endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let iam_endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let creds = Builder::new(contents)
             .maybe_iam_endpoint_override(Some(iam_endpoint))

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -2462,7 +2462,11 @@ mod tests {
         let builder_from_json = Builder::new(impersonated_credential);
 
         for builder in [builder_from_source, builder_from_json] {
-            let iam_endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+            let iam_endpoint = server
+                .url("/")
+                .to_string()
+                .trim_end_matches('/')
+                .to_string();
             let signer = builder
                 .maybe_iam_endpoint_override(Some(iam_endpoint))
                 .without_access_boundary()
@@ -2616,7 +2620,11 @@ mod tests {
         let builder_from_json = Builder::new(impersonated_credential);
 
         for builder in [builder_from_source, builder_from_json] {
-            let iam_endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+            let iam_endpoint = server
+                .url("/")
+                .to_string()
+                .trim_end_matches('/')
+                .to_string();
             let creds = builder
                 .maybe_iam_endpoint_override(Some(iam_endpoint))
                 .build_credentials()?;
@@ -2699,7 +2707,7 @@ mod tests {
             )
         );
 
-        let endpoint = server.url("").to_string();
+        let endpoint = server.url("/").to_string();
         let endpoint = endpoint.trim_end_matches('/');
 
         let creds = builder

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -1363,7 +1363,11 @@ mod tests {
             }))),
         );
 
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let signer = Builder::default()
             .with_endpoint(&endpoint)
@@ -1418,7 +1422,11 @@ mod tests {
             }))),
         );
 
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let creds = Builder::default()
             .with_endpoint(&endpoint)

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -1142,7 +1142,11 @@ mod tests {
             }))),
         );
 
-        let iam_endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let iam_endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let creds = Builder::new(service_account_key.clone())
             .maybe_iam_endpoint_override(Some(iam_endpoint))

--- a/src/auth/src/signer/iam.rs
+++ b/src/auth/src/signer/iam.rs
@@ -234,7 +234,11 @@ mod tests {
                 "signedBlob": signed_blob,
             }))),
         );
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let mut mock = MockCredentials::new();
         mock.expect_headers().return_once(|_extensions| {
@@ -279,7 +283,11 @@ mod tests {
             ),])
             .respond_with(status_code(500)),
         );
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let mut mock = MockCredentials::new();
         mock.expect_headers().return_once(|_extensions| {
@@ -321,7 +329,11 @@ mod tests {
                 }))
             ]),
         );
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
 
         let mut mock = MockCredentials::new();
         mock.expect_headers().returning(|_extensions| {

--- a/src/auth/src/signer/mds.rs
+++ b/src/auth/src/signer/mds.rs
@@ -155,7 +155,11 @@ mod tests {
         });
 
         let creds = Credentials::from(mock);
-        let endpoint = server.url("").to_string().trim_end_matches('/').to_string();
+        let endpoint = server
+            .url("/")
+            .to_string()
+            .trim_end_matches('/')
+            .to_string();
         let client = MDSClient::new(Some(endpoint.clone()));
         let mut signer = MDSSigner::new(client, creds);
         signer.iam_endpoint_override = Some(endpoint);

--- a/src/auth/tests/credentials.rs
+++ b/src/auth/tests/credentials.rs
@@ -584,7 +584,7 @@ mod tests {
 
         let test_quota_project = "test-quota-project";
         let mdcs = MdsBuilder::default()
-            .with_endpoint(server.url("").to_string().trim_end_matches("/"))
+            .with_endpoint(server.url("/").to_string().trim_end_matches('/'))
             .with_quota_project_id(test_quota_project)
             .build_access_token_credentials()?;
 

--- a/src/gax-internal/tests/http_client_errors.rs
+++ b/src/gax-internal/tests/http_client_errors.rs
@@ -170,7 +170,7 @@ mod tests {
 
             let server_pool = ServerPool::new(1);
             let server = server_pool.get_server();
-            let endpoint = server.url("").to_string(); // Base endpoint
+            let endpoint = server.url("/").to_string(); // Base endpoint
             let redirect_url = server.url("/loop").to_string();
 
             server.expect(

--- a/src/gax-internal/tests/http_request_builder.rs
+++ b/src/gax-internal/tests/http_request_builder.rs
@@ -51,7 +51,7 @@ mod tests {
         let mut config = ClientConfig::default();
         config.disable_follow_redirects = true;
         config.cred = Some(Anonymous::new().build());
-        let client = ReqwestClient::new(config, &server.url_str("")).await?;
+        let client = ReqwestClient::new(config, &server.url_str("/")).await?;
 
         let builder = client.http_builder_with_url(
             Method::PUT,

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -152,7 +152,7 @@ mod tests {
             ),
         );
 
-        let endpoint = server.url("");
+        let endpoint = server.url("/");
         let client = Storage::builder()
             .with_endpoint(endpoint.to_string())
             .with_credentials(Anonymous::new().build())

--- a/tests/o11y/src/detector.rs
+++ b/tests/o11y/src/detector.rs
@@ -362,7 +362,7 @@ mod tests {
             .respond_with(status_code(200).body(MOCK_METADATA)),
         );
         let detector = GoogleCloudResourceDetector::builder()
-            .with_endpoint(server.url("").to_string())
+            .with_endpoint(server.url("/").to_string())
             .build()
             .await?;
         let resource = detector.detect();
@@ -528,7 +528,7 @@ mod tests {
         );
 
         let detector = GoogleCloudResourceDetectorBuilder::new()
-            .with_endpoint(server.url("").to_string())
+            .with_endpoint(server.url("/").to_string())
             .with_attempt_count(3);
 
         let builder = Resource::builder_empty();
@@ -605,7 +605,7 @@ mod tests {
         );
 
         let detector = GoogleCloudResourceDetectorBuilder::new()
-            .with_endpoint(server.url("").to_string())
+            .with_endpoint(server.url("/").to_string())
             .with_attempt_count(3);
 
         let result = detector.fetch_instance_metadata().await?;
@@ -633,7 +633,7 @@ mod tests {
         );
 
         let detector = GoogleCloudResourceDetectorBuilder::new()
-            .with_endpoint(server.url("").to_string())
+            .with_endpoint(server.url("/").to_string())
             .with_attempt_timeout(Duration::from_millis(100))
             .with_attempt_count(2);
 
@@ -656,7 +656,7 @@ mod tests {
         );
 
         let detector = GoogleCloudResourceDetectorBuilder::new()
-            .with_endpoint(server.url("").to_string())
+            .with_endpoint(server.url("/").to_string())
             .with_attempt_count(3);
 
         let result = detector.fetch_instance_metadata().await;
@@ -674,7 +674,7 @@ mod tests {
             .respond_with(status_code(200).body(MOCK_METADATA)),
         );
         let detector =
-            GoogleCloudResourceDetectorBuilder::new().with_endpoint(server.url("").to_string());
+            GoogleCloudResourceDetectorBuilder::new().with_endpoint(server.url("/").to_string());
         (server, detector)
     }
 


### PR DESCRIPTION
This version fixed a bug on Uri creation, that apparently our tests depend on.