### PR TITLE
feat(spanner): implement FromValue for serde_json::Value with dynamic STRUCT/ARRAY deserialization

### DIFF
--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -150,13 +150,12 @@ fn from_value_recursive(
                 }
                 TypeCode::Float64 | TypeCode::Float32 => {
                     if s == "NaN" || s == "Infinity" || s == "-Infinity" {
-                        Ok(JsonValue::Null)
-                    } else {
-                        let f = s.parse::<f64>().map_err(|e| ConvertError::Convert(Box::new(e)))?;
-                        Ok(serde_json::Number::from_f64(f)
-                            .map(JsonValue::Number)
-                            .unwrap_or(JsonValue::Null))
+                        return Ok(JsonValue::Null);
                     }
+                    let f = s.parse::<f64>().map_err(|e| ConvertError::Convert(Box::new(e)))?;
+                    Ok(serde_json::Number::from_f64(f)
+                        .map(JsonValue::Number)
+                        .unwrap_or(JsonValue::Null))
                 }
                 _ => Ok(JsonValue::String(s.clone())),
             }

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -151,12 +151,11 @@ fn from_value_recursive(
                 TypeCode::Float64 | TypeCode::Float32 => {
                     if s == "NaN" || s == "Infinity" || s == "-Infinity" {
                         Ok(JsonValue::Null)
-                    } else if let Ok(f) = s.parse::<f64>() {
+                    } else {
+                        let f = s.parse::<f64>().map_err(|e| ConvertError::Convert(Box::new(e)))?;
                         Ok(serde_json::Number::from_f64(f)
                             .map(JsonValue::Number)
                             .unwrap_or(JsonValue::Null))
-                    } else {
-                        Ok(JsonValue::String(s.clone()))
                     }
                 }
                 _ => Ok(JsonValue::String(s.clone())),

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -135,11 +135,9 @@ fn from_value_recursive(
         Some(prost_types::value::Kind::NullValue(_)) => Ok(JsonValue::Null),
 
         Some(prost_types::value::Kind::NumberValue(n)) => {
-            if let Some(num) = serde_json::Number::from_f64(*n) {
-                Ok(JsonValue::Number(num))
-            } else {
-                Ok(JsonValue::Null)
-            }
+            Ok(serde_json::Number::from_f64(*n)
+                .map(JsonValue::Number)
+                .unwrap_or(JsonValue::Null))
         }
 
         Some(prost_types::value::Kind::StringValue(s)) => {

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -18,6 +18,7 @@ use crate::value::Value;
 use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
 use rust_decimal::Decimal;
+use serde_json::Value as JsonValue;
 use std::time::SystemTime;
 use time::{Date, OffsetDateTime};
 
@@ -76,6 +77,159 @@ where
 impl FromValue for Value {
     fn from_value(value: &Value, _type: &Type) -> Result<Self, ConvertError> {
         Ok(value.clone())
+    }
+}
+
+/// Converts any Spanner [`Value`] into a [`serde_json::Value`] using runtime [`Type`] metadata.
+///
+/// This enables dynamic deserialization of STRUCT, ARRAY, and nested
+/// `ARRAY<STRUCT<ARRAY<...>>>` columns without requiring predefined Rust types.
+///
+/// # Type mapping
+///
+/// | Spanner wire format | JSON output |
+/// |---------------------|-------------|
+/// | `NullValue` | `null` |
+/// | `BoolValue` | `true` / `false` |
+/// | `NumberValue` (finite) | JSON number |
+/// | `NumberValue` (NaN/±Infinity) | `null` (matches SDK's `into_serde_value`) |
+/// | `StringValue` | JSON string (or parsed JSON if `TypeCode::Json`) |
+/// | `ListValue` + `TypeCode::Struct` | JSON object (positional → named via metadata) |
+/// | `ListValue` + `TypeCode::Array` | JSON array |
+/// | `StructValue` (named wire format) | JSON object |
+///
+/// # Known limitations
+///
+/// - **NaN/Infinity → null**: Non-finite floats become `null` since JSON has no
+///   representation. Callers cannot distinguish these from genuine SQL NULLs.
+/// - **Duplicate field names**: Spanner allows structs with duplicate field names
+///   (e.g., unnamed columns). Since JSON objects require unique keys, last-write-wins
+///   applies via `serde_json::Map::insert`.
+/// - **Missing struct metadata**: When `TypeCode::Struct` is indicated but no
+///   `struct_type` metadata is available, positional values are returned as a plain
+///   JSON array to avoid silent data loss.
+impl FromValue for JsonValue {
+    fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError> {
+        from_value_recursive(value, type_, 0)
+    }
+}
+
+const MAX_RECURSION_DEPTH: usize = 64;
+
+fn from_value_recursive(
+    value: &Value,
+    type_: &Type,
+    depth: usize,
+) -> Result<JsonValue, ConvertError> {
+    if depth > MAX_RECURSION_DEPTH {
+        return Err(ConvertError::Convert(
+            "maximum nesting depth exceeded".into(),
+        ));
+    }
+
+    let default_type = Type::default();
+
+    match &value.0.kind {
+        Some(prost_types::value::Kind::NullValue(_)) => Ok(JsonValue::Null),
+
+        Some(prost_types::value::Kind::NumberValue(n)) => {
+            if let Some(num) = serde_json::Number::from_f64(*n) {
+                Ok(JsonValue::Number(num))
+            } else {
+                Ok(JsonValue::Null)
+            }
+        }
+
+        Some(prost_types::value::Kind::StringValue(s)) => {
+            if type_.code() == TypeCode::Json {
+                serde_json::from_str(s).map_err(|e| ConvertError::Convert(Box::new(e)))
+            } else {
+                Ok(JsonValue::String(s.clone()))
+            }
+        }
+
+        Some(prost_types::value::Kind::BoolValue(b)) => Ok(JsonValue::Bool(*b)),
+
+        Some(prost_types::value::Kind::StructValue(s)) => {
+            let s = crate::value::Struct::from_ref(s);
+            let mut map = serde_json::Map::new();
+
+            if let Some(struct_type) = type_.struct_type() {
+                for field in &struct_type.fields {
+                    let field_type = field
+                        .r#type
+                        .as_deref()
+                        .map(Type::from_ref)
+                        .unwrap_or(&default_type);
+                    let value = if let Some(v) = s.get(&field.name) {
+                        from_value_recursive(v, field_type, depth + 1)?
+                    } else {
+                        JsonValue::Null
+                    };
+                    map.insert(field.name.clone(), value);
+                }
+            } else {
+                for (k, v) in s.fields() {
+                    map.insert(
+                        k.to_string(),
+                        from_value_recursive(v, &default_type, depth + 1)?,
+                    );
+                }
+            }
+
+            Ok(JsonValue::Object(map))
+        }
+
+        Some(prost_types::value::Kind::ListValue(list)) => match type_.code() {
+            TypeCode::Struct => {
+                if let Some(struct_type) = type_.struct_type() {
+                    let mut map = serde_json::Map::new();
+                    for (i, field) in struct_type.fields.iter().enumerate() {
+                        let field_type = field
+                            .r#type
+                            .as_deref()
+                            .map(Type::from_ref)
+                            .unwrap_or(&default_type);
+                        let value = if let Some(v) = list.values.get(i) {
+                            let val = Value::from_ref(v);
+                            from_value_recursive(val, field_type, depth + 1)?
+                        } else {
+                            JsonValue::Null
+                        };
+                        map.insert(field.name.clone(), value);
+                    }
+                    Ok(JsonValue::Object(map))
+                } else {
+                    let mut arr = Vec::with_capacity(list.values.len());
+                    for v in &list.values {
+                        let val = Value::from_ref(v);
+                        arr.push(from_value_recursive(val, &default_type, depth + 1)?);
+                    }
+                    Ok(JsonValue::Array(arr))
+                }
+            }
+
+            TypeCode::Array => {
+                let element_type = type_.array_element_type().unwrap_or_default();
+                let mut arr = Vec::with_capacity(list.values.len());
+                for v in &list.values {
+                    let val = Value::from_ref(v);
+                    arr.push(from_value_recursive(val, &element_type, depth + 1)?);
+                }
+                Ok(JsonValue::Array(arr))
+            }
+
+            _ => {
+                let mut arr = Vec::with_capacity(list.values.len());
+                for v in &list.values {
+                    let val = Value::from_ref(v);
+                    arr.push(from_value_recursive(val, &default_type, depth + 1)?);
+                }
+                Ok(JsonValue::Array(arr))
+            }
+        },
+
+        None => Ok(JsonValue::Null),
     }
 }
 
@@ -624,5 +778,780 @@ mod tests {
         let v = crate::value::Value(prost_types::Value { kind: None });
         let err = Option::<i32>::from_value(&v, &types::int64()).unwrap_err();
         assert!(format!("{}", err).contains("expected String, got Null"));
+    }
+
+    // ── JSON value conversion tests ──────────────────────────────────────
+
+    #[test]
+    fn test_from_value_json_primitives() {
+        use serde_json::Value as JsonValue;
+
+        // String → JSON string
+        let v = "hello".to_value();
+        let j = JsonValue::from_value(&v, &types::string()).unwrap();
+        assert_eq!(j, JsonValue::String("hello".to_string()));
+
+        // INT64 is string-encoded on the wire → stays as JSON string
+        // (preserves full i64 range without precision loss)
+        let v = 42i64.to_value();
+        let j = JsonValue::from_value(&v, &types::int64()).unwrap();
+        assert_eq!(j, JsonValue::String("42".to_string()));
+
+        // Bool → JSON bool
+        let v = true.to_value();
+        let j = JsonValue::from_value(&v, &types::bool()).unwrap();
+        assert_eq!(j, JsonValue::Bool(true));
+
+        // Float64 → JSON number
+        let v = 3.14f64.to_value();
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, serde_json::json!(3.14));
+
+        // Null → JSON null
+        let v: Option<i64> = None;
+        let j = JsonValue::from_value(&v.to_value(), &types::int64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+
+        // Missing kind → JSON null
+        let v = crate::value::Value(prost_types::Value { kind: None });
+        let j = JsonValue::from_value(&v, &types::string()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+    }
+
+    #[test]
+    fn test_from_value_json_string_array() {
+        use serde_json::Value as JsonValue;
+
+        let str_array = vec!["a".to_string(), "b".to_string()];
+        let v = str_array.to_value();
+        let j = JsonValue::from_value(&v, &types::array(types::string())).unwrap();
+        assert_eq!(j, serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn test_from_value_json_int_array() {
+        use serde_json::Value as JsonValue;
+
+        // INT64 array — values are string-encoded
+        let int_array = vec![10i64, 20i64];
+        let v = int_array.to_value();
+        let j = JsonValue::from_value(&v, &types::array(types::int64())).unwrap();
+        assert_eq!(j, serde_json::json!(["10", "20"]));
+    }
+
+    #[test]
+    fn test_from_value_json_positional_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<name STRING, age INT64>
+        let struct_type = types::create_type(TypeCode::Struct);
+        let mut inner: mdl::Type = struct_type.0;
+        inner.struct_type = Some(Box::new(mdl::StructType {
+            fields: vec![
+                mdl::struct_type::Field::new()
+                    .set_name("name")
+                    .set_type(mdl::Type {
+                        code: mdl::TypeCode::String,
+                        ..Default::default()
+                    }),
+                mdl::struct_type::Field::new()
+                    .set_name("age")
+                    .set_type(mdl::Type {
+                        code: mdl::TypeCode::Int64,
+                        ..Default::default()
+                    }),
+            ],
+            _unknown_fields: Default::default(),
+        }));
+        let spanner_type = Type(inner);
+
+        // Wire value: positional ListValue ["Alice", "30"]
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("Alice".to_string())),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("30".to_string())),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"name": "Alice", "age": "30"}));
+    }
+
+    #[test]
+    fn test_from_value_json_array_of_structs() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: ARRAY<STRUCT<a STRING, b INT64>>
+        let elem_struct = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("a")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("b")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let array_type = mdl::Type {
+            code: mdl::TypeCode::Array,
+            array_element_type: Some(Box::new(elem_struct)),
+            ..Default::default()
+        };
+        let spanner_type = Type(array_type);
+
+        // Wire: [[x, 1], [y, 2]] — positional structs inside an array
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                            values: vec![
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "x".to_string(),
+                                    )),
+                                },
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "1".to_string(),
+                                    )),
+                                },
+                            ],
+                        })),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                            values: vec![
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "y".to_string(),
+                                    )),
+                                },
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "2".to_string(),
+                                    )),
+                                },
+                            ],
+                        })),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(
+            j,
+            serde_json::json!([
+                {"a": "x", "b": "1"},
+                {"a": "y", "b": "2"},
+            ])
+        );
+    }
+
+    #[test]
+    fn test_from_value_json_named_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<name STRING>
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![mdl::struct_type::Field::new()
+                    .set_name("name")
+                    .set_type(mdl::Type {
+                        code: mdl::TypeCode::String,
+                        ..Default::default()
+                    })],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: named StructValue (rare but valid)
+        let mut s = prost_types::Struct::default();
+        s.fields.insert(
+            "name".to_string(),
+            prost_types::Value {
+                kind: Some(prost_types::value::Kind::StringValue("Alice".to_string())),
+            },
+        );
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StructValue(s)),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"name": "Alice"}));
+    }
+
+    #[test]
+    fn test_from_value_json_named_struct_missing_fields_become_null() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type declares 2 fields but wire StructValue only has 1
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("present")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("absent")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: named StructValue with only "present" field
+        let mut s = prost_types::Struct::default();
+        s.fields.insert(
+            "present".to_string(),
+            prost_types::Value {
+                kind: Some(prost_types::value::Kind::StringValue("here".to_string())),
+            },
+        );
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StructValue(s)),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"present": "here", "absent": null}));
+    }
+
+    #[test]
+    fn test_from_value_json_spanner_json_column() {
+        use serde_json::Value as JsonValue;
+
+        // Spanner JSON column: value arrives as a StringValue containing JSON text
+        let json_str = r#"{"key": "value", "nested": [1, 2, 3]}"#;
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue(json_str.to_string())),
+        });
+
+        let j = JsonValue::from_value(&v, &types::json()).unwrap();
+        assert_eq!(
+            j,
+            serde_json::json!({"key": "value", "nested": [1, 2, 3]})
+        );
+    }
+
+    #[test]
+    fn test_from_value_json_nested_struct_in_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<outer_field STRING, inner STRUCT<x INT64, y BOOL>>
+        let inner_struct_type = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("x")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("y")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Bool,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+
+        let outer_type = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("outer_field")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("inner")
+                        .set_type(inner_struct_type),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(outer_type);
+
+        // Wire: positional list ["hello", ["42", true]]
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("hello".to_string())),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                            values: vec![
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "42".to_string(),
+                                    )),
+                                },
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::BoolValue(true)),
+                                },
+                            ],
+                        })),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(
+            j,
+            serde_json::json!({"outer_field": "hello", "inner": {"x": "42", "y": true}})
+        );
+    }
+
+    #[test]
+    fn test_from_value_json_null_in_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<name STRING, value INT64>
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("name")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("value")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: ["test", null]
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("test".to_string())),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::NullValue(0)),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"name": "test", "value": null}));
+    }
+
+    #[test]
+    fn test_from_value_json_nan_becomes_null() {
+        use serde_json::Value as JsonValue;
+
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::NumberValue(f64::NAN)),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::NumberValue(f64::INFINITY)),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::NumberValue(f64::NEG_INFINITY)),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+    }
+
+    #[test]
+    fn test_from_value_json_option_wrapping() {
+        use serde_json::Value as JsonValue;
+
+        // Option<JsonValue> for a non-null value
+        let v = "hello".to_value();
+        let j = Option::<JsonValue>::from_value(&v, &types::string()).unwrap();
+        assert_eq!(j, Some(JsonValue::String("hello".to_string())));
+
+        // Option<JsonValue> for a null value
+        let v: Option<String> = None;
+        let j = Option::<JsonValue>::from_value(&v.to_value(), &types::string()).unwrap();
+        assert_eq!(j, None);
+    }
+
+    #[test]
+    fn test_from_value_json_empty_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<> (zero fields)
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: empty positional list
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_from_value_json_unnamed_fields() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT with unnamed fields (empty string names)
+        // This is valid in Spanner for SELECT expressions without aliases.
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: positional values
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("val".to_string())),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("99".to_string())),
+                    },
+                ],
+            })),
+        });
+
+        // Unnamed fields map to empty-string keys; last write wins for duplicates.
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert!(j.is_object());
+        // With duplicate empty keys, the map retains the last inserted value
+        assert_eq!(j.as_object().unwrap().get("").unwrap(), &serde_json::json!("99"));
+    }
+
+    #[test]
+    fn test_from_value_json_vec_composition() {
+        use serde_json::Value as JsonValue;
+
+        // Vec<JsonValue> uses the existing Vec<T>: FromValue impl
+        let str_array = vec!["one".to_string(), "two".to_string()];
+        let v = str_array.to_value();
+        let res =
+            Vec::<JsonValue>::from_value(&v, &types::array(types::string())).unwrap();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0], JsonValue::String("one".to_string()));
+        assert_eq!(res[1], JsonValue::String("two".to_string()));
+    }
+
+    #[test]
+    fn test_from_value_json_struct_without_metadata() {
+        use serde_json::Value as JsonValue;
+
+        // StructValue wire format without type metadata — preserves raw field names
+        let mut s = prost_types::Struct::default();
+        s.fields.insert(
+            "raw_field".to_string(),
+            prost_types::Value {
+                kind: Some(prost_types::value::Kind::BoolValue(true)),
+            },
+        );
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StructValue(s)),
+        });
+
+        // Pass default type (no struct_type metadata)
+        let j = JsonValue::from_value(&v, &Type::default()).unwrap();
+        assert_eq!(j, serde_json::json!({"raw_field": true}));
+    }
+
+    #[test]
+    fn test_from_value_json_list_without_type_info() {
+        use serde_json::Value as JsonValue;
+
+        // ListValue with no type context — falls back to plain array
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("a".to_string())),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::BoolValue(false)),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &Type::default()).unwrap();
+        assert_eq!(j, serde_json::json!(["a", false]));
+    }
+
+    #[test]
+    fn test_from_value_json_invalid_json_column() {
+        use serde_json::Value as JsonValue;
+
+        // Spanner JSON column with invalid JSON text → error
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue("not valid json{".to_string())),
+        });
+
+        let err = JsonValue::from_value(&v, &types::json()).unwrap_err();
+        assert!(format!("{}", err).contains("cannot convert value"));
+    }
+
+    #[test]
+    fn test_from_value_json_missing_positional_fields_become_null() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type declares 3 fields but wire only has 1 value
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("a")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("b")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("c")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Bool,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: only one value present
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![prost_types::Value {
+                    kind: Some(prost_types::value::Kind::StringValue("only_a".to_string())),
+                }],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(
+            j,
+            serde_json::json!({"a": "only_a", "b": null, "c": null})
+        );
+    }
+
+    #[test]
+    fn test_from_value_json_array_of_json_columns() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: ARRAY<JSON>
+        let json_type = mdl::Type {
+            code: mdl::TypeCode::Json,
+            ..Default::default()
+        };
+        let array_type = mdl::Type {
+            code: mdl::TypeCode::Array,
+            array_element_type: Some(Box::new(json_type)),
+            ..Default::default()
+        };
+        let spanner_type = Type(array_type);
+
+        // Wire: array of JSON strings
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue(
+                            r#"{"x":1}"#.to_string(),
+                        )),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue(
+                            r#"{"y":2}"#.to_string(),
+                        )),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!([{"x": 1}, {"y": 2}]));
+    }
+
+    #[test]
+    fn test_from_value_json_nested_array_in_struct() {
+        use crate::generated::gapic_dataplane::model as mdl;
+        use serde_json::Value as JsonValue;
+
+        // Type: STRUCT<tags ARRAY<STRING>, id INT64>
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new()
+                        .set_name("tags")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Array,
+                            array_element_type: Some(Box::new(mdl::Type {
+                                code: mdl::TypeCode::String,
+                                ..Default::default()
+                            })),
+                            ..Default::default()
+                        }),
+                    mdl::struct_type::Field::new()
+                        .set_name("id")
+                        .set_type(mdl::Type {
+                            code: mdl::TypeCode::Int64,
+                            ..Default::default()
+                        }),
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: [["foo", "bar"], "42"]
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                values: vec![
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                            values: vec![
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "foo".to_string(),
+                                    )),
+                                },
+                                prost_types::Value {
+                                    kind: Some(prost_types::value::Kind::StringValue(
+                                        "bar".to_string(),
+                                    )),
+                                },
+                            ],
+                        })),
+                    },
+                    prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("42".to_string())),
+                    },
+                ],
+            })),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"tags": ["foo", "bar"], "id": "42"}));
+    }
+
+    #[test]
+    fn test_from_value_json_recursion_depth_limit() {
+        use serde_json::Value as JsonValue;
+
+        // Build a deeply nested ListValue (65 levels deep) to exceed MAX_RECURSION_DEPTH
+        let mut inner = prost_types::Value {
+            kind: Some(prost_types::value::Kind::BoolValue(true)),
+        };
+        for _ in 0..65 {
+            inner = prost_types::Value {
+                kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
+                    values: vec![inner],
+                })),
+            };
+        }
+        let v = crate::value::Value(inner);
+
+        let err = JsonValue::from_value(&v, &Type::default()).unwrap_err();
+        assert!(format!("{}", err).contains("nesting depth exceeded"));
     }
 }

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -134,11 +134,9 @@ fn from_value_recursive(
     match &value.0.kind {
         Some(prost_types::value::Kind::NullValue(_)) => Ok(JsonValue::Null),
 
-        Some(prost_types::value::Kind::NumberValue(n)) => {
-            Ok(serde_json::Number::from_f64(*n)
-                .map(JsonValue::Number)
-                .unwrap_or(JsonValue::Null))
-        }
+        Some(prost_types::value::Kind::NumberValue(n)) => Ok(serde_json::Number::from_f64(*n)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null)),
 
         Some(prost_types::value::Kind::StringValue(s)) => {
             let Some(t) = type_ else {
@@ -152,7 +150,9 @@ fn from_value_recursive(
                     if s == "NaN" || s == "Infinity" || s == "-Infinity" {
                         return Ok(JsonValue::Null);
                     }
-                    let f = s.parse::<f64>().map_err(|e| ConvertError::Convert(Box::new(e)))?;
+                    let f = s
+                        .parse::<f64>()
+                        .map_err(|e| ConvertError::Convert(Box::new(e)))?;
                     Ok(serde_json::Number::from_f64(f)
                         .map(JsonValue::Number)
                         .unwrap_or(JsonValue::Null))

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -141,28 +141,25 @@ fn from_value_recursive(
         }
 
         Some(prost_types::value::Kind::StringValue(s)) => {
-            if let Some(t) = type_ {
-                match t.code() {
-                    TypeCode::Json => {
-                        serde_json::from_str(s).map_err(|e| ConvertError::Convert(Box::new(e)))
-                    }
-                    TypeCode::Float64 | TypeCode::Float32 => {
-                        if s == "NaN" || s == "Infinity" || s == "-Infinity" {
-                            Ok(JsonValue::Null)
-                        } else if let Ok(f) = s.parse::<f64>() {
-                            if let Some(num) = serde_json::Number::from_f64(f) {
-                                Ok(JsonValue::Number(num))
-                            } else {
-                                Ok(JsonValue::Null)
-                            }
-                        } else {
-                            Ok(JsonValue::String(s.clone()))
-                        }
-                    }
-                    _ => Ok(JsonValue::String(s.clone())),
+            let Some(t) = type_ else {
+                return Ok(JsonValue::String(s.clone()));
+            };
+            match t.code() {
+                TypeCode::Json => {
+                    serde_json::from_str(s).map_err(|e| ConvertError::Convert(Box::new(e)))
                 }
-            } else {
-                Ok(JsonValue::String(s.clone()))
+                TypeCode::Float64 | TypeCode::Float32 => {
+                    if s == "NaN" || s == "Infinity" || s == "-Infinity" {
+                        Ok(JsonValue::Null)
+                    } else if let Ok(f) = s.parse::<f64>() {
+                        Ok(serde_json::Number::from_f64(f)
+                            .map(JsonValue::Number)
+                            .unwrap_or(JsonValue::Null))
+                    } else {
+                        Ok(JsonValue::String(s.clone()))
+                    }
+                }
+                _ => Ok(JsonValue::String(s.clone())),
             }
         }
 
@@ -186,20 +183,21 @@ fn struct_value_to_json(
     let s = crate::value::Struct::from_ref(s);
     let mut map = serde_json::Map::new();
 
-    if let Some(struct_type) = type_.and_then(|t| t.struct_type()) {
-        for field in &struct_type.fields {
-            let field_type = field.r#type.as_deref().map(Type::from_ref);
-            let value = if let Some(v) = s.get(&field.name) {
-                from_value_recursive(v, field_type, depth)?
-            } else {
-                JsonValue::Null
-            };
-            map.insert(field.name.clone(), value);
-        }
-    } else {
+    let Some(struct_type) = type_.and_then(|t| t.struct_type()) else {
         for (k, v) in s.fields() {
             map.insert(k.clone(), from_value_recursive(v, None, depth)?);
         }
+        return Ok(JsonValue::Object(map));
+    };
+
+    for field in &struct_type.fields {
+        let field_type = field.r#type.as_deref().map(Type::from_ref);
+        let value = if let Some(v) = s.get(&field.name) {
+            from_value_recursive(v, field_type, depth)?
+        } else {
+            JsonValue::Null
+        };
+        map.insert(field.name.clone(), value);
     }
 
     Ok(JsonValue::Object(map))
@@ -213,27 +211,27 @@ fn list_value_to_json(
     let code = type_.map_or(TypeCode::Unspecified, |t| t.code());
     match code {
         TypeCode::Struct => {
-            if let Some(struct_type) = type_.and_then(|t| t.struct_type()) {
-                let mut map = serde_json::Map::new();
-                for (i, field) in struct_type.fields.iter().enumerate() {
-                    let field_type = field.r#type.as_deref().map(Type::from_ref);
-                    let value = if let Some(v) = list.values.get(i) {
-                        let val = Value::from_ref(v);
-                        from_value_recursive(val, field_type, depth)?
-                    } else {
-                        JsonValue::Null
-                    };
-                    map.insert(field.name.clone(), value);
-                }
-                Ok(JsonValue::Object(map))
-            } else {
+            let Some(struct_type) = type_.and_then(|t| t.struct_type()) else {
                 let mut arr = Vec::with_capacity(list.values.len());
                 for v in &list.values {
                     let val = Value::from_ref(v);
                     arr.push(from_value_recursive(val, None, depth)?);
                 }
-                Ok(JsonValue::Array(arr))
+                return Ok(JsonValue::Array(arr));
+            };
+
+            let mut map = serde_json::Map::new();
+            for (i, field) in struct_type.fields.iter().enumerate() {
+                let field_type = field.r#type.as_deref().map(Type::from_ref);
+                let value = if let Some(v) = list.values.get(i) {
+                    let val = Value::from_ref(v);
+                    from_value_recursive(val, field_type, depth)?
+                } else {
+                    JsonValue::Null
+                };
+                map.insert(field.name.clone(), value);
             }
+            Ok(JsonValue::Object(map))
         }
 
         TypeCode::Array => {

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -825,9 +825,9 @@ mod tests {
         assert_eq!(j, JsonValue::Bool(true));
 
         // Float64 → JSON number
-        let v = 3.14f64.to_value();
+        let v = 1.5f64.to_value();
         let j = JsonValue::from_value(&v, &types::float64()).unwrap();
-        assert_eq!(j, serde_json::json!(3.14));
+        assert_eq!(j, serde_json::json!(1.5));
 
         // Null → JSON null
         let v: Option<i64> = None;

--- a/src/spanner/src/from_value.rs
+++ b/src/spanner/src/from_value.rs
@@ -93,13 +93,18 @@ impl FromValue for Value {
 /// | `BoolValue` | `true` / `false` |
 /// | `NumberValue` (finite) | JSON number |
 /// | `NumberValue` (NaN/±Infinity) | `null` (matches SDK's `into_serde_value`) |
-/// | `StringValue` | JSON string (or parsed JSON if `TypeCode::Json`) |
+/// | `StringValue` (standard) | JSON string (includes stringified `INT64`, `NUMERIC`, Base64 `BYTES`, `TIMESTAMP`, `DATE`) |
+/// | `StringValue` (+ `TypeCode::Json`) | Parsed JSON object/array/value |
 /// | `ListValue` + `TypeCode::Struct` | JSON object (positional → named via metadata) |
 /// | `ListValue` + `TypeCode::Array` | JSON array |
 /// | `StructValue` (named wire format) | JSON object |
 ///
 /// # Known limitations
 ///
+/// - **Precision Safety**: Types such as `INT64`, `NUMERIC`, and temporal types (which
+///   Spanner transmits as `StringValue` on the wire) are preserved as JSON strings.
+///   This prevents precision loss (e.g. for integers exceeding $2^{53}-1$ or
+///   high-precision decimals) during deserialization.
 /// - **NaN/Infinity → null**: Non-finite floats become `null` since JSON has no
 ///   representation. Callers cannot distinguish these from genuine SQL NULLs.
 /// - **Duplicate field names**: Spanner allows structs with duplicate field names
@@ -110,24 +115,21 @@ impl FromValue for Value {
 ///   JSON array to avoid silent data loss.
 impl FromValue for JsonValue {
     fn from_value(value: &Value, type_: &Type) -> Result<Self, ConvertError> {
-        from_value_recursive(value, type_, 0)
+        from_value_recursive(value, Some(type_), 0)
     }
 }
 
-const MAX_RECURSION_DEPTH: usize = 64;
-
 fn from_value_recursive(
     value: &Value,
-    type_: &Type,
+    type_: Option<&Type>,
     depth: usize,
 ) -> Result<JsonValue, ConvertError> {
+    const MAX_RECURSION_DEPTH: usize = 64;
     if depth > MAX_RECURSION_DEPTH {
         return Err(ConvertError::Convert(
             "maximum nesting depth exceeded".into(),
         ));
     }
-
-    let default_type = Type::default();
 
     match &value.0.kind {
         Some(prost_types::value::Kind::NullValue(_)) => Ok(JsonValue::Null),
@@ -141,8 +143,26 @@ fn from_value_recursive(
         }
 
         Some(prost_types::value::Kind::StringValue(s)) => {
-            if type_.code() == TypeCode::Json {
-                serde_json::from_str(s).map_err(|e| ConvertError::Convert(Box::new(e)))
+            if let Some(t) = type_ {
+                match t.code() {
+                    TypeCode::Json => {
+                        serde_json::from_str(s).map_err(|e| ConvertError::Convert(Box::new(e)))
+                    }
+                    TypeCode::Float64 | TypeCode::Float32 => {
+                        if s == "NaN" || s == "Infinity" || s == "-Infinity" {
+                            Ok(JsonValue::Null)
+                        } else if let Ok(f) = s.parse::<f64>() {
+                            if let Some(num) = serde_json::Number::from_f64(f) {
+                                Ok(JsonValue::Number(num))
+                            } else {
+                                Ok(JsonValue::Null)
+                            }
+                        } else {
+                            Ok(JsonValue::String(s.clone()))
+                        }
+                    }
+                    _ => Ok(JsonValue::String(s.clone())),
+                }
             } else {
                 Ok(JsonValue::String(s.clone()))
             }
@@ -150,86 +170,92 @@ fn from_value_recursive(
 
         Some(prost_types::value::Kind::BoolValue(b)) => Ok(JsonValue::Bool(*b)),
 
-        Some(prost_types::value::Kind::StructValue(s)) => {
-            let s = crate::value::Struct::from_ref(s);
-            let mut map = serde_json::Map::new();
+        Some(prost_types::value::Kind::StructValue(s)) => struct_value_to_json(s, type_, depth + 1),
 
-            if let Some(struct_type) = type_.struct_type() {
-                for field in &struct_type.fields {
-                    let field_type = field
-                        .r#type
-                        .as_deref()
-                        .map(Type::from_ref)
-                        .unwrap_or(&default_type);
-                    let value = if let Some(v) = s.get(&field.name) {
-                        from_value_recursive(v, field_type, depth + 1)?
+        Some(prost_types::value::Kind::ListValue(list)) => {
+            list_value_to_json(list, type_, depth + 1)
+        }
+
+        None => Ok(JsonValue::Null),
+    }
+}
+
+fn struct_value_to_json(
+    s: &prost_types::Struct,
+    type_: Option<&Type>,
+    depth: usize,
+) -> Result<JsonValue, ConvertError> {
+    let s = crate::value::Struct::from_ref(s);
+    let mut map = serde_json::Map::new();
+
+    if let Some(struct_type) = type_.and_then(|t| t.struct_type()) {
+        for field in &struct_type.fields {
+            let field_type = field.r#type.as_deref().map(Type::from_ref);
+            let value = if let Some(v) = s.get(&field.name) {
+                from_value_recursive(v, field_type, depth)?
+            } else {
+                JsonValue::Null
+            };
+            map.insert(field.name.clone(), value);
+        }
+    } else {
+        for (k, v) in s.fields() {
+            map.insert(k.clone(), from_value_recursive(v, None, depth)?);
+        }
+    }
+
+    Ok(JsonValue::Object(map))
+}
+
+fn list_value_to_json(
+    list: &prost_types::ListValue,
+    type_: Option<&Type>,
+    depth: usize,
+) -> Result<JsonValue, ConvertError> {
+    let code = type_.map_or(TypeCode::Unspecified, |t| t.code());
+    match code {
+        TypeCode::Struct => {
+            if let Some(struct_type) = type_.and_then(|t| t.struct_type()) {
+                let mut map = serde_json::Map::new();
+                for (i, field) in struct_type.fields.iter().enumerate() {
+                    let field_type = field.r#type.as_deref().map(Type::from_ref);
+                    let value = if let Some(v) = list.values.get(i) {
+                        let val = Value::from_ref(v);
+                        from_value_recursive(val, field_type, depth)?
                     } else {
                         JsonValue::Null
                     };
                     map.insert(field.name.clone(), value);
                 }
+                Ok(JsonValue::Object(map))
             } else {
-                for (k, v) in s.fields() {
-                    map.insert(
-                        k.to_string(),
-                        from_value_recursive(v, &default_type, depth + 1)?,
-                    );
+                let mut arr = Vec::with_capacity(list.values.len());
+                for v in &list.values {
+                    let val = Value::from_ref(v);
+                    arr.push(from_value_recursive(val, None, depth)?);
                 }
+                Ok(JsonValue::Array(arr))
             }
-
-            Ok(JsonValue::Object(map))
         }
 
-        Some(prost_types::value::Kind::ListValue(list)) => match type_.code() {
-            TypeCode::Struct => {
-                if let Some(struct_type) = type_.struct_type() {
-                    let mut map = serde_json::Map::new();
-                    for (i, field) in struct_type.fields.iter().enumerate() {
-                        let field_type = field
-                            .r#type
-                            .as_deref()
-                            .map(Type::from_ref)
-                            .unwrap_or(&default_type);
-                        let value = if let Some(v) = list.values.get(i) {
-                            let val = Value::from_ref(v);
-                            from_value_recursive(val, field_type, depth + 1)?
-                        } else {
-                            JsonValue::Null
-                        };
-                        map.insert(field.name.clone(), value);
-                    }
-                    Ok(JsonValue::Object(map))
-                } else {
-                    let mut arr = Vec::with_capacity(list.values.len());
-                    for v in &list.values {
-                        let val = Value::from_ref(v);
-                        arr.push(from_value_recursive(val, &default_type, depth + 1)?);
-                    }
-                    Ok(JsonValue::Array(arr))
-                }
+        TypeCode::Array => {
+            let element_type = type_.and_then(|t| t.array_element_type());
+            let mut arr = Vec::with_capacity(list.values.len());
+            for v in &list.values {
+                let val = Value::from_ref(v);
+                arr.push(from_value_recursive(val, element_type.as_ref(), depth)?);
             }
+            Ok(JsonValue::Array(arr))
+        }
 
-            TypeCode::Array => {
-                let element_type = type_.array_element_type().unwrap_or_default();
-                let mut arr = Vec::with_capacity(list.values.len());
-                for v in &list.values {
-                    let val = Value::from_ref(v);
-                    arr.push(from_value_recursive(val, &element_type, depth + 1)?);
-                }
-                Ok(JsonValue::Array(arr))
+        _ => {
+            let mut arr = Vec::with_capacity(list.values.len());
+            for v in &list.values {
+                let val = Value::from_ref(v);
+                arr.push(from_value_recursive(val, None, depth)?);
             }
-
-            _ => {
-                let mut arr = Vec::with_capacity(list.values.len());
-                for v in &list.values {
-                    let val = Value::from_ref(v);
-                    arr.push(from_value_recursive(val, &default_type, depth + 1)?);
-                }
-                Ok(JsonValue::Array(arr))
-            }
-        },
-
-        None => Ok(JsonValue::Null),
+            Ok(JsonValue::Array(arr))
+        }
     }
 }
 
@@ -477,8 +503,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::generated::gapic_dataplane::model as mdl;
     use crate::to_value::ToValue;
     use crate::types;
+    use serde_json::Value as JsonValue;
 
     #[test]
     fn test_from_value_string() {
@@ -784,8 +812,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_primitives() {
-        use serde_json::Value as JsonValue;
-
         // String → JSON string
         let v = "hello".to_value();
         let j = JsonValue::from_value(&v, &types::string()).unwrap();
@@ -820,8 +846,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_string_array() {
-        use serde_json::Value as JsonValue;
-
         let str_array = vec!["a".to_string(), "b".to_string()];
         let v = str_array.to_value();
         let j = JsonValue::from_value(&v, &types::array(types::string())).unwrap();
@@ -830,8 +854,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_int_array() {
-        use serde_json::Value as JsonValue;
-
         // INT64 array — values are string-encoded
         let int_array = vec![10i64, 20i64];
         let v = int_array.to_value();
@@ -841,9 +863,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_positional_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<name STRING, age INT64>
         let struct_type = types::create_type(TypeCode::Struct);
         let mut inner: mdl::Type = struct_type.0;
@@ -868,16 +887,18 @@ mod tests {
 
         // Wire value: positional ListValue ["Alice", "30"]
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("Alice".to_string())),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("30".to_string())),
-                    },
-                ],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("Alice".to_string())),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("30".to_string())),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -886,9 +907,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_array_of_structs() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: ARRAY<STRUCT<a STRING, b INT64>>
         let elem_struct = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -920,42 +938,48 @@ mod tests {
 
         // Wire: [[x, 1], [y, 2]] — positional structs inside an array
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                            values: vec![
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "x".to_string(),
-                                    )),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::ListValue(
+                                prost_types::ListValue {
+                                    values: vec![
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "x".to_string(),
+                                            )),
+                                        },
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "1".to_string(),
+                                            )),
+                                        },
+                                    ],
                                 },
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "1".to_string(),
-                                    )),
+                            )),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::ListValue(
+                                prost_types::ListValue {
+                                    values: vec![
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "y".to_string(),
+                                            )),
+                                        },
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "2".to_string(),
+                                            )),
+                                        },
+                                    ],
                                 },
-                            ],
-                        })),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                            values: vec![
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "y".to_string(),
-                                    )),
-                                },
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "2".to_string(),
-                                    )),
-                                },
-                            ],
-                        })),
-                    },
-                ],
-            })),
+                            )),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -970,23 +994,21 @@ mod tests {
 
     #[test]
     fn test_from_value_json_named_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<name STRING>
-        let struct_type_mdl = mdl::Type {
-            code: mdl::TypeCode::Struct,
-            struct_type: Some(Box::new(mdl::StructType {
-                fields: vec![mdl::struct_type::Field::new()
-                    .set_name("name")
-                    .set_type(mdl::Type {
-                        code: mdl::TypeCode::String,
-                        ..Default::default()
-                    })],
-                _unknown_fields: Default::default(),
-            })),
-            ..Default::default()
-        };
+        let struct_type_mdl =
+            mdl::Type {
+                code: mdl::TypeCode::Struct,
+                struct_type: Some(Box::new(mdl::StructType {
+                    fields: vec![mdl::struct_type::Field::new().set_name("name").set_type(
+                        mdl::Type {
+                            code: mdl::TypeCode::String,
+                            ..Default::default()
+                        },
+                    )],
+                    _unknown_fields: Default::default(),
+                })),
+                ..Default::default()
+            };
         let spanner_type = Type(struct_type_mdl);
 
         // Wire: named StructValue (rare but valid)
@@ -1007,9 +1029,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_named_struct_missing_fields_become_null() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type declares 2 fields but wire StructValue only has 1
         let struct_type_mdl = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1052,8 +1071,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_spanner_json_column() {
-        use serde_json::Value as JsonValue;
-
         // Spanner JSON column: value arrives as a StringValue containing JSON text
         let json_str = r#"{"key": "value", "nested": [1, 2, 3]}"#;
         let v = crate::value::Value(prost_types::Value {
@@ -1061,17 +1078,11 @@ mod tests {
         });
 
         let j = JsonValue::from_value(&v, &types::json()).unwrap();
-        assert_eq!(
-            j,
-            serde_json::json!({"key": "value", "nested": [1, 2, 3]})
-        );
+        assert_eq!(j, serde_json::json!({"key": "value", "nested": [1, 2, 3]}));
     }
 
     #[test]
     fn test_from_value_json_nested_struct_in_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<outer_field STRING, inner STRUCT<x INT64, y BOOL>>
         let inner_struct_type = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1117,27 +1128,31 @@ mod tests {
 
         // Wire: positional list ["hello", ["42", true]]
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("hello".to_string())),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                            values: vec![
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "42".to_string(),
-                                    )),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("hello".to_string())),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::ListValue(
+                                prost_types::ListValue {
+                                    values: vec![
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "42".to_string(),
+                                            )),
+                                        },
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::BoolValue(true)),
+                                        },
+                                    ],
                                 },
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::BoolValue(true)),
-                                },
-                            ],
-                        })),
-                    },
-                ],
-            })),
+                            )),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -1149,9 +1164,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_null_in_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<name STRING, value INT64>
         let struct_type_mdl = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1178,16 +1190,18 @@ mod tests {
 
         // Wire: ["test", null]
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("test".to_string())),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::NullValue(0)),
-                    },
-                ],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("test".to_string())),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::NullValue(0)),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -1196,8 +1210,7 @@ mod tests {
 
     #[test]
     fn test_from_value_json_nan_becomes_null() {
-        use serde_json::Value as JsonValue;
-
+        // NumberValue representations
         let v = crate::value::Value(prost_types::Value {
             kind: Some(prost_types::value::Kind::NumberValue(f64::NAN)),
         });
@@ -1215,12 +1228,33 @@ mod tests {
         });
         let j = JsonValue::from_value(&v, &types::float64()).unwrap();
         assert_eq!(j, JsonValue::Null);
+
+        // StringValue representations (as sent by Spanner wire format)
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue("NaN".to_string())),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue(
+                "Infinity".to_string(),
+            )),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
+
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::StringValue(
+                "-Infinity".to_string(),
+            )),
+        });
+        let j = JsonValue::from_value(&v, &types::float64()).unwrap();
+        assert_eq!(j, JsonValue::Null);
     }
 
     #[test]
     fn test_from_value_json_option_wrapping() {
-        use serde_json::Value as JsonValue;
-
         // Option<JsonValue> for a non-null value
         let v = "hello".to_value();
         let j = Option::<JsonValue>::from_value(&v, &types::string()).unwrap();
@@ -1234,9 +1268,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_empty_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<> (zero fields)
         let struct_type_mdl = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1250,9 +1281,9 @@ mod tests {
 
         // Wire: empty positional list
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue { values: vec![] },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -1261,9 +1292,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_unnamed_fields() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT with unnamed fields (empty string names)
         // This is valid in Spanner for SELECT expressions without aliases.
         let struct_type_mdl = mdl::Type {
@@ -1291,34 +1319,36 @@ mod tests {
 
         // Wire: positional values
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("val".to_string())),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("99".to_string())),
-                    },
-                ],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("val".to_string())),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("99".to_string())),
+                        },
+                    ],
+                },
+            )),
         });
 
         // Unnamed fields map to empty-string keys; last write wins for duplicates.
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
         assert!(j.is_object());
         // With duplicate empty keys, the map retains the last inserted value
