### PR TITLE
chore: bump MSRV to 1.88

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# We need to support 1.87. Stop clippy from issuing newer warnings.
-msrv = "1.87.0"
+# We need to support 1.88. Stop clippy from issuing newer warnings.
+msrv = "1.88.0"

--- a/.gcb/builds/.terraform.lock.hcl
+++ b/.gcb/builds/.terraform.lock.hcl
@@ -21,3 +21,23 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fe789dc52fc029c18e92db0efb3b013d15679b81c1ab633fa69b3eacde9842ac",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.11.2"
+  constraints = "~> 0.11.0"
+  hashes = [
+    "h1:qg3O4PmHnlPcvuZ2LvzOYEAPGOKtccgD5kPdQPZw094=",
+    "zh:02588b5b8ba5d31e86d93edc93b306bcbf47c789f576769245968cc157a9e8c5",
+    "zh:088a30c23796133678d1d6614da5cf5544430570408a17062288b58c0bd67ac8",
+    "zh:0df5faa072d67616154d38021934d8a8a316533429a3f582df3b4b48c836cf89",
+    "zh:12edeeaef96c47f694bd1ba7ead6ccdb96028b25df352eea4bc5e40de7a59177",
+    "zh:1e859504a656a6e988f07b908e6ffe946b28bfb56889417c0a07ea9605a3b7b0",
+    "zh:64a6ae0320d4956c4fdb05629cfcebd03bcbd2206e2d733f2f18e4a97f4d5c7c",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:924d137959193bf7aee6ebf241fbb9aec46d6eef828c5cf8d3c588770acae7b2",
+    "zh:b3cc76281a4faa9c2293a2460fc6962f6539e900994053f85185304887dddab8",
+    "zh:cbb40c791d4a1cdba56cffa43a9c0ed8e69930d49aa6bd931546b18c36e3b720",
+    "zh:d227d43594f8cb3d24f1fdd71382f14502cbe2a6deaddbc74242656bb5b38daf",
+    "zh:d4840641c46176bb9d70ba3aff09de749282136c779996b546c81e5ff701bbf6",
+  ]
+}

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -139,7 +139,7 @@ locals {
       config       = "complex.yaml"
       flags        = local.unstable_flags
       script       = "test"
-      rust_version = "1.87"
+      rust_version = "1.88"
     }
     test-unstable-cfg = {
       config = "complex.yaml"

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -38,7 +38,6 @@ locals {
     "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
     "--cfg google_cloud_unstable_grpc_server_streaming",
-    "--cfg google_cloud_unstable_tracing"
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
@@ -268,6 +268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -326,11 +335,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122ec45a44b270afd1402f351b782c676b173e3c3fb28d86ff7ebfb4d86a4ee4"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -349,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -461,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -591,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -609,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -619,11 +629,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -633,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -713,15 +722,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -776,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -835,7 +844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5496,9 +5505,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -5607,18 +5616,18 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5879,7 +5888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -6230,16 +6239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6315,9 +6314,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6327,9 +6326,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -6338,6 +6337,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -6390,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru-slab"
@@ -6432,9 +6432,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -6476,9 +6476,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -6575,9 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -7531,7 +7531,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7590,7 +7590,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7861,11 +7861,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -7880,9 +7881,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7959,9 +7960,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -8019,12 +8020,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8297,7 +8298,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8418,9 +8419,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -8433,15 +8434,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8597,9 +8598,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
@@ -8628,9 +8629,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8640,9 +8641,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -8651,9 +8652,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8667,9 +8668,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-types"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
  "prost",
  "prost-types",
@@ -8697,20 +8698,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -8820,9 +8821,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -8924,9 +8925,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8996,9 +8997,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9009,9 +9010,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9019,9 +9020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9029,9 +9030,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9042,9 +9043,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -9098,9 +9099,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9131,7 +9132,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9351,9 +9352,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -9498,18 +9499,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9518,9 +9519,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -9542,6 +9543,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,7 +359,7 @@ license      = "Apache-2.0"
 repository   = "https://github.com/googleapis/google-cloud-rust/tree/main"
 keywords     = ["gcp", "google-cloud", "google-cloud-rust", "sdk"]
 categories   = ["network-programming"]
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 
 # Define a custom profile for builds on GHA. The standard profiles exhaust the
 # available disk space on the free GHA runners. The GHA builds cannot take

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ client libraries for Rust.
 
 ## Minimum Supported Rust Version (MSRV)
 
-We require Rust >= 1.87. We plan to update the MSRV periodically. However, the
+We require Rust >= 1.88. We plan to update the MSRV periodically. However, the
 development branch will always compile with the `rustc` versions released within
 the previous year.
 

--- a/deny.toml
+++ b/deny.toml
@@ -27,7 +27,6 @@ feature-depth = 1
 git-fetch-with-cli = false
 ignore = [
   { id = "RUSTSEC-2023-0071", reason = "Only used in tests and no new version available" },
-  { id = "RUSTSEC-2026-0009", reason = "Only affects RFC 2822 dates, which we do not use. An update is not possible, it requires bumping the MSRV to 1.88" },
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -25,9 +25,7 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 git-fetch-with-cli = false
-ignore = [
-  { id = "RUSTSEC-2023-0071", reason = "Only used in tests and no new version available" },
-]
+ignore             = [{ id = "RUSTSEC-2023-0071", reason = "Only used in tests and no new version available" }]
 
 [licenses]
 allow                = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT", "Unicode-3.0"]

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -9,7 +9,7 @@ compile the code, run the unit tests, and formatting miscellaneous files.
 We recommend that you follow the [Getting Started][getting-started-rust] guide.
 Once you have `cargo` and `rustup` installed the rest is relatively easy.
 
-You will need rust >= 1.87 (released around 2025-05-15). Check the version you
+You will need rust >= 1.88 (released around 2025-06-26). Check the version you
 have installed with:
 
 ```shell

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -1479,10 +1479,10 @@ impl ProgrammaticBuilder {
         }
         if config_builder.token_url.is_none() {
             let mut token_url = STS_TOKEN_URL.to_string();
-            if let Some(ref ud) = config_builder.universe_domain {
-                if ud != DEFAULT_UNIVERSE_DOMAIN {
-                    token_url = token_url.replace(DEFAULT_UNIVERSE_DOMAIN, ud);
-                }
+            if let Some(ref ud) = config_builder.universe_domain
+                && ud != DEFAULT_UNIVERSE_DOMAIN
+            {
+                token_url = token_url.replace(DEFAULT_UNIVERSE_DOMAIN, ud);
             }
             config_builder = config_builder.with_token_url(token_url);
         }

--- a/src/auth/src/credentials/external_account_sources/aws_sourced.rs
+++ b/src/auth/src/credentials/external_account_sources/aws_sourced.rs
@@ -271,16 +271,17 @@ fn parse_region_from_zone(zone: &str) -> Option<&str> {
     if zone.is_empty() {
         return None;
     }
-    if let Some(last_char) = zone.chars().last() {
-        if last_char.is_ascii_alphabetic() && zone.len() > 1 {
-            let potential_region = &zone[..zone.len() - 1];
-            if potential_region
-                .chars()
-                .last()
-                .is_some_and(|c| c.is_ascii_digit())
-            {
-                return Some(potential_region);
-            }
+    if let Some(last_char) = zone.chars().last()
+        && last_char.is_ascii_alphabetic()
+        && zone.len() > 1
+    {
+        let potential_region = &zone[..zone.len() - 1];
+        if potential_region
+            .chars()
+            .last()
+            .is_some_and(|c| c.is_ascii_digit())
+        {
+            return Some(potential_region);
         }
     }
     Some(zone)

--- a/src/auth/src/credentials/internal/jwk_client.rs
+++ b/src/auth/src/credentials/internal/jwk_client.rs
@@ -56,10 +56,10 @@ impl JwkClient {
         let mut cache = self.cache.try_write().map_err(|_e| {
             CredentialsError::from_msg(false, "failed to obtain lock to read certificate cache")
         })?;
-        if let Some(entry) = cache.get(key_id_str) {
-            if entry.expires_at > Instant::now() {
-                return Ok(entry.key.clone());
-            }
+        if let Some(entry) = cache.get(key_id_str)
+            && entry.expires_at > Instant::now()
+        {
+            return Ok(entry.key.clone());
         }
 
         let jwks_url = self.resolve_jwks_url(alg, jwks_url)?;

--- a/src/auth/src/credentials/internal/sts_exchange.rs
+++ b/src/auth/src/credentials/internal/sts_exchange.rs
@@ -86,10 +86,10 @@ impl STSHandler {
             params.insert("actor_token_type", actor_token_type);
         }
 
-        if let Some(options) = req.extra_options {
-            if let Ok(value) = serde_json::to_value(options) {
-                params.insert("options", value.to_string());
-            }
+        if let Some(options) = req.extra_options
+            && let Ok(value) = serde_json::to_value(options)
+        {
+            params.insert("options", value.to_string());
         }
 
         self.execute(req.url, req.authentication, req.headers, params)

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -529,10 +529,8 @@ impl ReqwestClient {
 }
 
 pub fn map_send_error(err: ::reqwest::Error) -> Error {
-    if let Some(e) = as_inner::<hyper::Error, _>(&err) {
-        if e.is_user() {
-            return Error::ser(err);
-        }
+    if as_inner::<hyper::Error, _>(&err).is_some_and(|e| e.is_user()) {
+        return Error::ser(err);
     }
     match err {
         e if e.is_connect() => Error::connect(e),

--- a/src/gax-internal/src/observability/client_signals/recorder.rs
+++ b/src/gax-internal/src/observability/client_signals/recorder.rs
@@ -359,13 +359,13 @@ impl ClientSnapshot {
     ///
     /// Use with the "server.address" attribute.
     pub fn server_address(&self) -> String {
-        if let Some(uri) = self.sanitized_url().and_then(|u| u.parse::<Uri>().ok()) {
-            if let Some(host) = uri.host() {
-                return host
-                    .trim_start_matches('[')
-                    .trim_end_matches(']')
-                    .to_string();
-            }
+        if let Some(uri) = self.sanitized_url().and_then(|u| u.parse::<Uri>().ok())
+            && let Some(host) = uri.host()
+        {
+            return host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .to_string();
         }
         self.info.default_host.to_string()
     }
@@ -376,10 +376,10 @@ impl ClientSnapshot {
     ///
     /// Use with the "server.port" attribute after casting to `i64`.
     pub fn server_port(&self) -> u16 {
-        if let Some(uri) = self.sanitized_url().and_then(|u| u.parse::<Uri>().ok()) {
-            if let Some(host) = uri.authority().and_then(|a| a.port_u16()) {
-                return host;
-            }
+        if let Some(uri) = self.sanitized_url().and_then(|u| u.parse::<Uri>().ok())
+            && let Some(host) = uri.authority().and_then(|a| a.port_u16())
+        {
+            return host;
         }
         HTTPS_PORT
     }

--- a/src/gax-internal/src/observability/client_signals/with_transport_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_transport_span.rs
@@ -187,10 +187,10 @@ mod tests {
                 .execute(request)
                 .await
                 .map_err(|e| google_cloud_gax::error::Error::io(e.to_string()));
-            if let Some(recorder) = RequestRecorder::current() {
-                if let Ok(r) = &res {
-                    recorder.on_http_response(r);
-                }
+            if let Some(recorder) = RequestRecorder::current()
+                && let Ok(r) = &res
+            {
+                recorder.on_http_response(r);
             }
             res
         };
@@ -308,10 +308,10 @@ mod tests {
                 .execute(request)
                 .await
                 .map_err(|e| google_cloud_gax::error::Error::io(e.to_string()));
-            if let Some(recorder) = RequestRecorder::current() {
-                if let Ok(r) = &res {
-                    recorder.on_http_response(r);
-                }
+            if let Some(recorder) = RequestRecorder::current()
+                && let Ok(r) = &res
+            {
+                recorder.on_http_response(r);
             }
             res
         };

--- a/src/gax/src/paginator.rs
+++ b/src/gax/src/paginator.rs
@@ -304,10 +304,10 @@ where
     /// Enable the `unstable-stream` feature to convert this to a [Stream].
     async fn next(&mut self) -> Option<Result<T::PageItem, E>> {
         loop {
-            if let Some(ref mut iter) = self.current_items {
-                if let Some(item) = iter.next() {
-                    return Some(Ok(item));
-                }
+            if let Some(ref mut iter) = self.current_items
+                && let Some(item) = iter.next()
+            {
+                return Some(Ok(item));
             }
 
             let next_page = self.stream.next().await;

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -759,10 +759,10 @@ impl ReadContextTransactionSelector {
                 let guard = lazy
                     .lock()
                     .map_err(|_| internal_error("transaction state mutex poisoned"))?;
-                if let TransactionState::Started(selector, _) = &*guard {
-                    if let Some(Selector::Id(id)) = &selector.selector {
-                        return Ok(Some(id.clone()));
-                    }
+                if let TransactionState::Started(selector, _) = &*guard
+                    && let Some(Selector::Id(id)) = &selector.selector
+                {
+                    return Ok(Some(id.clone()));
                 }
             }
         }

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -106,12 +106,12 @@ impl ReadWriteTransactionBuilder {
     }
 
     pub(crate) fn with_previous_transaction_id(mut self, id: Option<bytes::Bytes>) -> Self {
-        if let Some(id) = id {
-            if let Some(Mode::ReadWrite(rw)) = self.options.mode.take() {
-                self.options = self
-                    .options
-                    .set_read_write(rw.set_multiplexed_session_previous_transaction_id(id));
-            }
+        if let Some(id) = id
+            && let Some(Mode::ReadWrite(rw)) = self.options.mode.take()
+        {
+            self.options = self
+                .options
+                .set_read_write(rw.set_multiplexed_session_previous_transaction_id(id));
         }
         self
     }
@@ -245,15 +245,14 @@ impl CheckServiceError for ProtoResultSet {
 /// This implementation evaluates that payload so fallback handlers can recover.
 impl CheckServiceError for ExecuteBatchDmlResponse {
     fn check_service_error(&self) -> Option<Error> {
-        if self.result_sets.is_empty() {
-            if let Some(status) = &self.status {
-                if status.code != Code::Ok as i32 {
-                    let rpc_status = Status::default()
-                        .set_code(status.code)
-                        .set_message(status.message.clone());
-                    return Some(Error::service(rpc_status));
-                }
-            }
+        if self.result_sets.is_empty()
+            && let Some(status) = &self.status
+            && status.code != Code::Ok as i32
+        {
+            let rpc_status = Status::default()
+                .set_code(status.code)
+                .set_message(status.message.clone());
+            return Some(Error::service(rpc_status));
         }
         None
     }

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -566,12 +566,11 @@ impl ResultSet {
         }
 
         let mut values_iter = values.into_iter();
-        if self.chunked {
-            if let Some(last_val) = self.buffered_values.last_mut() {
-                if let Some(first_new) = values_iter.next() {
-                    merge_values(last_val, first_new)?;
-                }
-            }
+        if self.chunked
+            && let Some(last_val) = self.buffered_values.last_mut()
+            && let Some(first_new) = values_iter.next()
+        {
+            merge_values(last_val, first_new)?;
         }
 
         self.buffered_values.extend(values_iter);

--- a/src/spanner/src/result_set_metadata.rs
+++ b/src/spanner/src/result_set_metadata.rs
@@ -47,12 +47,12 @@ impl ResultSetMetadata {
         let mut column_types = Vec::new();
         let mut undeclared_parameters = std::collections::BTreeMap::new();
 
-        if let Some(m) = &metadata {
-            if let Some(undeclared) = &m.undeclared_parameters {
-                for field in &undeclared.fields {
-                    let param_type = field.r#type.clone().map(Into::into).unwrap_or_default();
-                    undeclared_parameters.insert(field.name.clone(), param_type);
-                }
+        if let Some(m) = &metadata
+            && let Some(undeclared) = &m.undeclared_parameters
+        {
+            for field in &undeclared.fields {
+                let param_type = field.r#type.clone().map(Into::into).unwrap_or_default();
+                undeclared_parameters.insert(field.name.clone(), param_type);
             }
         }
 

--- a/src/storage/benchmarks/random/src/args.rs
+++ b/src/storage/benchmarks/random/src/args.rs
@@ -82,10 +82,10 @@ impl Args {
         if self.min_range_count == 0 {
             bail!("invalid min-range-count, must be greater than zero")
         }
-        if let RandomSize::Values(v) = &self.range_size {
-            if v.is_empty() {
-                bail!("empty list of values in range-size")
-            }
+        if let RandomSize::Values(v) = &self.range_size
+            && v.is_empty()
+        {
+            bail!("empty list of values in range-size")
         }
         if self.range_size.min() == 0 {
             bail!("invalid range-size, minimum must be greater than zero")

--- a/src/storage/benchmarks/w1r3/src/main.rs
+++ b/src/storage/benchmarks/w1r3/src/main.rs
@@ -134,10 +134,10 @@ async fn main() -> anyhow::Result<()> {
     }
     tracing::info!("DONE");
 
-    if let Some(tracer_provider) = tracer_provider {
-        if let Err(e) = tracer_provider.shutdown() {
-            eprintln!("error shutting down trace provider: {e}");
-        }
+    if let Some(tracer_provider) = tracer_provider
+        && let Err(e) = tracer_provider.shutdown()
+    {
+        eprintln!("error shutting down trace provider: {e}");
     }
 
     Ok(())

--- a/src/storage/src/storage/perform_upload/buffered.rs
+++ b/src/storage/src/storage/perform_upload/buffered.rs
@@ -222,10 +222,9 @@ where
             .resource
             .as_ref()
             .and_then(|r| r.checksums.as_ref())
+            && let Err(mismatch) = self::checksum_validate(pre, &object.checksums)
         {
-            if let Err(mismatch) = self::checksum_validate(pre, &object.checksums) {
-                return err(mismatch, object);
-            }
+            return err(mismatch, object);
         }
         let computed = self.payload.lock().await.final_checksum();
         if let Err(mismatch) = self::checksum_validate(&computed, &object.checksums) {

--- a/src/storage/src/storage/perform_upload/buffered/progress.rs
+++ b/src/storage/src/storage/perform_upload/buffered/progress.rs
@@ -174,10 +174,10 @@ impl InProgressUpload {
 
     pub fn put_body(&self) -> Body {
         let stream = unfold(Some(self.buffer.clone()), move |state| async move {
-            if let Some(mut payload) = state {
-                if let Some(next) = payload.pop_front() {
-                    return Some((Ok::<bytes::Bytes, Error>(next), Some(payload)));
-                }
+            if let Some(mut payload) = state
+                && let Some(next) = payload.pop_front()
+            {
+                return Some((Ok::<bytes::Bytes, Error>(next), Some(payload)));
             }
             None
         });

--- a/tests/o11y/src/auth.rs
+++ b/tests/o11y/src/auth.rs
@@ -217,10 +217,11 @@ mod tests {
                     data: headers.clone(),
                 }),
                 MockState::NotModified(expected_etag) => {
-                    if let Some(etag) = extensions.get::<EntityTag>() {
-                        if etag == expected_etag {
-                            return Ok(CacheableResource::NotModified);
-                        }
+                    if extensions
+                        .get::<EntityTag>()
+                        .is_some_and(|etag| etag == expected_etag)
+                    {
+                        return Ok(CacheableResource::NotModified);
                     }
                     // Fallback if etag doesn't match or is missing
                     Err(CredentialsError::from_msg(false, "etag mismatch"))

--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -91,14 +91,14 @@ pub async fn wait_for_trace(
                 }
             }
             Err(e) => {
-                if let Some(status) = e.status() {
-                    if status.code == Code::NotFound || status.code == Code::Internal {
-                        println!(
-                            "Trace not found yet (or internal error), retrying... Error: {:?}",
-                            e
-                        );
-                        continue;
-                    }
+                if let Some(status) = e.status()
+                    && (status.code == Code::NotFound || status.code == Code::Internal)
+                {
+                    println!(
+                        "Trace not found yet (or internal error), retrying... Error: {:?}",
+                        e
+                    );
+                    continue;
                 }
                 return Err(e.into());
             }

--- a/tests/spanner/src/batch_write.rs
+++ b/tests/spanner/src/batch_write.rs
@@ -188,11 +188,13 @@ pub async fn batch_write_partial_failure(db_client: &DatabaseClient) -> Result<(
         while let Some(response) = stream.next().await {
             match response {
                 Ok(resp) => {
-                    if let Some(status) = &resp.status {
-                        if status.code == Code::Aborted as i32 {
-                            aborted = true;
-                            break;
-                        }
+                    if resp
+                        .status
+                        .as_ref()
+                        .is_some_and(|s| s.code == Code::Aborted as i32)
+                    {
+                        aborted = true;
+                        break;
                     }
                     process_batch_write_response(&resp, &mut seen_ok, &mut seen_err);
                 }

--- a/tools/minimal-version-helper/src/main.rs
+++ b/tools/minimal-version-helper/src/main.rs
@@ -87,34 +87,36 @@ fn prep(is_local: bool) -> Result<()> {
         .and_then(|d| d.as_table_like_mut())
     {
         for (key, value) in deps.iter_mut() {
-            if let Some(dep_table) = value.as_table_like_mut() {
-                if dep_table.contains_key("path") && dep_table.contains_key("version") {
-                    let package_name = dep_table
-                        .get("package")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(key.get()) // if there is no name specified, use the key.
-                        .to_string();
-                    path_deps.insert(
-                        package_name.clone(),
-                        Package {
-                            version: dep_table
-                                .get("version")
-                                .expect("version key exists")
-                                .as_str()
-                                .expect("version value is a &str")
-                                .to_string(),
-                            path: dep_table
-                                .get("path")
-                                .expect("path key exists")
-                                .as_str()
-                                .expect("path value is a &str")
-                                .to_string(),
-                        },
-                    );
-                    // Remove path from the Cargo.toml.
-                    dep_table.remove("path");
-                }
+            let Some(dep_table) = value.as_table_like_mut() else {
+                continue;
+            };
+            if !dep_table.contains_key("path") || !dep_table.contains_key("version") {
+                continue;
             }
+            let package_name = dep_table
+                .get("package")
+                .and_then(|v| v.as_str())
+                .unwrap_or(key.get()) // if there is no name specified, use the key.
+                .to_string();
+            path_deps.insert(
+                package_name.clone(),
+                Package {
+                    version: dep_table
+                        .get("version")
+                        .expect("version key exists")
+                        .as_str()
+                        .expect("version value is a &str")
+                        .to_string(),
+                    path: dep_table
+                        .get("path")
+                        .expect("path key exists")
+                        .as_str()
+                        .expect("path value is a &str")
+                        .to_string(),
+                },
+            );
+            // Remove path from the Cargo.toml.
+            dep_table.remove("path");
         }
     }
 


### PR DESCRIPTION
It is more than a year since 1.87 was released. I left the `extract_if()` cleanup for a future PR.
