### PR TITLE
doc: update issue reference format in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ feat(storage): add new storage bucket feature
 
 A new feature is added to storage.
 
-Fixes \#238
+Fixes https://github.com/googleapis/google-cloud-rust/issues/238
 ```
 
 ### First line

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ feat(storage): add new storage bucket feature
 
 A new feature is added to storage.
 
-Fixes https://github.com/googleapis/google-cloud-rust/issues/238
+Fixes #238
 ```
 
 ### First line


### PR DESCRIPTION
Fix the last line of the commit message example, which previously had an unnecessary slash.