### PR TITLE
ci: disable cache during doc pushes

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -152,6 +152,11 @@ jobs:
           path: |
             ~/.cargo
           key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
+          # Disable caching completely during release runs. This gives us peace
+          # of mind w.r.t. cache poisoning attacks that install nefarious
+          # versions of `mdbook` or otherwise create evil instances of the
+          # user guide.
+          if: github.event_name != 'release'
       - name: Setup Rust ${{ matrix.rust-version }}
         run: |
           set -e


### PR DESCRIPTION
It is possible to create a nefarious `googleapis.github.io` site by first poisoning the cache with a bad mdbook (or other dependency) version, and then publishing a site that hosts cross-site scripting attacks (or worse).

I think this attack is implausible for us, because we review the code before merging, so the cache for `main` and release branches is unlikely to be poisoned.

But I could be wrong, and it is easier to perform static analysis if we just stop the cache from being used during releases. It is not as-if- we need these steps to be fast.