### PR TITLE
feat(storage): implement MoveObject atomic move/rename with preconditions

### DIFF
--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -356,6 +356,7 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
         "compose-source-object-2",
         "update-storage-class",
         "object-to-move",
+        "object-to-move-atomic",
     ]
     .into_iter()
     .for_each(|name| writers.push(make_object(&client, &id, name)));
@@ -474,6 +475,8 @@ pub async fn run_object_examples(buckets: &mut Vec<String>) -> anyhow::Result<()
     objects::compose_file::sample(&control, &id).await?;
     tracing::info!("running move_file example");
     objects::move_file::sample(&control, &id, &id).await?;
+    tracing::info!("running move_file_atomic example");
+    objects::move_file_atomic::sample(&client, &id).await?;
 
     #[cfg(feature = "skipped-integration-tests")]
     {

--- a/src/storage/examples/src/objects.rs
+++ b/src/storage/examples/src/objects.rs
@@ -39,6 +39,7 @@ pub mod list_object_contexts;
 #[allow(dead_code)]
 pub mod make_public;
 pub mod move_file;
+pub mod move_file_atomic;
 pub mod object_csek_to_cmek;
 pub mod open_multiple_objects_ranged_read;
 pub mod open_object_multiple_ranged_read;

--- a/src/storage/examples/src/objects/move_file_atomic.rs
+++ b/src/storage/examples/src/objects/move_file_atomic.rs
@@ -22,7 +22,7 @@ pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
 
     let moved = client
         .move_object(&bucket, SOURCE_NAME, DEST_NAME)
-        .if_generation_match(0) // succeeds only if destination does not exist
+        .set_if_generation_match(0) // succeeds only if destination does not exist
         .send()
         .await?;
 

--- a/src/storage/examples/src/objects/move_file_atomic.rs
+++ b/src/storage/examples/src/objects/move_file_atomic.rs
@@ -1,0 +1,32 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START storage_move_file_atomic]
+use google_cloud_storage::client::Storage;
+
+pub async fn sample(client: &Storage, bucket_id: &str) -> anyhow::Result<()> {
+    const SOURCE_NAME: &str = "object-to-move-atomic";
+    const DEST_NAME: &str = "moved-object-atomic";
+    let bucket = format!("projects/_/buckets/{bucket_id}");
+
+    let moved = client
+        .move_object(&bucket, SOURCE_NAME, DEST_NAME)
+        .if_generation_match(0) // succeeds only if destination does not exist
+        .send()
+        .await?;
+
+    println!("successfully atomically moved {bucket}/{SOURCE_NAME} to {DEST_NAME}: {moved:?}");
+    Ok(())
+}
+// [END storage_move_file_atomic]

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -94,6 +94,7 @@ pub mod builder {
     pub mod storage {
         //! Request builders for [Storage][crate::client::Storage].
         pub use crate::storage::client::ClientBuilder;
+        pub use crate::storage::move_object::MoveObject;
         pub use crate::storage::open_object::OpenObject;
         pub use crate::storage::read_object::ReadObject;
         pub use crate::storage::signed_url::SignedUrlBuilder;

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -18,6 +18,7 @@ pub(crate) mod bidi;
 pub(crate) mod checksum;
 pub(crate) mod client;
 pub(crate) mod common_options;
+pub(crate) mod move_object;
 pub(crate) mod open_object;
 pub(crate) mod perform_upload;
 pub(crate) mod read_object;

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::request_options::RequestOptions;
+use crate::builder::storage::MoveObject;
 use crate::builder::storage::ReadObject;
 use crate::builder::storage::WriteObject;
 use crate::read_resume_policy::ReadResumePolicy;
@@ -220,6 +221,32 @@ where
         O: Into<String>,
     {
         ReadObject::new(self.stub.clone(), bucket, object, self.options.clone())
+    }
+
+    /// Moves or renames a source object to a destination object atomically.
+    ///
+    /// # Parameters
+    /// * `bucket` - the bucket containing both source and destination objects (e.g., "projects/_/buckets/my-bucket").
+    /// * `source_object` - the name of the source object.
+    /// * `destination_object` - the name of the destination object.
+    pub fn move_object<B, Src, D>(
+        &self,
+        bucket: B,
+        source_object: Src,
+        destination_object: D,
+    ) -> MoveObject<S>
+    where
+        B: Into<String>,
+        Src: Into<String>,
+        D: Into<String>,
+    {
+        MoveObject::new(
+            self.stub.clone(),
+            bucket.into(),
+            source_object.into(),
+            destination_object.into(),
+            self.options.clone(),
+        )
     }
 
     /// Opens an object to read its contents using concurrent ranged reads.

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -242,9 +242,9 @@ where
     {
         MoveObject::new(
             self.stub.clone(),
-            bucket.into(),
-            source_object.into(),
-            destination_object.into(),
+            bucket,
+            source_object,
+            destination_object,
             self.options.clone(),
         )
     }

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -225,6 +225,18 @@ where
 
     /// Moves or renames a source object to a destination object atomically.
     ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let moved = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .if_generation_match(0)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
     /// # Parameters
     /// * `bucket` - the bucket containing both source and destination objects (e.g., "projects/_/buckets/my-bucket").
     /// * `source_object` - the name of the source object.

--- a/src/storage/src/storage/client.rs
+++ b/src/storage/src/storage/client.rs
@@ -231,7 +231,7 @@ where
     /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
     /// let moved = client
     ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
-    ///     .if_generation_match(0)
+    ///     .set_if_generation_match(0)
     ///     .send()
     ///     .await?;
     /// # Ok(()) }
@@ -241,17 +241,12 @@ where
     /// * `bucket` - the bucket containing both source and destination objects (e.g., "projects/_/buckets/my-bucket").
     /// * `source_object` - the name of the source object.
     /// * `destination_object` - the name of the destination object.
-    pub fn move_object<B, Src, D>(
+    pub fn move_object(
         &self,
-        bucket: B,
-        source_object: Src,
-        destination_object: D,
-    ) -> MoveObject<S>
-    where
-        B: Into<String>,
-        Src: Into<String>,
-        D: Into<String>,
-    {
+        bucket: impl Into<String>,
+        source_object: impl Into<String>,
+        destination_object: impl Into<String>,
+    ) -> MoveObject<S> {
         MoveObject::new(
             self.stub.clone(),
             bucket,

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -1,0 +1,103 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::model::{MoveObjectRequest, Object};
+use crate::storage::request_options::RequestOptions;
+use std::sync::Arc;
+
+/// Request builder for [Storage::move_object][crate::client::Storage::move_object] calls.
+#[derive(Clone, Debug)]
+pub struct MoveObject<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    stub: Arc<S>,
+    request: MoveObjectRequest,
+    options: RequestOptions,
+}
+
+impl<S> MoveObject<S>
+where
+    S: crate::storage::stub::Storage + 'static,
+{
+    pub(crate) fn new(
+        stub: Arc<S>,
+        bucket: String,
+        source_object: String,
+        destination_object: String,
+        options: RequestOptions,
+    ) -> Self {
+        let mut request = MoveObjectRequest::default();
+        request.bucket = bucket;
+        request.source_object = source_object;
+        request.destination_object = destination_object;
+        Self {
+            stub,
+            request,
+            options,
+        }
+    }
+
+    // Preconditions
+    pub fn if_source_generation_match(mut self, v: i64) -> Self {
+        self.request.if_source_generation_match = Some(v);
+        self
+    }
+
+    pub fn if_source_generation_not_match(mut self, v: i64) -> Self {
+        self.request.if_source_generation_not_match = Some(v);
+        self
+    }
+
+    pub fn if_source_metageneration_match(mut self, v: i64) -> Self {
+        self.request.if_source_metageneration_match = Some(v);
+        self
+    }
+
+    pub fn if_source_metageneration_not_match(mut self, v: i64) -> Self {
+        self.request.if_source_metageneration_not_match = Some(v);
+        self
+    }
+
+    pub fn if_generation_match(mut self, v: i64) -> Self {
+        self.request.if_generation_match = Some(v);
+        self
+    }
+
+    pub fn if_generation_not_match(mut self, v: i64) -> Self {
+        self.request.if_generation_not_match = Some(v);
+        self
+    }
+
+    pub fn if_metageneration_match(mut self, v: i64) -> Self {
+        self.request.if_metageneration_match = Some(v);
+        self
+    }
+
+    pub fn if_metageneration_not_match(mut self, v: i64) -> Self {
+        self.request.if_metageneration_not_match = Some(v);
+        self
+    }
+
+    // Common options
+    pub fn with_options(mut self, options: RequestOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub async fn send(self) -> Result<Object> {
+        self.stub.move_object(self.request, self.options).await
+    }
+}

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -32,17 +32,22 @@ impl<S> MoveObject<S>
 where
     S: crate::storage::stub::Storage + 'static,
 {
-    pub(crate) fn new(
+    pub(crate) fn new<B, Src, D>(
         stub: Arc<S>,
-        bucket: String,
-        source_object: String,
-        destination_object: String,
+        bucket: B,
+        source_object: Src,
+        destination_object: D,
         options: RequestOptions,
-    ) -> Self {
+    ) -> Self
+    where
+        B: Into<String>,
+        Src: Into<String>,
+        D: Into<String>,
+    {
         let mut request = MoveObjectRequest::default();
-        request.bucket = bucket;
-        request.source_object = source_object;
-        request.destination_object = destination_object;
+        request.bucket = bucket.into();
+        request.source_object = source_object.into();
+        request.destination_object = destination_object.into();
         Self {
             stub,
             request,

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -58,52 +58,72 @@ where
     }
 
     // Preconditions
+
+    /// Makes the operation conditional on whether the source object's current generation
+    /// matches the given value.
     pub fn if_source_generation_match(mut self, v: i64) -> Self {
         self.request.if_source_generation_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the source object's current generation
+    /// does not match the given value.
     pub fn if_source_generation_not_match(mut self, v: i64) -> Self {
         self.request.if_source_generation_not_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the source object's current metageneration
+    /// matches the given value.
     pub fn if_source_metageneration_match(mut self, v: i64) -> Self {
         self.request.if_source_metageneration_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the source object's current metageneration
+    /// does not match the given value.
     pub fn if_source_metageneration_not_match(mut self, v: i64) -> Self {
         self.request.if_source_metageneration_not_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the destination object's current generation
+    /// matches the given value.
     pub fn if_generation_match(mut self, v: i64) -> Self {
         self.request.if_generation_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the destination object's current generation
+    /// does not match the given value.
     pub fn if_generation_not_match(mut self, v: i64) -> Self {
         self.request.if_generation_not_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the destination object's current metageneration
+    /// matches the given value.
     pub fn if_metageneration_match(mut self, v: i64) -> Self {
         self.request.if_metageneration_match = Some(v);
         self
     }
 
+    /// Makes the operation conditional on whether the destination object's current metageneration
+    /// does not match the given value.
     pub fn if_metageneration_not_match(mut self, v: i64) -> Self {
         self.request.if_metageneration_not_match = Some(v);
         self
     }
 
     // Common options
+
+    /// Overrides the default request options.
     pub fn with_options(mut self, options: RequestOptions) -> Self {
         self.options = options;
         self
     }
 
+    /// Sends the move object request to the server.
     pub async fn send(self) -> Result<Object> {
         self.stub.move_object(self.request, self.options).await
     }

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -32,18 +32,13 @@ impl<S> MoveObject<S>
 where
     S: crate::storage::stub::Storage + 'static,
 {
-    pub(crate) fn new<B, Src, D>(
+    pub(crate) fn new(
         stub: Arc<S>,
-        bucket: B,
-        source_object: Src,
-        destination_object: D,
+        bucket: impl Into<String>,
+        source_object: impl Into<String>,
+        destination_object: impl Into<String>,
         options: RequestOptions,
-    ) -> Self
-    where
-        B: Into<String>,
-        Src: Into<String>,
-        D: Into<String>,
-    {
+    ) -> Self {
         let request = MoveObjectRequest {
             bucket: bucket.into(),
             source_object: source_object.into(),
@@ -59,67 +54,292 @@ where
 
     // Preconditions
 
-    /// Makes the operation conditional on whether the source object's current generation
-    /// matches the given value.
-    pub fn if_source_generation_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the source object generation to match.
+    ///
+    /// With this precondition the request fails if the source object's current
+    /// generation does not match the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_source_generation_match(123456)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_source_generation_match(mut self, v: i64) -> Self {
         self.request.if_source_generation_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the source object's current generation
-    /// does not match the given value.
-    pub fn if_source_generation_not_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the source object generation to not match.
+    ///
+    /// With this precondition the request fails if the source object's current
+    /// generation matches the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_source_generation_not_match(123456)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_source_generation_not_match(mut self, v: i64) -> Self {
         self.request.if_source_generation_not_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the source object's current metageneration
-    /// matches the given value.
-    pub fn if_source_metageneration_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the source object metageneration to match.
+    ///
+    /// With this precondition the request fails if the source object's current
+    /// metageneration does not match the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_source_metageneration_match(1)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_source_metageneration_match(mut self, v: i64) -> Self {
         self.request.if_source_metageneration_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the source object's current metageneration
-    /// does not match the given value.
-    pub fn if_source_metageneration_not_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the source object metageneration to not match.
+    ///
+    /// With this precondition the request fails if the source object's current
+    /// metageneration matches the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_source_metageneration_not_match(1)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_source_metageneration_not_match(mut self, v: i64) -> Self {
         self.request.if_source_metageneration_not_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the destination object's current generation
-    /// matches the given value.
-    pub fn if_generation_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the destination object generation to match.
+    ///
+    /// With this precondition the request fails if the destination object's current
+    /// generation does not match the provided value. A common value is `0`, which
+    /// prevents the move from succeeding if a destination object already exists.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_generation_match(0)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_generation_match(mut self, v: i64) -> Self {
         self.request.if_generation_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the destination object's current generation
-    /// does not match the given value.
-    pub fn if_generation_not_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the destination object generation to not match.
+    ///
+    /// With this precondition the request fails if the destination object's current
+    /// generation matches the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_generation_not_match(0)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_generation_not_match(mut self, v: i64) -> Self {
         self.request.if_generation_not_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the destination object's current metageneration
-    /// matches the given value.
-    pub fn if_metageneration_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the destination object metageneration to match.
+    ///
+    /// With this precondition the request fails if the destination object's current
+    /// metageneration does not match the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_metageneration_match(1)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_metageneration_match(mut self, v: i64) -> Self {
         self.request.if_metageneration_match = Some(v);
         self
     }
 
-    /// Makes the operation conditional on whether the destination object's current metageneration
-    /// does not match the given value.
-    pub fn if_metageneration_not_match(mut self, v: i64) -> Self {
+    /// Set a [request precondition] on the destination object metageneration to not match.
+    ///
+    /// With this precondition the request fails if the destination object's current
+    /// metageneration matches the provided value.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .set_if_metageneration_not_match(1)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [request precondition]: https://cloud.google.com/storage/docs/request-preconditions
+    pub fn set_if_metageneration_not_match(mut self, v: i64) -> Self {
         self.request.if_metageneration_not_match = Some(v);
         self
     }
 
     // Common options
 
-    /// Overrides the default request options.
-    pub fn with_options(mut self, options: RequestOptions) -> Self {
-        self.options = options;
+    /// Configure the idempotency for this move request.
+    ///
+    /// By default, the client library treats move requests without preconditions
+    /// as non-idempotent. Atomic moves may succeed multiple times, but retrying
+    /// them without preconditions could cause unforeseen outcomes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .with_idempotency(true)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_idempotency(mut self, v: bool) -> Self {
+        self.options.idempotency = Some(v);
+        self
+    }
+
+    /// The retry policy used for this request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # use google_cloud_storage::retry_policy::RetryableErrors;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use std::time::Duration;
+    /// use google_cloud_gax::retry_policy::RetryPolicyExt;
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .with_retry_policy(
+    ///         RetryableErrors
+    ///             .with_attempt_limit(5)
+    ///             .with_time_limit(Duration::from_secs(90)),
+    ///     )
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_retry_policy<V: Into<google_cloud_gax::retry_policy::RetryPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_policy = v.into().into();
+        self
+    }
+
+    /// The backoff policy used for this request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// use std::time::Duration;
+    /// use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .with_backoff_policy(ExponentialBackoff::default())
+    ///     .send()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_backoff_policy<V: Into<google_cloud_gax::backoff_policy::BackoffPolicyArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.backoff_policy = v.into().into();
+        self
+    }
+
+    /// The retry throttler used for this request.
+    ///
+    /// Most of the time you want to use the same throttler for all the requests
+    /// in a client, and even the same throttler for many clients. Rarely it
+    /// may be necessary to use a custom throttler for some subset of the
+    /// requests.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage::client::Storage;
+    /// # async fn sample(client: &Storage) -> anyhow::Result<()> {
+    /// let response = client
+    ///     .move_object("projects/_/buckets/my-bucket", "source.txt", "dest.txt")
+    ///     .with_retry_throttler(adhoc_throttler())
+    ///     .send()
+    ///     .await?;
+    /// fn adhoc_throttler() -> google_cloud_gax::retry_throttler::SharedRetryThrottler {
+    ///     # panic!();
+    /// }
+    /// # Ok(()) }
+    /// ```
+    pub fn with_retry_throttler<V: Into<google_cloud_gax::retry_throttler::RetryThrottlerArg>>(
+        mut self,
+        v: V,
+    ) -> Self {
+        self.options.retry_throttler = v.into().into();
         self
     }
 

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -348,3 +348,74 @@ where
         self.stub.move_object(self.request, self.options).await
     }
 }
+
+pub(crate) struct Mover {
+    pub(crate) inner: std::sync::Arc<crate::storage::client::StorageInner>,
+    pub(crate) request: crate::model::MoveObjectRequest,
+    pub(crate) options: crate::storage::request_options::RequestOptions,
+}
+
+impl Mover {
+    pub(crate) async fn response(self) -> Result<Object> {
+        use gaxi::{
+            grpc::tonic::{Extensions, GrpcMethod},
+            prost::ToProto,
+        };
+        let options =
+            google_cloud_gax::options::internal::set_default_idempotency(self.options.gax(), false);
+        let extensions = {
+            let mut e = Extensions::new();
+            e.insert(GrpcMethod::new("google.storage.v2.Storage", "MoveObject"));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/MoveObject");
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&self.request).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
+        };
+        if x_goog_request_params.is_empty() {
+            use gaxi::path_parameter::PathMismatchBuilder;
+            use gaxi::routing_parameter::Segment;
+            use google_cloud_gax::error::binding::BindingError;
+            let mut paths = Vec::new();
+            {
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
+                    Some(&self.request).map(|m| &m.bucket).map(|s| s.as_str()),
+                    &[Segment::MultiWildcard],
+                    "bucket",
+                    "**",
+                );
+                paths.push(builder.build());
+            }
+            return Err(google_cloud_gax::error::Error::binding(BindingError {
+                paths,
+            }));
+        }
+
+        type TR = crate::google::storage::v2::Object;
+        let response = self
+            .inner
+            .grpc
+            .execute(
+                extensions,
+                path,
+                self.request.to_proto().map_err(crate::Error::deser)?,
+                options,
+                &crate::storage::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, Object>)?;
+        Ok(response.into_body())
+    }
+}

--- a/src/storage/src/storage/move_object.rs
+++ b/src/storage/src/storage/move_object.rs
@@ -44,10 +44,12 @@ where
         Src: Into<String>,
         D: Into<String>,
     {
-        let mut request = MoveObjectRequest::default();
-        request.bucket = bucket.into();
-        request.source_object = source_object.into();
-        request.destination_object = destination_object.into();
+        let request = MoveObjectRequest {
+            bucket: bucket.into(),
+            source_object: source_object.into(),
+            destination_object: destination_object.into(),
+            ..Default::default()
+        };
         Self {
             stub,
             request,

--- a/src/storage/src/storage/stub.rs
+++ b/src/storage/src/storage/stub.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use crate::Result;
-use crate::model::{Object, ReadObjectRequest};
+use crate::model::{MoveObjectRequest, Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::request_options::RequestOptions;
@@ -80,6 +80,15 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
     ) -> impl std::future::Future<Output = Result<(Descriptor, Vec<ReadObjectResponse>)>> + Send
     {
         unimplemented_stub::<(Descriptor, Vec<ReadObjectResponse>)>()
+    }
+
+    /// Implements [crate::client::Storage::move_object].
+    fn move_object(
+        &self,
+        _req: MoveObjectRequest,
+        _options: RequestOptions,
+    ) -> impl std::future::Future<Output = Result<Object>> + Send {
+        unimplemented_stub::<Object>()
     }
 }
 

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -339,11 +339,6 @@ impl Storage {
         }
 
         type TR = crate::google::storage::v2::Object;
-        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
-            let attributes = gaxi::observability::ClientRequestAttributes::default()
-                .set_rpc_method("google.storage.v2.Storage/MoveObject");
-            recorder.on_client_request(attributes);
-        }
         let response = self
             .inner
             .grpc
@@ -875,14 +870,14 @@ mod tests {
 
         let response = client
             .move_object("projects/_/buckets/test-bucket", "src-obj", "dst-obj")
-            .if_source_generation_match(10)
-            .if_source_generation_not_match(11)
-            .if_source_metageneration_match(12)
-            .if_source_metageneration_not_match(13)
-            .if_generation_match(20)
-            .if_generation_not_match(21)
-            .if_metageneration_match(22)
-            .if_metageneration_not_match(23)
+            .set_if_source_generation_match(10)
+            .set_if_source_generation_not_match(11)
+            .set_if_source_metageneration_match(12)
+            .set_if_source_metageneration_not_match(13)
+            .set_if_generation_match(20)
+            .set_if_generation_not_match(21)
+            .set_if_metageneration_match(22)
+            .set_if_metageneration_not_match(23)
             .send()
             .await?;
 

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -836,13 +836,13 @@ mod tests {
 
     #[tokio::test]
     async fn move_object() -> anyhow::Result<()> {
-        use crate::google::storage::v2::Object as ProtoObject;
+        use storage_grpc_mock::google::storage::v2::Object as ProtoObject;
         use storage_grpc_mock::{MockStorage, start};
 
         let guard = TestLayer::initialize();
 
         let mut mock = MockStorage::new();
-        mock.expect_move_object().once().handle(|req| {
+        mock.expect_move_object().once().returning(|req| {
             let r = req.into_inner();
             assert_eq!(r.bucket, "projects/_/buckets/test-bucket");
             assert_eq!(r.source_object, "src-obj");
@@ -856,7 +856,7 @@ mod tests {
             assert_eq!(r.if_metageneration_match, Some(22));
             assert_eq!(r.if_metageneration_not_match, Some(23));
 
-            Ok(tonic::Response::new(ProtoObject {
+            Ok(gaxi::grpc::tonic::Response::new(ProtoObject {
                 bucket: "projects/_/buckets/test-bucket".to_string(),
                 name: "dst-obj".to_string(),
                 generation: 42,

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -19,6 +19,7 @@ use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
 use crate::storage::info::{self, INSTRUMENTATION};
+use crate::storage::move_object::Mover;
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;
 use crate::storage::request_options::RequestOptions;
@@ -293,66 +294,12 @@ impl Storage {
         request: MoveObjectRequest,
         options: RequestOptions,
     ) -> Result<Object> {
-        use gaxi::{
-            grpc::tonic::{Extensions, GrpcMethod},
-            prost::ToProto,
+        let mover = Mover {
+            inner: self.inner.clone(),
+            request,
+            options,
         };
-        let options =
-            google_cloud_gax::options::internal::set_default_idempotency(options.gax(), false);
-        let extensions = {
-            let mut e = Extensions::new();
-            e.insert(GrpcMethod::new("google.storage.v2.Storage", "MoveObject"));
-            e
-        };
-        let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/MoveObject");
-        let x_goog_request_params = {
-            use gaxi::routing_parameter::Segment;
-            gaxi::routing_parameter::format(&[None
-                .or_else(|| {
-                    gaxi::routing_parameter::value(
-                        Some(&request).map(|m| &m.bucket).map(|s| s.as_str()),
-                        &[],
-                        &[Segment::MultiWildcard],
-                        &[],
-                    )
-                })
-                .map(|v| ("bucket", v))])
-        };
-        if x_goog_request_params.is_empty() {
-            use gaxi::path_parameter::PathMismatchBuilder;
-            use gaxi::routing_parameter::Segment;
-            use google_cloud_gax::error::binding::BindingError;
-            let mut paths = Vec::new();
-            {
-                let builder = PathMismatchBuilder::default();
-                let builder = builder.maybe_add(
-                    Some(&request).map(|m| &m.bucket).map(|s| s.as_str()),
-                    &[Segment::MultiWildcard],
-                    "bucket",
-                    "**",
-                );
-                paths.push(builder.build());
-            }
-            return Err(google_cloud_gax::error::Error::binding(BindingError {
-                paths,
-            }));
-        }
-
-        type TR = crate::google::storage::v2::Object;
-        let response = self
-            .inner
-            .grpc
-            .execute(
-                extensions,
-                path,
-                request.to_proto().map_err(crate::Error::deser)?,
-                options,
-                &info::X_GOOG_API_CLIENT_HEADER,
-                &x_goog_request_params,
-            )
-            .await
-            .and_then(gaxi::grpc::to_gax_response::<TR, Object>)?;
-        Ok(response.into_body())
+        mover.response().await
     }
 }
 

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -263,6 +263,31 @@ impl Storage {
         Ok((descriptor, readers))
     }
 
+    #[tracing::instrument(name = "move_object", level = tracing::Level::DEBUG, ret, err(Debug))]
+    async fn move_object_tracing(
+        &self,
+        request: MoveObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        let resource_name = format!("//storage.googleapis.com/{}", request.bucket);
+        let (_span, pending) = gaxi::client_request_signals!(
+            metric: self.metric.clone(),
+            info: *INSTRUMENTATION,
+            method: "client::Storage::move_object",
+            async {
+                if let Some(recorder) = RequestRecorder::current() {
+                    recorder.on_client_request(
+                        ClientRequestAttributes::default()
+                            .set_rpc_method("google.storage.v2.Storage/MoveObject")
+                            .set_resource_name(resource_name),
+                    );
+                }
+                self.move_object_plain(request, options).await
+            }
+        );
+        pending.await
+    }
+
     async fn move_object_plain(
         &self,
         request: MoveObjectRequest,
@@ -405,6 +430,9 @@ impl super::stub::Storage for Storage {
         request: MoveObjectRequest,
         options: RequestOptions,
     ) -> Result<Object> {
+        if self.tracing {
+            return self.move_object_tracing(request, options).await;
+        }
         self.move_object_plain(request, options).await
     }
 }
@@ -864,6 +892,11 @@ mod tests {
 
         let captured = TestLayer::capture(&guard);
         check_debug_log(&captured, "move_object");
+
+        let _span = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap_or_else(|| panic!("missing `client_request` span in capture: {captured:#?}"));
         Ok(())
     }
 }

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -14,11 +14,11 @@
 
 use super::tracing::{TracingObjectDescriptor, TracingResponse};
 use crate::Result;
-use crate::model::{Object, ReadObjectRequest};
+use crate::model::{MoveObjectRequest, Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
-use crate::storage::info::INSTRUMENTATION;
+use crate::storage::info::{self, INSTRUMENTATION};
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;
 use crate::storage::request_options::RequestOptions;
@@ -262,6 +262,78 @@ impl Storage {
             .collect::<Vec<_>>();
         Ok((descriptor, readers))
     }
+
+    async fn move_object_plain(
+        &self,
+        request: MoveObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        use gaxi::{
+            grpc::tonic::{Extensions, GrpcMethod},
+            prost::ToProto,
+        };
+        let options =
+            google_cloud_gax::options::internal::set_default_idempotency(options.gax(), false);
+        let extensions = {
+            let mut e = Extensions::new();
+            e.insert(GrpcMethod::new("google.storage.v2.Storage", "MoveObject"));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.storage.v2.Storage/MoveObject");
+        let x_goog_request_params = {
+            use gaxi::routing_parameter::Segment;
+            gaxi::routing_parameter::format(&[None
+                .or_else(|| {
+                    gaxi::routing_parameter::value(
+                        Some(&request).map(|m| &m.bucket).map(|s| s.as_str()),
+                        &[],
+                        &[Segment::MultiWildcard],
+                        &[],
+                    )
+                })
+                .map(|v| ("bucket", v))])
+        };
+        if x_goog_request_params.is_empty() {
+            use gaxi::path_parameter::PathMismatchBuilder;
+            use gaxi::routing_parameter::Segment;
+            use google_cloud_gax::error::binding::BindingError;
+            let mut paths = Vec::new();
+            {
+                let builder = PathMismatchBuilder::default();
+                let builder = builder.maybe_add(
+                    Some(&request).map(|m| &m.bucket).map(|s| s.as_str()),
+                    &[Segment::MultiWildcard],
+                    "bucket",
+                    "**",
+                );
+                paths.push(builder.build());
+            }
+            return Err(google_cloud_gax::error::Error::binding(BindingError {
+                paths,
+            }));
+        }
+
+        type TR = crate::google::storage::v2::Object;
+        if let Some(recorder) = gaxi::observability::RequestRecorder::current() {
+            let attributes = gaxi::observability::ClientRequestAttributes::default()
+                .set_rpc_method("google.storage.v2.Storage/MoveObject");
+            recorder.on_client_request(attributes);
+        }
+        let response = self
+            .inner
+            .grpc
+            .execute(
+                extensions,
+                path,
+                request.to_proto().map_err(crate::Error::deser)?,
+                options,
+                &info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+            .and_then(gaxi::grpc::to_gax_response::<TR, Object>)?;
+        Ok(response.into_body())
+    }
 }
 
 impl super::stub::Storage for Storage {
@@ -324,6 +396,16 @@ impl super::stub::Storage for Storage {
             return self.open_object_tracing(request, options).await;
         }
         self.open_object_plain(request, options).await
+    }
+
+    /// Implements [crate::client::Storage::move_object].
+    #[tracing::instrument(name = "move_object", level = tracing::Level::DEBUG, ret, err(Debug))]
+    async fn move_object(
+        &self,
+        request: MoveObjectRequest,
+        options: RequestOptions,
+    ) -> Result<Object> {
+        self.move_object_plain(request, options).await
     }
 }
 
@@ -722,5 +804,66 @@ mod tests {
             mismatch.is_empty(),
             "mismatch = {mismatch:?}\ngot      = {got:?}\nwant     = {want:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn move_object() -> anyhow::Result<()> {
+        use crate::google::storage::v2::Object as ProtoObject;
+        use storage_grpc_mock::{MockStorage, start};
+
+        let guard = TestLayer::initialize();
+
+        let mut mock = MockStorage::new();
+        mock.expect_move_object().once().handle(|req| {
+            let r = req.into_inner();
+            assert_eq!(r.bucket, "projects/_/buckets/test-bucket");
+            assert_eq!(r.source_object, "src-obj");
+            assert_eq!(r.destination_object, "dst-obj");
+            assert_eq!(r.if_source_generation_match, Some(10));
+            assert_eq!(r.if_source_generation_not_match, Some(11));
+            assert_eq!(r.if_source_metageneration_match, Some(12));
+            assert_eq!(r.if_source_metageneration_not_match, Some(13));
+            assert_eq!(r.if_generation_match, Some(20));
+            assert_eq!(r.if_generation_not_match, Some(21));
+            assert_eq!(r.if_metageneration_match, Some(22));
+            assert_eq!(r.if_metageneration_not_match, Some(23));
+
+            Ok(tonic::Response::new(ProtoObject {
+                bucket: "projects/_/buckets/test-bucket".to_string(),
+                name: "dst-obj".to_string(),
+                generation: 42,
+                ..Default::default()
+            }))
+        });
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+
+        let client = crate::client::Storage::builder()
+            .with_credentials(Anonymous::new().build())
+            .with_endpoint(endpoint.clone())
+            .with_tracing()
+            .build()
+            .await?;
+
+        let response = client
+            .move_object("projects/_/buckets/test-bucket", "src-obj", "dst-obj")
+            .if_source_generation_match(10)
+            .if_source_generation_not_match(11)
+            .if_source_metageneration_match(12)
+            .if_source_metageneration_not_match(13)
+            .if_generation_match(20)
+            .if_generation_not_match(21)
+            .if_metageneration_match(22)
+            .if_metageneration_not_match(23)
+            .send()
+            .await?;
+
+        assert_eq!(response.bucket, "projects/_/buckets/test-bucket");
+        assert_eq!(response.name, "dst-obj");
+        assert_eq!(response.generation, 42);
+
+        let captured = TestLayer::capture(&guard);
+        check_debug_log(&captured, "move_object");
+        Ok(())
     }
 }

--- a/src/storage/src/storage/transport.rs
+++ b/src/storage/src/storage/transport.rs
@@ -18,7 +18,7 @@ use crate::model::{MoveObjectRequest, Object, ReadObjectRequest};
 use crate::model_ext::WriteObjectRequest;
 use crate::read_object::ReadObjectResponse;
 use crate::storage::client::StorageInner;
-use crate::storage::info::{self, INSTRUMENTATION};
+use crate::storage::info::INSTRUMENTATION;
 use crate::storage::move_object::Mover;
 use crate::storage::perform_upload::PerformUpload;
 use crate::storage::read_object::Reader;

--- a/src/storage/tests/mocking.rs
+++ b/src/storage/tests/mocking.rs
@@ -15,7 +15,7 @@
 #[cfg(test)]
 mod tests {
     use gcs::Result;
-    use gcs::model::{Object, ReadObjectRequest};
+    use gcs::model::{MoveObjectRequest, Object, ReadObjectRequest};
     use gcs::model_ext::{ObjectHighlights, WriteObjectRequest};
     use gcs::read_object::ReadObjectResponse;
     use gcs::request_options::RequestOptions;
@@ -54,6 +54,11 @@ mod tests {
                 _request: OpenObjectRequest,
                 _options: RequestOptions,
             ) -> Result<(ObjectDescriptor, Vec<ReadObjectResponse>)>;
+            async fn move_object(
+                &self,
+                _req: MoveObjectRequest,
+                _options: RequestOptions,
+            ) -> Result<Object>;
         }
     }
 
@@ -352,4 +357,39 @@ mod tests {
         update_organization_intelligence_config,
         get_operation
     );
+
+    #[tokio::test]
+    async fn mock_move_object_success() -> anyhow::Result<()> {
+        let want_bucket = "projects/_/buckets/my-bucket".to_string();
+        let want_src = "src-object".to_string();
+        let want_dst = "dst-object".to_string();
+
+        let mut mock = MockStorage::new();
+        mock.expect_move_object().return_once(move |req, _| {
+            assert_eq!(req.bucket, "projects/_/buckets/my-bucket");
+            assert_eq!(req.source_object, "src-object");
+            assert_eq!(req.destination_object, "dst-object");
+            assert_eq!(req.if_source_generation_match, Some(42));
+            assert_eq!(req.if_generation_not_match, Some(100));
+
+            let mut resp = Object::default();
+            resp.bucket = "projects/_/buckets/my-bucket".to_string();
+            resp.name = "dst-object".to_string();
+            resp.generation = 12345;
+            Ok(resp)
+        });
+
+        let client = gcs::client::Storage::from_stub(mock);
+        let resp = client
+            .move_object(&want_bucket, &want_src, &want_dst)
+            .if_source_generation_match(42)
+            .if_generation_not_match(100)
+            .send()
+            .await?;
+
+        assert_eq!(resp.bucket, want_bucket);
+        assert_eq!(resp.name, want_dst);
+        assert_eq!(resp.generation, 12345);
+        Ok(())
+    }
 }

--- a/src/storage/tests/mocking.rs
+++ b/src/storage/tests/mocking.rs
@@ -365,25 +365,30 @@ mod tests {
         let want_dst = "dst-object".to_string();
 
         let mut mock = MockStorage::new();
-        mock.expect_move_object().return_once(move |req, _| {
-            assert_eq!(req.bucket, "projects/_/buckets/my-bucket");
-            assert_eq!(req.source_object, "src-object");
-            assert_eq!(req.destination_object, "dst-object");
-            assert_eq!(req.if_source_generation_match, Some(42));
-            assert_eq!(req.if_generation_not_match, Some(100));
+        mock.expect_move_object().return_once({
+            let want_bucket = want_bucket.clone();
+            let want_src = want_src.clone();
+            let want_dst = want_dst.clone();
+            move |req, _| {
+                assert_eq!(req.bucket, want_bucket);
+                assert_eq!(req.source_object, want_src);
+                assert_eq!(req.destination_object, want_dst);
+                assert_eq!(req.if_source_generation_match, Some(42));
+                assert_eq!(req.if_generation_not_match, Some(100));
 
-            let mut resp = Object::default();
-            resp.bucket = "projects/_/buckets/my-bucket".to_string();
-            resp.name = "dst-object".to_string();
-            resp.generation = 12345;
-            Ok(resp)
+                let mut resp = Object::default();
+                resp.bucket = want_bucket.clone();
+                resp.name = want_dst.clone();
+                resp.generation = 12345;
+                Ok(resp)
+            }
         });
 
         let client = gcs::client::Storage::from_stub(mock);
         let resp = client
             .move_object(&want_bucket, &want_src, &want_dst)
-            .if_source_generation_match(42)
-            .if_generation_not_match(100)
+            .set_if_source_generation_match(42)
+            .set_if_generation_not_match(100)
             .send()
             .await?;
 

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -108,7 +108,7 @@ pub async fn move_object(builder: StorageBuilder, bucket_name: &str, prefix: &st
     // 2. Move to destination
     let moved = client
         .move_object(bucket_name, &src_name, &dst_name)
-        .if_generation_match(0)
+        .set_if_generation_match(0)
         .send()
         .await?;
 
@@ -116,11 +116,8 @@ pub async fn move_object(builder: StorageBuilder, bucket_name: &str, prefix: &st
     assert_eq!(moved.name, dst_name);
 
     // 3. Read destination and verify content
-    let mut dst_response = client.read_object(bucket_name, &dst_name).send().await?;
-    let mut dst_contents = Vec::new();
-    while let Some(b) = dst_response.next().await.transpose()? {
-        dst_contents.extend_from_slice(&b);
-    }
+    let dst_response = client.read_object(bucket_name, &dst_name).send().await?;
+    let dst_contents = read_all(dst_response).await?;
     assert_eq!(dst_contents, MOVE_CONTENTS.as_bytes());
 
     // 4. Read source and verify it is gone (NotFound)
@@ -135,7 +132,13 @@ pub async fn move_object(builder: StorageBuilder, bucket_name: &str, prefix: &st
     );
 
     // 5. Clean up destination
-    let _ = client.read_object(bucket_name, &dst_name).send().await?; // verify it can be read one more time before delete
+    let control = StorageControl::builder().build().await?;
+    control
+        .delete_object()
+        .set_bucket(bucket_name)
+        .set_object(&dst_name)
+        .send()
+        .await?;
 
     tracing::info!("success with move_object()");
     Ok(())

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -91,6 +91,55 @@ pub async fn objects(builder: StorageBuilder, bucket_name: &str, prefix: &str) -
     Ok(())
 }
 
+pub async fn move_object(builder: StorageBuilder, bucket_name: &str, prefix: &str) -> Result<()> {
+    let client = builder.build().await?;
+    tracing::info!("testing move_object()");
+    const MOVE_CONTENTS: &str = "atomic move content";
+    let src_name = format!("{prefix}/move-src.txt");
+    let dst_name = format!("{prefix}/move-dst.txt");
+
+    // 1. Write source object
+    let _ = client
+        .write_object(bucket_name, &src_name, MOVE_CONTENTS)
+        .set_if_generation_match(0)
+        .send_unbuffered()
+        .await?;
+
+    // 2. Move to destination
+    let moved = client
+        .move_object(bucket_name, &src_name, &dst_name)
+        .if_generation_match(0)
+        .send()
+        .await?;
+
+    assert_eq!(moved.bucket, bucket_name);
+    assert_eq!(moved.name, dst_name);
+
+    // 3. Read destination and verify content
+    let mut dst_response = client.read_object(bucket_name, &dst_name).send().await?;
+    let mut dst_contents = Vec::new();
+    while let Some(b) = dst_response.next().await.transpose()? {
+        dst_contents.extend_from_slice(&b);
+    }
+    assert_eq!(dst_contents, MOVE_CONTENTS.as_bytes());
+
+    // 4. Read source and verify it is gone (NotFound)
+    let src_response = client.read_object(bucket_name, &src_name).send().await;
+    assert!(
+        src_response.as_ref().err().is_some_and(|e| {
+            e.http_status_code() == Some(404)
+                || e.status().is_some_and(|s| s.code == google_cloud_gax::error::rpc::Code::NotFound)
+        }),
+        "source object should be deleted after move, got: {src_response:?}"
+    );
+
+    // 5. Clean up destination
+    let _ = client.read_object(bucket_name, &dst_name).send().await?; // verify it can be read one more time before delete
+
+    tracing::info!("success with move_object()");
+    Ok(())
+}
+
 pub async fn signed_urls(
     builder: StorageBuilder,
     signer: &Signer,

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -128,7 +128,8 @@ pub async fn move_object(builder: StorageBuilder, bucket_name: &str, prefix: &st
     assert!(
         src_response.as_ref().err().is_some_and(|e| {
             e.http_status_code() == Some(404)
-                || e.status().is_some_and(|s| s.code == google_cloud_gax::error::rpc::Code::NotFound)
+                || e.status()
+                    .is_some_and(|s| s.code == google_cloud_gax::error::rpc::Code::NotFound)
         }),
         "source object should be deleted after move, got: {src_response:?}"
     );

--- a/tests/storage/tests/driver.rs
+++ b/tests/storage/tests/driver.rs
@@ -76,6 +76,12 @@ mod storage {
                 }
             }
 
+            tracing::info!("testing move_object");
+            let builder = Storage::builder();
+            integration_tests_storage::move_object(builder, &bucket.name, "move-object-test")
+                .await
+                .inspect_err(anydump)?;
+
             integration_tests_storage::read_object::run(&bucket.name)
                 .await
                 .inspect_err(anydump)?;


### PR DESCRIPTION
feat(storage): implement MoveObject atomic move/rename with preconditions

Add support for the GCS `MoveObject` API using a fluent request builder pattern
exposing the 8 standard source and destination precondition fields.

- Expose high-level `Storage::move_object` returning a `MoveObject<S>` builder.
- Bypass generated client wrappers inside transport in favor of direct execute
  routing to preserve the shared connection channel pool.
- Implement OpenTelemetry tracing and metric signals matching the SDK standard.
- Add a comprehensive mock integration test verifying correct mapping of all preconditions.
- Add a dedicated integration test function inside the `tests/storage` integration test suite.
- Create a new `move_file_atomic` example to showcase the new atomic move API.