### PR TITLE
feat(o11y): regenerate client libraries with consolidated `LroRecorder`

### DIFF
--- a/src/generated/api/apikeys/v2/src/tracing.rs
+++ b/src/generated/api/apikeys/v2/src/tracing.rs
@@ -166,7 +166,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -174,9 +176,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/api/servicemanagement/v1/src/tracing.rs
+++ b/src/generated/api/servicemanagement/v1/src/tracing.rs
@@ -292,7 +292,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -300,9 +302,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/api/serviceusage/v1/src/tracing.rs
+++ b/src/generated/api/serviceusage/v1/src/tracing.rs
@@ -152,7 +152,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -160,9 +162,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/appengine/v1/src/tracing.rs
+++ b/src/generated/appengine/v1/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -299,7 +301,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -307,9 +311,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -488,7 +492,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -496,9 +502,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -663,7 +669,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -671,9 +679,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -866,7 +874,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -874,9 +884,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -985,7 +995,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -993,9 +1005,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1160,7 +1172,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1168,9 +1182,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1335,7 +1349,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1343,9 +1359,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/bigtable/admin/v2/src/tracing.rs
+++ b/src/generated/bigtable/admin/v2/src/tracing.rs
@@ -502,7 +502,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -510,9 +512,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1139,7 +1141,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1147,9 +1151,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/aiplatform/v1/src/tracing.rs
+++ b/src/generated/cloud/aiplatform/v1/src/tracing.rs
@@ -191,7 +191,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -199,9 +201,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -677,7 +679,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -685,9 +689,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -995,7 +999,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1003,9 +1009,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1355,7 +1361,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1363,9 +1371,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1603,7 +1611,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1611,9 +1621,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2005,7 +2015,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2013,9 +2025,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2281,7 +2293,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2289,9 +2303,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2655,7 +2669,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2663,9 +2679,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2917,7 +2933,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2925,9 +2943,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3431,7 +3449,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3439,9 +3459,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3735,7 +3755,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3743,9 +3765,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4025,7 +4047,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4033,9 +4057,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4371,7 +4395,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4379,9 +4405,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4703,7 +4729,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4711,9 +4739,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -5428,7 +5456,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5436,9 +5466,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -5690,7 +5720,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5698,9 +5730,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -5938,7 +5970,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5946,9 +5980,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -6606,7 +6640,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -6614,9 +6650,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -6868,7 +6904,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -6876,9 +6914,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -7130,7 +7168,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7138,9 +7178,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -7630,7 +7670,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7638,9 +7680,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -8088,7 +8130,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8096,9 +8140,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -8406,7 +8450,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8414,9 +8460,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -8808,7 +8854,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8816,9 +8864,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -9140,7 +9188,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9148,9 +9198,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -9402,7 +9452,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9410,9 +9462,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -9706,7 +9758,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9714,9 +9768,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -10038,7 +10092,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -10046,9 +10102,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -10370,7 +10426,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -10378,9 +10436,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -10674,7 +10732,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -10682,9 +10742,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -11314,7 +11374,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11322,9 +11384,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -11716,7 +11778,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11724,9 +11788,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -12020,7 +12084,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12028,9 +12094,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -12464,7 +12530,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12472,9 +12540,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/alloydb/v1/src/tracing.rs
+++ b/src/generated/cloud/alloydb/v1/src/tracing.rs
@@ -110,7 +110,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -118,9 +120,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -803,7 +805,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -811,9 +815,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/apigateway/v1/src/tracing.rs
+++ b/src/generated/cloud/apigateway/v1/src/tracing.rs
@@ -278,7 +278,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -286,9 +288,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/apihub/v1/src/tracing.rs
+++ b/src/generated/cloud/apihub/v1/src/tracing.rs
@@ -628,7 +628,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -636,9 +638,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -859,7 +861,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -867,9 +871,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1034,7 +1038,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1042,9 +1048,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1279,7 +1285,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1287,9 +1295,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1496,7 +1504,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1504,9 +1514,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1699,7 +1709,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1707,9 +1719,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1916,7 +1928,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1924,9 +1938,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2273,7 +2287,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2281,9 +2297,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2504,7 +2520,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2512,9 +2530,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2749,7 +2767,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2757,9 +2777,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/apphub/v1/src/tracing.rs
+++ b/src/generated/cloud/apphub/v1/src/tracing.rs
@@ -516,7 +516,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -524,9 +526,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/asset/v1/src/tracing.rs
+++ b/src/generated/cloud/asset/v1/src/tracing.rs
@@ -376,7 +376,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -384,9 +386,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/assuredworkloads/v1/src/tracing.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/tracing.rs
@@ -152,7 +152,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -160,9 +162,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/auditmanager/v1/src/tracing.rs
+++ b/src/generated/cloud/auditmanager/v1/src/tracing.rs
@@ -208,7 +208,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -216,9 +218,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/backupdr/v1/src/tracing.rs
+++ b/src/generated/cloud/backupdr/v1/src/tracing.rs
@@ -658,7 +658,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -666,9 +668,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -889,7 +891,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -897,9 +901,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/baremetalsolution/v2/src/tracing.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/tracing.rs
@@ -698,7 +698,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -706,9 +708,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/tracing.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/tracing.rs
@@ -222,7 +222,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -230,9 +232,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/tracing.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/tracing.rs
@@ -222,7 +222,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -230,9 +232,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/tracing.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/tracing.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/tracing.rs
@@ -208,7 +208,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -216,9 +218,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/tracing.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/tracing.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/tracing.rs
@@ -460,7 +460,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -468,9 +470,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/certificatemanager/v1/src/tracing.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/tracing.rs
@@ -502,7 +502,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -510,9 +512,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/ces/v1/src/tracing.rs
+++ b/src/generated/cloud/ces/v1/src/tracing.rs
@@ -768,7 +768,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -776,9 +778,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -957,7 +959,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -965,9 +969,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1160,7 +1164,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1168,9 +1174,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1335,7 +1341,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1343,9 +1351,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/chronicle/v1/src/tracing.rs
+++ b/src/generated/cloud/chronicle/v1/src/tracing.rs
@@ -110,7 +110,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -118,9 +120,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -271,7 +273,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -279,9 +283,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -432,7 +436,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -440,9 +446,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -705,7 +711,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -713,9 +721,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1048,7 +1056,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1056,9 +1066,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1251,7 +1261,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1259,9 +1271,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1427,7 +1439,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1435,9 +1449,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1574,7 +1588,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1582,9 +1598,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1875,7 +1891,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1883,9 +1901,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2064,7 +2082,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2072,9 +2092,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2365,7 +2385,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2373,9 +2395,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/clouddms/v1/src/tracing.rs
+++ b/src/generated/cloud/clouddms/v1/src/tracing.rs
@@ -712,7 +712,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -720,9 +722,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/cloudsecuritycompliance/v1/src/tracing.rs
+++ b/src/generated/cloud/cloudsecuritycompliance/v1/src/tracing.rs
@@ -152,7 +152,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -160,9 +162,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -355,7 +357,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -363,9 +367,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -656,7 +660,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -664,9 +670,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -901,7 +907,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -909,9 +917,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1146,7 +1154,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1154,9 +1164,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/tracing.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -285,7 +287,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -293,9 +297,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/compute/v1/src/tracing.rs
+++ b/src/generated/cloud/compute/v1/src/tracing.rs
@@ -368,7 +368,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -376,38 +378,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -632,7 +608,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -640,38 +618,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -936,7 +888,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -944,38 +898,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1282,7 +1210,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1290,38 +1220,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1460,7 +1364,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1468,38 +1374,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1920,7 +1800,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1928,38 +1810,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2112,7 +1968,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2120,38 +1978,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2472,7 +2304,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2480,38 +2314,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2678,7 +2486,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2686,38 +2496,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2898,7 +2682,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2906,38 +2692,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3104,7 +2864,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3112,38 +2874,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3310,7 +3046,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3318,38 +3056,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3516,7 +3228,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3524,38 +3238,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3722,7 +3410,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3730,38 +3420,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4072,7 +3736,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4080,38 +3746,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4264,7 +3904,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4272,38 +3914,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4484,7 +4100,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4492,38 +4110,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4690,7 +4282,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4698,38 +4292,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4896,7 +4464,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4904,38 +4474,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5202,7 +4746,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5210,38 +4756,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5380,7 +4900,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5388,38 +4910,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5826,7 +5322,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5834,38 +5332,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6074,7 +5546,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -6082,38 +5556,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6210,7 +5658,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -6218,38 +5668,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6430,7 +5854,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -6438,38 +5864,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7252,7 +6652,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7260,38 +6662,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7458,7 +6834,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7466,38 +6844,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7692,7 +7044,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7700,38 +7054,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7928,7 +7256,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -7936,38 +7266,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8134,7 +7438,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8142,38 +7448,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8382,7 +7662,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8390,38 +7672,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8718,7 +7974,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -8726,38 +7984,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9024,7 +8256,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9032,38 +8266,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9244,7 +8452,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9252,38 +8462,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9550,7 +8734,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9558,38 +8744,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9728,7 +8888,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9736,38 +8898,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9962,7 +9098,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -9970,38 +9108,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10364,7 +9476,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -10372,38 +9486,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10712,7 +9800,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -10720,38 +9810,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11030,7 +10094,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11038,38 +10104,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11250,7 +10290,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11258,38 +10300,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11657,7 +10673,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11665,38 +10683,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11863,7 +10855,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -11871,38 +10865,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12013,7 +10981,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12021,38 +10991,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12317,7 +11261,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12325,38 +11271,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12523,7 +11443,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12531,38 +11453,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12743,7 +11639,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12751,38 +11649,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12949,7 +11821,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -12957,38 +11831,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13183,7 +12031,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -13191,38 +12041,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13459,7 +12283,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -13467,38 +12293,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13637,7 +12437,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -13645,38 +12447,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13857,7 +12633,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -13865,38 +12643,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14275,7 +13027,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -14283,38 +13037,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14481,7 +13209,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -14489,38 +13219,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14687,7 +13391,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -14695,38 +13401,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14893,7 +13573,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -14901,38 +13583,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15113,7 +13769,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -15121,38 +13779,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15293,7 +13925,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -15301,38 +13935,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15725,7 +14333,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -15733,38 +14343,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15903,7 +14487,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -15911,38 +14497,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16067,7 +14627,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -16075,38 +14637,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16189,7 +14725,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -16197,38 +14735,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16395,7 +14907,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -16403,38 +14917,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16615,7 +15103,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -16623,38 +15113,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16821,7 +15285,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -16829,38 +15295,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17169,7 +15609,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -17177,38 +15619,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17361,7 +15777,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -17369,38 +15787,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17695,7 +16087,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -17703,38 +16097,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17831,7 +16199,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -17839,38 +16209,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18065,7 +16409,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18073,38 +16419,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18229,7 +16549,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18237,38 +16559,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18421,7 +16717,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18429,38 +16727,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18599,7 +16871,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18607,38 +16881,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18805,7 +17053,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18813,38 +17063,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18969,7 +17193,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -18977,38 +17203,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19175,7 +17375,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -19183,38 +17385,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19469,7 +17645,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -19477,38 +17655,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19633,7 +17785,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -19641,38 +17795,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19853,7 +17981,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -19861,38 +17991,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20115,7 +18219,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -20123,38 +18229,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20349,7 +18429,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -20357,38 +18439,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20513,7 +18569,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -20521,38 +18579,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20677,7 +18709,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -20685,38 +18719,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21023,7 +19031,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -21031,38 +19041,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21201,7 +19185,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -21209,38 +19195,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21479,7 +19439,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -21487,38 +19449,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21713,7 +19649,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -21721,38 +19659,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21849,7 +19761,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -21857,38 +19771,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22083,7 +19971,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -22091,38 +19981,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22261,7 +20125,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -22269,38 +20135,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22467,7 +20307,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -22475,38 +20317,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22787,7 +20603,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -22795,38 +20613,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23063,7 +20855,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -23071,38 +20865,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23241,7 +21009,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -23249,38 +21019,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23447,7 +21191,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -23455,38 +21201,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23709,7 +21429,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -23717,38 +21439,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23915,7 +21611,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -23923,38 +21621,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -24205,7 +21877,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -24213,38 +21887,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -24453,7 +22101,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -24461,38 +22111,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -24673,7 +22297,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -24681,38 +22307,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -24865,7 +22465,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -24873,38 +22475,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -25113,7 +22689,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -25121,38 +22699,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -25333,7 +22885,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -25341,38 +22895,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -25525,7 +23053,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -25533,38 +23063,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -25703,7 +23207,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -25711,38 +23217,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -25967,7 +23447,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -25975,38 +23457,12 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
-            {
+            if google_cloud_lro::LroRecorder::current().is_some() {
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        _span.record("gcp.longrunning.done", op.done);
-                        if op.done {
-                            let code = match &op.result {
-                                Some(
-                                    google_cloud_longrunning::model::operation::Result::Error(
-                                        status,
-                                    ),
-                                ) => status.code,
-                                _ => 0,
-                            };
-                            _span.record("gcp.longrunning.status_code", code);
-                            if let Some(
-                                google_cloud_longrunning::model::operation::Result::Error(status),
-                            ) = &op.result
-                            {
-                                _span.record("otel.status_code", "ERROR");
-                                _span.record("otel.status_description", &status.message);
-                                _span.record("rpc.response.status_code", status.code);
-                                _span.record(
-                                    "error.type",
-                                    google_cloud_gax::error::rpc::Code::from(status.code)
-                                        .to_string(),
-                                );
-                            }
-                        }
+                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
+                        _span.record("gcp.longrunning.done", done);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");

--- a/src/generated/cloud/config/v1/src/tracing.rs
+++ b/src/generated/cloud/config/v1/src/tracing.rs
@@ -670,7 +670,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -678,9 +680,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/configdelivery/v1/src/tracing.rs
+++ b/src/generated/cloud/configdelivery/v1/src/tracing.rs
@@ -446,7 +446,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -454,9 +456,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/connectors/v1/src/tracing.rs
+++ b/src/generated/cloud/connectors/v1/src/tracing.rs
@@ -376,7 +376,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -384,9 +386,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/contactcenterinsights/v1/src/tracing.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/tracing.rs
@@ -1104,7 +1104,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1112,9 +1114,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/datacatalog/lineage/v1/src/tracing.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/tracing.rs
@@ -306,7 +306,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -314,9 +316,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/datacatalog/v1/src/tracing.rs
+++ b/src/generated/cloud/datacatalog/v1/src/tracing.rs
@@ -586,7 +586,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -594,9 +596,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -915,7 +917,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -923,9 +927,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1090,7 +1094,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1098,9 +1104,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/dataform/v1/src/tracing.rs
+++ b/src/generated/cloud/dataform/v1/src/tracing.rs
@@ -1118,7 +1118,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1126,9 +1128,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/datafusion/v1/src/tracing.rs
+++ b/src/generated/cloud/datafusion/v1/src/tracing.rs
@@ -166,7 +166,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -174,9 +176,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/dataplex/v1/src/tracing.rs
+++ b/src/generated/cloud/dataplex/v1/src/tracing.rs
@@ -348,7 +348,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -356,9 +358,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1097,7 +1099,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1105,9 +1109,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1384,7 +1388,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1392,9 +1398,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1601,7 +1607,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1609,9 +1617,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1958,7 +1966,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1966,9 +1976,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2385,7 +2395,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2393,9 +2405,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2742,7 +2754,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2750,9 +2764,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3085,7 +3099,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3093,9 +3109,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3666,7 +3682,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3674,9 +3692,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/dataproc/v1/src/tracing.rs
+++ b/src/generated/cloud/dataproc/v1/src/tracing.rs
@@ -180,7 +180,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -188,9 +190,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -411,7 +413,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -419,9 +423,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -712,7 +716,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -720,9 +726,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -999,7 +1005,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1007,9 +1015,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1230,7 +1238,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1238,9 +1248,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1489,7 +1499,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1497,9 +1509,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1734,7 +1746,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1742,9 +1756,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2021,7 +2035,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2029,9 +2045,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/datastream/v1/src/tracing.rs
+++ b/src/generated/cloud/datastream/v1/src/tracing.rs
@@ -460,7 +460,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -468,9 +470,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/deploy/v1/src/tracing.rs
+++ b/src/generated/cloud/deploy/v1/src/tracing.rs
@@ -768,7 +768,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -776,9 +778,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/developerconnect/v1/src/tracing.rs
+++ b/src/generated/cloud/developerconnect/v1/src/tracing.rs
@@ -460,7 +460,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -468,9 +470,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -733,7 +735,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -741,9 +745,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/dialogflow/cx/v3/src/tracing.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/tracing.rs
@@ -275,7 +275,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -283,9 +285,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -467,7 +469,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -475,9 +479,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -645,7 +649,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -653,9 +659,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -893,7 +899,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -901,9 +909,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1183,7 +1191,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1191,9 +1201,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1417,7 +1427,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1425,9 +1437,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1665,7 +1677,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1673,9 +1687,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1955,7 +1969,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1963,9 +1979,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2189,7 +2205,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2197,9 +2215,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2437,7 +2455,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2445,9 +2465,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2671,7 +2691,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2679,9 +2701,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2989,7 +3011,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2997,9 +3021,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3223,7 +3247,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3231,9 +3257,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3429,7 +3455,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3437,9 +3465,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3649,7 +3677,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3657,9 +3687,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3967,7 +3997,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3975,9 +4007,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4271,7 +4303,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4279,9 +4313,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4491,7 +4525,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4499,9 +4535,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4739,7 +4775,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4747,9 +4785,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4973,7 +5011,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4981,9 +5021,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/dialogflow/v2/src/tracing.rs
+++ b/src/generated/cloud/dialogflow/v2/src/tracing.rs
@@ -249,7 +249,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -257,9 +259,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -441,7 +443,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -449,9 +453,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -675,7 +679,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -683,9 +689,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -979,7 +985,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -987,9 +995,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1199,7 +1207,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1207,9 +1217,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1489,7 +1499,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1497,9 +1509,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1751,7 +1763,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1759,9 +1773,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2027,7 +2041,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2035,9 +2051,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2219,7 +2235,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2227,9 +2245,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2523,7 +2541,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2531,9 +2551,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2771,7 +2791,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2779,9 +2801,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2949,7 +2971,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2957,9 +2981,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3169,7 +3193,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3177,9 +3203,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3375,7 +3401,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3383,9 +3411,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3637,7 +3665,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3645,9 +3675,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3871,7 +3901,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3879,9 +3911,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4147,7 +4179,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4155,9 +4189,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4311,7 +4345,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4319,9 +4355,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4531,7 +4567,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4539,9 +4577,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4751,7 +4789,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4759,9 +4799,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4971,7 +5011,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4979,9 +5021,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -5191,7 +5233,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -5199,9 +5243,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/discoveryengine/v1/src/tracing.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/tracing.rs
@@ -94,7 +94,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -102,9 +104,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -272,7 +274,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -280,9 +284,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -478,7 +482,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -486,9 +492,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -684,7 +690,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -692,9 +700,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -988,7 +996,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -996,9 +1006,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1180,7 +1190,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1188,9 +1200,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1428,7 +1440,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1436,9 +1450,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1634,7 +1648,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1642,9 +1658,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1798,7 +1814,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1806,9 +1824,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2018,7 +2036,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2026,9 +2046,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2168,7 +2188,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2176,9 +2198,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2318,7 +2340,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2326,9 +2350,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2454,7 +2478,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2462,9 +2488,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2646,7 +2672,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2654,9 +2682,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2810,7 +2838,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2818,9 +2848,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2960,7 +2990,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2968,9 +3000,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3110,7 +3142,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3118,9 +3152,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3302,7 +3336,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3310,9 +3346,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3634,7 +3670,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3642,9 +3680,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3826,7 +3864,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3834,9 +3874,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3990,7 +4030,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3998,9 +4040,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/documentai/v1/src/tracing.rs
+++ b/src/generated/cloud/documentai/v1/src/tracing.rs
@@ -404,7 +404,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -412,9 +414,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/domains/v1/src/tracing.rs
+++ b/src/generated/cloud/domains/v1/src/tracing.rs
@@ -278,7 +278,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -286,9 +288,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/edgecontainer/v1/src/tracing.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/tracing.rs
@@ -376,7 +376,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -384,9 +386,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/edgenetwork/v1/src/tracing.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/tracing.rs
@@ -460,7 +460,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -468,9 +470,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/eventarc/v1/src/tracing.rs
+++ b/src/generated/cloud/eventarc/v1/src/tracing.rs
@@ -684,7 +684,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -692,9 +694,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/filestore/v1/src/tracing.rs
+++ b/src/generated/cloud/filestore/v1/src/tracing.rs
@@ -348,7 +348,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -356,9 +358,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/financialservices/v1/src/tracing.rs
+++ b/src/generated/cloud/financialservices/v1/src/tracing.rs
@@ -628,7 +628,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -636,9 +638,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/functions/v2/src/tracing.rs
+++ b/src/generated/cloud/functions/v2/src/tracing.rs
@@ -236,7 +236,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -244,9 +246,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/geminidataanalytics/v1/src/tracing.rs
+++ b/src/generated/cloud/geminidataanalytics/v1/src/tracing.rs
@@ -250,7 +250,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -258,9 +260,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -495,7 +497,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -503,9 +507,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/gkebackup/v1/src/tracing.rs
+++ b/src/generated/cloud/gkebackup/v1/src/tracing.rs
@@ -684,7 +684,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -692,9 +694,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/gkehub/v1/src/tracing.rs
+++ b/src/generated/cloud/gkehub/v1/src/tracing.rs
@@ -684,7 +684,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -692,9 +694,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/gkemulticloud/v1/src/tracing.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -565,7 +567,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -573,9 +577,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -978,7 +982,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -986,9 +992,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/hypercomputecluster/v1/src/tracing.rs
+++ b/src/generated/cloud/hypercomputecluster/v1/src/tracing.rs
@@ -166,7 +166,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -174,9 +176,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/ids/v1/src/tracing.rs
+++ b/src/generated/cloud/ids/v1/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/kms/v1/src/tracing.rs
+++ b/src/generated/cloud/kms/v1/src/tracing.rs
@@ -166,7 +166,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -174,9 +176,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -383,7 +385,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -391,9 +395,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -642,7 +646,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -650,9 +656,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -929,7 +935,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -937,9 +945,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1566,7 +1574,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1574,9 +1584,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/licensemanager/v1/src/tracing.rs
+++ b/src/generated/cloud/licensemanager/v1/src/tracing.rs
@@ -278,7 +278,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -286,9 +288,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/lustre/v1/src/tracing.rs
+++ b/src/generated/cloud/lustre/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/managedidentities/v1/src/tracing.rs
+++ b/src/generated/cloud/managedidentities/v1/src/tracing.rs
@@ -208,7 +208,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -216,9 +218,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/managedkafka/schemaregistry/v1/src/tracing.rs
+++ b/src/generated/cloud/managedkafka/schemaregistry/v1/src/tracing.rs
@@ -474,7 +474,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -482,9 +484,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/managedkafka/v1/src/tracing.rs
+++ b/src/generated/cloud/managedkafka/v1/src/tracing.rs
@@ -390,7 +390,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -398,9 +400,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -761,7 +763,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -769,9 +773,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/memcache/v1/src/tracing.rs
+++ b/src/generated/cloud/memcache/v1/src/tracing.rs
@@ -208,7 +208,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -216,9 +218,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/memorystore/v1/src/tracing.rs
+++ b/src/generated/cloud/memorystore/v1/src/tracing.rs
@@ -306,7 +306,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -314,9 +316,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/metastore/v1/src/tracing.rs
+++ b/src/generated/cloud/metastore/v1/src/tracing.rs
@@ -390,7 +390,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -398,9 +400,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -677,7 +679,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -685,9 +689,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/migrationcenter/v1/src/tracing.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/tracing.rs
@@ -768,7 +768,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -776,9 +778,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/netapp/v1/src/tracing.rs
+++ b/src/generated/cloud/netapp/v1/src/tracing.rs
@@ -1090,7 +1090,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1098,9 +1100,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/networkconnectivity/v1/src/tracing.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/tracing.rs
@@ -390,7 +390,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -398,9 +400,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -776,7 +778,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -784,9 +788,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1315,7 +1319,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1323,9 +1329,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1602,7 +1608,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1610,9 +1618,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1875,7 +1883,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1883,9 +1893,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/networkmanagement/v1/src/tracing.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/tracing.rs
@@ -222,7 +222,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -230,9 +232,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -537,7 +539,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -545,9 +549,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -824,7 +828,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -832,9 +838,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/networksecurity/v1/src/tracing.rs
+++ b/src/generated/cloud/networksecurity/v1/src/tracing.rs
@@ -264,7 +264,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -272,9 +274,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -607,7 +609,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -615,9 +619,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -894,7 +898,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -902,9 +908,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1307,7 +1313,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1315,9 +1323,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1804,7 +1812,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1812,9 +1822,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2301,7 +2311,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2309,9 +2321,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3148,7 +3160,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3156,9 +3170,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3505,7 +3519,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3513,9 +3529,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -3863,7 +3879,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -3871,9 +3889,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -4192,7 +4210,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -4200,9 +4220,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/networkservices/v1/src/tracing.rs
+++ b/src/generated/cloud/networkservices/v1/src/tracing.rs
@@ -418,7 +418,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -426,9 +428,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1447,7 +1449,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1455,9 +1459,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/notebooks/v2/src/tracing.rs
+++ b/src/generated/cloud/notebooks/v2/src/tracing.rs
@@ -306,7 +306,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -314,9 +316,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/optimization/v1/src/tracing.rs
+++ b/src/generated/cloud/optimization/v1/src/tracing.rs
@@ -82,7 +82,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -90,9 +92,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/oracledatabase/v1/src/tracing.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/tracing.rs
@@ -908,7 +908,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -916,9 +918,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/tracing.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/tracing.rs
@@ -404,7 +404,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -412,9 +414,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -551,7 +553,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -559,9 +563,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/osconfig/v1/src/tracing.rs
+++ b/src/generated/cloud/osconfig/v1/src/tracing.rs
@@ -222,7 +222,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -230,9 +232,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -495,7 +497,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -503,9 +507,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/parallelstore/v1/src/tracing.rs
+++ b/src/generated/cloud/parallelstore/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/policysimulator/v1/src/tracing.rs
+++ b/src/generated/cloud/policysimulator/v1/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -285,7 +287,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -293,9 +297,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/tracing.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/tracing.rs
@@ -292,7 +292,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -300,9 +302,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/tracing.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/tracing.rs
@@ -236,7 +236,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -244,9 +246,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/redis/cluster/v1/src/tracing.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/tracing.rs
@@ -306,7 +306,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -314,9 +316,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/redis/v1/src/tracing.rs
+++ b/src/generated/cloud/redis/v1/src/tracing.rs
@@ -250,7 +250,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -258,9 +260,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/resourcemanager/v3/src/tracing.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/tracing.rs
@@ -208,7 +208,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -216,9 +218,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -383,7 +385,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -391,9 +395,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -628,7 +632,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -636,9 +642,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -789,7 +795,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -797,9 +805,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -936,7 +944,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -944,9 +954,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1167,7 +1177,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1175,9 +1187,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1398,7 +1410,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1406,9 +1420,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/retail/v2/src/tracing.rs
+++ b/src/generated/cloud/retail/v2/src/tracing.rs
@@ -82,7 +82,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -90,9 +92,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -355,7 +357,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -363,9 +367,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -488,7 +492,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -496,9 +502,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -677,7 +683,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -685,9 +693,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -782,7 +790,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -790,9 +800,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -957,7 +967,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -965,9 +977,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1174,7 +1186,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1182,9 +1196,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1307,7 +1321,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1315,9 +1331,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1580,7 +1596,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1588,9 +1606,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1713,7 +1731,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1721,9 +1741,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1916,7 +1936,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1924,9 +1946,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2091,7 +2113,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2099,9 +2123,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/run/v2/src/tracing.rs
+++ b/src/generated/cloud/run/v2/src/tracing.rs
@@ -82,7 +82,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -90,9 +92,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -271,7 +273,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -279,9 +283,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -502,7 +506,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -510,9 +516,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -775,7 +781,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -783,9 +791,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -964,7 +972,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -972,9 +982,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1223,7 +1233,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1231,9 +1243,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1398,7 +1410,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1406,9 +1420,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1643,7 +1657,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1651,9 +1667,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/securesourcemanager/v1/src/tracing.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/tracing.rs
@@ -866,7 +866,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -874,9 +876,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/security/privateca/v1/src/tracing.rs
+++ b/src/generated/cloud/security/privateca/v1/src/tracing.rs
@@ -544,7 +544,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -552,9 +554,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/securitycenter/v2/src/tracing.rs
+++ b/src/generated/cloud/securitycenter/v2/src/tracing.rs
@@ -628,7 +628,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -636,9 +638,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/securityposture/v1/src/tracing.rs
+++ b/src/generated/cloud/securityposture/v1/src/tracing.rs
@@ -292,7 +292,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -300,9 +302,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/shell/v1/src/tracing.rs
+++ b/src/generated/cloud/shell/v1/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/speech/v2/src/tracing.rs
+++ b/src/generated/cloud/speech/v2/src/tracing.rs
@@ -404,7 +404,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -412,9 +414,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/storagebatchoperations/v1/src/tracing.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/tracing.rs
@@ -194,7 +194,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -202,9 +204,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/storageinsights/v1/src/tracing.rs
+++ b/src/generated/cloud/storageinsights/v1/src/tracing.rs
@@ -292,7 +292,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -300,9 +302,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/talent/v4/src/tracing.rs
+++ b/src/generated/cloud/talent/v4/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -229,7 +231,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -237,9 +241,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -334,7 +338,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -342,9 +348,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -565,7 +571,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -573,9 +581,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -740,7 +748,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -748,9 +758,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/telcoautomation/v1/src/tracing.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/tracing.rs
@@ -600,7 +600,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -608,9 +610,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/texttospeech/v1/src/tracing.rs
+++ b/src/generated/cloud/texttospeech/v1/src/tracing.rs
@@ -96,7 +96,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -104,9 +106,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -215,7 +217,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -223,9 +227,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/tpu/v2/src/tracing.rs
+++ b/src/generated/cloud/tpu/v2/src/tracing.rs
@@ -348,7 +348,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -356,9 +358,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/translate/v3/src/tracing.rs
+++ b/src/generated/cloud/translate/v3/src/tracing.rs
@@ -628,7 +628,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -636,9 +638,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/vectorsearch/v1/src/tracing.rs
+++ b/src/generated/cloud/vectorsearch/v1/src/tracing.rs
@@ -152,7 +152,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -160,9 +162,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -411,7 +413,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -419,9 +423,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -740,7 +744,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -748,9 +754,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/video/livestream/v1/src/tracing.rs
+++ b/src/generated/cloud/video/livestream/v1/src/tracing.rs
@@ -572,7 +572,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -580,9 +582,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/video/stitcher/v1/src/tracing.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/tracing.rs
@@ -488,7 +488,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -496,9 +498,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/videointelligence/v1/src/tracing.rs
+++ b/src/generated/cloud/videointelligence/v1/src/tracing.rs
@@ -82,7 +82,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -90,9 +92,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/vision/v1/src/tracing.rs
+++ b/src/generated/cloud/vision/v1/src/tracing.rs
@@ -110,7 +110,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -118,9 +120,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -481,7 +483,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -489,9 +493,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/visionai/v1/src/tracing.rs
+++ b/src/generated/cloud/visionai/v1/src/tracing.rs
@@ -110,7 +110,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -118,9 +120,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -523,7 +525,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -531,9 +535,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1062,7 +1066,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1070,9 +1076,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1279,7 +1285,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1287,9 +1295,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1762,7 +1770,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1770,9 +1780,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -2805,7 +2815,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -2813,9 +2825,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/vmmigration/v1/src/tracing.rs
+++ b/src/generated/cloud/vmmigration/v1/src/tracing.rs
@@ -964,7 +964,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -972,9 +974,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/vmwareengine/v1/src/tracing.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/tracing.rs
@@ -1174,7 +1174,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1182,9 +1184,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/vpcaccess/v1/src/tracing.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/tracing.rs
@@ -138,7 +138,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -146,9 +148,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/webrisk/v1/src/tracing.rs
+++ b/src/generated/cloud/webrisk/v1/src/tracing.rs
@@ -138,7 +138,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -146,9 +148,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/workflows/v1/src/tracing.rs
+++ b/src/generated/cloud/workflows/v1/src/tracing.rs
@@ -180,7 +180,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -188,9 +190,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/cloud/workstations/v1/src/tracing.rs
+++ b/src/generated/cloud/workstations/v1/src/tracing.rs
@@ -390,7 +390,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -398,9 +400,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/datastore/admin/v1/src/tracing.rs
+++ b/src/generated/datastore/admin/v1/src/tracing.rs
@@ -152,7 +152,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -160,9 +162,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/devtools/artifactregistry/v1/src/tracing.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/tracing.rs
@@ -782,7 +782,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -790,9 +792,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/devtools/cloudbuild/v1/src/tracing.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/tracing.rs
@@ -320,7 +320,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -328,9 +330,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/devtools/cloudbuild/v2/src/tracing.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/tracing.rs
@@ -292,7 +292,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -300,9 +302,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/firestore/admin/v1/src/tracing.rs
+++ b/src/generated/firestore/admin/v1/src/tracing.rs
@@ -516,7 +516,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -524,9 +526,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/iam/v2/src/tracing.rs
+++ b/src/generated/iam/v2/src/tracing.rs
@@ -124,7 +124,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -132,9 +134,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/iam/v3/src/tracing.rs
+++ b/src/generated/iam/v3/src/tracing.rs
@@ -138,7 +138,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -146,9 +148,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -328,7 +330,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -336,9 +340,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/identity/accesscontextmanager/v1/src/tracing.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/tracing.rs
@@ -418,7 +418,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -426,9 +428,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/logging/v2/src/tracing.rs
+++ b/src/generated/logging/v2/src/tracing.rs
@@ -138,7 +138,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -146,9 +148,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -705,7 +707,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -713,9 +717,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -908,7 +912,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -916,9 +922,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/monitoring/metricsscope/v1/src/tracing.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/tracing.rs
@@ -110,7 +110,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -118,9 +120,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/showcase/src/tracing.rs
+++ b/src/generated/showcase/src/tracing.rs
@@ -278,7 +278,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -286,9 +288,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -593,7 +595,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -601,9 +605,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -880,7 +884,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -888,9 +894,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1237,7 +1243,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1245,9 +1253,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1524,7 +1532,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1532,9 +1542,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {
@@ -1839,7 +1849,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -1847,9 +1859,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/spanner/admin/database/v1/src/tracing.rs
+++ b/src/generated/spanner/admin/database/v1/src/tracing.rs
@@ -432,7 +432,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -440,9 +442,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/spanner/admin/instance/v1/src/tracing.rs
+++ b/src/generated/spanner/admin/instance/v1/src/tracing.rs
@@ -362,7 +362,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -370,9 +372,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/generated/storagetransfer/v1/src/tracing.rs
+++ b/src/generated/storagetransfer/v1/src/tracing.rs
@@ -264,7 +264,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -272,9 +274,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {

--- a/src/lro/src/internal.rs
+++ b/src/lro/src/internal.rs
@@ -36,6 +36,6 @@ pub use either::Either;
 #[cfg(google_cloud_unstable_tracing)]
 pub use ext::{PollerExt, PollerOptions, TracingDetails};
 #[cfg(google_cloud_unstable_tracing)]
-pub(crate) use tracing::LroRecorder;
+pub use tracing::LroRecorder;
 #[cfg(google_cloud_unstable_tracing)]
 pub use tracing::Tracing;

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -17,20 +17,6 @@ use google_cloud_gax::polling_state::PollingState;
 use tracing::{Instrument, Span, info_span};
 
 #[cfg(google_cloud_unstable_tracing)]
-use crate::POLL_ATTEMPT_COUNT;
-
-#[cfg(google_cloud_unstable_tracing)]
-tokio::task_local! {
-    /// A task-local context propagating the active LRO `Span`.
-    ///
-    /// This is accessed across module boundaries to dynamically retrieve the
-    /// active span context, allowing the inner pollers to record the LRO's actual
-    /// operation name/resource destination ID when first fetched, without requiring
-    /// passing tracing parameters through all method signatures.
-    pub(crate) static LRO_SPAN: Span;
-}
-
-#[cfg(google_cloud_unstable_tracing)]
 tokio::task_local! {
     static LRO_RECORDER: LroRecorder;
 }
@@ -38,19 +24,24 @@ tokio::task_local! {
 #[cfg(google_cloud_unstable_tracing)]
 /// A recorder that manages LRO spans and propagates active telemetry context.
 ///
-/// Since `LroRecorder` is cloned to establish task-local scopes (like `LRO_RECORDER`),
-/// it is designed to be completely **stateless** and read-only, wrapping only the active LRO `Span`.
-/// Stateful counting (e.g., `poll_attempt_count`) is managed entirely on the decorator itself,
-/// completely eliminating any risk of divergent state or cloning race conditions.
+/// To prevent concurrent mutation race conditions under multi-threaded tokio executors,
+/// `LroRecorder` is completely immutable. Context updates (like setting the transient `attempt_count`
+/// during a polling cycle) are performed using copy-on-write builders (`with_attempt_count`)
+/// to establish new immutable task-local scopes.
 #[derive(Clone, Debug)]
-pub(crate) struct LroRecorder {
+pub struct LroRecorder {
     span: Span,
+    attempt_count: Option<u32>,
 }
 
 #[cfg(google_cloud_unstable_tracing)]
 impl LroRecorder {
+    /// Creates a new `LroRecorder` wrapping the given tracing `Span`.
     pub fn new(span: Span) -> Self {
-        Self { span }
+        Self {
+            span,
+            attempt_count: None,
+        }
     }
 
     /// Returns the recorder in the current task scope.
@@ -66,8 +57,25 @@ impl LroRecorder {
         LRO_RECORDER.scope(self.clone(), future).await
     }
 
+    /// Returns the active LRO tracing `Span` wrapped by this recorder.
     pub fn span(&self) -> &Span {
         &self.span
+    }
+
+    /// Returns the current LRO polling attempt count, if active.
+    pub fn attempt_count(&self) -> Option<u32> {
+        self.attempt_count
+    }
+
+    /// Creates a new clone of `LroRecorder` carrying the specified LRO polling attempt count.
+    ///
+    /// Since `LroRecorder` is immutable to guarantee thread-safety, this updates the context
+    /// via copy-on-write, returning a new value to be bound to a new task-local scope.
+    pub fn with_attempt_count(&self, count: u32) -> Self {
+        Self {
+            span: self.span.clone(),
+            attempt_count: Some(count),
+        }
     }
 
     pub fn record_destination_id(&self, name: &str) {
@@ -163,14 +171,11 @@ where
             let inner = &mut self.inner;
             let span = self.recorder.span().clone();
 
-            // We map both the stateless LRO span context scope AND the transient POLL_ATTEMPT_COUNT
-            // task-local key (using our stateful `attempt` count) for the duration of the active poll future.
-            self.recorder
-                .scope(async move {
-                    POLL_ATTEMPT_COUNT
-                        .scope(attempt, async move { inner.poll().instrument(span).await })
-                        .await
-                })
+            // We map the consolidated LroRecorder (holding the active LRO span and stateful attempt count)
+            // for the duration of the active poll future.
+            let recorder = self.recorder.with_attempt_count(attempt);
+            recorder
+                .scope(async move { inner.poll().instrument(span).await })
                 .await
         }
         #[cfg(not(google_cloud_unstable_tracing))]
@@ -283,7 +288,9 @@ mod tests {
     #[cfg(google_cloud_unstable_tracing)]
     impl Poller<Duration, Timestamp> for CountingPoller {
         async fn poll(&mut self) -> Option<PollingResult<Duration, Timestamp>> {
-            let attempt = POLL_ATTEMPT_COUNT.try_with(|c| *c).unwrap();
+            let attempt = LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .unwrap();
             self.attempts.push(attempt);
             Some(PollingResult::InProgress(None))
         }

--- a/src/lro/src/lib.rs
+++ b/src/lro/src/lib.rs
@@ -130,13 +130,7 @@ pub enum PollingResult<ResponseType, MetadataType> {
 pub mod internal;
 
 #[cfg(google_cloud_unstable_tracing)]
-pub use internal::{PollerOptions, TracingDetails};
-
-#[cfg(google_cloud_unstable_tracing)]
-#[doc(hidden)]
-tokio::task_local! {
-    pub static POLL_ATTEMPT_COUNT: u32;
-}
+pub use internal::{LroRecorder, PollerOptions, TracingDetails};
 
 pub(crate) mod sealed {
     use google_cloud_gax::polling_state::PollingState;

--- a/src/storage/src/generated/gapic_control/tracing.rs
+++ b/src/storage/src/generated/gapic_control/tracing.rs
@@ -432,7 +432,9 @@ where
             self.inner.get_operation(req, options));
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if let Ok(attempt) = google_cloud_lro::POLL_ATTEMPT_COUNT.try_with(|c| *c) {
+            if let Some(attempt) =
+                google_cloud_lro::LroRecorder::current().and_then(|r| r.attempt_count())
+            {
                 _span.record("gcp.longrunning.poll_attempt_count", attempt);
                 _span.record("gcp.longrunning.done", false);
             }
@@ -440,9 +442,9 @@ where
         let result = pending.await;
         #[cfg(google_cloud_unstable_tracing)]
         {
-            if google_cloud_lro::POLL_ATTEMPT_COUNT
-                .try_with(|c| *c)
-                .is_ok()
+            if google_cloud_lro::LroRecorder::current()
+                .and_then(|r| r.attempt_count())
+                .is_some()
             {
                 match &result {
                     Ok(response) => {


### PR DESCRIPTION
Regenerate using the updated librarian template (https://github.com/googleapis/librarian/pull/6259). Telemetry decorator stubs now propagate and query the consolidated `LroRecorder` context directly.