### PR TITLE
refactor(spanner): align builder setter method naming conventions

### DIFF
--- a/src/spanner/src/batch_dml.rs
+++ b/src/spanner/src/batch_dml.rs
@@ -52,12 +52,12 @@ impl BatchDmlBuilder {
     /// let statement1 = Statement::builder("UPDATE users SET active = true WHERE id = 1").build();
     /// let batch = BatchDml::builder()
     ///     .add_statement(statement1)
-    ///     .with_request_tag("my-tag")
+    ///     .set_request_tag("my-tag")
     ///     .build();
     /// ```
     ///
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
-    pub fn with_request_tag(mut self, tag: impl Into<String>) -> Self {
+    pub fn set_request_tag(mut self, tag: impl Into<String>) -> Self {
         self.request_options
             .get_or_insert_with(RequestOptions::default)
             .request_tag = tag.into();
@@ -228,7 +228,7 @@ mod tests {
 
         let batch = BatchDml::builder()
             .add_statement(stmt)
-            .with_request_tag("tag1")
+            .set_request_tag("tag1")
             .build();
 
         assert_eq!(batch.statements.len(), 1);

--- a/src/spanner/src/batch_read_only_transaction.rs
+++ b/src/spanner/src/batch_read_only_transaction.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
 /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
 /// let read_only_transaction = db_client.batch_read_only_transaction()
-///     .with_timestamp_bound(TimestampBound::strong())
+///     .set_timestamp_bound(TimestampBound::strong())
 ///     .build()
 ///     .await?;
 /// # Ok(())
@@ -63,13 +63,13 @@ impl BatchReadOnlyTransactionBuilder {
     /// # use google_cloud_spanner::client::TimestampBound;
     /// # async fn set_bound(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
-    /// let builder = db_client.batch_read_only_transaction().with_timestamp_bound(TimestampBound::strong());
+    /// let builder = db_client.batch_read_only_transaction().set_timestamp_bound(TimestampBound::strong());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_timestamp_bound(self, bound: TimestampBound) -> Self {
+    pub fn set_timestamp_bound(self, bound: TimestampBound) -> Self {
         Self {
-            inner: self.inner.with_timestamp_bound(bound),
+            inner: self.inner.set_timestamp_bound(bound),
         }
     }
 
@@ -275,13 +275,13 @@ impl Partition {
     /// # let partitions = transaction.partition_query(Statement::builder("SELECT * FROM Users").build(), PartitionOptions::default()).await?;
     /// // On a worker receiving a partition, execute it with Data Boost:
     /// let mut result_set = partitions[0].clone()
-    ///     .with_data_boost(true)
+    ///     .set_data_boost(true)
     ///     .execute(&db_client)
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_data_boost(mut self, enabled: bool) -> Self {
+    pub fn set_data_boost(mut self, enabled: bool) -> Self {
         match &mut self.inner {
             PartitionedOperation::Query(req) => req.data_boost_enabled = enabled,
             PartitionedOperation::Read(req) => req.data_boost_enabled = enabled,
@@ -742,7 +742,7 @@ pub(crate) mod tests {
 
         let tx = db_client
             .batch_read_only_transaction()
-            .with_timestamp_bound(TimestampBound::strong())
+            .set_timestamp_bound(TimestampBound::strong())
             .build()
             .await?;
 
@@ -855,7 +855,7 @@ pub(crate) mod tests {
             gax_options: GaxRequestOptions::default(),
         };
 
-        let _result_set = partition.with_data_boost(true).execute(&db_client).await?;
+        let _result_set = partition.set_data_boost(true).execute(&db_client).await?;
 
         Ok(())
     }
@@ -889,7 +889,7 @@ pub(crate) mod tests {
             gax_options: GaxRequestOptions::default(),
         };
 
-        let _result_set = partition.with_data_boost(true).execute(&db_client).await?;
+        let _result_set = partition.set_data_boost(true).execute(&db_client).await?;
 
         Ok(())
     }

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -180,7 +180,7 @@ impl DatabaseClient {
     ///     .build();
     ///
     /// let response = db.write_only_transaction()
-    ///     .with_transaction_tag("my-tag")
+    ///     .set_transaction_tag("my-tag")
     ///     .build()
     ///     .write(vec![mutation])
     ///     .await?;

--- a/src/spanner/src/read.rs
+++ b/src/spanner/src/read.rs
@@ -36,7 +36,7 @@ use std::time::Duration;
 /// // Read specific rows using an index.
 /// let read_by_id = ReadRequest::builder("Users", vec!["Id", "Name"])
 ///     .with_index("UsersByIndex", key![1_i64])
-///     .with_limit(10)
+///     .set_limit(10)
 ///     .build();
 /// ```
 ///
@@ -129,12 +129,12 @@ impl ConfiguredReadRequestBuilder {
     /// # use google_cloud_spanner::client::{ReadRequest, KeySet};
     /// let request = ReadRequest::builder("Users", vec!["Id"])
     ///     .with_keys(KeySet::all())
-    ///     .with_limit(10)
+    ///     .set_limit(10)
     ///     .build();
     /// ```
     ///
     /// If fewer rows are found, only the matching rows will be returned.
-    pub fn with_limit(mut self, limit: i64) -> Self {
+    pub fn set_limit(mut self, limit: i64) -> Self {
         self.limit = Some(limit);
         self
     }
@@ -146,12 +146,12 @@ impl ConfiguredReadRequestBuilder {
     /// # use google_cloud_spanner::client::{ReadRequest, KeySet};
     /// let request = ReadRequest::builder("Users", vec!["Id"])
     ///     .with_keys(KeySet::all())
-    ///     .with_request_tag("my-tag")
+    ///     .set_request_tag("my-tag")
     ///     .build();
     /// ```
     ///
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
-    pub fn with_request_tag(mut self, tag: impl Into<String>) -> Self {
+    pub fn set_request_tag(mut self, tag: impl Into<String>) -> Self {
         self.request_options
             .get_or_insert_with(crate::model::RequestOptions::default)
             .request_tag = tag.into();
@@ -166,10 +166,10 @@ impl ConfiguredReadRequestBuilder {
     /// # use google_cloud_spanner::model::request_options::Priority;
     /// let request = ReadRequest::builder("Users", vec!["Id"])
     ///     .with_keys(KeySet::all())
-    ///     .with_priority(Priority::Low)
+    ///     .set_priority(Priority::Low)
     ///     .build();
     /// ```
-    pub fn with_priority(mut self, priority: Priority) -> Self {
+    pub fn set_priority(mut self, priority: Priority) -> Self {
         self.request_options
             .get_or_insert_with(crate::model::RequestOptions::default)
             .priority = priority;
@@ -185,13 +185,13 @@ impl ConfiguredReadRequestBuilder {
     /// let dro = DirectedReadOptions::default();
     /// let req = ReadRequest::builder("MyTable", vec!["col1"])
     ///     .with_keys(KeySet::all())
-    ///     .with_directed_read_options(dro)
+    ///     .set_directed_read_options(dro)
     ///     .build();
     /// ```
     ///
     /// DirectedReadOptions can only be specified for a read-only transaction,
     /// otherwise Spanner returns an INVALID_ARGUMENT error.
-    pub fn with_directed_read_options(mut self, options: DirectedReadOptions) -> Self {
+    pub fn set_directed_read_options(mut self, options: DirectedReadOptions) -> Self {
         self.directed_read_options = Some(options);
         self
     }
@@ -204,7 +204,7 @@ impl ConfiguredReadRequestBuilder {
     /// # use google_cloud_spanner::model::read_request::OrderBy;
     /// let request = ReadRequest::builder("Users", vec!["Id"])
     ///     .with_keys(KeySet::all())
-    ///     .with_order_by(OrderBy::NoOrder);
+    ///     .set_order_by(OrderBy::NoOrder);
     /// ```
     ///
     /// By default, Spanner returns result rows in primary key order (or index key
@@ -214,7 +214,7 @@ impl ConfiguredReadRequestBuilder {
     /// (`ORDER_BY_PRIMARY_KEY`) order, setting `ORDER_BY_NO_ORDER` option allows
     /// Spanner to optimize row retrieval, resulting in lower latencies in certain
     /// cases (for example, bulk point lookups).
-    pub fn with_order_by(mut self, order_by: OrderBy) -> Self {
+    pub fn set_order_by(mut self, order_by: OrderBy) -> Self {
         self.order_by = Some(order_by);
         self
     }
@@ -227,7 +227,7 @@ impl ConfiguredReadRequestBuilder {
     /// # use google_cloud_spanner::model::read_request::LockHint;
     /// let request = ReadRequest::builder("Users", vec!["Id"])
     ///     .with_keys(KeySet::all())
-    ///     .with_lock_hint(LockHint::Exclusive);
+    ///     .set_lock_hint(LockHint::Exclusive);
     /// ```
     ///
     /// Lock hints can only be used with read-write transactions.
@@ -242,7 +242,7 @@ impl ConfiguredReadRequestBuilder {
     ///
     /// Request exclusive locks judiciously because they block others from reading that
     /// data for the entire transaction, rather than just when the writes are being performed.
-    pub fn with_lock_hint(mut self, lock_hint: LockHint) -> Self {
+    pub fn set_lock_hint(mut self, lock_hint: LockHint) -> Self {
         self.lock_hint = Some(lock_hint);
         self
     }
@@ -383,7 +383,7 @@ mod tests {
     fn with_limit() {
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_limit(42)
+            .set_limit(42)
             .build();
         assert_eq!(req.limit, Some(42));
     }
@@ -392,7 +392,7 @@ mod tests {
     fn with_request_tag() {
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_request_tag("tag1")
+            .set_request_tag("tag1")
             .build();
         assert_eq!(
             req.request_options
@@ -406,7 +406,7 @@ mod tests {
     fn with_priority() {
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_priority(Priority::High)
+            .set_priority(Priority::High)
             .build();
         assert_eq!(
             req.request_options
@@ -421,7 +421,7 @@ mod tests {
         let dro = DirectedReadOptions::default();
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_directed_read_options(dro.clone())
+            .set_directed_read_options(dro.clone())
             .build();
         assert_eq!(req.directed_read_options, Some(dro));
     }
@@ -430,7 +430,7 @@ mod tests {
     fn with_order_by() {
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_order_by(OrderBy::PrimaryKey)
+            .set_order_by(OrderBy::PrimaryKey)
             .build();
         assert_eq!(req.order_by, Some(OrderBy::PrimaryKey));
     }
@@ -439,7 +439,7 @@ mod tests {
     fn with_lock_hint() {
         let req = ReadRequest::builder("MyTable", vec!["col1"])
             .with_keys(KeySet::all())
-            .with_lock_hint(LockHint::Exclusive)
+            .set_lock_hint(LockHint::Exclusive)
             .build();
         assert_eq!(req.lock_hint, Some(LockHint::Exclusive));
     }

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -35,7 +35,7 @@ use tokio::sync::Notify;
 /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
 /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
 /// let read_only_tx = db_client.single_use()
-///     .with_timestamp_bound(TimestampBound::strong())
+///     .set_timestamp_bound(TimestampBound::strong())
 ///     .build();
 /// # Ok(())
 /// # }
@@ -61,7 +61,7 @@ impl SingleUseReadOnlyTransactionBuilder {
     /// # use google_cloud_spanner::client::TimestampBound;
     /// # async fn set_bound(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
-    /// let builder = db_client.single_use().with_timestamp_bound(TimestampBound::strong());
+    /// let builder = db_client.single_use().set_timestamp_bound(TimestampBound::strong());
     /// # Ok(())
     /// # }
     /// ```
@@ -69,7 +69,7 @@ impl SingleUseReadOnlyTransactionBuilder {
     /// which tells Spanner how to choose a timestamp at which to read the data.
     ///
     /// See <https://docs.cloud.google.com/spanner/docs/timestamp-bounds> for more information.
-    pub fn with_timestamp_bound(mut self, bound: TimestampBound) -> Self {
+    pub fn set_timestamp_bound(mut self, bound: TimestampBound) -> Self {
         self.timestamp_bound = Some(bound);
         self
     }
@@ -220,7 +220,7 @@ pub enum BeginTransactionOption {
 /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
 /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
 /// let read_only_tx = db_client.read_only_transaction()
-///     .with_timestamp_bound(TimestampBound::strong())
+///     .set_timestamp_bound(TimestampBound::strong())
 ///     .build()
 ///     .await?;
 /// # Ok(())
@@ -284,11 +284,11 @@ impl MultiUseReadOnlyTransactionBuilder {
     /// # use google_cloud_spanner::client::TimestampBound;
     /// # async fn set_bound(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
-    /// let builder = db_client.read_only_transaction().with_timestamp_bound(TimestampBound::strong());
+    /// let builder = db_client.read_only_transaction().set_timestamp_bound(TimestampBound::strong());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_timestamp_bound(mut self, bound: TimestampBound) -> Self {
+    pub fn set_timestamp_bound(mut self, bound: TimestampBound) -> Self {
         self.timestamp_bound = Some(bound);
         self
     }
@@ -1079,7 +1079,7 @@ pub(crate) mod tests {
 
         let tx2 = db_client
             .single_use()
-            .with_timestamp_bound(crate::timestamp_bound::TimestampBound::max_staleness(
+            .set_timestamp_bound(crate::timestamp_bound::TimestampBound::max_staleness(
                 std::time::Duration::from_secs(10),
             ))
             .build();

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -91,12 +91,12 @@ impl ReadWriteTransactionBuilder {
         }
     }
 
-    pub(crate) fn with_isolation_level(mut self, isolation_level: IsolationLevel) -> Self {
+    pub(crate) fn set_isolation_level(mut self, isolation_level: IsolationLevel) -> Self {
         self.options = self.options.set_isolation_level(isolation_level);
         self
     }
 
-    pub(crate) fn with_read_lock_mode(mut self, read_lock_mode: ReadLockMode) -> Self {
+    pub(crate) fn set_read_lock_mode(mut self, read_lock_mode: ReadLockMode) -> Self {
         if let Some(Mode::ReadWrite(rw)) = self.options.mode.take() {
             self.options = self
                 .options
@@ -105,7 +105,7 @@ impl ReadWriteTransactionBuilder {
         self
     }
 
-    pub(crate) fn with_previous_transaction_id(mut self, id: Option<bytes::Bytes>) -> Self {
+    pub(crate) fn set_previous_transaction_id(mut self, id: Option<bytes::Bytes>) -> Self {
         if let Some(id) = id {
             if let Some(Mode::ReadWrite(rw)) = self.options.mode.take() {
                 self.options = self
@@ -116,27 +116,27 @@ impl ReadWriteTransactionBuilder {
         self
     }
 
-    pub(crate) fn with_transaction_tag(mut self, tag: impl Into<String>) -> Self {
+    pub(crate) fn set_transaction_tag(mut self, tag: impl Into<String>) -> Self {
         self.transaction_tag = Some(tag.into());
         self
     }
 
-    pub(crate) fn with_commit_priority(mut self, priority: Priority) -> Self {
+    pub(crate) fn set_commit_priority(mut self, priority: Priority) -> Self {
         self.commit_priority = priority;
         self
     }
 
-    pub(crate) fn with_max_commit_delay(mut self, delay: Duration) -> Self {
+    pub(crate) fn set_max_commit_delay(mut self, delay: Duration) -> Self {
         self.max_commit_delay = Some(delay);
         self
     }
 
-    pub(crate) fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+    pub(crate) fn set_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
         self.options = self.options.set_exclude_txn_from_change_streams(exclude);
         self
     }
 
-    pub(crate) fn with_return_commit_stats(mut self, return_stats: bool) -> Self {
+    pub(crate) fn set_return_commit_stats(mut self, return_stats: bool) -> Self {
         self.return_commit_stats = return_stats;
         self
     }
@@ -1107,8 +1107,8 @@ mod tests {
 
         let tx = ReadWriteTransactionBuilder::new(db_client.clone())
             .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
-            .with_return_commit_stats(true)
-            .with_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
+            .set_return_commit_stats(true)
+            .set_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
             .build(None)
             .await
             .expect("Failed to build transaction");
@@ -1179,7 +1179,7 @@ mod tests {
 
         let tx = ReadWriteTransactionBuilder::new(db_client.clone())
             .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
-            .with_commit_priority(Priority::Low)
+            .set_commit_priority(Priority::Low)
             .build(None)
             .await
             .expect("Failed to build transaction");
@@ -1909,8 +1909,8 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
 
         let _tx = ReadWriteTransactionBuilder::new(db_client.clone())
-            .with_isolation_level(IsolationLevel::Serializable)
-            .with_read_lock_mode(ReadLockMode::Pessimistic)
+            .set_isolation_level(IsolationLevel::Serializable)
+            .set_read_lock_mode(ReadLockMode::Pessimistic)
             .with_begin_transaction_option(BeginTransactionOption::ExplicitBegin)
             .build(None)
             .await
@@ -1935,7 +1935,7 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
 
         let _tx = ReadWriteTransactionBuilder::new(db_client.clone())
-            .with_exclude_txn_from_change_streams(true)
+            .set_exclude_txn_from_change_streams(true)
             .with_begin_transaction_option(BeginTransactionOption::ExplicitBegin)
             .build(None)
             .await
@@ -2229,7 +2229,7 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
 
         let tx = ReadWriteTransactionBuilder::new(db_client.clone())
-            .with_max_commit_delay(Duration::new(0, 200_000_000).unwrap())
+            .set_max_commit_delay(Duration::new(0, 200_000_000).unwrap())
             .with_begin_transaction_option(begin_transaction_option)
             .build(None)
             .await
@@ -2761,7 +2761,7 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
         let tx = ReadWriteTransactionBuilder::new(db_client)
             .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
-            .with_transaction_tag("fallback-test-tag")
+            .set_transaction_tag("fallback-test-tag")
             .build(None)
             .await?;
 

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -94,12 +94,12 @@ impl StatementBuilder {
     /// ```
     /// # use google_cloud_spanner::client::Statement;
     /// let statement = Statement::builder("SELECT * FROM users")
-    ///     .with_request_tag("my-tag")
+    ///     .set_request_tag("my-tag")
     ///     .build();
     /// ```
     ///
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
-    pub fn with_request_tag(mut self, tag: impl Into<String>) -> Self {
+    pub fn set_request_tag(mut self, tag: impl Into<String>) -> Self {
         self.request_options
             .get_or_insert_with(crate::model::RequestOptions::default)
             .request_tag = tag.into();
@@ -113,10 +113,10 @@ impl StatementBuilder {
     /// # use google_cloud_spanner::client::Statement;
     /// # use google_cloud_spanner::model::request_options::Priority;
     /// let statement = Statement::builder("SELECT * FROM users")
-    ///     .with_priority(Priority::Low)
+    ///     .set_priority(Priority::Low)
     ///     .build();
     /// ```
-    pub fn with_priority(mut self, priority: Priority) -> Self {
+    pub fn set_priority(mut self, priority: Priority) -> Self {
         self.request_options
             .get_or_insert_with(crate::model::RequestOptions::default)
             .priority = priority;
@@ -130,13 +130,13 @@ impl StatementBuilder {
     /// # use google_cloud_spanner::model::DirectedReadOptions;
     /// let dro = DirectedReadOptions::default();
     /// let stmt = Statement::builder("SELECT * FROM users")
-    ///     .with_directed_read_options(dro)
+    ///     .set_directed_read_options(dro)
     ///     .build();
     /// ```
     ///
     /// DirectedReadOptions can only be specified for a read-only transaction,
     /// otherwise Spanner returns an INVALID_ARGUMENT error.
-    pub fn with_directed_read_options(mut self, options: DirectedReadOptions) -> Self {
+    pub fn set_directed_read_options(mut self, options: DirectedReadOptions) -> Self {
         self.directed_read_options = Some(options);
         self
     }
@@ -150,10 +150,10 @@ impl StatementBuilder {
     /// let options = QueryOptions::default()
     ///     .set_optimizer_version("latest");
     /// let statement = Statement::builder("SELECT * FROM users")
-    ///     .with_query_options(options)
+    ///     .set_query_options(options)
     ///     .build();
     /// ```
-    pub fn with_query_options(mut self, options: QueryOptions) -> Self {
+    pub fn set_query_options(mut self, options: QueryOptions) -> Self {
         self.query_options = Some(options);
         self
     }
@@ -165,10 +165,10 @@ impl StatementBuilder {
     /// # use google_cloud_spanner::client::Statement;
     /// # use google_cloud_spanner::model::execute_sql_request::QueryMode;
     /// let statement = Statement::builder("SELECT * FROM users")
-    ///     .with_query_mode(QueryMode::Plan)
+    ///     .set_query_mode(QueryMode::Plan)
     ///     .build();
     /// ```
-    pub fn with_query_mode(mut self, mode: QueryMode) -> Self {
+    pub fn set_query_mode(mut self, mode: QueryMode) -> Self {
         self.query_mode = Some(mode);
         self
     }
@@ -273,13 +273,13 @@ impl Statement {
     /// let statement = Statement::builder("SELECT * FROM users WHERE id = @id")
     ///     .add_param("id", &42)
     ///     .build();
-    /// let mut query_plan = tx.execute_query(statement.clone().with_query_mode(QueryMode::Plan)).await?;
+    /// let mut query_plan = tx.execute_query(statement.clone().set_query_mode(QueryMode::Plan)).await?;
     /// # Ok(())
     /// # }
     /// ```
     ///
     /// This method consumes the statement and returns a new one with the specified mode.
-    pub fn with_query_mode(mut self, mode: QueryMode) -> Self {
+    pub fn set_query_mode(mut self, mode: QueryMode) -> Self {
         self.query_mode = Some(mode);
         self
     }
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn with_request_tag() {
         let stmt = Statement::builder("SELECT * FROM users")
-            .with_request_tag("tag1")
+            .set_request_tag("tag1")
             .build();
         assert_eq!(
             stmt.request_options
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn with_priority() {
         let stmt = Statement::builder("SELECT * FROM users")
-            .with_priority(Priority::High)
+            .set_priority(Priority::High)
             .build();
         assert_eq!(
             stmt.request_options
@@ -495,7 +495,7 @@ mod tests {
     fn with_directed_read_options() {
         let dro = DirectedReadOptions::default();
         let stmt = Statement::builder("SELECT * FROM users")
-            .with_directed_read_options(dro.clone())
+            .set_directed_read_options(dro.clone())
             .build();
         assert_eq!(stmt.directed_read_options, Some(dro));
     }
@@ -504,7 +504,7 @@ mod tests {
     fn with_query_options() -> anyhow::Result<()> {
         let query_options = QueryOptions::default().set_optimizer_version("1");
         let stmt = Statement::builder("SELECT * FROM users")
-            .with_query_options(query_options.clone())
+            .set_query_options(query_options.clone())
             .build();
         assert_eq!(
             stmt.query_options
@@ -527,7 +527,7 @@ mod tests {
     #[test]
     fn with_query_mode() -> anyhow::Result<()> {
         let stmt = Statement::builder("SELECT * FROM users")
-            .with_query_mode(QueryMode::Plan)
+            .set_query_mode(QueryMode::Plan)
             .build();
         assert_eq!(stmt.query_mode, Some(QueryMode::Plan));
 
@@ -541,7 +541,7 @@ mod tests {
         let stmt = Statement::builder("SELECT * FROM users").build();
         assert_eq!(stmt.query_mode, None);
 
-        let stmt = stmt.with_query_mode(QueryMode::Profile);
+        let stmt = stmt.set_query_mode(QueryMode::Profile);
         assert_eq!(stmt.query_mode, Some(QueryMode::Profile));
 
         let req = stmt.into_request();

--- a/src/spanner/src/timestamp_bound.rs
+++ b/src/spanner/src/timestamp_bound.rs
@@ -25,7 +25,7 @@ use std::fmt::Debug;
 /// let client = Spanner::builder().build().await.unwrap();
 /// let db = client.database_client("projects/p/instances/i/databases/d").build().await.unwrap();
 ///
-/// let tx = db.single_use().with_timestamp_bound(TimestampBound::strong()).build();
+/// let tx = db.single_use().set_timestamp_bound(TimestampBound::strong()).build();
 /// # Ok(())
 /// # }
 /// ```

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -242,7 +242,7 @@ impl TransactionRunnerBuilder {
     /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client
     ///     .read_write_transaction()
-    ///     .with_isolation_level(IsolationLevel::Serializable)
+    ///     .set_isolation_level(IsolationLevel::Serializable)
     ///     .build()
     ///     .await?;
     /// # Ok(())
@@ -250,8 +250,8 @@ impl TransactionRunnerBuilder {
     /// ```
     ///
     /// See also: <https://docs.cloud.google.com/spanner/docs/isolation-levels>
-    pub fn with_isolation_level(mut self, isolation_level: IsolationLevel) -> Self {
-        self.builder = self.builder.with_isolation_level(isolation_level);
+    pub fn set_isolation_level(mut self, isolation_level: IsolationLevel) -> Self {
+        self.builder = self.builder.set_isolation_level(isolation_level);
         self
     }
 
@@ -265,7 +265,7 @@ impl TransactionRunnerBuilder {
     /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client
     ///     .read_write_transaction()
-    ///     .with_read_lock_mode(ReadLockMode::Pessimistic)
+    ///     .set_read_lock_mode(ReadLockMode::Pessimistic)
     ///     .build()
     ///     .await?;
     /// # Ok(())
@@ -273,8 +273,8 @@ impl TransactionRunnerBuilder {
     /// ```
     ///
     /// See also: <https://docs.cloud.google.com/spanner/docs/concurrency-control>
-    pub fn with_read_lock_mode(mut self, read_lock_mode: ReadLockMode) -> Self {
-        self.builder = self.builder.with_read_lock_mode(read_lock_mode);
+    pub fn set_read_lock_mode(mut self, read_lock_mode: ReadLockMode) -> Self {
+        self.builder = self.builder.set_read_lock_mode(read_lock_mode);
         self
     }
 
@@ -286,7 +286,7 @@ impl TransactionRunnerBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client.read_write_transaction()
-    ///     .with_transaction_tag("my-tag")
+    ///     .set_transaction_tag("my-tag")
     ///     .build()
     ///     .await?;
     /// # Ok(())
@@ -296,8 +296,8 @@ impl TransactionRunnerBuilder {
     /// The tag is applied to all statements executed within the transaction.
     ///
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
-    pub fn with_transaction_tag(mut self, tag: impl Into<String>) -> Self {
-        self.builder = self.builder.with_transaction_tag(tag);
+    pub fn set_transaction_tag(mut self, tag: impl Into<String>) -> Self {
+        self.builder = self.builder.set_transaction_tag(tag);
         self
     }
 
@@ -347,14 +347,14 @@ impl TransactionRunnerBuilder {
     /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client
     ///     .read_write_transaction()
-    ///     .with_commit_priority(Priority::Low)
+    ///     .set_commit_priority(Priority::Low)
     ///     .build()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_commit_priority(mut self, priority: Priority) -> Self {
-        self.builder = self.builder.with_commit_priority(priority);
+    pub fn set_commit_priority(mut self, priority: Priority) -> Self {
+        self.builder = self.builder.set_commit_priority(priority);
         self
     }
 
@@ -368,7 +368,7 @@ impl TransactionRunnerBuilder {
     /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client
     ///     .read_write_transaction()
-    ///     .with_max_commit_delay(Duration::try_from("0.2s").unwrap())
+    ///     .set_max_commit_delay(Duration::try_from("0.2s").unwrap())
     ///     .build()
     ///     .await?;
     /// # Ok(())
@@ -380,8 +380,8 @@ impl TransactionRunnerBuilder {
     /// Increasing this value can increase throughput at the expense of latency.
     /// The value must be between 0 and 500 milliseconds. If not set, or set to 0,
     /// Spanner does not delay the commit.
-    pub fn with_max_commit_delay(mut self, delay: Duration) -> Self {
-        self.builder = self.builder.with_max_commit_delay(delay);
+    pub fn set_max_commit_delay(mut self, delay: Duration) -> Self {
+        self.builder = self.builder.set_max_commit_delay(delay);
         self
     }
 
@@ -393,7 +393,7 @@ impl TransactionRunnerBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client.read_write_transaction()
-    ///     .with_exclude_txn_from_change_streams(true)
+    ///     .set_exclude_txn_from_change_streams(true)
     ///     .build()
     ///     .await?;
     /// # Ok(())
@@ -407,8 +407,8 @@ impl TransactionRunnerBuilder {
     ///
     /// When set to `false` or not specified, modifications from this transaction are recorded in all change streams
     /// tracking columns modified by this transaction.
-    pub fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
-        self.builder = self.builder.with_exclude_txn_from_change_streams(exclude);
+    pub fn set_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.builder = self.builder.set_exclude_txn_from_change_streams(exclude);
         self
     }
 
@@ -420,7 +420,7 @@ impl TransactionRunnerBuilder {
     /// # async fn run_tx(client: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// # let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let runner = db_client.read_write_transaction()
-    ///     .with_return_commit_stats(true)
+    ///     .set_return_commit_stats(true)
     ///     .build()
     ///     .await?;
     ///
@@ -438,8 +438,8 @@ impl TransactionRunnerBuilder {
     /// ```
     ///
     /// See also: <https://docs.cloud.google.com/spanner/docs/commit-statistics>
-    pub fn with_return_commit_stats(mut self, return_stats: bool) -> Self {
-        self.builder = self.builder.with_return_commit_stats(return_stats);
+    pub fn set_return_commit_stats(mut self, return_stats: bool) -> Self {
+        self.builder = self.builder.set_return_commit_stats(return_stats);
         self
     }
 
@@ -601,7 +601,7 @@ impl TransactionRunner {
                 Err(e) => {
                     if is_aborted(&e) {
                         let current_tx_id = current_tx_id.clone();
-                        self.builder = self.builder.with_previous_transaction_id(current_tx_id);
+                        self.builder = self.builder.set_previous_transaction_id(current_tx_id);
                     }
 
                     backoff_if_aborted(
@@ -848,7 +848,7 @@ mod tests {
 
         let (db_client, _server) = setup_db_client(mock).await;
         let runner = TransactionRunnerBuilder::new(db_client)
-            .with_return_commit_stats(true)
+            .set_return_commit_stats(true)
             .with_begin_transaction_option(begin_transaction_option)
             .build()
             .await
@@ -1474,8 +1474,8 @@ mod tests {
 
         // Validate builder chaining safely accepts and compiles options dynamically
         let _runner = TransactionRunnerBuilder::new(db_client)
-            .with_isolation_level(IsolationLevel::Serializable)
-            .with_read_lock_mode(ReadLockMode::Pessimistic)
+            .set_isolation_level(IsolationLevel::Serializable)
+            .set_read_lock_mode(ReadLockMode::Pessimistic)
             .with_retry_policy(retry_policy)
             .build()
             .await
@@ -1712,7 +1712,7 @@ mod tests {
 
         let runner = TransactionRunnerBuilder::new(db_client)
             .with_begin_transaction_option(begin_transaction_option)
-            .with_transaction_tag("my-test-tag")
+            .set_transaction_tag("my-test-tag")
             .build()
             .await?;
 
@@ -1797,7 +1797,7 @@ mod tests {
         let (db_client, _server) = setup_db_client(mock).await;
 
         let runner = TransactionRunnerBuilder::new(db_client)
-            .with_exclude_txn_from_change_streams(true)
+            .set_exclude_txn_from_change_streams(true)
             .with_begin_transaction_option(begin_transaction_option)
             .build()
             .await?;
@@ -1881,7 +1881,7 @@ mod tests {
 
         let (db_client, _server) = setup_db_client(mock).await;
         let runner = TransactionRunnerBuilder::new(db_client)
-            .with_max_commit_delay(Duration::try_from("0.2s").unwrap())
+            .set_max_commit_delay(Duration::try_from("0.2s").unwrap())
             .with_begin_transaction_option(begin_transaction_option)
             .build()
             .await?;

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -65,14 +65,14 @@ impl WriteOnlyTransactionBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let transaction = db_client.write_only_transaction()
-    ///     .with_transaction_tag("my-tag")
+    ///     .set_transaction_tag("my-tag")
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
     ///
     /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
-    pub fn with_transaction_tag(mut self, tag: impl Into<String>) -> Self {
+    pub fn set_transaction_tag(mut self, tag: impl Into<String>) -> Self {
         self.transaction_tag = Some(tag.into());
         self
     }
@@ -86,12 +86,12 @@ impl WriteOnlyTransactionBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let transaction = db_client.write_only_transaction()
-    ///     .with_commit_priority(Priority::Low)
+    ///     .set_commit_priority(Priority::Low)
     ///     .build();
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_commit_priority(mut self, priority: Priority) -> Self {
+    pub fn set_commit_priority(mut self, priority: Priority) -> Self {
         self.commit_priority = priority;
         self
     }
@@ -105,7 +105,7 @@ impl WriteOnlyTransactionBuilder {
     /// # async fn sample(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let transaction = db_client.write_only_transaction()
-    ///     .with_max_commit_delay(Duration::try_from("0.1s").unwrap())
+    ///     .set_max_commit_delay(Duration::try_from("0.1s").unwrap())
     ///     .build();
     /// # Ok(())
     /// # }
@@ -116,7 +116,7 @@ impl WriteOnlyTransactionBuilder {
     /// Increasing this value can increase throughput at the expense of latency.
     /// The value must be between 0 and 500 milliseconds. If not set, or set to 0,
     /// Spanner does not delay the commit.
-    pub fn with_max_commit_delay(mut self, delay: Duration) -> Self {
+    pub fn set_max_commit_delay(mut self, delay: Duration) -> Self {
         self.max_commit_delay = Some(delay);
         self
     }
@@ -129,7 +129,7 @@ impl WriteOnlyTransactionBuilder {
     /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
     /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
     /// let transaction = db_client.write_only_transaction()
-    ///     .with_exclude_txn_from_change_streams(true)
+    ///     .set_exclude_txn_from_change_streams(true)
     ///     .build();
     /// # Ok(())
     /// # }
@@ -142,7 +142,7 @@ impl WriteOnlyTransactionBuilder {
     ///
     /// When set to `false` or not specified, modifications from this transaction are recorded in all change streams
     /// tracking columns modified by this transaction.
-    pub fn with_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+    pub fn set_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
         self.exclude_txn_from_change_streams = exclude;
         self
     }
@@ -160,7 +160,7 @@ impl WriteOnlyTransactionBuilder {
     ///     .build();
     ///
     /// let response = db.write_only_transaction()
-    ///     .with_return_commit_stats(true)
+    ///     .set_return_commit_stats(true)
     ///     .build()
     ///     .write(vec![mutation])
     ///     .await?;
@@ -173,7 +173,7 @@ impl WriteOnlyTransactionBuilder {
     /// ```
     ///
     /// See also: <https://docs.cloud.google.com/spanner/docs/commit-statistics>
-    pub fn with_return_commit_stats(mut self, return_stats: bool) -> Self {
+    pub fn set_return_commit_stats(mut self, return_stats: bool) -> Self {
         self.return_commit_stats = return_stats;
         self
     }
@@ -380,7 +380,7 @@ impl WriteOnlyTransaction {
     ///     .build();
     ///
     /// let response = db.write_only_transaction()
-    ///     .with_transaction_tag("my-tag")
+    ///     .set_transaction_tag("my-tag")
     ///     .build()
     ///     .write(vec![mutation])
     ///     .await?;
@@ -501,7 +501,7 @@ impl WriteOnlyTransaction {
     ///     .build();
     ///
     /// let response = db.write_only_transaction()
-    ///     .with_transaction_tag("my-tag")
+    ///     .set_transaction_tag("my-tag")
     ///     .build()
     ///     .write_at_least_once(vec![mutation])
     ///     .await?;
@@ -682,8 +682,8 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_transaction_tag("my_tag")
-            .with_commit_priority(Priority::High)
+            .set_transaction_tag("my_tag")
+            .set_commit_priority(Priority::High)
             .build()
             .write_at_least_once(vec![mutation])
             .await;
@@ -818,7 +818,7 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_return_commit_stats(true)
+            .set_return_commit_stats(true)
             .build()
             .write_at_least_once(vec![mutation])
             .await?;
@@ -868,7 +868,7 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_return_commit_stats(true)
+            .set_return_commit_stats(true)
             .build()
             .write(vec![mutation])
             .await?;
@@ -919,7 +919,7 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_exclude_txn_from_change_streams(true)
+            .set_exclude_txn_from_change_streams(true)
             .build()
             .write_at_least_once(vec![mutation])
             .await;
@@ -973,7 +973,7 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_exclude_txn_from_change_streams(true)
+            .set_exclude_txn_from_change_streams(true)
             .build()
             .write(vec![mutation])
             .await;
@@ -1151,8 +1151,8 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_return_commit_stats(true)
-            .with_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
+            .set_return_commit_stats(true)
+            .set_max_commit_delay(Duration::new(0, 200_000_000).expect("valid duration"))
             .build()
             .write(vec![mutation])
             .await?;
@@ -1300,7 +1300,7 @@ mod tests {
 
         let res = db_client
             .write_only_transaction()
-            .with_max_commit_delay(Duration::try_from("0.1s").unwrap())
+            .set_max_commit_delay(Duration::try_from("0.1s").unwrap())
             .build()
             .write_at_least_once(vec![mutation])
             .await;

--- a/tests/spanner/src/batch_dml.rs
+++ b/tests/spanner/src/batch_dml.rs
@@ -42,7 +42,7 @@ pub async fn successful_batch_update(db_client: &DatabaseClient) -> anyhow::Resu
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("batch-success-tag")
+        .set_transaction_tag("batch-success-tag")
         .build()
         .await?;
 
@@ -128,7 +128,7 @@ pub async fn partial_batch_update_failure(db_client: &DatabaseClient) -> anyhow:
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("batch-partial-tag")
+        .set_transaction_tag("batch-partial-tag")
         .build()
         .await?;
 
@@ -179,7 +179,7 @@ pub async fn partial_batch_update_failure(db_client: &DatabaseClient) -> anyhow:
 pub async fn empty_batch_statement_rejection(db_client: &DatabaseClient) -> anyhow::Result<()> {
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("batch-empty-tag")
+        .set_transaction_tag("batch-empty-tag")
         .build()
         .await?;
 
@@ -207,7 +207,7 @@ pub async fn empty_batch_statement_rejection(db_client: &DatabaseClient) -> anyh
 pub async fn unsupported_query_in_batch_dml(db_client: &DatabaseClient) -> anyhow::Result<()> {
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("batch-query-tag")
+        .set_transaction_tag("batch-query-tag")
         .build()
         .await?;
 
@@ -252,7 +252,7 @@ pub async fn unsupported_returning_clause(db_client: &DatabaseClient) -> anyhow:
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("batch-returning-tag")
+        .set_transaction_tag("batch-returning-tag")
         .build()
         .await?;
 
@@ -292,7 +292,7 @@ pub async fn continue_after_empty_batch_statement(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("continue-empty-tag")
+        .set_transaction_tag("continue-empty-tag")
         .build()
         .await?;
 
@@ -340,7 +340,7 @@ pub async fn continue_after_invalid_first_statement_in_batch(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("continue-invalid-tag")
+        .set_transaction_tag("continue-invalid-tag")
         .build()
         .await?;
 
@@ -406,7 +406,7 @@ pub async fn continue_after_invalid_second_statement_in_batch(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("continue-second-invalid-tag")
+        .set_transaction_tag("continue-second-invalid-tag")
         .build()
         .await?;
 

--- a/tests/spanner/src/batch_read_only_transaction.rs
+++ b/tests/spanner/src/batch_read_only_transaction.rs
@@ -247,7 +247,7 @@ pub async fn partition_tuning_and_data_boost(db_client: &DatabaseClient) -> anyh
         .expect("Failed to create executor database client");
     let mut rows_received = 0;
     for partition in partitions {
-        let boosted_partition = partition.with_data_boost(true);
+        let boosted_partition = partition.set_data_boost(true);
         let mut result_set = boosted_partition.execute(&execution_client).await?;
         while let Some(row) = result_set.next().await.transpose()? {
             rows_received += 1;

--- a/tests/spanner/src/concurrent_inline_begin.rs
+++ b/tests/spanner/src/concurrent_inline_begin.rs
@@ -213,7 +213,7 @@ pub async fn test_concurrent_inline_begin_with_snapshot_consistency() -> anyhow:
     // 6. Spawn 20 tasks with random workloads
     let tx = intercepted_db
         .read_only_transaction()
-        .with_timestamp_bound(TimestampBound::read_timestamp(snapshot_time))
+        .set_timestamp_bound(TimestampBound::read_timestamp(snapshot_time))
         .with_begin_transaction_option(BeginTransactionOption::InlineBegin)
         .build()
         .await?;

--- a/tests/spanner/src/directed_read.rs
+++ b/tests/spanner/src/directed_read.rs
@@ -24,7 +24,7 @@ pub async fn read_only_with_directed_read(db_client: &DatabaseClient) -> anyhow:
 
     let read = ReadRequest::builder("AllTypes", vec!["Id"])
         .with_keys(KeySet::all())
-        .with_directed_read_options(dro)
+        .set_directed_read_options(dro)
         .build();
 
     let mut result_set = db_client
@@ -47,7 +47,7 @@ pub async fn read_write_with_directed_read_error(db_client: &DatabaseClient) -> 
 
     let read = ReadRequest::builder("AllTypes", vec!["Id"])
         .with_keys(KeySet::all())
-        .with_directed_read_options(dro)
+        .set_directed_read_options(dro)
         .build();
 
     // Read-write transaction runner

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -609,7 +609,7 @@ pub async fn query_with_options(db_client: &DatabaseClient) -> anyhow::Result<()
     let sql = "SELECT 1";
     let query_options = QueryOptions::default().set_optimizer_version("1");
     let stmt = Statement::builder(sql)
-        .with_query_options(query_options)
+        .set_query_options(query_options)
         .build();
 
     let mut rs = rot.execute_query(stmt).await?;
@@ -625,7 +625,7 @@ pub async fn query_plan(db_client: &DatabaseClient) -> anyhow::Result<()> {
 
     let sql = "SELECT 1 as num";
     let stmt = Statement::builder(sql)
-        .with_query_mode(QueryMode::Plan)
+        .set_query_mode(QueryMode::Plan)
         .build();
 
     let mut rs = rot.execute_query(stmt).await?;
@@ -658,7 +658,7 @@ pub async fn query_profile(db_client: &DatabaseClient) -> anyhow::Result<()> {
 
     let sql = "SELECT 1 as num";
     let stmt = Statement::builder(sql)
-        .with_query_mode(QueryMode::Profile)
+        .set_query_mode(QueryMode::Profile)
         .build();
 
     let mut rs = rot.execute_query(stmt).await?;
@@ -682,7 +682,7 @@ pub async fn dml_plan(db_client: &DatabaseClient) -> anyhow::Result<()> {
         .run(async |tx| {
             let sql = "UPDATE AllTypes SET ColBool = TRUE WHERE Id = @id";
             let stmt = Statement::builder(sql)
-                .with_query_mode(QueryMode::Plan)
+                .set_query_mode(QueryMode::Plan)
                 .build();
 
             let mut rs = tx.execute_query(stmt).await?;

--- a/tests/spanner/src/read.rs
+++ b/tests/spanner/src/read.rs
@@ -210,7 +210,7 @@ pub async fn read_with_limit(db_client: &DatabaseClient) -> anyhow::Result<()> {
 
     let read = ReadRequest::builder("AllTypes", vec!["Id", "ColString"])
         .with_keys(keyset)
-        .with_limit(2) // limit to 2 rows
+        .set_limit(2) // limit to 2 rows
         .build();
 
     let mut result_set = db_client

--- a/tests/spanner/src/read_only_transaction_options.rs
+++ b/tests/spanner/src/read_only_transaction_options.rs
@@ -24,7 +24,7 @@ pub async fn read_only_bounded_staleness(db_client: &DatabaseClient) -> anyhow::
     // 1. Strong read-only transaction (Default / Strong)
     let tx = db_client
         .read_only_transaction()
-        .with_timestamp_bound(TimestampBound::strong())
+        .set_timestamp_bound(TimestampBound::strong())
         .build()
         .await?;
 
@@ -83,7 +83,7 @@ pub async fn read_only_bounded_staleness(db_client: &DatabaseClient) -> anyhow::
     // Query the database at the exact past timestamp.
     let tx = db_client
         .read_only_transaction()
-        .with_timestamp_bound(TimestampBound::read_timestamp(spanner_now_wkt))
+        .set_timestamp_bound(TimestampBound::read_timestamp(spanner_now_wkt))
         .build()
         .await?;
 
@@ -102,7 +102,7 @@ pub async fn read_only_bounded_staleness(db_client: &DatabaseClient) -> anyhow::
     // 3. Exact staleness (1 second)
     let tx = db_client
         .read_only_transaction()
-        .with_timestamp_bound(TimestampBound::exact_staleness(Duration::from_secs(1)))
+        .set_timestamp_bound(TimestampBound::exact_staleness(Duration::from_secs(1)))
         .build()
         .await?;
 
@@ -140,7 +140,7 @@ pub async fn read_only_bounded_staleness(db_client: &DatabaseClient) -> anyhow::
     let spanner_now_minus_5 = spanner_now - time::Duration::seconds(5);
     let tx = db_client
         .single_use()
-        .with_timestamp_bound(TimestampBound::min_read_timestamp(spanner_now_minus_5))
+        .set_timestamp_bound(TimestampBound::min_read_timestamp(spanner_now_minus_5))
         .build();
 
     let mut rs = tx
@@ -152,7 +152,7 @@ pub async fn read_only_bounded_staleness(db_client: &DatabaseClient) -> anyhow::
     // Note: max_staleness can only be set for single-use read-only transactions.
     let tx = db_client
         .single_use()
-        .with_timestamp_bound(TimestampBound::max_staleness(Duration::from_secs(5)))
+        .set_timestamp_bound(TimestampBound::max_staleness(Duration::from_secs(5)))
         .build();
 
     let mut rs = tx

--- a/tests/spanner/src/read_write_transaction.rs
+++ b/tests/spanner/src/read_write_transaction.rs
@@ -34,14 +34,14 @@ pub async fn successful_read_write_transaction(db_client: &DatabaseClient) -> an
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("success-tag")
+        .set_transaction_tag("success-tag")
         .build()
         .await?;
     runner
         .run(async |transaction| {
             let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
                 .add_param("id", &id)
-                .with_request_tag("select-tag")
+                .set_request_tag("select-tag")
                 .build();
             let mut result_set = transaction.execute_query(statement).await?;
             let row = result_set
@@ -55,7 +55,7 @@ pub async fn successful_read_write_transaction(db_client: &DatabaseClient) -> an
                 Statement::builder("UPDATE AllTypes SET ColInt64 = @new_val WHERE Id = @id")
                     .add_param("new_val", &(current_val + 50))
                     .add_param("id", &id)
-                    .with_request_tag("update-tag")
+                    .set_request_tag("update-tag")
                     .build();
             transaction.execute_update(update_statement).await?;
 
@@ -101,14 +101,14 @@ pub async fn rolled_back_read_write_transaction(db_client: &DatabaseClient) -> a
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("rollback-tag")
+        .set_transaction_tag("rollback-tag")
         .build()
         .await?;
     let res: google_cloud_spanner::Result<()> = runner
         .run(async |transaction| {
             let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
                 .add_param("id", &id)
-                .with_request_tag("select-tag")
+                .set_request_tag("select-tag")
                 .build();
             let mut result_set = transaction.execute_query(statement).await?;
             let row = result_set
@@ -122,7 +122,7 @@ pub async fn rolled_back_read_write_transaction(db_client: &DatabaseClient) -> a
                 Statement::builder("UPDATE AllTypes SET ColInt64 = @new_val WHERE Id = @id")
                     .add_param("new_val", &(current_val + 50))
                     .add_param("id", &id)
-                    .with_request_tag("update-tag")
+                    .set_request_tag("update-tag")
                     .build();
             transaction.execute_update(update_statement).await?;
 
@@ -200,7 +200,7 @@ pub async fn concurrent_read_write_transaction_retries(
 
             let runner = client
                 .read_write_transaction()
-                .with_transaction_tag("concurrent-tag")
+                .set_transaction_tag("concurrent-tag")
                 .build()
                 .await
                 .expect("Failed to build transaction runner");
@@ -218,7 +218,7 @@ pub async fn concurrent_read_write_transaction_retries(
                         )
                         .add_param("start", &start_id)
                         .add_param("end", &end_id)
-                        .with_request_tag("concurrent-select")
+                        .set_request_tag("concurrent-select")
                         .build()
                     };
                     let mut result_set = transaction.execute_query(statement).await?;
@@ -234,7 +234,7 @@ pub async fn concurrent_read_write_transaction_retries(
                         )
                         .add_param("inc", &50_i64)
                         .add_param("id", &update_id)
-                        .with_request_tag("concurrent-update")
+                        .set_request_tag("concurrent-update")
                         .build()
                     };
                     transaction.execute_update(update_statement).await?;
@@ -296,7 +296,7 @@ pub async fn read_write_transaction_with_mutations(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("mutations-tag")
+        .set_transaction_tag("mutations-tag")
         .build()
         .await?;
     runner
@@ -363,7 +363,7 @@ pub async fn read_write_transaction_mutation_only(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("only-mutations-tag")
+        .set_transaction_tag("only-mutations-tag")
         .build()
         .await?;
     runner
@@ -423,7 +423,7 @@ pub async fn read_write_transaction_multiple_queries_and_dml(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("multi-query-tag")
+        .set_transaction_tag("multi-query-tag")
         .build()
         .await?;
     runner
@@ -514,7 +514,7 @@ pub async fn consecutive_reads(db_client: &DatabaseClient) -> anyhow::Result<()>
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("consecutive-reads-tag")
+        .set_transaction_tag("consecutive-reads-tag")
         .build()
         .await?;
 
@@ -602,7 +602,7 @@ pub async fn mixed_reads_and_queries(db_client: &DatabaseClient) -> anyhow::Resu
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("mixed-operations-tag")
+        .set_transaction_tag("mixed-operations-tag")
         .build()
         .await?;
 
@@ -689,7 +689,7 @@ pub async fn multiple_execute_updates(db_client: &DatabaseClient) -> anyhow::Res
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("multiple-updates-tag")
+        .set_transaction_tag("multiple-updates-tag")
         .build()
         .await?;
 
@@ -761,7 +761,7 @@ pub async fn read_your_writes_consistency(db_client: &DatabaseClient) -> anyhow:
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("read-your-writes-tag")
+        .set_transaction_tag("read-your-writes-tag")
         .build()
         .await?;
 
@@ -826,7 +826,7 @@ pub async fn buffered_mutation_interleaving(db_client: &DatabaseClient) -> anyho
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("buffered-interleaving-tag")
+        .set_transaction_tag("buffered-interleaving-tag")
         .build()
         .await?;
 
@@ -872,7 +872,7 @@ pub async fn buffered_mutation_interleaving(db_client: &DatabaseClient) -> anyho
 pub async fn initial_statement_failure_handling(db_client: &DatabaseClient) -> anyhow::Result<()> {
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("initial-fail-tag")
+        .set_transaction_tag("initial-fail-tag")
         .build()
         .await?;
 
@@ -923,7 +923,7 @@ pub async fn intermediate_statement_constraint_error(
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("constraint-error-tag")
+        .set_transaction_tag("constraint-error-tag")
         .build()
         .await?;
 
@@ -975,7 +975,7 @@ pub async fn buffered_mutation_commit_rejection(db_client: &DatabaseClient) -> a
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("commit-rejection-tag")
+        .set_transaction_tag("commit-rejection-tag")
         .build()
         .await?;
 
@@ -1026,7 +1026,7 @@ pub async fn application_error_explicit_rollback(db_client: &DatabaseClient) -> 
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("explicit-rollback-tag")
+        .set_transaction_tag("explicit-rollback-tag")
         .build()
         .await?;
 
@@ -1096,7 +1096,7 @@ pub async fn continue_after_initial_query_error(db_client: &DatabaseClient) -> a
 
     let runner = db_client
         .read_write_transaction()
-        .with_transaction_tag("continue-after-err-tag")
+        .set_transaction_tag("continue-after-err-tag")
         .build()
         .await?;
 

--- a/tests/spanner/src/read_write_transaction_options.rs
+++ b/tests/spanner/src/read_write_transaction_options.rs
@@ -47,10 +47,10 @@ pub async fn runner_commit_configurations(db_client: &DatabaseClient) -> anyhow:
 
     let runner = db_client
         .read_write_transaction()
-        .with_commit_priority(Priority::Low)
-        .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
-        .with_exclude_txn_from_change_streams(true)
-        .with_return_commit_stats(true)
+        .set_commit_priority(Priority::Low)
+        .set_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+        .set_exclude_txn_from_change_streams(true)
+        .set_return_commit_stats(true)
         .build()
         .await?;
 

--- a/tests/spanner/src/write.rs
+++ b/tests/spanner/src/write.rs
@@ -209,7 +209,7 @@ async fn write_internal(
 
     let write_tx = db_client
         .write_only_transaction()
-        .with_transaction_tag("write-only-tag")
+        .set_transaction_tag("write-only-tag")
         .build();
     let commit_ts = match method {
         WriteMethod::WriteAtLeastOnce => write_tx.write_at_least_once(vec![m1, m2]).await?,

--- a/tests/spanner/src/write_only_transaction_options.rs
+++ b/tests/spanner/src/write_only_transaction_options.rs
@@ -75,10 +75,10 @@ pub async fn write_only_commit_configurations(db_client: &DatabaseClient) -> any
     run_write_only_options_test(db_client, "wo-conf", 101, |client, mutations| {
         client
             .write_only_transaction()
-            .with_commit_priority(Priority::Low)
-            .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
-            .with_exclude_txn_from_change_streams(true)
-            .with_return_commit_stats(true)
+            .set_commit_priority(Priority::Low)
+            .set_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+            .set_exclude_txn_from_change_streams(true)
+            .set_return_commit_stats(true)
             .build()
             .write(mutations)
     })
@@ -91,10 +91,10 @@ pub async fn write_only_at_least_once_commit_configurations(
     run_write_only_options_test(db_client, "wo-least-once", 202, |client, mutations| {
         client
             .write_only_transaction()
-            .with_commit_priority(Priority::Low)
-            .with_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
-            .with_exclude_txn_from_change_streams(true)
-            .with_return_commit_stats(true)
+            .set_commit_priority(Priority::Low)
+            .set_max_commit_delay(WktDuration::try_from("0.2s").expect("valid wkt duration"))
+            .set_exclude_txn_from_change_streams(true)
+            .set_return_commit_stats(true)
             .build()
             .write_at_least_once(mutations)
     })


### PR DESCRIPTION
Align handwritten Cloud Spanner client builders with workspace conventions:
- Rename payload/domain field setters from `with_foo` to `set_foo`.
- Retain `with_foo` prefix for client-side and runtime configuration setters (e.g., retry/backoff policies, timeouts, begin options).
- Update all internal unit tests, doc comments, and code examples to use the updated builder setter API.
- Refactor all integration tests to match the renamed builder setter methods.

Fixes #5579