### PR TITLE
test(spanner): retry internal errors from the Emulator

### DIFF
--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -20,7 +20,9 @@ use crate::model::{
 };
 use crate::server_streaming::builder;
 use gaxi::options::{ClientConfig, Credentials};
+use google_cloud_auth::credentials::anonymous;
 use google_cloud_gax::client_builder::ClientBuilder as GaxClientBuilder;
+use google_cloud_gax::client_builder::internal::new_builder;
 use google_cloud_gax::options::{
     RequestOptions as GaxRequestOptions, internal::RequestOptionsExt as _,
 };
@@ -49,6 +51,7 @@ pub struct Spanner {
     pub(crate) channels: Vec<Channel>,
     pub(crate) counter: std::sync::Arc<AtomicUsize>,
     pub(crate) config: ClientConfig,
+    pub(crate) is_emulator: bool,
 }
 
 /// A factory for constructing `Spanner` clients.
@@ -58,7 +61,21 @@ impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
     type Client = Spanner;
     type Credentials = Credentials;
 
-    async fn build(self, config: ClientConfig) -> crate::ClientBuilderResult<Self::Client> {
+    async fn build(self, mut config: ClientConfig) -> crate::ClientBuilderResult<Self::Client> {
+        let mut is_emulator = false;
+        if let Some(endpoint) = std::env::var("SPANNER_EMULATOR_HOST")
+            .ok()
+            .filter(|s| !s.is_empty())
+        {
+            is_emulator = true;
+            if config.endpoint.is_none() {
+                config.endpoint = Some(parse_emulator_endpoint(&endpoint));
+            }
+            if config.cred.is_none() {
+                config.cred = Some(anonymous::Builder::new().build());
+            }
+        }
+
         let num_channels = std::env::var("SPANNER_NUM_CHANNELS")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
@@ -73,6 +90,7 @@ impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
             channels,
             counter: std::sync::Arc::new(AtomicUsize::new(0)),
             config,
+            is_emulator,
         })
     }
 }