-        assert_eq!(j.as_object().unwrap().get("").unwrap(), &serde_json::json!("99"));
+        assert_eq!(
+            j.as_object().unwrap().get("").unwrap(),
+            &serde_json::json!("99")
+        );
     }
 
     #[test]
     fn test_from_value_json_vec_composition() {
-        use serde_json::Value as JsonValue;
-
         // Vec<JsonValue> uses the existing Vec<T>: FromValue impl
         let str_array = vec!["one".to_string(), "two".to_string()];
         let v = str_array.to_value();
-        let res =
-            Vec::<JsonValue>::from_value(&v, &types::array(types::string())).unwrap();
+        let res = Vec::<JsonValue>::from_value(&v, &types::array(types::string())).unwrap();
         assert_eq!(res.len(), 2);
         assert_eq!(res[0], JsonValue::String("one".to_string()));
         assert_eq!(res[1], JsonValue::String("two".to_string()));
@@ -1326,8 +1356,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_struct_without_metadata() {
-        use serde_json::Value as JsonValue;
-
         // StructValue wire format without type metadata — preserves raw field names
         let mut s = prost_types::Struct::default();
         s.fields.insert(
@@ -1347,20 +1375,20 @@ mod tests {
 
     #[test]
     fn test_from_value_json_list_without_type_info() {
-        use serde_json::Value as JsonValue;
-
         // ListValue with no type context — falls back to plain array
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("a".to_string())),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::BoolValue(false)),
-                    },
-                ],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("a".to_string())),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::BoolValue(false)),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &Type::default()).unwrap();
@@ -1369,11 +1397,11 @@ mod tests {
 
     #[test]
     fn test_from_value_json_invalid_json_column() {
-        use serde_json::Value as JsonValue;
-
         // Spanner JSON column with invalid JSON text → error
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::StringValue("not valid json{".to_string())),
+            kind: Some(prost_types::value::Kind::StringValue(
+                "not valid json{".to_string(),
+            )),
         });
 
         let err = JsonValue::from_value(&v, &types::json()).unwrap_err();
