### PR TITLE
chore(spanner): bump version again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,7 +4691,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-spanner"
-version = "0.34.0-preview"
+version = "0.34.1-preview"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1366,7 +1366,7 @@ libraries:
       - googleapis
     skip_release: true
   - name: google-cloud-spanner
-    version: 0.34.0-preview
+    version: 0.34.1-preview
     copyright_year: "2026"
     output: src/spanner
     rust:

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-spanner"
-version     = "0.34.0-preview"
+version     = "0.34.1-preview"
 description = "Google Cloud Client Libraries for Rust - Spanner"
 # Inherit other attributes from the workspace.
 edition.workspace      = true


### PR DESCRIPTION
librarian does not like that `Cargo.toml` has not changed since the last release, but we want to release this library:

```bash
go run github.com/googleapis/librarian/cmd/librarian@${V} publish --dry-run -v
... ...
/Users/coryan/.cargo/bin/cargo workspaces plan --skip-published
2026/06/04 09:44:17 librarian: unplanned crate "google-cloud-spanner" found in workspace plan
exit status 1
```
