### PR TITLE
fix(o11y): handle rpc errors in metrics e2e test

### DIFF
--- a/tests/o11y/src/e2e.rs
+++ b/tests/o11y/src/e2e.rs
@@ -118,7 +118,7 @@ pub async fn try_get_metric(
     let end = Timestamp::try_from(SystemTime::now())?;
     let start = Timestamp::try_from(SystemTime::now() - Duration::from_secs(300))?;
     let (key, value) = label;
-    let response = client
+    let response = match client
         .list_time_series()
         .set_name(format!("projects/{project_id}"))
         .set_interval(TimeInterval::new().set_end_time(end).set_start_time(start))
@@ -126,7 +126,19 @@ pub async fn try_get_metric(
             r#"metric.type = "{metric_name}" AND metric.label.{key} = "{value}""#
         ))
         .send()
-        .await?;
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            if let Some(status) = e.status()
+                && (status.code == Code::NotFound || status.code == Code::Internal)
+            {
+                println!("Metric list returned {:?}, retrying...", status.code);
+                return Ok(None);
+            }
+            return Err(e.into());
+        }
+    };
     Ok(Some(response).filter(|r| !r.time_series.is_empty()))
 }
 


### PR DESCRIPTION
The metrics e2e test queries Cloud Monitoring to verify telemetry propagation. While PR #5583 fixed a flake by continuing the retry loop when the API returned an empty list, the test would still crash if the backend returned an actual RPC error (like `INTERNAL` or `NOT_FOUND`).

This updates `try_get_metric` to catch `Code::Internal` and `Code::NotFound` errors and return `Ok(None)`. This ensures these transient errors are treated as data not ready yet so the loop can wait and retry.

Fixes #5850