@@ -175,22 +193,7 @@ impl Spanner {
     /// detects and connects to the Spanner emulator if the `SPANNER_EMULATOR_HOST`
     /// environment variable is set.
     pub fn builder() -> ClientBuilder {
-        let builder = google_cloud_gax::client_builder::internal::new_builder(Factory);
-        // The Spanner client should automatically use the Spanner emulator if the
-        // SPANNER_EMULATOR_HOST environment variable is set.
-        let Some(endpoint) = std::env::var("SPANNER_EMULATOR_HOST")
-            .ok()
-            .filter(|s| !s.is_empty())
-        else {
-            return builder;
-        };
-
-        // Determine if we need to prefix the endpoint with a scheme
-        let full_endpoint = parse_emulator_endpoint(&endpoint);
-
-        builder
-            .with_endpoint(full_endpoint)
-            .with_credentials(google_cloud_auth::credentials::anonymous::Builder::new().build())
+        new_builder(Factory)
     }
 
     /// Returns a builder for the [DatabaseAdmin] client.
@@ -221,11 +224,7 @@ impl Spanner {
         C: Clone + From<Credentials>,
     {
         if let Some(ref endpoint) = self.config.endpoint {
-            let is_emulator = std::env::var("SPANNER_EMULATOR_HOST")
-                .ok()
-                .filter(|s| !s.is_empty())
-                .is_some();
-            let ep = map_emulator_admin_endpoint(endpoint, is_emulator);
+            let ep = map_emulator_admin_endpoint(endpoint, self.is_emulator);
             builder = builder.with_endpoint(ep);
         }
         if let Some(ref cred) = self.config.cred {
@@ -279,7 +278,12 @@ impl Spanner {
             }],
             counter: std::sync::Arc::new(AtomicUsize::new(0)),
             config: ClientConfig::default(),
+            is_emulator: false,
         }
+    }
+
+    pub(crate) fn is_emulator(&self) -> bool {
+        self.is_emulator
     }
 
     pub(crate) fn get_channel(&self, hint: usize) -> &Channel {

--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -54,6 +54,10 @@ pub struct DatabaseClient {
 }
 
 impl DatabaseClient {
+    pub(crate) fn is_emulator(&self) -> bool {
+        self.spanner.is_emulator()
+    }
+
     /// Returns a builder for a single-use read-only transaction.
     ///
     /// # Example

--- a/src/spanner/src/partitioned_dml_transaction.rs
+++ b/src/spanner/src/partitioned_dml_transaction.rs
@@ -180,9 +180,9 @@ impl PartitionedDmlTransaction {
         let base_request = statement.into_request();
         let channel_hint = self.client.spanner.next_channel_hint();
         let client = self.client;
+        let is_emulator = client.is_emulator();
 
-        // Execute the statement and retry if the transaction is aborted by Spanner.
-        retry_aborted(&*self.retry_policy, || {
+        let action = || {
             let begin_request = begin_request.clone();
             let base_request = base_request.clone();
             let session_name = session_name.clone();
@@ -214,8 +214,9 @@ impl PartitionedDmlTransaction {
 
                 extract_lower_bound_update_count_from_stream(stream).await
             }
-        })
-        .await
+        };
+
+        retry_aborted(&*self.retry_policy, action, is_emulator).await
     }
 
     fn amend_gax_options(&self, options: &mut GaxRequestOptions) {

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -63,7 +63,7 @@ use wkt::Duration;
 /// A builder for [ReadWriteTransaction].
 #[derive(Clone, Debug)]
 pub(crate) struct ReadWriteTransactionBuilder {
-    client: DatabaseClient,
+    pub(crate) client: DatabaseClient,
     options: TransactionOptions,
     transaction_tag: Option<String>,
     max_commit_delay: Option<Duration>,

--- a/src/spanner/src/transaction_retry_policy.rs
+++ b/src/spanner/src/transaction_retry_policy.rs
@@ -104,6 +104,7 @@ impl TransactionRetryPolicy for BasicTransactionRetryPolicy {
 pub(crate) async fn retry_aborted<T, F, Fut>(
     policy: &dyn TransactionRetryPolicy,
     mut f: F,
+    is_emulator: bool,
 ) -> crate::Result<T>
 where
     F: FnMut() -> Fut,
@@ -120,7 +121,15 @@ where
         match f().await {
             Ok(v) => return Ok(v),
             Err(e) => {
-                backoff_if_aborted(e, attempts, start_time.elapsed(), policy, &backoff).await?;
+                backoff_if_aborted(
+                    e,
+                    attempts,
+                    start_time.elapsed(),
+                    policy,
+                    &backoff,
+                    is_emulator,
+                )
+                .await?;
             }
         }
     }
@@ -149,6 +158,18 @@ pub(crate) fn default_retry_backoff() -> ExponentialBackoff {
         .unwrap()
 }
 
+pub(crate) fn is_internal_emulator_error(err: &crate::Error) -> bool {
+    if let Some(status) = err.status() {
+        status.code == google_cloud_gax::error::rpc::Code::Internal
+            && status.message.contains("Schema generation")
+            && status
+                .message
+                .contains("was not registered with the Action Manager")
+    } else {
+        false
+    }
+}
+
 /// Evaluates the error against the retry policy and delays execution if a retry is warranted.
 /// Returns Ok(()) after sleeping if a retry should occur, otherwise returns Err with the original error.
 pub(crate) async fn backoff_if_aborted(
@@ -157,8 +178,17 @@ pub(crate) async fn backoff_if_aborted(
     elapsed: Duration,
     policy: &dyn TransactionRetryPolicy,
     backoff: &ExponentialBackoff,
+    is_emulator: bool,
 ) -> crate::Result<()> {
-    if !is_aborted(&err) {
+    let should_retry = if is_aborted(&err) {
+        true
+    } else if is_emulator {
+        is_internal_emulator_error(&err)
+    } else {
+        false
+    };
+
+    if !should_retry {
         return Err(err);
     }
 
@@ -265,19 +295,28 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn retry_aborted_success_first_try() {
         let policy = BasicTransactionRetryPolicy::default();
-        let res = retry_aborted(&policy, || async { Ok::<i32, Error>(42) }).await;
+        let res = retry_aborted(
+            &policy,
+            || async { Ok::<i32, Error>(42) },
+            /* is_emulator = */ false,
+        )
+        .await;
         assert_eq!(res.expect("Transaction should succeed cleanly"), 42);
     }
 
     #[tokio::test]
     async fn retry_aborted_not_aborted_error() {
         let policy = BasicTransactionRetryPolicy::default();
-        let res = retry_aborted(&policy, || async {
-            let status = Status::default()
-                .set_code(Code::Unavailable)
-                .set_message("server unavailable");
-            Err::<i32, Error>(Error::service(status))
-        })
+        let res = retry_aborted(
+            &policy,
+            || async {
+                let status = Status::default()
+                    .set_code(Code::Unavailable)
+                    .set_message("server unavailable");
+                Err::<i32, Error>(Error::service(status))
+            },
+            /* is_emulator = */ false,
+        )
         .await;
 
         let err = res.unwrap_err();
@@ -294,13 +333,17 @@ pub(crate) mod tests {
             .with_total_timeout(Duration::from_secs(0));
         let attempts = Arc::new(AtomicU32::new(0));
 
-        let res = retry_aborted(&policy, || {
-            let attempts = attempts.clone();
-            async move {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                Err::<i32, Error>(create_aborted_error(None))
-            }
-        })
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<i32, Error>(create_aborted_error(None))
+                }
+            },
+            /* is_emulator = */ false,
+        )
         .await;
 
         assert!(res.is_err());
@@ -313,17 +356,21 @@ pub(crate) mod tests {
         let attempts = Arc::new(AtomicU32::new(0));
 
         let start = tokio::time::Instant::now();
-        let res = retry_aborted(&policy, || {
-            let attempts = attempts.clone();
-            async move {
-                let current = attempts.fetch_add(1, Ordering::SeqCst);
-                if current == 0 {
-                    Err::<i32, Error>(create_aborted_error(Some(Duration::from_nanos(1))))
-                } else {
-                    Ok::<i32, Error>(100)
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    let current = attempts.fetch_add(1, Ordering::SeqCst);
+                    if current == 0 {
+                        Err::<i32, Error>(create_aborted_error(Some(Duration::from_nanos(1))))
+                    } else {
+                        Ok::<i32, Error>(100)
+                    }
                 }
-            }
-        })
+            },
+            /* is_emulator = */ false,
+        )
         .await;
         let elapsed = start.elapsed();
 
@@ -341,17 +388,21 @@ pub(crate) mod tests {
         let policy = BasicTransactionRetryPolicy::default();
         let attempts = Arc::new(AtomicU32::new(0));
 
-        let res = retry_aborted(&policy, || {
-            let attempts = attempts.clone();
-            async move {
-                let current = attempts.fetch_add(1, Ordering::SeqCst);
-                if current == 0 {
-                    Err::<i32, Error>(create_aborted_error(None))
-                } else {
-                    Ok::<i32, Error>(100)
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    let current = attempts.fetch_add(1, Ordering::SeqCst);
+                    if current == 0 {
+                        Err::<i32, Error>(create_aborted_error(None))
+                    } else {
+                        Ok::<i32, Error>(100)
+                    }
                 }
-            }
-        })
+            },
+            /* is_emulator = */ false,
+        )
         .await;
 
         assert_eq!(
@@ -368,15 +419,19 @@ pub(crate) mod tests {
             .with_total_timeout(Duration::from_secs(1));
         let attempts = Arc::new(AtomicU32::new(0));
 
-        let res = retry_aborted(&policy, || {
-            let attempts = attempts.clone();
-            async move {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                // Return a retry delay of 600ms so that after 2 attempts (1.2s total delay),
-                // we should definitely exceed the 1 second timeout for the 3rd fail check.
-                Err::<i32, Error>(create_aborted_error(Some(Duration::from_millis(600))))
-            }
-        })
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    // Return a retry delay of 600ms so that after 2 attempts (1.2s total delay),
+                    // we should definitely exceed the 1 second timeout for the 3rd fail check.
+                    Err::<i32, Error>(create_aborted_error(Some(Duration::from_millis(600))))
+                }
+            },
+            /* is_emulator = */ false,
+        )
         .await;
 
         assert!(res.is_err());
@@ -441,16 +496,72 @@ pub(crate) mod tests {
         let policy = CustomPolicy;
         let attempts = Arc::new(AtomicU32::new(0));
 
-        let res = retry_aborted(&policy, || {
-            let attempts = attempts.clone();
-            async move {
-                attempts.fetch_add(1, Ordering::SeqCst);
-                Err::<i32, Error>(create_aborted_error(None))
-            }
-        })
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<i32, Error>(create_aborted_error(None))
+                }
+            },
+            /* is_emulator = */ false,
+        )
         .await;
 
         assert!(res.is_err());
         assert_eq!(attempts.load(Ordering::SeqCst), 3); // Initial + 2 failures check
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_aborted_emulator_internal_schema_error() {
+        let policy = BasicTransactionRetryPolicy::default();
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let make_schema_error = || {
+            let status = Status::default().set_code(Code::Internal).set_message(
+                "INTERNAL: Schema generation 0 was not registered with the Action Manager",
+            );
+            Error::service(status)
+        };
+
+        // If not running on emulator, it should fail immediately (no retry)
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                let err = make_schema_error();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<i32, Error>(err)
+                }
+            },
+            /* is_emulator = */ false,
+        )
+        .await;
+        assert!(res.is_err());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        // If running on the emulator, it should retry just like aborted error
+        attempts.store(0, Ordering::SeqCst);
+        let res = retry_aborted(
+            &policy,
+            || {
+                let attempts = attempts.clone();
+                let err = make_schema_error();
+                async move {
+                    let current = attempts.fetch_add(1, Ordering::SeqCst);
+                    if current == 0 {
+                        Err::<i32, Error>(err)
+                    } else {
+                        Ok::<i32, Error>(200)
+                    }
+                }
+            },
+            /* is_emulator = */ true,
+        )
+        .await;
+        assert_eq!(res.expect("should succeed after retry"), 200);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
     }
 }

