### PR TITLE
fix(spanner): retry transport errors

### DIFF
--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -117,16 +117,19 @@ macro_rules! define_idempotent_rpc {
                 .inner
                 .$method()
                 .with_request(request)
-                .with_options(with_default_idempotency(options))
+                .with_options(apply_request_defaults(options))
                 .send()
                 .await
         }
     };
 }
 
-fn with_default_idempotency(mut options: crate::RequestOptions) -> crate::RequestOptions {
+fn apply_request_defaults(mut options: crate::RequestOptions) -> crate::RequestOptions {
     if options.idempotent().is_none() {
         options.set_idempotency(true);
+    }
+    if options.retry_policy().is_none() {
+        options.set_retry_policy(crate::retry_policy::SpannerRetryPolicy::new());
     }
     options
 }
@@ -607,6 +610,66 @@ mod tests {
         assert_eq!(
             session.name,
             "projects/test-project/instances/test-instance/databases/test-db/sessions/456"
+        );
+    }
+
+    #[tokio_test_no_panics]
+    async fn test_create_session_transport_retry() {
+        // 1. Setup Mock Server
+        let mut mock = MockSpanner::new();
+        let mut seq = mockall::Sequence::new();
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                let mut status = Status::unavailable("connection reset");
+                let mut headers = std::mem::take(status.metadata_mut()).into_headers();
+                headers.insert("content-type", http::HeaderValue::from_static("text/html"));
+                *status.metadata_mut() = MetadataMap::from_headers(headers);
+                Err(status)
+            });
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Ok(gaxi::grpc::tonic::Response::new(mock_v1::Session {
+                    name: "projects/test-project/instances/test-instance/databases/test-db/sessions/789".to_string(),
+                    ..Default::default()
+                }))
+            });
+
+        // 2. Start mock server
+        let (address, _server) = start("0.0.0.0:0", mock)
+            .await
+            .expect("Failed to start mock server");
+
+        // 3. Configure Client to use mock endpoint
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("Failed to build client");
+
+        // 4. Call CreateSession
+        let mut req = CreateSessionRequest::new();
+        req.database =
+            "projects/test-project/instances/test-instance/databases/test-db".to_string();
+
+        let session = client
+            .create_session(
+                req,
+                crate::RequestOptions::default(),
+                client.next_channel_hint(),
+            )
+            .await
+            .expect("Failed to call create_session after transport error retry");
+
+        // 5. Verify Response
+        assert_eq!(
+            session.name,
+            "projects/test-project/instances/test-instance/databases/test-db/sessions/789",
+            "Expected session name to match the second successful response after transport retry"
         );
     }
 

--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -81,6 +81,7 @@ pub(crate) mod read_only_transaction;
 pub(crate) mod read_write_transaction;
 pub(crate) mod result_set;
 pub(crate) mod result_set_metadata;
+pub(crate) mod retry_policy;
 pub(crate) mod row;
 pub(crate) mod server_streaming;
 pub(crate) mod session_maintainer;

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -41,13 +41,14 @@ use crate::read_only_transaction::{
     BeginTransactionOption, ReadContext, ReadContextTransactionSelector, TransactionState,
 };
 use crate::result_set::ResultSet;
+use crate::retry_policy::SpannerRetryPolicy;
 use crate::statement::Statement;
 use crate::transaction_retry_policy::is_aborted;
 use crate::write_only_transaction::create_commit_request;
 use google_cloud_gax::error::Error as GaxError;
 use google_cloud_gax::error::rpc::{Code, Status};
 use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
-use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicy};
+use google_cloud_gax::retry_policy::RetryPolicy;
 use google_cloud_gax::retry_result::RetryResult;
 use google_cloud_gax::retry_state::RetryState;
 use google_cloud_gax::throttle_result::ThrottleResult;
