### PR TITLE
fix(o11y): record `gcp.resource.destination.id` on T3 client request spans

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -724,6 +724,10 @@ mod tests {
                 ("server.address", "example.com"),
                 ("server.port", "443"),
                 ("url.full", "/google.test.v1.EchoService/Echo"),
+                (
+                    "gcp.resource.destination.id",
+                    "//test.googleapis.com/test-only",
+                ),
             ]
             .map(|(k, v)| (k, v.to_string())),
         );

--- a/src/gax-internal/src/observability/client_signals/with_client_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_span.rs
@@ -19,9 +19,10 @@
 use super::RequestRecorder;
 use crate::observability::attributes::SCHEMA_URL_VALUE;
 use crate::observability::attributes::keys::{
-    ERROR_TYPE, GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_VERSION, GCP_SCHEMA_URL,
-    HTTP_REQUEST_METHOD, HTTP_REQUEST_RESEND_COUNT, NETWORK_PEER_ADDRESS, NETWORK_PEER_PORT,
-    OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION, RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
+    ERROR_TYPE, GCP_CLIENT_ARTIFACT, GCP_CLIENT_REPO, GCP_CLIENT_VERSION,
+    GCP_RESOURCE_DESTINATION_ID, GCP_SCHEMA_URL, HTTP_REQUEST_METHOD, HTTP_REQUEST_RESEND_COUNT,
+    NETWORK_PEER_ADDRESS, NETWORK_PEER_PORT, OTEL_STATUS_CODE, OTEL_STATUS_DESCRIPTION,
+    RPC_RESPONSE_STATUS_CODE, RPC_SYSTEM_NAME,
 };
 use crate::observability::attributes::otel_status_codes;
 use crate::observability::errors::ErrorType;
@@ -85,6 +86,7 @@ where
                     { HTTP_RESPONSE_STATUS_CODE } = snapshot.http_status_code().map(|v| v as i64),
                     { HTTP_REQUEST_METHOD } = snapshot.http_method(),
                     { HTTP_REQUEST_RESEND_COUNT } = snapshot.http_resend_count().map(|v| v as i64),
+                    { GCP_RESOURCE_DESTINATION_ID } = snapshot.resource_name(),
                     { OTEL_STATUS_CODE } = otel_status_codes::UNSET
                 );
             }
@@ -110,6 +112,7 @@ where
                     { HTTP_RESPONSE_STATUS_CODE } = snapshot.http_status_code().map(|v| v as i64),
                     { HTTP_REQUEST_METHOD } = snapshot.http_method(),
                     { HTTP_REQUEST_RESEND_COUNT } = snapshot.http_resend_count().map(|v| v as i64),
+                    { GCP_RESOURCE_DESTINATION_ID } = snapshot.resource_name(),
                     { OTEL_STATUS_CODE } = otel_status_codes::ERROR,
                     { OTEL_STATUS_DESCRIPTION } = error.to_string()
                 );
@@ -187,6 +190,10 @@ mod tests {
                 ("server.address", "example.com"),
                 ("server.port", "443"),
                 ("url.full", "https://example.com/"),
+                (
+                    "gcp.resource.destination.id",
+                    "//test.googleapis.com/test-only",
+                ),
             ]
             .map(|(k, v)| (k, v.to_string())),
         );
@@ -257,6 +264,10 @@ mod tests {
                 ("error.type", "404"),
                 ("http.request.method", "GET"),
                 ("http.response.status_code", "404"),
+                (
+                    "gcp.resource.destination.id",
+                    "//test.googleapis.com/test-only",
+                ),
             ]
             .into_iter()
             .map(|(k, v)| (k, v.to_string()))

--- a/src/gax-internal/tests/http_observability.rs
+++ b/src/gax-internal/tests/http_observability.rs
@@ -497,6 +497,7 @@ mod tests {
             ("network.peer.address", server_addr.ip().to_string().into()),
             ("network.peer.port", (server_addr.port() as i64).into()),
             ("url.full", format!("{}/test", server_url).into()),
+            ("gcp.resource.destination.id", TEST_RESOURCE.into()),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -558,6 +559,7 @@ mod tests {
             ("url.full", "https://127.0.0.1:1/test".into()),
             ("http.request.method", "GET".into()),
             ("otel.status_code", "ERROR".into()),
+            ("gcp.resource.destination.id", TEST_RESOURCE.into()),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -608,6 +610,7 @@ mod tests {
             ("url.full", format!("{}/test", server_url).into()),
             ("http.request.method", "GET".into()),
             ("otel.status_code", "UNSET".into()),
+            ("gcp.resource.destination.id", TEST_RESOURCE.into()),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -651,6 +654,7 @@ mod tests {
             ("http.request.method", "GET".into()),
             ("otel.status_code", "ERROR".into()),
             ("error.type", "CLIENT_CONNECTION_ERROR".into()),
+            ("gcp.resource.destination.id", TEST_RESOURCE.into()),
         ]
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))


### PR DESCRIPTION
The `client_request_signals!` macro pre-registered `"gcp.resource.destination.id" = Empty` during span creation, but it was never recorded. This PR fixes that gap  by recording `gcp.resource.destination.id` on T3 client-level request spans.