### PR TITLE
ci: add `google_cloud_unstable_tracing` to trigger flags

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -38,6 +38,7 @@ locals {
     "--cfg google_cloud_unstable_trust_boundaries",
     "--cfg google_cloud_unstable_storage_bidi",
     "--cfg google_cloud_unstable_grpc_server_streaming",
+    "--cfg google_cloud_unstable_tracing",
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"


### PR DESCRIPTION
The `google_cloud_unstable_tracing` configuration flag was missing from the GCB triggers definition. This leaves tracing-related clippy warnings undetected.