### PR TITLE
feat(auth): enable regional access boundaries by default

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -35,7 +35,6 @@ locals {
   gcb_secret_name = "projects/${var.project}/secrets/github-github-oauthtoken-319d75/versions/latest"
 
   unstable_flags = join(" ", [
-    "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
     "--cfg google_cloud_unstable_grpc_server_streaming",
   ])

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.96" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -550,7 +550,6 @@ unexpected_cfgs = { level = "deny", check-cfg = [
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',
   'cfg(google_cloud_unstable_tracing)',
-  'cfg(google_cloud_unstable_trust_boundaries)',
   # Enables re-generation of protos. Only needed on major version updates to
   # Prost and/or Tonic.
   'cfg(google_cloud_generate_protos)',

--- a/src/auth/.gcb/builds/triggers/main.tf
+++ b/src/auth/.gcb/builds/triggers/main.tf
@@ -165,7 +165,7 @@ locals {
     }
     integration-unstable = {
       config = "integration.yaml"
-      flags  = "--cfg google_cloud_unstable_trust_boundaries"
+      flags  = ""
     }
   }
 }

--- a/src/auth/src/access_boundary.rs
+++ b/src/auth/src/access_boundary.rs
@@ -79,9 +79,7 @@ impl AccessBoundary {
     {
         let (tx_header, rx_header) = watch::channel((None, EntityTag::new()));
 
-        if Self::is_enabled() {
-            tokio::spawn(refresh_task(provider, tx_header));
-        }
+        tokio::spawn(refresh_task(provider, tx_header));
 
         Self { rx_header }
     }
@@ -89,16 +87,6 @@ impl AccessBoundary {
     pub(crate) fn new_no_op() -> Self {
         let (_, rx_header) = watch::channel((None, EntityTag::new()));
         Self { rx_header }
-    }
-    fn is_enabled() -> bool {
-        #[cfg(google_cloud_unstable_trust_boundaries)]
-        {
-            true
-        }
-        #[cfg(not(google_cloud_unstable_trust_boundaries))]
-        {
-            false
-        }
     }
 
     fn latest_header_value_and_entity_tag(&self) -> (Option<String>, EntityTag) {
@@ -258,15 +246,6 @@ where
             cache: Arc::new(Mutex::new(EntityTagCache::new())),
         }
     }
-
-    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
-    pub(crate) async fn wait_for_boundary(&self) {
-        let mut rx = self.access_boundary.rx_header.clone();
-        if rx.borrow().0.is_some() {
-            return;
-        }
-        let _ = rx.changed().await;
-    }
 }
 
 impl<T> CredentialsWithAccessBoundary<T>
