### PR TITLE
ci: enable `google_cloud_unstable_tracing` in GCB and GHA

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -37,7 +37,8 @@ locals {
   unstable_flags = join(" ", [
     "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
-    "--cfg google_cloud_unstable_grpc_server_streaming"
+    "--cfg google_cloud_unstable_grpc_server_streaming",
+    "--cfg google_cloud_unstable_tracing"
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.95" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
 
 jobs:
   build:


### PR DESCRIPTION
Add the `--cfg google_cloud_unstable_tracing` configuration flag to both GitHub Actions workflows and Google Cloud Build triggers. This ensures compilation and linting checks are run with unstable tracing enabled.

Enforcing this flag in CI will potentially cause several tests to fail and trigger compilation errors for LRO tracing (due to missing dependencies or imports in certain generated libraries). I will address and resolve these failures individually in subsequent commits.