### PR TITLE
feat(o11y): add `record_polling_attributes` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3567,6 +3567,7 @@ dependencies = [
  "futures",
  "google-cloud-auth",
  "google-cloud-gax",
+ "google-cloud-gax-internal",
  "google-cloud-longrunning",
  "google-cloud-lro",
  "google-cloud-rpc",

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -56,6 +56,7 @@ tracing = { workspace = true }
 [target.'cfg(google_cloud_unstable_tracing)'.dev-dependencies]
 tracing-subscriber      = { workspace = true, features = ["registry"] }
 google-cloud-test-utils = { workspace = true }
+gaxi = { workspace = true, features = ["_internal-common"] }
 
 [features]
 unstable-stream = ["dep:futures", "dep:pin-project"]

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -56,7 +56,7 @@ tracing = { workspace = true }
 [target.'cfg(google_cloud_unstable_tracing)'.dev-dependencies]
 tracing-subscriber      = { workspace = true, features = ["registry"] }
 google-cloud-test-utils = { workspace = true }
-gaxi = { workspace = true, features = ["_internal-common"] }
+gaxi                    = { workspace = true, features = ["_internal-common"] }
 
 [features]
 unstable-stream = ["dep:futures", "dep:pin-project"]

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -98,20 +98,6 @@ impl LroRecorder {
     }
 }
 
-/// Helper macro to create a tracing span for polling standard LROs with consistently named attributes.
-#[cfg(test)]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! polling_span {
-    ($name:expr) => {
-        tracing::info_span!(
-            $name,
-            "gcp.longrunning.poll_attempt_count" = tracing::field::Empty,
-            "gcp.longrunning.done" = tracing::field::Empty,
-        )
-    };
-}
-
 /// Injects LRO-specific telemetry attributes into the active span.
 #[macro_export]
 #[doc(hidden)]