--- a/src/spanner/src/transaction_runner.rs
+++ b/src/spanner/src/transaction_runner.rs
@@ -612,6 +612,7 @@ impl TransactionRunner {
                         start_time.elapsed(),
                         self.retry_policy.as_ref(),
                         &backoff,
+                        self.builder.client.is_emulator(),
                     )
                     .await?;
                 }

--- a/src/spanner/src/write_only_transaction.rs
+++ b/src/spanner/src/write_only_transaction.rs
@@ -416,8 +416,9 @@ impl WriteOnlyTransaction {
 
         let max_commit_delay = self.max_commit_delay;
         let return_commit_stats = self.return_commit_stats;
+        let is_emulator = client.is_emulator();
 
-        retry_aborted(&*self.retry_policy, || {
+        let action = || {
             let client = client.clone();
             let session_name = session_name.clone();
             let req_options = req_options.clone();
@@ -486,8 +487,9 @@ impl WriteOnlyTransaction {
                     Ok(response)
                 }
             }
-        })
-        .await
+        };
+
+        retry_aborted(&*self.retry_policy, action, is_emulator).await
     }
 
     /// Writes a set of mutations at least once using a single Commit RPC.
@@ -543,8 +545,9 @@ impl WriteOnlyTransaction {
             .set_return_commit_stats(self.return_commit_stats);
         let client = self.client;
         let channel_hint = client.spanner.next_channel_hint();
+        let is_emulator = client.is_emulator();
 
-        retry_aborted(&*self.retry_policy, || {
+        let action = || {
             let client = client.clone();
             let request = request.clone();
             let commit_gax_options = commit_gax_options.clone();
@@ -555,8 +558,9 @@ impl WriteOnlyTransaction {
                     .commit(request, commit_gax_options, channel_hint)
                     .await
             }
-        })
-        .await
+        };
+
+        retry_aborted(&*self.retry_policy, action, is_emulator).await
     }
 
     fn begin_gax_options(&self) -> GaxRequestOptions {


### PR DESCRIPTION
The latest version of the Spanner Emulator can return an INTERNAL error if DDL statements and read/write transactions are executed concurrently. This change adds a specific error to the set of errors that are retried by the Spanner client when it is running agains the Emulator. This additional check is only done if the client is connected to the Emulator, and not if the client is connected to real Spanner.

Note: The test that failed and triggered the creation of this ticket, is not the actual culprit, and a similar failure could in theory happen for any of the other tests for the Spanner client that execute a read/write transaction.

Fixes #5826