@@ -1382,9 +1410,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_missing_positional_fields_become_null() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type declares 3 fields but wire only has 1 value
         let struct_type_mdl = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1417,25 +1442,21 @@ mod tests {
 
         // Wire: only one value present
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![prost_types::Value {
-                    kind: Some(prost_types::value::Kind::StringValue("only_a".to_string())),
-                }],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("only_a".to_string())),
+                    }],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
-        assert_eq!(
-            j,
-            serde_json::json!({"a": "only_a", "b": null, "c": null})
-        );
+        assert_eq!(j, serde_json::json!({"a": "only_a", "b": null, "c": null}));
     }
 
     #[test]
     fn test_from_value_json_array_of_json_columns() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: ARRAY<JSON>
         let json_type = mdl::Type {
             code: mdl::TypeCode::Json,
@@ -1450,20 +1471,22 @@ mod tests {
 
         // Wire: array of JSON strings
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue(
-                            r#"{"x":1}"#.to_string(),
-                        )),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue(
-                            r#"{"y":2}"#.to_string(),
-                        )),
-                    },
-                ],
-            })),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue(
+                                r#"{"x":1}"#.to_string(),
+                            )),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue(
+                                r#"{"y":2}"#.to_string(),
+                            )),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -1472,9 +1495,6 @@ mod tests {
 
     #[test]
     fn test_from_value_json_nested_array_in_struct() {
-        use crate::generated::gapic_dataplane::model as mdl;
-        use serde_json::Value as JsonValue;
-
         // Type: STRUCT<tags ARRAY<STRING>, id INT64>
         let struct_type_mdl = mdl::Type {
             code: mdl::TypeCode::Struct,
@@ -1505,29 +1525,33 @@ mod tests {
 
         // Wire: [["foo", "bar"], "42"]
         let v = crate::value::Value(prost_types::Value {
-            kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                values: vec![
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                            values: vec![
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "foo".to_string(),
-                                    )),
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::ListValue(
+                                prost_types::ListValue {
+                                    values: vec![
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "foo".to_string(),
+                                            )),
+                                        },
+                                        prost_types::Value {
+                                            kind: Some(prost_types::value::Kind::StringValue(
+                                                "bar".to_string(),
+                                            )),
+                                        },
+                                    ],
                                 },
-                                prost_types::Value {
-                                    kind: Some(prost_types::value::Kind::StringValue(
-                                        "bar".to_string(),
-                                    )),
-                                },
-                            ],
-                        })),
-                    },
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("42".to_string())),
-                    },
-                ],
-            })),
+                            )),
+                        },
+                        prost_types::Value {
+                            kind: Some(prost_types::value::Kind::StringValue("42".to_string())),
+                        },
+                    ],
+                },
+            )),
         });
 
         let j = JsonValue::from_value(&v, &spanner_type).unwrap();
