### PR TITLE
impl(o11y): consolidate LRO span and attempt count under `LroRecorder`

### DIFF
--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -36,6 +36,6 @@ pub use either::Either;
 #[cfg(google_cloud_unstable_tracing)]
 pub use ext::{PollerExt, PollerOptions, TracingDetails};
 #[cfg(google_cloud_unstable_tracing)]
-pub(crate) use tracing::LroRecorder;
+pub use tracing::LroRecorder;
 #[cfg(google_cloud_unstable_tracing)]
 pub use tracing::Tracing;

--- a/src/lro/src/internal/aip151.rs
+++ b/src/lro/src/internal/aip151.rs
@@ -27,6 +27,9 @@ use google_cloud_wkt::Empty;
 use google_cloud_wkt::message::Message;
 use std::sync::Arc;
 
+#[cfg(google_cloud_unstable_tracing)]
+use super::LroRecorder;
+
 pub type Operation<R, M> = crate::details::Operation<R, M>;
 
 /// Creates a new `impl Poller<R, M>` from the closures created by the generator.
@@ -281,7 +284,7 @@ where
             #[cfg(google_cloud_unstable_tracing)]
             if let Ok(ref op) = result {
                 let name = op.name();
-                if let Some(recorder) = crate::internal::LroRecorder::current() {
+                if let Some(recorder) = LroRecorder::current() {
                     recorder.record_destination_id(&name);
                 }
             }
@@ -295,10 +298,8 @@ where
             let (op, poll) =
                 crate::details::handle_poll(self.error_policy.clone(), &self.state, name, result);
             #[cfg(google_cloud_unstable_tracing)]
-            if let Some(ref next_name) = op {
-                if let Some(recorder) = crate::internal::LroRecorder::current() {
-                    recorder.record_destination_id(next_name);
-                }
+            if let (Some(next_name), Some(recorder)) = (&op, LroRecorder::current()) {
+                recorder.record_destination_id(next_name);
             }
             self.operation = op;
             return Some(poll);

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -31,6 +31,9 @@ use google_cloud_gax::polling_state::PollingState;
 use google_cloud_gax::retry_result::RetryResult;
 use std::sync::Arc;
 
+#[cfg(google_cloud_unstable_tracing)]
+use super::LroRecorder;
+
 /// Defines the trait for an "Operation" type in the discovery poller.
 ///
 /// In discovery-based services each client library defines a different type as
@@ -120,10 +123,9 @@ where
             let result = start().await;
             #[cfg(google_cloud_unstable_tracing)]
             if let Ok(ref op) = result {
-                if let Some(name) = op.name() {
-                    if let Some(recorder) = crate::internal::LroRecorder::current() {
-                        recorder.record_destination_id(name);
-                    }
+                let name = op.name();
+                if let (Some(name), Some(recorder)) = (name, LroRecorder::current()) {
+                    recorder.record_destination_id(name);
                 }
             }
             let (op, poll) = self::handle_start(result);
@@ -136,10 +138,8 @@ where
             let (op, poll) =
                 self::handle_poll(self.error_policy.clone(), &self.state, name, result);
             #[cfg(google_cloud_unstable_tracing)]
-            if let Some(ref next_name) = op {
-                if let Some(recorder) = crate::internal::LroRecorder::current() {
-                    recorder.record_destination_id(next_name);
-                }
+            if let (Some(next_name), Some(recorder)) = (&op, LroRecorder::current()) {
+                recorder.record_destination_id(next_name);
             }
             self.operation = op;
             return Some(poll);

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -29,6 +29,7 @@ tokio::task_local! {
 /// during a polling cycle) are performed using copy-on-write builders (`with_attempt_count`)
 /// to establish new immutable task-local scopes.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct LroRecorder {
     span: Span,
     attempt_count: Option<u32>,

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -17,20 +17,6 @@ use google_cloud_gax::polling_state::PollingState;
 use tracing::{Instrument, Span, info_span};
 
 #[cfg(google_cloud_unstable_tracing)]
-use crate::POLL_ATTEMPT_COUNT;
-
-#[cfg(google_cloud_unstable_tracing)]
-tokio::task_local! {
-    /// A task-local context propagating the active LRO `Span`.
-    ///
-    /// This is accessed across module boundaries to dynamically retrieve the
-    /// active span context, allowing the inner pollers to record the LRO's actual
-    /// operation name/resource destination ID when first fetched, without requiring
-    /// passing tracing parameters through all method signatures.
-    pub(crate) static LRO_SPAN: Span;
-}
-
-#[cfg(google_cloud_unstable_tracing)]
 tokio::task_local! {
     static LRO_RECORDER: LroRecorder;
 }
@@ -38,19 +24,24 @@ tokio::task_local! {
 #[cfg(google_cloud_unstable_tracing)]
 /// A recorder that manages LRO spans and propagates active telemetry context.
 ///
-/// Since `LroRecorder` is cloned to establish task-local scopes (like `LRO_RECORDER`),
-/// it is designed to be completely **stateless** and read-only, wrapping only the active LRO `Span`.
-/// Stateful counting (e.g., `poll_attempt_count`) is managed entirely on the decorator itself,
-/// completely eliminating any risk of divergent state or cloning race conditions.
+/// To prevent concurrent mutation race conditions under multi-threaded tokio executors,
+/// `LroRecorder` is completely immutable. Context updates (like setting the transient `attempt_count`
+/// during a polling cycle) are performed using copy-on-write builders (`with_attempt_count`)
+/// to establish new immutable task-local scopes.
 #[derive(Clone, Debug)]
-pub(crate) struct LroRecorder {
+pub struct LroRecorder {
     span: Span,
+    attempt_count: Option<u32>,
 }
 
 #[cfg(google_cloud_unstable_tracing)]
 impl LroRecorder {
+    /// Creates a new `LroRecorder` wrapping the given tracing `Span`.
     pub fn new(span: Span) -> Self {
-        Self { span }
+        Self {
+            span,
+            attempt_count: None,
+        }
     }
 
     /// Returns the recorder in the current task scope.
@@ -66,8 +57,25 @@ impl LroRecorder {
         LRO_RECORDER.scope(self.clone(), future).await
     }
 
+    /// Returns the active LRO tracing `Span` wrapped by this recorder.
     pub fn span(&self) -> &Span {
         &self.span
+    }
+
+    /// Returns the current LRO polling attempt count, if active.
+    pub fn attempt_count(&self) -> Option<u32> {
+        self.attempt_count
+    }
+
+    /// Creates a new clone of `LroRecorder` carrying the specified LRO polling attempt count.
+    ///
+    /// Since `LroRecorder` is immutable to guarantee thread-safety, this updates the context
+    /// via copy-on-write, returning a new value to be bound to a new task-local scope.
+    pub fn with_attempt_count(&self, count: u32) -> Self {
+        Self {
+            span: self.span.clone(),
+            attempt_count: Some(count),
+        }
     }
 
     pub fn record_destination_id(&self, name: &str) {
@@ -163,14 +171,11 @@ where
             let inner = &mut self.inner;
             let span = self.recorder.span().clone();
 
-            // We map both the stateless LRO span context scope AND the transient POLL_ATTEMPT_COUNT
-            // task-local key (using our stateful `attempt` count) for the duration of the active poll future.
-            self.recorder
-                .scope(async move {
-                    POLL_ATTEMPT_COUNT
-                        .scope(attempt, async move { inner.poll().instrument(span).await })
-                        .await
-                })
+            // We map the consolidated LroRecorder (holding the active LRO span and stateful attempt count)
+            // for the duration of the active poll future.
+            let recorder = self.recorder.with_attempt_count(attempt);
+            recorder
+                .scope(async move { inner.poll().instrument(span).await })
                 .await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
@@ -283,7 +288,9 @@ mod tests {
     #[cfg(google_cloud_unstable_tracing)]
     impl Poller<Duration, Timestamp> for CountingPoller {
         async fn poll(&mut self) -> Option<PollingResult<Duration, Timestamp>> {
-            let attempt = POLL_ATTEMPT_COUNT.try_with(|c| *c).unwrap();
+            let attempt = LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .unwrap();
             self.attempts.push(attempt);
             Some(PollingResult::InProgress(None))
         }

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -16,12 +16,10 @@ use crate::{Poller, PollingResult, Result, sealed};
 use google_cloud_gax::polling_state::PollingState;
 use tracing::{Instrument, Span, info_span};
 
-#[cfg(google_cloud_unstable_tracing)]
 tokio::task_local! {
     static LRO_RECORDER: LroRecorder;
 }
 
-#[cfg(google_cloud_unstable_tracing)]
 /// A recorder that manages LRO spans and propagates active telemetry context.
 ///
 /// To prevent concurrent mutation race conditions under multi-threaded tokio executors,
@@ -35,7 +33,6 @@ pub struct LroRecorder {
     attempt_count: Option<u32>,
 }
 
-#[cfg(google_cloud_unstable_tracing)]
 impl LroRecorder {
     /// Creates a new `LroRecorder` wrapping the given tracing `Span`.
     pub fn new(span: Span) -> Self {
@@ -105,29 +102,19 @@ impl LroRecorder {
 #[derive(Clone, Debug)]
 pub struct Tracing<P> {
     inner: P,
-    #[cfg(google_cloud_unstable_tracing)]
     recorder: LroRecorder,
     /// Stateful count of poll attempts managed directly on the decorator.
-    #[cfg(google_cloud_unstable_tracing)]
     poll_attempt_count: u32,
-    #[cfg(google_cloud_unstable_tracing)]
     started: bool,
-    #[cfg(not(google_cloud_unstable_tracing))]
-    span: Span,
 }
 
 impl<P> Tracing<P> {
     pub(crate) fn new(inner: P, span: Span) -> Self {
         Self {
             inner,
-            #[cfg(google_cloud_unstable_tracing)]
             recorder: LroRecorder::new(span),
-            #[cfg(google_cloud_unstable_tracing)]
             poll_attempt_count: 0,
-            #[cfg(google_cloud_unstable_tracing)]
             started: false,
-            #[cfg(not(google_cloud_unstable_tracing))]
-            span,
         }
     }
 }
@@ -138,18 +125,10 @@ where
 {
     async fn backoff(&mut self, state: &PollingState) {
         let span = info_span!("LRO Sleep");
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let inner = &mut self.inner;
-            return self
-                .recorder
-                .record_action(|_| async move { inner.backoff(state).instrument(span).await })
-                .await;
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        {
-            self.inner.backoff(state).await
-        }
+        let inner = &mut self.inner;
+        self.recorder
+            .record_action(|_| async move { inner.backoff(state).instrument(span).await })
+            .await
     }
 }
 
@@ -160,53 +139,39 @@ where
     MetadataType: Send,
 {
     async fn poll(&mut self) -> Option<PollingResult<ResponseType, MetadataType>> {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            // Stateful count of poll attempts is managed directly on the decorator instance,
-            // which is called via `&mut self` and is safe from divergent mutations.
-            let attempt = if self.started {
-                self.poll_attempt_count += 1;
-                self.poll_attempt_count
-            } else {
-                self.started = true;
-                0 // Initial triggers record nothing
-            };
+        // Stateful count of poll attempts is managed directly on the decorator instance,
+        // which is called via `&mut self` and is safe from divergent mutations.
+        let attempt = if self.started {
+            self.poll_attempt_count += 1;
+            self.poll_attempt_count
+        } else {
+            self.started = true;
+            0 // Initial triggers record nothing
+        };
 
-            let inner = &mut self.inner;
-            let span = self.recorder.span().clone();
+        let inner = &mut self.inner;
+        let span = self.recorder.span().clone();
 
-            // We map the consolidated LroRecorder (holding the active LRO span and stateful attempt count)
-            // for the duration of the active poll future.
-            let recorder = self.recorder.with_attempt_count(attempt);
-            recorder
-                .scope(async move { inner.poll().instrument(span).await })
-                .await
-        }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        {
-            self.inner.poll().await
-        }
+        // We map the consolidated LroRecorder (holding the active LRO span and stateful attempt count)
+        // for the duration of the active poll future.
+        let recorder = self.recorder.with_attempt_count(attempt);
+        recorder
+            .scope(async move { inner.poll().instrument(span).await })
+            .await
     }
 
     async fn until_done(self) -> Result<ResponseType> {
-        #[cfg(google_cloud_unstable_tracing)]
-        {
-            let this = self;
-            let recorder = this.recorder.clone();
-            let result = recorder
-                .record_action(|wait_span| async move {
-                    crate::until_done(this).instrument(wait_span).await
-                })
-                .await;
-            if let Err(ref e) = result {
-                recorder.record_error(e);
-            }
-            result
+        let this = self;
+        let recorder = this.recorder.clone();
+        let result = recorder
+            .record_action(|wait_span| async move {
+                crate::until_done(this).instrument(wait_span).await
+            })
+            .await;
+        if let Err(ref e) = result {
+            recorder.record_error(e);
         }
-        #[cfg(not(google_cloud_unstable_tracing))]
-        {
-            crate::until_done(self).await
-        }
+        result
     }
     #[cfg(feature = "unstable-stream")]
     fn into_stream(
@@ -243,7 +208,6 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test]
     async fn test_tracing_decorator_error_reporting() {
         let guard = google_cloud_test_utils::test_layer::TestLayer::initialize();
@@ -281,17 +245,17 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     struct CountingPoller {
         attempts: Vec<u32>,
     }
-    #[cfg(google_cloud_unstable_tracing)]
     impl sealed::Poller for CountingPoller {
         async fn backoff(&mut self, _state: &PollingState) {}
     }
-    #[cfg(google_cloud_unstable_tracing)]
     impl Poller<Duration, Timestamp> for CountingPoller {
         async fn poll(&mut self) -> Option<PollingResult<Duration, Timestamp>> {
+            // Safe to unwrap because this mock poller is only called under the `Tracing::poll`
+            // decorator, which guarantees that an active `LroRecorder` is in scope with a
+            // populated attempt count.
             let attempt = LroRecorder::current()
                 .and_then(|r| r.attempt_count())
                 .unwrap();
@@ -309,7 +273,6 @@ mod tests {
         }
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test]
     async fn test_tracing_decorator_attempt_counting() {
         let span = tracing::info_span!("test_lro_span");
@@ -328,7 +291,6 @@ mod tests {
         assert_eq!(traced.inner.attempts, vec![0, 1, 2]);
     }
 
-    #[cfg(google_cloud_unstable_tracing)]
     #[tokio::test]
     async fn test_lro_recorder_span_nesting() {
         let span = tracing::info_span!("test_lro_span");

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -64,6 +64,9 @@ impl LroRecorder {
     }
 
     /// Returns the current LRO polling attempt count, if active.
+    ///
+    /// This returns `Some(u32)` when queried during an active polling attempt,
+    /// and `None` otherwise (e.g., when executing outside the scope of an active polling cycle).
     pub fn attempt_count(&self) -> Option<u32> {
         self.attempt_count
     }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -130,13 +130,7 @@ pub enum PollingResult<ResponseType, MetadataType> {
 pub mod internal;
 
 #[cfg(google_cloud_unstable_tracing)]
-pub use internal::{PollerOptions, TracingDetails};
-
-#[cfg(google_cloud_unstable_tracing)]
-#[doc(hidden)]
-tokio::task_local! {
-    pub static POLL_ATTEMPT_COUNT: u32;
-}
+pub use internal::{LroRecorder, PollerOptions, TracingDetails};
 
 pub(crate) mod sealed {
     use google_cloud_gax::polling_state::PollingState;


### PR DESCRIPTION
Simplify how we track LRO polling attempts and trace spans. Instead of managing three separate, nested task-local variables, we consolidate LRO span propagation and attempt counting into a single struct `LroRecorder`. 

This implementation is 100% lock-free and requires no `Arc` or `Mutex` locks because `LroRecorder` is read-only. Instead of locking and modifying a shared counter inside the active task, the poller just creates a copy of the recorder with the new attempt count and runs the polling future inside that scope. 

Because async tasks are isolated and the context is immutable, threads never compete to write to the same memory. 

Follow up 2 for https://github.com/googleapis/google-cloud-rust/pull/5695
