### PR TITLE
chore(spanner): prepare for preview release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-spanner"
-version = "0.0.0"
+version = "0.34.0-preview"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1366,9 +1366,9 @@ libraries:
       - googleapis
     skip_release: true
   - name: google-cloud-spanner
+    version: 0.34.0-preview
     copyright_year: "2026"
     output: src/spanner
-    skip_release: true
     rust:
       modules:
         - module_path: crate::generated::gapic_dataplane::model

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 name        = "google-cloud-spanner"
 publish     = false
-version     = "0.0.0"
+version     = "0.34.0-preview"
 description = "Google Cloud Client Libraries for Rust - Spanner"
 # Inherit other attributes from the workspace.
 edition.workspace      = true

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -14,7 +14,6 @@
 
 [package]
 name        = "google-cloud-spanner"
-publish     = false
 version     = "0.34.0-preview"
 description = "Google Cloud Client Libraries for Rust - Spanner"
 # Inherit other attributes from the workspace.

--- a/src/spanner/README.md
+++ b/src/spanner/README.md
@@ -2,9 +2,10 @@
 
 This crate implements the [Spanner] client library.
 
-**WARNING:** this crate is under active development. We expect multiple breaking
-changes in the upcoming releases. Testing is also incomplete, we do **not**
-recommend that you use this crate in production. We welcome feedback about the
-APIs, documentation, missing features, bugs, etc.
+**WARNING:** this is a preview release of the crate. We believe the APIs to be
+stable. We also are seeking feedback about the APIs and may need to make
+breaking changes if we discover that some parts are hard to use.
+
+We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 
 [spanner]: https://cloud.google.com/spanner

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -14,10 +14,11 @@
 
 //! Google Cloud Client Libraries for Rust - Spanner
 //!
-//! **WARNING:** this crate is under active development. We expect multiple
-//! breaking changes in the upcoming releases. Testing is also incomplete, we do
-//! **not** recommend that you use this crate in production. We welcome feedback
-//! about the APIs, documentation, missing features, bugs, etc.
+//! **WARNING:** this is a preview release of the crate. We believe the APIs to be stable. We also
+//! are seeking feedback about the APIs and may need to make breaking changes if we discover that
+//! some parts are hard to use.
+//!
+//! We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 
 pub use batch_dml::BatchDml;
 pub use batch_dml::BatchDmlBuilder;


### PR DESCRIPTION
Update the version number to be higher than the existing `google-cloud-spanner` crate.

Use `*-preview` to minimize the impact of breaking changes.

Update the README and lib.rs documentation to describe the status.