@@ -1536,22 +1560,77 @@ mod tests {
 
     #[test]
     fn test_from_value_json_recursion_depth_limit() {
-        use serde_json::Value as JsonValue;
-
         // Build a deeply nested ListValue (65 levels deep) to exceed MAX_RECURSION_DEPTH
         let mut inner = prost_types::Value {
             kind: Some(prost_types::value::Kind::BoolValue(true)),
         };
         for _ in 0..65 {
             inner = prost_types::Value {
-                kind: Some(prost_types::value::Kind::ListValue(prost_types::ListValue {
-                    values: vec![inner],
-                })),
+                kind: Some(prost_types::value::Kind::ListValue(
+                    prost_types::ListValue {
+                        values: vec![inner],
+                    },
+                )),
             };
         }
         let v = crate::value::Value(inner);
 
         let err = JsonValue::from_value(&v, &Type::default()).unwrap_err();
         assert!(format!("{}", err).contains("nesting depth exceeded"));
+    }
+
+    #[test]
+    fn test_from_value_json_array_without_element_type() {
+        // Type: ARRAY but array_element_type is None
+        let array_type = mdl::Type {
+            code: mdl::TypeCode::Array,
+            array_element_type: None,
+            ..Default::default()
+        };
+        let spanner_type = Type(array_type);
+
+        // Wire: array of strings
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("hello".to_string())),
+                    }],
+                },
+            )),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!(["hello"]));
+    }
+
+    #[test]
+    fn test_from_value_json_struct_with_missing_field_type() {
+        // Type: STRUCT where field "a" has no type metadata
+        let struct_type_mdl = mdl::Type {
+            code: mdl::TypeCode::Struct,
+            struct_type: Some(Box::new(mdl::StructType {
+                fields: vec![
+                    mdl::struct_type::Field::new().set_name("a"), // type is None
+                ],
+                _unknown_fields: Default::default(),
+            })),
+            ..Default::default()
+        };
+        let spanner_type = Type(struct_type_mdl);
+
+        // Wire: positional list ["hello"]
+        let v = crate::value::Value(prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("hello".to_string())),
+                    }],
+                },
+            )),
+        });
+
+        let j = JsonValue::from_value(&v, &spanner_type).unwrap();
+        assert_eq!(j, serde_json::json!({"a": "hello"}));
     }
 }

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -137,6 +137,22 @@ impl Type {
             .as_deref()
             .map(|t| Type(t.clone()))
     }
