### PR TITLE
chore(spanner): need versioned dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,28 +512,28 @@ google-cloud-osconfig-v1                        = { default-features = false, ve
 google-cloud-oslogin-common                     = { default-features = false, version = "1.6.0", path = "src/generated/oslogin/common" }
 google-cloud-recommender-v1                     = { default-features = false, version = "1.10.0", path = "src/generated/cloud/recommender/v1" }
 google-cloud-rpc-context                        = { default-features = false, version = "1.5.0", path = "src/generated/rpc/context" }
+google-cloud-spanner-admin-database-v1          = { default-features = false, version = "1.11.0", path = "src/generated/spanner/admin/database/v1" }
+google-cloud-spanner-admin-instance-v1          = { default-features = false, version = "1.11.0", path = "src/generated/spanner/admin/instance/v1" }
 # Used in integration tests, these are leaf nodes in the dependency graph. Should not get a `version`.
-google-cloud-speech-v2                 = { default-features = false, path = "src/generated/cloud/speech/v2" }
-google-cloud-secretmanager-v1          = { default-features = false, path = "src/generated/cloud/secretmanager/v1" }
-google-cloud-aiplatform-v1             = { default-features = false, path = "src/generated/cloud/aiplatform/v1" }
-google-cloud-compute-v1                = { default-features = false, path = "src/generated/cloud/compute/v1" }
-google-cloud-storage                   = { default-features = false, path = "src/storage" }
-google-cloud-pubsub                    = { default-features = false, path = "src/pubsub" }
-google-cloud-spanner                   = { default-features = false, path = "src/spanner" }
-google-cloud-spanner-admin-database-v1 = { default-features = false, path = "src/generated/spanner/admin/database/v1" }
-google-cloud-spanner-admin-instance-v1 = { default-features = false, path = "src/generated/spanner/admin/instance/v1" }
-google-cloud-bigquery-v2               = { default-features = false, path = "src/generated/cloud/bigquery/v2" }
-google-cloud-iam-credentials-v1        = { default-features = false, path = "src/generated/iam/credentials/v1" }
-google-cloud-language-v2               = { default-features = false, path = "src/generated/cloud/language/v2" }
-google-cloud-dns-v1                    = { default-features = false, path = "src/generated/cloud/dns/v1" }
-google-cloud-firestore                 = { default-features = false, path = "src/firestore" }
-google-cloud-monitoring-v3             = { default-features = false, path = "src/generated/monitoring/v3" }
-google-cloud-showcase-v1beta1          = { default-features = false, path = "src/generated/showcase" }
-google-cloud-telcoautomation-v1        = { default-features = false, path = "src/generated/cloud/telcoautomation/v1" }
-google-cloud-trace-v1                  = { default-features = false, path = "src/generated/devtools/cloudtrace/v1" }
-google-cloud-workflows-v1              = { default-features = false, path = "src/generated/cloud/workflows/v1" }
-google-cloud-workflows-executions-v1   = { default-features = false, path = "src/generated/cloud/workflows/executions/v1" }
-secretmanager-openapi-v1               = { default-features = false, path = "src/generated/openapi-validation" }
+google-cloud-speech-v2               = { default-features = false, path = "src/generated/cloud/speech/v2" }
+google-cloud-secretmanager-v1        = { default-features = false, path = "src/generated/cloud/secretmanager/v1" }
+google-cloud-aiplatform-v1           = { default-features = false, path = "src/generated/cloud/aiplatform/v1" }
+google-cloud-compute-v1              = { default-features = false, path = "src/generated/cloud/compute/v1" }
+google-cloud-storage                 = { default-features = false, path = "src/storage" }
+google-cloud-pubsub                  = { default-features = false, path = "src/pubsub" }
+google-cloud-spanner                 = { default-features = false, path = "src/spanner" }
+google-cloud-bigquery-v2             = { default-features = false, path = "src/generated/cloud/bigquery/v2" }
+google-cloud-iam-credentials-v1      = { default-features = false, path = "src/generated/iam/credentials/v1" }
+google-cloud-language-v2             = { default-features = false, path = "src/generated/cloud/language/v2" }
+google-cloud-dns-v1                  = { default-features = false, path = "src/generated/cloud/dns/v1" }
+google-cloud-firestore               = { default-features = false, path = "src/firestore" }
+google-cloud-monitoring-v3           = { default-features = false, path = "src/generated/monitoring/v3" }
+google-cloud-showcase-v1beta1        = { default-features = false, path = "src/generated/showcase" }
+google-cloud-telcoautomation-v1      = { default-features = false, path = "src/generated/cloud/telcoautomation/v1" }
+google-cloud-trace-v1                = { default-features = false, path = "src/generated/devtools/cloudtrace/v1" }
+google-cloud-workflows-v1            = { default-features = false, path = "src/generated/cloud/workflows/v1" }
+google-cloud-workflows-executions-v1 = { default-features = false, path = "src/generated/cloud/workflows/executions/v1" }
+secretmanager-openapi-v1             = { default-features = false, path = "src/generated/openapi-validation" }
 # Local test packages (never add a version)
 google-cloud-test-macros  = { path = "src/test-macros" }
 google-cloud-test-utils   = { default-features = false, path = "src/test-utils" }


### PR DESCRIPTION
I missed this: to publish `google-cloud-spanner` it must have version numbers for all its dependencies.