### PR TITLE
ci: cooldown period for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
     groups:
       github-actions:
         patterns:
@@ -26,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       opentelemetry-crates:
         patterns:


### PR DESCRIPTION
Prevent some supply chain attacks by waiting before taking an update. The expectation is the community may detect these attacks and new advisories or versions appear before we pick them up.