### PR TITLE
feat(o11y): track `destination_id` state in `LroRecorder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6079,6 +6079,7 @@ dependencies = [
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-gax-internal",
+ "google-cloud-lro",
  "google-cloud-monitoring-v3",
  "google-cloud-showcase-v1beta1",
  "google-cloud-storage",

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -31,6 +31,7 @@ tokio::task_local! {
 pub struct LroRecorder {
     span: Span,
     attempt_count: Option<u32>,
+    destination_id: std::sync::Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl LroRecorder {
@@ -39,6 +40,7 @@ impl LroRecorder {
         Self {
             span,
             attempt_count: None,
+            destination_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -100,11 +102,22 @@ impl LroRecorder {
         Self {
             span: self.span.clone(),
             attempt_count: Some(count),
+            destination_id: self.destination_id.clone(),
         }
     }
 
     pub fn record_destination_id(&self, name: &str) {
         self.span.record("gcp.resource.destination.id", name);
+        if let Ok(mut guard) = self.destination_id.lock() {
+            *guard = Some(name.to_string());
+        }
+    }
+
+    pub fn destination_id(&self) -> Option<String> {
+        self.destination_id
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().cloned())
     }
 
     pub fn record_error(&self, err: &crate::Error) {
@@ -132,6 +145,10 @@ macro_rules! record_polling_attributes {
                 let span = &$span;
                 span.record("gcp.longrunning.poll_attempt_count", attempt);
                 span.record("gcp.longrunning.done", false);
+            }
+            if let Some(dest_id) = recorder.destination_id() {
+                let span = &$span;
+                span.record("gcp.resource.destination.id", dest_id);
             }
         }
     };
@@ -335,6 +352,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_lro_recorder_span_nesting() {
+        let _guard = TestLayer::initialize();
         let span = tracing::info_span!("test_lro_span");
         let recorder = LroRecorder::new(span.clone());
 
@@ -361,6 +379,7 @@ mod tests {
             client_request_signals!(info: &InstrumentationClientInfo::default(), method: "test");
 
         let recorder = LroRecorder::new(span.clone()).with_attempt_count(42);
+        recorder.record_destination_id("my-test-lro-id");
 
         recorder
             .scope(async move {
@@ -383,6 +402,14 @@ mod tests {
         assert_eq!(
             got.attributes.get("gcp.longrunning.done"),
             Some(&google_cloud_test_utils::test_layer::AttributeValue::Boolean(false))
+        );
+        assert_eq!(
+            got.attributes.get("gcp.resource.destination.id"),
+            Some(
+                &google_cloud_test_utils::test_layer::AttributeValue::String(
+                    std::borrow::Cow::Borrowed("my-test-lro-id")
+                )
+            )
         );
     }
 

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -23,15 +23,19 @@ tokio::task_local! {
 /// A recorder that manages LRO spans and propagates active telemetry context.
 ///
 /// To prevent concurrent mutation race conditions under multi-threaded tokio executors,
-/// `LroRecorder` is completely immutable. Context updates (like setting the transient `attempt_count`
+/// `LroRecorder` is largely immutable. Context updates (like setting the transient `attempt_count`
 /// during a polling cycle) are performed using copy-on-write builders (`with_attempt_count`)
-/// to establish new immutable task-local scopes.
+/// to establish new task-local scopes.
+///
+/// The `destination_id` is an exception: it is a write-once, read-many value shared across
+/// all clones of a given recorder, ensuring that once discovered, the ID propagates to all
+/// future polling spans.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct LroRecorder {
     span: Span,
     attempt_count: Option<u32>,
-    destination_id: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    destination_id: std::sync::Arc<std::sync::OnceLock<String>>,
 }
 
 impl LroRecorder {
@@ -40,7 +44,7 @@ impl LroRecorder {
         Self {
             span,
             attempt_count: None,
-            destination_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            destination_id: std::sync::Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -108,16 +112,11 @@ impl LroRecorder {
 
     pub fn record_destination_id(&self, name: &str) {
         self.span.record("gcp.resource.destination.id", name);
-        if let Ok(mut guard) = self.destination_id.lock() {
-            *guard = Some(name.to_string());
-        }
+        let _ = self.destination_id.set(name.to_string());
     }
 
     pub fn destination_id(&self) -> Option<String> {
-        self.destination_id
-            .lock()
-            .ok()
-            .and_then(|g| g.as_ref().cloned())
+        self.destination_id.get().cloned()
     }
 
     pub fn record_error(&self, err: &crate::Error) {

--- a/tests/o11y/Cargo.toml
+++ b/tests/o11y/Cargo.toml
@@ -32,6 +32,7 @@ chrono                        = { workspace = true, features = ["now"] }
 futures.workspace             = true
 google-cloud-auth.workspace   = true
 google-cloud-gax.workspace    = true
+google-cloud-lro.workspace    = true
 gaxi                          = { workspace = true, features = ["_internal-grpc-client"] }
 google-cloud-test-utils       = { workspace = true }
 google-cloud-showcase-v1beta1 = { workspace = true, features = ["default"] }


### PR DESCRIPTION
Introduce a synchronized `destination_id` state to `google_cloud_lro::LroRecorder` to persist the extracted resource destination ID across polling iterations.

This serves as the underlying plumbing for generated tracing decorators to inject `gcp.resource.destination.id` into LRO spans.