@@ -738,7 +739,7 @@ pub(crate) fn amend_gax_options(
         let inner_policy = options
             .retry_policy()
             .clone()
-            .unwrap_or_else(|| Arc::new(Aip194Strict));
+            .unwrap_or_else(|| Arc::new(SpannerRetryPolicy::new()));
         let bounded_policy = TransactionBoundedRetryPolicy {
             inner: inner_policy,
             deadline,

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -20,15 +20,16 @@ use crate::model::result_set_stats::RowCount;
 use crate::precommit::PrecommitTokenTracker;
 use crate::read_only_transaction::{ReadContextTransactionSelector, TransactionState};
 use crate::result_set_metadata::ResultSetMetadata;
+use crate::retry_policy::SpannerRetryPolicy;
 use crate::row::Row;
 use crate::server_streaming::stream::PartialResultSetStream;
 use bytes::Bytes;
 use gaxi::prost::FromProto;
 use google_cloud_gax::backoff_policy::BackoffPolicy;
-use google_cloud_gax::error::Error as GaxError;
 use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
 use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
-use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
+use google_cloud_gax::retry_policy::RetryPolicyExt;
+use google_cloud_gax::retry_result::RetryResult;
 use google_cloud_gax::retry_state::RetryState;
 use std::collections::VecDeque;
 use std::mem::take;
@@ -155,7 +156,7 @@ impl ResultSet {
 
     fn apply_defaults(mut gax_options: GaxRequestOptions) -> GaxRequestOptions {
         if gax_options.retry_policy().is_none() {
-            gax_options.set_retry_policy(Aip194Strict.with_attempt_limit(10));
+            gax_options.set_retry_policy(SpannerRetryPolicy::new().with_attempt_limit(10));
         }
         if gax_options.backoff_policy().is_none() {
             gax_options.set_backoff_policy(Self::default_backoff_policy());
@@ -461,24 +462,31 @@ impl ResultSet {
         self.local_metadata = Some(meta);
         Ok(())
     }
-
     async fn handle_stream_error(&mut self, e: crate::Error) -> crate::Result<()> {
-        if self.safe_to_retry && self.should_retry(&e) {
-            self.retry_count += 1;
-            // Clear the buffer and restart the stream using the last
-            // resume_token that we have seen.
-            self.partial_result_sets_buffer.clear();
+        let mut e = e;
+        if self.safe_to_retry {
+            match self.check_retry(e) {
+                Ok(()) => {
+                    self.retry_count += 1;
+                    // Clear the buffer and restart the stream using the last
+                    // resume_token that we have seen.
+                    self.partial_result_sets_buffer.clear();
 
-            // Apply backoff delay if policy is present
-            if let Some(policy) = self.gax_options.backoff_policy() {
-                let state =
-                    RetryState::new(self.safe_to_retry).set_attempt_count(self.retry_count as u32);
-                let delay = policy.on_failure(&state);
-                sleep(delay).await;
+                    // Apply backoff delay if policy is present
+                    if let Some(policy) = self.gax_options.backoff_policy() {
+                        let state = RetryState::new(self.safe_to_retry)
+                            .set_attempt_count(self.retry_count as u32);
+                        let delay = policy.on_failure(&state);
+                        sleep(delay).await;
+                    }
+
+                    self.restart_stream().await?;
+                    return Ok(());
+                }
+                Err(err) => {
+                    e = err;
+                }
             }
-
-            self.restart_stream().await?;
-            return Ok(());
         }
 
         // Check if this stream included an inlined BeginTransaction option
@@ -663,17 +671,17 @@ impl ResultSet {
         Ok(())
     }
 
-    fn should_retry(&self, e: &crate::Error) -> bool {
+    fn check_retry(&self, e: crate::Error) -> Result<(), crate::Error> {
         if let Some(policy) = self.gax_options.retry_policy() {
             let state =
                 RetryState::new(self.safe_to_retry).set_attempt_count(self.retry_count as u32);
 
-            if let Some(status) = e.status() {
-                let gax_error = GaxError::service(status.clone());
-                return policy.on_error(&state, gax_error).is_continue();
+            match policy.on_error(&state, e) {
+                RetryResult::Continue(_) => return Ok(()),
+                RetryResult::Permanent(err) | RetryResult::Exhausted(err) => return Err(err),
             }
         }
-        false
+        Err(e)
     }
 }
 
@@ -773,7 +781,7 @@ pub(crate) mod tests {
     use crate::read::ReadRequest;
     use crate::statement::Statement;
     use crate::transaction::BeginTransactionOption;
-    use gaxi::grpc::tonic::{Code as GrpcCode, Response, Status};
+    use gaxi::grpc::tonic::{Code as GrpcCode, MetadataMap, Response, Status};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_gax::backoff_policy::BackoffPolicy;
     use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
@@ -1233,6 +1241,101 @@ pub(crate) mod tests {
         assert_eq!(row2.raw_values()[0].0, string_val("row2"));
 
         assert!(rs.next().await.is_none());
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn test_result_set_transport_error_retry() -> anyhow::Result<()> {
+        let mut mock = MockSpanner::new();
+        let mut seq = mockall::Sequence::new();
+
+        // Fail with transport error in the middle of stream on first call
+        mock.expect_streaming_read()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_request| {
+                let mut status = Status::unavailable("connection reset");
+                let mut headers = std::mem::take(status.metadata_mut()).into_headers();
+                headers.insert("content-type", http::HeaderValue::from_static("text/html"));
+                *status.metadata_mut() = MetadataMap::from_headers(headers);
+                let stream = adapt([
+                    Ok(PartialResultSet {
+                        metadata: metadata(2),
+                        values: vec![string_val("row1"), string_val("b")],
+                        resume_token: b"token1".to_vec(),
+                        ..Default::default()
+                    }),
+                    Err(status),
+                ]);
+                Ok(Response::from(stream))
+            });
+
+        // Succeed on second call
+        mock.expect_streaming_read()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_request| {
+                let stream = adapt([Ok(PartialResultSet {
+                    values: vec![string_val("row2"), string_val("d")],
+                    resume_token: b"token2".to_vec(),
+                    last: true,
+                    ..Default::default()
+                })]);
+                Ok(Response::from(stream))
+            });
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(Session {
+                name: "session".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (address, _server) = start("127.0.0.1:0", mock).await?;
+
+        let client: Spanner = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let db_client = client.database_client("db").build().await?;
+        let tx = db_client.single_use().build();
+
+        let mut mock_backoff = MockBackoffPolicy::new();
+        mock_backoff
+            .expect_on_failure()
+            .times(1)
+            .returning(|_| Duration::from_nanos(1));
+
+        let read_req = ReadRequest::builder("table", vec!["Id", "Value"])
+            .with_keys(KeySet::all())
+            .with_backoff_policy(mock_backoff)
+            .build();
+
+        let mut rs: ResultSet = tx.execute_read(read_req).await?;
+
+        let row1 = rs.next().await.expect("Stream ended unexpectedly")?;
+        assert_eq!(
+            row1.raw_values()[0].0,
+            string_val("row1"),
+            "Expected row1 to be read successfully before transport error"
+        );
+
+        // This next() call should trigger the retry because the previous stream ended with a transport error.
+        let row2 = rs.next().await.expect("Stream ended unexpectedly")?;
+        assert_eq!(
+            row2.raw_values()[0].0,
+            string_val("row2"),
+            "Expected stream to resume and return row2 after transport error retry"
+        );
+
+        assert!(
+            rs.next().await.is_none(),
+            "Expected stream to end successfully"
+        );
 
         Ok(())
     }

--- a/src/spanner/src/retry_policy.rs
+++ b/src/spanner/src/retry_policy.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use google_cloud_gax::error::Error;
+use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicy};
+use google_cloud_gax::retry_result::RetryResult;
+use google_cloud_gax::retry_state::RetryState;
+use google_cloud_gax::throttle_result::ThrottleResult;
+use std::time::Duration;
+
+/// A custom retry policy for Cloud Spanner that decorates/extends `Aip194Strict`.
+///
+/// Spanner allows transport/connection errors to be retried on idempotent operations.
+/// This policy explicitly allows retries on these transport/network errors if the request is idempotent.
+#[derive(Clone, Debug)]
+pub(crate) struct SpannerRetryPolicy {
+    inner: Aip194Strict,
+}
+
+impl SpannerRetryPolicy {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Aip194Strict,
+        }
+    }
+}
+
+impl Default for SpannerRetryPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RetryPolicy for SpannerRetryPolicy {
+    fn on_error(&self, state: &RetryState, error: Error) -> RetryResult {
+        // 1. Strict AIP-194 checks (Unavailable, is_transient_and_before_rpc)
+        let result = self.inner.on_error(state, error);
+        match result {
+            // If the strict AIP-194 checks classified the error as permanent (such as a transport
+            // error that occurred post-headers), we override it to Continue if the request is idempotent.
+            RetryResult::Permanent(error)
+                if state.idempotent && (error.is_transport() || error.is_io()) =>
+            {
+                RetryResult::Continue(error)
+            }
+            res => res,
+        }
+    }
+
+    fn on_throttle(&self, state: &RetryState, error: Error) -> ThrottleResult {
+        self.inner.on_throttle(state, error)
+    }
+
+    fn remaining_time(&self, state: &RetryState) -> Option<Duration> {
+        self.inner.remaining_time(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_gax::error::Error as GaxError;
+    use google_cloud_gax::error::rpc::{Code, Status};
+    use http::HeaderMap;
+
+    #[test]
+    fn test_spanner_retry_policy_idempotent() {
+        let policy = SpannerRetryPolicy::new();
+        let state = RetryState::new(true); // idempotent = true
+
+        // 1. Service UNAVAILABLE error should be retried (via inner AIP-194)
+        let status = Status::default()
+            .set_code(Code::Unavailable)
+            .set_message("Service Unavailable");
+        let err = GaxError::service(status);
+        assert!(
+            policy.on_error(&state, err).is_continue(),
+            "Expected UNAVAILABLE to be retried when idempotent"
+        );
+
+        // 2. Service PERMISSION_DENIED error should not be retried
+        let status = Status::default()
+            .set_code(Code::PermissionDenied)
+            .set_message("Denied");
+        let err = GaxError::service(status);
+        assert!(
+            policy.on_error(&state, err).is_permanent(),
+            "Expected PERMISSION_DENIED to not be retried"
+        );
+
+        // 3. IO/Transport error should be retried when idempotent
+        let err = GaxError::transport(
+            HeaderMap::new(),
+            std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection closed"),
+        );
+        assert!(
+            policy.on_error(&state, err).is_continue(),
+            "Expected transport connection reset to be retried when idempotent"
+        );
+    }
+
+    #[test]
+    fn test_spanner_retry_policy_non_idempotent() {
+        let policy = SpannerRetryPolicy::new();
+        let state = RetryState::new(false); // idempotent = false
+
+        // 1. Service UNAVAILABLE error should NOT be retried (AIP-194 requires idempotency)
+        let status = Status::default()
+            .set_code(Code::Unavailable)
+            .set_message("Service Unavailable");
+        let err = GaxError::service(status);
+        assert!(
+            policy.on_error(&state, err).is_permanent(),
+            "Expected UNAVAILABLE to be permanent when non-idempotent"
+        );
+
+        // 2. IO/Transport error should NOT be retried when non-idempotent
+        let err = GaxError::transport(
+            HeaderMap::new(),
+            std::io::Error::new(std::io::ErrorKind::ConnectionReset, "connection closed"),
+        );
+        assert!(
+            policy.on_error(&state, err).is_permanent(),
+            "Expected transport connection reset to not be retried when non-idempotent"
+        );
+    }
+}


### PR DESCRIPTION
Transport errors, like `hyper::Error(Canceled, "connection closed")` and `hyper::Error(Http2, GoAway(load_shed))` were not retried by the Spanner client. These are safe to retry for Spanner, as Spanner has built-in protection against potentially replayed RPCs (or in the specific cases where replays would be a problem, the API is clearly documented as such, such as for write_at_least_once).