@@ -214,6 +200,8 @@ where
 mod tests {
     use super::*;
     use crate::Error;
+    use gaxi::client_request_signals;
+    use gaxi::options::InstrumentationClientInfo;
     use google_cloud_test_utils::test_layer::TestLayer;
     use google_cloud_wkt::{Duration, Timestamp};
 
@@ -345,7 +333,8 @@ mod tests {
     async fn record_polling_attributes_macro() {
         let guard = TestLayer::initialize();
 
-        let span = crate::polling_span!("test_span");
+        let span =
+            client_request_signals!(info: &InstrumentationClientInfo::default(), method: "test");
 
         let recorder = LroRecorder::new(span.clone()).with_attempt_count(42);
 
@@ -358,7 +347,10 @@ mod tests {
         drop(recorder);
 
         let captured = TestLayer::capture(&guard);
-        let got = captured.iter().find(|s| s.name == "test_span").unwrap();
+        let got = captured
+            .iter()
+            .find(|s| s.name == "client_request")
+            .unwrap();
 
         assert_eq!(
             got.attributes.get("gcp.longrunning.poll_attempt_count"),
@@ -375,7 +367,8 @@ mod tests {
     async fn record_polling_attributes_macro_no_recorder() {
         let guard = TestLayer::initialize();
 
-        let span = crate::polling_span!("test_span_no_recorder");
+        let span =
+            client_request_signals!(info: &InstrumentationClientInfo::default(), method: "test");
 
         crate::record_polling_attributes!(&span);
 
@@ -384,7 +377,7 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         let got = captured
             .iter()
-            .find(|s| s.name == "test_span_no_recorder")
+            .find(|s| s.name == "client_request")
             .unwrap();
 
         assert!(
@@ -400,7 +393,8 @@ mod tests {
     async fn record_polling_attributes_macro_no_attempt_count() {
         let guard = TestLayer::initialize();
 
-        let span = crate::polling_span!("test_span_no_attempt");
+        let span =
+            client_request_signals!(info: &InstrumentationClientInfo::default(), method: "test");
 
         let recorder = LroRecorder::new(span.clone());
 
@@ -415,7 +409,7 @@ mod tests {
         let captured = TestLayer::capture(&guard);
         let got = captured
             .iter()
-            .find(|s| s.name == "test_span_no_attempt")
+            .find(|s| s.name == "client_request")
             .unwrap();
 
         assert!(

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -98,6 +98,34 @@ impl LroRecorder {
     }
 }
 
+/// Helper macro to create a tracing span for polling standard LROs with consistently named attributes.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! polling_span {
+    ($name:expr) => {
+        tracing::info_span!(
+            $name,
+            "gcp.longrunning.poll_attempt_count" = tracing::field::Empty,
+            "gcp.longrunning.done" = tracing::field::Empty,
+        )
+    };
+}
+
+/// Injects LRO-specific telemetry attributes into the active span.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! record_polling_attributes {
+    ($span:expr) => {
+        if let Some(recorder) = $crate::LroRecorder::current() {
+            if let Some(attempt) = recorder.attempt_count() {
+                let span = &$span;
+                span.record("gcp.longrunning.poll_attempt_count", attempt);
+                span.record("gcp.longrunning.done", false);
+            }
+        }
+    };
+}
+
 /// Decorate a poller with tracing information.
 #[derive(Clone, Debug)]
 pub struct Tracing<P> {
@@ -185,6 +213,7 @@ where
 mod tests {
     use super::*;
     use crate::Error;
+    use google_cloud_test_utils::test_layer::TestLayer;
     use google_cloud_wkt::{Duration, Timestamp};
 
     struct FailingPoller;
@@ -210,12 +239,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_tracing_decorator_error_reporting() {
-        let guard = google_cloud_test_utils::test_layer::TestLayer::initialize();
+        let guard = TestLayer::initialize();
 
         let span = tracing::info_span!(
             "test_span",
-            otel.status_code = tracing::field::Empty,
-            otel.status_description = tracing::field::Empty,
+            "otel.status_code" = tracing::field::Empty,
+            "otel.status_description" = tracing::field::Empty,
         );
 
         let poller = Tracing::new(FailingPoller, span);
@@ -224,7 +253,7 @@ mod tests {
         assert!(got.is_err());
 
         {
-            let captured = google_cloud_test_utils::test_layer::TestLayer::capture(&guard);
+            let captured = TestLayer::capture(&guard);
             let got = captured
                 .iter()
                 .find(|s| s.name == "test_span")
@@ -308,5 +337,91 @@ mod tests {
                 assert_eq!(active_recorder.span, span_clone);
             })
             .await;
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test]
+    async fn record_polling_attributes_macro() {
+        let guard = TestLayer::initialize();
+
+        let span = crate::polling_span!("test_span");
+
+        let recorder = LroRecorder::new(span.clone()).with_attempt_count(42);
+
+        recorder
+            .scope(async move {
+                crate::record_polling_attributes!(&span);
+            })
+            .await;
+
+        drop(recorder);
+
+        let captured = TestLayer::capture(&guard);
+        let got = captured.iter().find(|s| s.name == "test_span").unwrap();
+
+        assert_eq!(
+            got.attributes.get("gcp.longrunning.poll_attempt_count"),
+            Some(&google_cloud_test_utils::test_layer::AttributeValue::UInt64(42))
+        );
+        assert_eq!(
+            got.attributes.get("gcp.longrunning.done"),
+            Some(&google_cloud_test_utils::test_layer::AttributeValue::Boolean(false))
+        );
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test]
+    async fn record_polling_attributes_macro_no_recorder() {
+        let guard = TestLayer::initialize();
+
+        let span = crate::polling_span!("test_span_no_recorder");
+
+        crate::record_polling_attributes!(&span);
+
+        drop(span); // capture it
+
+        let captured = TestLayer::capture(&guard);
+        let got = captured
+            .iter()
+            .find(|s| s.name == "test_span_no_recorder")
+            .unwrap();
+
+        assert!(
+            got.attributes
+                .get("gcp.longrunning.poll_attempt_count")
+                .is_none()
+        );
+        assert!(got.attributes.get("gcp.longrunning.done").is_none());
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test]
+    async fn record_polling_attributes_macro_no_attempt_count() {
+        let guard = TestLayer::initialize();
+
+        let span = crate::polling_span!("test_span_no_attempt");
+
+        let recorder = LroRecorder::new(span.clone());
+
+        recorder
+            .scope(async move {
+                crate::record_polling_attributes!(&span);
+            })
+            .await;
+
+        drop(recorder);
+
+        let captured = TestLayer::capture(&guard);
+        let got = captured
+            .iter()
+            .find(|s| s.name == "test_span_no_attempt")
+            .unwrap();
+
+        assert!(
+            got.attributes
+                .get("gcp.longrunning.poll_attempt_count")
+                .is_none()
+        );
+        assert!(got.attributes.get("gcp.longrunning.done").is_none());
     }
 }

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -99,6 +99,7 @@ impl LroRecorder {
 }
 
 /// Helper macro to create a tracing span for polling standard LROs with consistently named attributes.
+#[cfg(test)]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! polling_span {


### PR DESCRIPTION
Introduce the `record_polling_attributes!` macro to `google-cloud-lro` to encapsulate the boilerplate required for injecting LRO telemetry attributes (e.g., poll attempt count) into the active span.

For https://github.com/googleapis/librarian/pull/6275