### PR TITLE
ci: deflake cargo fetching

### DIFF
--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -32,7 +32,6 @@ options:
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
     - GCB_TRIGGER_NAME=${TRIGGER_NAME}
-    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -46,7 +45,13 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     args: ['.gcb/scripts/cargo-fetch.sh']
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/${_SCRIPT}.sh']
 substitutions:
   _SCCACHE_VERSION: 'v0.12.0'

--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -32,6 +32,7 @@ options:
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
     - GCB_TRIGGER_NAME=${TRIGGER_NAME}
+    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -42,6 +43,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - name: 'rust:${_RUST_VERSION}-bookworm'
     args: ['.gcb/scripts/${_SCRIPT}.sh']
 substitutions:

--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -46,12 +46,12 @@ steps:
     name: 'rust:${_RUST_VERSION}-bookworm'
     args: ['.gcb/scripts/cargo-fetch.sh']
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/${_SCRIPT}.sh']
 substitutions:
   _SCCACHE_VERSION: 'v0.12.0'

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -31,6 +31,7 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
+    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -41,6 +42,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - name: 'gcr.io/cloud-builders/curl'
     automapSubstitutions: true
     script: |

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -45,8 +45,8 @@ steps:
     name: 'rust:${_RUST_VERSION}-bookworm'
     args: ['.gcb/scripts/cargo-fetch.sh']
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
   - name: 'gcr.io/cloud-builders/curl'
     automapSubstitutions: true
     script: |
@@ -60,8 +60,8 @@ steps:
       chmod 755 /workspace/.bin/codecovcli
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/${_SCRIPT}.sh']
     secretEnv: ['CODECOV_TOKEN']
     env:

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -31,7 +31,6 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
-    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -45,6 +44,9 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     args: ['.gcb/scripts/cargo-fetch.sh']
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
   - name: 'gcr.io/cloud-builders/curl'
     automapSubstitutions: true
     script: |
@@ -57,6 +59,9 @@ steps:
 
       chmod 755 /workspace/.bin/codecovcli
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/${_SCRIPT}.sh']
     secretEnv: ['CODECOV_TOKEN']
     env:

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -27,7 +27,6 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
-    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -40,9 +39,15 @@ steps:
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: Validate default crypto provider behavior
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -40,14 +40,14 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: Validate default crypto provider behavior
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -27,6 +27,7 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
+    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -37,6 +38,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - id: Validate default crypto provider behavior
     name: 'rust:${_RUST_VERSION}-bookworm'
     script: |

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -31,7 +31,6 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
-    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -44,6 +43,9 @@ steps:
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Install terraform'
     name: 'gcr.io/cloud-builders/curl'
@@ -57,6 +59,9 @@ steps:
       curl -fsSL --retry 5 --retry-delay 15 "${URL}" -o /workspace/.download/terraform.zip
       sha256sum -c <(echo "${_TERRAFORM_SHA256} */workspace/.download/terraform.zip")
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     id: 'Search for typos'
     script: |
       #!/usr/bin/env bash
@@ -67,6 +72,9 @@ steps:
         cargo install typos-cli --version 1.45.0 --locked
       typos
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     id: 'Verify all files have a copyright boilerplate'
     script: |
       #!/usr/bin/env bash
@@ -76,6 +84,9 @@ steps:
         ':!:testdata/**' ':!:**.md' ':!:**.mustache' ':!:**/generated/protos/**' | \
         xargs -0 -r -P "$(nproc)" -n 50 target/release/check-copyright
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     id: 'Format TOML files'
     script: |
       #!/usr/bin/env bash
@@ -87,6 +98,9 @@ steps:
       git ls-files -z -- '*.toml' ':!:testdata/**' ':!:**/generated/**' | \
         xargs -0 taplo fmt
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     id: 'Format Rust files'
     script: |
       #!/usr/bin/env bash
@@ -141,6 +155,9 @@ steps:
   # `git`. We could install `git` on that image, but that is as hard / slow as
   # installing `terraform` on Debian.
   - name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     id: 'Format Terraform (.tf) files'
     script: |
       #!/usr/bin/env bash

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -44,8 +44,8 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Install terraform'
     name: 'gcr.io/cloud-builders/curl'
@@ -60,8 +60,8 @@ steps:
       sha256sum -c <(echo "${_TERRAFORM_SHA256} */workspace/.download/terraform.zip")
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     id: 'Search for typos'
     script: |
       #!/usr/bin/env bash
@@ -73,8 +73,8 @@ steps:
       typos
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     id: 'Verify all files have a copyright boilerplate'
     script: |
       #!/usr/bin/env bash
@@ -85,8 +85,8 @@ steps:
         xargs -0 -r -P "$(nproc)" -n 50 target/release/check-copyright
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     id: 'Format TOML files'
     script: |
       #!/usr/bin/env bash
@@ -99,8 +99,8 @@ steps:
         xargs -0 taplo fmt
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     id: 'Format Rust files'
     script: |
       #!/usr/bin/env bash
@@ -156,8 +156,8 @@ steps:
   # installing `terraform` on Debian.
   - name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     id: 'Format Terraform (.tf) files'
     script: |
       #!/usr/bin/env bash

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -31,6 +31,7 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
+    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -41,6 +42,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Install terraform'
     name: 'gcr.io/cloud-builders/curl'
     automapSubstitutions: true

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -40,8 +40,8 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Start Spanner Emulator'
     name: 'gcr.io/cloud-builders/docker'
@@ -55,8 +55,8 @@ steps:
   - id: Run integration tests
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -27,7 +27,6 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
-    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -40,6 +39,9 @@ steps:
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Start Spanner Emulator'
     name: 'gcr.io/cloud-builders/docker'
