### PR TITLE
chore: update librarian to v0.16.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.15.0
+version: v0.16.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Update the Librarian version and generate the code using the version. It did not generate code diff.