+
+    /// Returns the struct type metadata, or `None` if this type is not a struct.
+    ///
+    /// When `code() == TypeCode::Struct`, this provides the field names and
+    /// their types. This is essential for reconstructing named fields from the
+    /// positional `ListValue` wire format that Spanner uses for STRUCT values.
+    pub fn struct_type(&self) -> Option<&crate::generated::gapic_dataplane::model::StructType> {
+        self.0.struct_type.as_deref()
+    }
+
+    /// Safely reinterprets a reference to the inner model type as a reference to Type.
+    /// Logical safety is guaranteed by #[repr(transparent)].
+    pub(crate) fn from_ref(v: &crate::generated::gapic_dataplane::model::Type) -> &Self {
+        // Safety: Type is #[repr(transparent)] wrapper around model::Type.
+        unsafe { &*(v as *const crate::generated::gapic_dataplane::model::Type as *const Type) }
+    }
 }
 
 impl gaxi::prost::ToProto<i32> for TypeCode {

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -152,7 +152,7 @@ impl Type {
     /// Safely reinterprets a reference to the inner model type as a reference to Type.
     /// Logical safety is guaranteed by #[repr(transparent)].
     pub(crate) fn from_ref(v: &model::Type) -> &Self {
-        // Safety: Type is #[repr(transparent)] wrapper around model::Type.
+        // SAFETY: Type is #[repr(transparent)] wrapper around model::Type.
         unsafe { &*(v as *const model::Type as *const Type) }
     }
 }

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -15,14 +15,16 @@
 // TODO(#4969)
 #![allow(dead_code)]
 
+use crate::generated::gapic_dataplane::model;
 use crate::generated::gapic_dataplane::model::TypeAnnotationCode;
+use crate::google::spanner::v1 as spanner_v1;
 use gaxi::prost::ConvertError;
 use std::sync::LazyLock;
 
 /// Spanner type definition.
 #[derive(Clone, Debug, PartialEq, Default)]
 #[repr(transparent)]
-pub struct Type(pub(crate) crate::generated::gapic_dataplane::model::Type);
+pub struct Type(pub(crate) model::Type);
 
 macro_rules! define_type_code {
     ($($variant:ident = $val:expr),* $(,)?) => {
@@ -105,20 +107,20 @@ define_type_code!(
     Uuid = 17,
 );
 
-impl From<crate::generated::gapic_dataplane::model::Type> for Type {
-    fn from(value: crate::generated::gapic_dataplane::model::Type) -> Self {
+impl From<model::Type> for Type {
+    fn from(value: model::Type) -> Self {
         Type(value)
     }
 }
 
-impl From<Type> for crate::generated::gapic_dataplane::model::Type {
+impl From<Type> for model::Type {
     fn from(value: Type) -> Self {
         value.0
     }
 }
 
-impl From<crate::google::spanner::v1::Type> for Type {
-    fn from(value: crate::google::spanner::v1::Type) -> Self {
+impl From<spanner_v1::Type> for Type {
+    fn from(value: spanner_v1::Type) -> Self {
         use gaxi::prost::FromProto;
         value.cnv().unwrap_or_default().into()
     }
@@ -143,15 +145,15 @@ impl Type {
     /// When `code() == TypeCode::Struct`, this provides the field names and
     /// their types. This is essential for reconstructing named fields from the
     /// positional `ListValue` wire format that Spanner uses for STRUCT values.
-    pub fn struct_type(&self) -> Option<&crate::generated::gapic_dataplane::model::StructType> {
+    pub fn struct_type(&self) -> Option<&model::StructType> {
         self.0.struct_type.as_deref()
     }
 
     /// Safely reinterprets a reference to the inner model type as a reference to Type.
     /// Logical safety is guaranteed by #[repr(transparent)].
-    pub(crate) fn from_ref(v: &crate::generated::gapic_dataplane::model::Type) -> &Self {
+    pub(crate) fn from_ref(v: &model::Type) -> &Self {
         // Safety: Type is #[repr(transparent)] wrapper around model::Type.
-        unsafe { &*(v as *const crate::generated::gapic_dataplane::model::Type as *const Type) }
+        unsafe { &*(v as *const model::Type as *const Type) }
     }
 }
 

--- a/tests/spanner/src/query.rs
+++ b/tests/spanner/src/query.rs
@@ -709,3 +709,110 @@ pub async fn dml_plan(db_client: &DatabaseClient) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+pub async fn query_json_value(db_client: &DatabaseClient) -> anyhow::Result<()> {
+    let rot = db_client.single_use().build();
+
+    let sql = r#"
+    WITH Data AS (
+      SELECT
+        1 AS id,
+        ARRAY(SELECT AS STRUCT 'apple' AS fruit, 5 AS quantity) AS inventory,
+        JSON '{"a": 1, "b": [true, false]}' AS payload,
+        TRUE AS col_bool,
+        'hello' AS col_string,
+        CAST('hello' AS BYTES) AS col_bytes,
+        NUMERIC '9.99' AS col_numeric,
+        DATE '2026-06-10' AS col_date,
+        TIMESTAMP '2026-06-10T10:00:00Z' AS col_timestamp,
+        CAST('NaN' AS FLOAT64) AS col_float64_nan,
+        CAST('Infinity' AS FLOAT64) AS col_float64_inf,
+        CAST('-Infinity' AS FLOAT64) AS col_float64_neginf,
+        CAST('NaN' AS FLOAT32) AS col_float32_nan,
+        CAST('Infinity' AS FLOAT32) AS col_float32_inf,
+        CAST('-Infinity' AS FLOAT32) AS col_float32_neginf,
+        CAST(NULL AS INT64) AS col_null
+    )
+    SELECT * FROM Data
+    "#;
+
+    let stmt = Statement::builder(sql).build();
+    let mut rs = rot.execute_query(stmt).await?;
+
+    let mut rows = Vec::new();
+    while let Some(row) = rs.next().await {
+        rows.push(row?);
+    }
+
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+
+    // Deserialize id (INT64) as serde_json::Value
+    let id_val: serde_json::Value = row.try_get("id")?;
+    assert_eq!(id_val, serde_json::json!("1"));
+
+    // Deserialize inventory (ARRAY<STRUCT<fruit STRING, quantity INT64>>) as serde_json::Value
+    let inventory_val: serde_json::Value = row.try_get("inventory")?;
+    assert_eq!(
+        inventory_val,
+        serde_json::json!([{"fruit": "apple", "quantity": "5"}])
+    );
+
+    // Deserialize payload (JSON) as serde_json::Value
+    let payload_val: serde_json::Value = row.try_get("payload")?;
+    assert_eq!(payload_val, serde_json::json!({"a": 1, "b": [true, false]}));
+
+    // Deserialize col_bool (BOOL) as serde_json::Value
+    let col_bool: serde_json::Value = row.try_get("col_bool")?;
+    assert_eq!(col_bool, serde_json::json!(true));
+
+    // Deserialize col_string (STRING) as serde_json::Value
+    let col_string: serde_json::Value = row.try_get("col_string")?;
+    assert_eq!(col_string, serde_json::json!("hello"));
+
+    // Deserialize col_bytes (BYTES) as serde_json::Value (should be Base64-encoded)
+    let col_bytes: serde_json::Value = row.try_get("col_bytes")?;
+    assert_eq!(col_bytes, serde_json::json!("aGVsbG8="));
+
+    // Deserialize col_numeric (NUMERIC) as serde_json::Value
+    let col_numeric: serde_json::Value = row.try_get("col_numeric")?;
+    assert_eq!(col_numeric, serde_json::json!("9.99"));
+
+    // Deserialize col_date (DATE) as serde_json::Value
+    let col_date: serde_json::Value = row.try_get("col_date")?;
+    assert_eq!(col_date, serde_json::json!("2026-06-10"));
+
+    // Deserialize col_timestamp (TIMESTAMP) as serde_json::Value
+    let col_timestamp: serde_json::Value = row.try_get("col_timestamp")?;
+    assert_eq!(col_timestamp, serde_json::json!("2026-06-10T10:00:00Z"));
+
+    // Deserialize col_float64_nan (FLOAT64 NaN) as serde_json::Value (should be null)
+    let col_float64_nan: serde_json::Value = row.try_get("col_float64_nan")?;
+    assert_eq!(col_float64_nan, serde_json::Value::Null);
+
+    // Deserialize col_float64_inf (FLOAT64 Infinity) as serde_json::Value (should be null)
+    let col_float64_inf: serde_json::Value = row.try_get("col_float64_inf")?;
+    assert_eq!(col_float64_inf, serde_json::Value::Null);
+
+    // Deserialize col_float64_neginf (FLOAT64 -Infinity) as serde_json::Value (should be null)
+    let col_float64_neginf: serde_json::Value = row.try_get("col_float64_neginf")?;
+    assert_eq!(col_float64_neginf, serde_json::Value::Null);
+
+    // Deserialize col_float32_nan (FLOAT32 NaN) as serde_json::Value (should be null)
+    let col_float32_nan: serde_json::Value = row.try_get("col_float32_nan")?;
+    assert_eq!(col_float32_nan, serde_json::Value::Null);
+
+    // Deserialize col_float32_inf (FLOAT32 Infinity) as serde_json::Value (should be null)
+    let col_float32_inf: serde_json::Value = row.try_get("col_float32_inf")?;
+    assert_eq!(col_float32_inf, serde_json::Value::Null);
+
+    // Deserialize col_float32_neginf (FLOAT32 -Infinity) as serde_json::Value (should be null)
+    let col_float32_neginf: serde_json::Value = row.try_get("col_float32_neginf")?;
+    assert_eq!(col_float32_neginf, serde_json::Value::Null);
+
+    // Deserialize col_null (NULL) as serde_json::Value (should be null)
+    let col_null: serde_json::Value = row.try_get("col_null")?;
+    assert_eq!(col_null, serde_json::Value::Null);
+
+    Ok(())
+}

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -60,6 +60,7 @@ mod spanner {
     define_test_suites! {
         async fn run_query_tests(db_client: &DatabaseClient) -> anyhow::Result<()> {
             integration_tests_spanner::query::simple_query(db_client).await?;
+            integration_tests_spanner::query::query_json_value(db_client).await?;
             integration_tests_spanner::query::query_with_parameters(db_client).await?;
             integration_tests_spanner::query::result_set_metadata(db_client).await?;
             integration_tests_spanner::query::multi_use_read_only_transaction(db_client).await?;


### PR DESCRIPTION
## Summary

Implements `FromValue for serde_json::Value` to enable dynamic deserialization of **all** Spanner column types — including STRUCT, ARRAY, and nested `ARRAY<STRUCT<ARRAY<...>>>` — without requiring predefined Rust structs.

This unblocks:
- Change stream TVF queries (deeply nested struct results)
- Partition reads on tables with STRUCT/ARRAY columns
- Any query returning structured data in a schema-agnostic pipeline

### Usage:
```rust
let value: serde_json::Value = row.try_get("any_struct_or_array_column")?;
// Works for ANY schema — uses runtime Type metadata from result set
```

Resolves #5860