@@ -52,6 +54,9 @@ steps:
     waitFor: ['-']
   - id: Run integration tests
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -27,6 +27,7 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
+    - CARGO_HOME=/workspace/.cargo
   workerPool: 'projects/${PROJECT_ID}/locations/${_POOL_REGION}/workerPools/${_POOL_ID}'
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
@@ -37,6 +38,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Start Spanner Emulator'
     name: 'gcr.io/cloud-builders/docker'
     script: |

--- a/.gcb/scripts/cargo-fetch.sh
+++ b/.gcb/scripts/cargo-fetch.sh
@@ -15,6 +15,12 @@
 
 set -ev
 
+echo HOME=$HOME
+echo HOME
+ls -l $HOME || true
+echo HOME/.cargo
+ls -l ${HOME}/.cargo || true
+
 maximum=5
 delay=10
 for attempt in $(seq 1 ${maximum}); do
@@ -28,3 +34,9 @@ for attempt in $(seq 1 ${maximum}); do
     sleep $((delay))
     delay=$((2 * delay))
 done
+
+echo HOME=$HOME
+echo HOME
+ls -l $HOME || true
+echo HOME/.cargo
+ls -l ${HOME}/.cargo || true

--- a/.gcb/scripts/cargo-fetch.sh
+++ b/.gcb/scripts/cargo-fetch.sh
@@ -13,13 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -ev
-
-echo HOME=$HOME
-echo HOME
-ls -l $HOME || true
-echo HOME/.cargo
-ls -l ${HOME}/.cargo || true
+set -e
 
 maximum=5
 delay=10
@@ -34,9 +28,3 @@ for attempt in $(seq 1 ${maximum}); do
     sleep $((delay))
     delay=$((2 * delay))
 done
-
-echo HOME=$HOME
-echo HOME
-ls -l $HOME || true
-echo HOME/.cargo
-ls -l ${HOME}/.cargo || true

--- a/.gcb/scripts/cargo-fetch.sh
+++ b/.gcb/scripts/cargo-fetch.sh
@@ -21,7 +21,7 @@ for attempt in $(seq 1 ${maximum}); do
     if cargo fetch; then
         exit 0
     fi
-    if "${attempt}" == "${maximum}"; then
+    if [[ "${attempt}" == "${maximum}" ]]; then
         echo "Cannot fetch dependencies after ${maximum} attempts"
         exit 1
     fi

--- a/.gcb/scripts/cargo-fetch.sh
+++ b/.gcb/scripts/cargo-fetch.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ev
+
+maximum=5
+delay=10
+for attempt in $(seq 1 ${maximum}); do
+    if cargo fetch; then
+        exit 0
+    fi
+    if "${attempt}" == "${maximum}"; then
+        echo "Cannot fetch dependencies after ${maximum} attempts"
+        exit 1
+    fi
+    sleep $((delay))
+    delay=$((2 * delay))
+done

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -24,7 +24,6 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
-    - CARGO_HOME=/workspace/.cargo
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
   - id: 'Set up build cache'
@@ -36,9 +35,15 @@ steps:
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Run auth integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e
@@ -46,6 +51,9 @@ steps:
         --package integration-tests-auth
   - id: 'Run External Account integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
+    volumes:
+    - name: 'fetched'
+      path: /builder/home/.cargo
     env:
       - 'EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL=${_EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL}'
       - 'GOOGLE_WORKLOAD_IDENTITY_OIDC_AUDIENCE=${_WORKLOAD_IDENTITY_AUDIENCE}'

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -36,14 +36,14 @@ steps:
   - id: 'Download dependencies'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Run auth integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     script: |
       #!/usr/bin/env bash
       set -e
@@ -52,8 +52,8 @@ steps:
   - id: 'Run External Account integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
     volumes:
-    - name: 'fetched'
-      path: /builder/home/.cargo
+      - name: 'fetched'
+        path: /builder/home/.cargo
     env:
       - 'EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL=${_EXTERNAL_ACCOUNT_SERVICE_ACCOUNT_EMAIL}'
       - 'GOOGLE_WORKLOAD_IDENTITY_OIDC_AUDIENCE=${_WORKLOAD_IDENTITY_AUDIENCE}'

--- a/src/auth/.gcb/integration.yaml
+++ b/src/auth/.gcb/integration.yaml
@@ -24,6 +24,7 @@ options:
     - RUSTC_WRAPPER=/workspace/.bin/sccache
     - RUSTFLAGS=${_UNSTABLE_CFG_FLAGS}
     - RUSTDOCFLAGS=${_UNSTABLE_CFG_FLAGS}
+    - CARGO_HOME=/workspace/.cargo
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/integration-test-runner@${PROJECT_ID}.iam.gserviceaccount.com'
 steps:
   - id: 'Set up build cache'
@@ -33,6 +34,9 @@ steps:
     env:
       - _SCCACHE_VERSION=${_SCCACHE_VERSION}
       - _SCCACHE_SHA256=${_SCCACHE_SHA256}
+  - id: 'Download dependencies'
+    name: 'rust:${_RUST_VERSION}-bookworm'
+    args: ['.gcb/scripts/cargo-fetch.sh']
   - id: 'Run auth integration tests'
     name: 'rust:${_RUST_VERSION}-bookworm'
     script: |


### PR DESCRIPTION
We are getting network errors while `cargo` is trying to download things. This may be a change in behavior with Rust 1.96 (the upgrade was roughly correlated with these new errors), or a new type of error in the network / servers that `cargo` was not ready for.

Fixes #5810 