@@ -307,10 +286,6 @@ where
     T: dynamic::AccessTokenCredentialsProvider + 'static,
 {
     async fn headers(&self, extensions: Extensions) -> Result<CacheableResource<HeaderMap>> {
-        if !AccessBoundary::is_enabled() {
-            return self.credentials.headers(extensions).await;
-        }
-
         let tag = extensions.get::<EntityTag>();
         let mut guard = self.cache.lock().await;
 
@@ -679,6 +654,19 @@ pub(crate) mod tests {
         }
     }
 
+    impl<T> CredentialsWithAccessBoundary<T>
+    where
+        T: dynamic::AccessTokenCredentialsProvider + 'static,
+    {
+        pub(crate) async fn wait_for_boundary(&self) {
+            let mut rx = self.access_boundary.rx_header.clone();
+            if rx.borrow().0.is_some() {
+                return;
+            }
+            let _ = rx.changed().await;
+        }
+    }
+
     #[test]
     #[parallel]
     fn test_service_account_url() {
@@ -715,7 +703,6 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_fetch_access_boundary_success() -> TestResult {
         let server = Server::run();
         server.expect(
@@ -764,7 +751,6 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_fetch_access_boundary_mds_success() -> TestResult {
         use crate::mds::MDS_DEFAULT_URI;
 
@@ -1073,7 +1059,6 @@ pub(crate) mod tests {
 
     #[tokio::test(start_paused = true)]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_entity_tag_caching_behavior() -> TestResult {
         let mut mock_creds = MockCredentials::new();
         let latest_token_etag = Arc::new(std::sync::RwLock::new(EntityTag::new()));
@@ -1250,7 +1235,6 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_credentials_with_access_boundary_non_default_universe() -> TestResult {
         let mut mock = MockCredentials::new();
         mock.expect_headers().returning(|_extensions| {
@@ -1283,7 +1267,6 @@ pub(crate) mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn test_mds_provider_non_default_universe() -> TestResult {
         let mut mock = MockCredentials::new();
         mock.expect_universe_domain()

--- a/src/auth/src/credentials/external_account.rs
+++ b/src/auth/src/credentials/external_account.rs
@@ -746,12 +746,6 @@ impl Builder {
         self
     }
 
-    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
-    fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
-        self.iam_endpoint_override = iam_endpoint_override;
-        self
-    }
-
     /// Returns a [Credentials] instance with the configured settings.
     ///
     /// # Errors
@@ -1546,6 +1540,13 @@ mod tests {
     use std::fmt;
     use test_case::test_case;
     use time::OffsetDateTime;
+
+    impl Builder {
+        fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
+            self.iam_endpoint_override = iam_endpoint_override;
+            self
+        }
+    }
 
     #[derive(Debug)]
     struct TestProviderError;
@@ -2476,7 +2477,6 @@ mod tests {
         "workforce_pool"
     )]
     #[tokio::test]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary(audience: &str, iam_path: &str) -> anyhow::Result<()> {
         use crate::credentials::tests::get_access_boundary_from_headers;
 

--- a/src/auth/src/credentials/impersonated.rs
+++ b/src/auth/src/credentials/impersonated.rs
@@ -2546,7 +2546,6 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::{get_access_boundary_from_headers, get_token_from_headers};
         let server = Server::run();

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -1386,7 +1386,6 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::get_access_boundary_from_headers;
         use crate::mds::MDS_UNIVERSE_DOMAIN_URI;

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -294,12 +294,6 @@ impl Builder {
         self
     }
 
-    #[cfg(all(test, google_cloud_unstable_trust_boundaries))]
-    fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
-        self.iam_endpoint_override = iam_endpoint_override;
-        self
-    }
-
     fn build_token_provider(self) -> BuildResult<ServiceAccountTokenProvider> {
         let service_account_key =
             serde_json::from_value::<ServiceAccountKey>(self.service_account_key)
@@ -659,6 +653,13 @@ mod tests {
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
     const SSJ_REGEX: &str = r"(?<header>[^\.]+)\.(?<claims>[^\.]+)\.(?<sig>[^\.]+)";
+
+    impl Builder {
+        fn maybe_iam_endpoint_override(mut self, iam_endpoint_override: Option<String>) -> Self {
+            self.iam_endpoint_override = iam_endpoint_override;
+            self
+        }
+    }
 
     #[test]
     #[parallel]
@@ -1118,7 +1119,6 @@ mod tests {
 
     #[tokio::test]
     #[parallel]
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     async fn e2e_access_boundary() -> TestResult {
         use crate::credentials::tests::get_access_boundary_from_headers;
         use httptest::responders::json_encoded;

--- a/tests/integration-auth/src/lib.rs
+++ b/tests/integration-auth/src/lib.rs
@@ -52,7 +52,6 @@ pub async fn service_account() -> anyhow::Result<()> {
     let _e = ScopedEnv::set("GOOGLE_APPLICATION_CREDENTIALS", path.to_str().unwrap());
     let creds = AccessTokenCredentialBuilder::default().build_access_token_credentials()?;
 
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     verify_access_boundaries(&creds).await?;
 
     // Construct a new SecretManager client using the credentials.
@@ -90,7 +89,6 @@ pub async fn service_account_with_audience() -> anyhow::Result<()> {
         ))
         .build_access_token_credentials()?;
 
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     verify_access_boundaries(&creds).await?;
 
     // Construct a new SecretManager client using the credentials.
@@ -130,7 +128,6 @@ pub async fn impersonated() -> anyhow::Result<()> {
             ))
             .build_access_token_credentials()?;
 
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     verify_access_boundaries(&impersonated_creds).await?;
 
     let client = SecretManagerService::builder()
@@ -194,7 +191,6 @@ pub async fn mds() -> anyhow::Result<()> {
     // Uses MDS on CI
     let creds = AccessTokenCredentialBuilder::default().build_access_token_credentials()?;
 
-    #[cfg(google_cloud_unstable_trust_boundaries)]
     verify_access_boundaries(&creds).await?;
 
     // Construct a new SecretManager client using the MDS credentials.
@@ -706,7 +702,6 @@ pub async fn id_token_impersonated() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(google_cloud_unstable_trust_boundaries)]
 pub async fn verify_access_boundaries<C>(creds: &C) -> anyhow::Result<()>
 where
     C: google_cloud_auth::credentials::CredentialsProvider + ?Sized,


### PR DESCRIPTION
Towards #5719 