### PR TITLE
fix(auth): retry more transient errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,6 +1682,7 @@ dependencies = [
  "hmac 0.13.0",
  "http",
  "httptest",
+ "hyper",
  "jsonwebtoken",
  "mockall",
  "mutants",

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -41,7 +41,6 @@ chrono                = { workspace = true, features = ["clock"] }
 hex                   = { workspace = true, features = ["std"] }
 hmac.workspace        = true
 http.workspace        = true
-hyper.workspace       = true
 reqwest               = { workspace = true, features = ["form", "json", "query", "rustls-no-provider"] }
 rustls                = { workspace = true, features = ["logging", "std", "tls12"] }
 rustls-pki-types      = { workspace = true, features = ["std"] }
@@ -63,6 +62,7 @@ google-cloud-gax.workspace = true
 [dev-dependencies]
 anyhow.workspace      = true
 httptest.workspace    = true
+hyper.workspace       = true
 mockall.workspace     = true
 regex.workspace       = true
 rsa                   = { workspace = true, features = ["pem", "sha2"] }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -41,6 +41,7 @@ chrono                = { workspace = true, features = ["clock"] }
 hex                   = { workspace = true, features = ["std"] }
 hmac.workspace        = true
 http.workspace        = true
+hyper.workspace       = true
 reqwest               = { workspace = true, features = ["form", "json", "query", "rustls-no-provider"] }
 rustls                = { workspace = true, features = ["logging", "std", "tls12"] }
 rustls-pki-types      = { workspace = true, features = ["std"] }

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -145,10 +145,10 @@ fn is_retryable(err: &reqwest::Error) -> bool {
         }
         if let Some(io_err) = as_inner::<std::io::Error, _>(hyper_err) {
             use std::io::ErrorKind;
-            match io_err.kind() {
-                ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted => return true,
-                _ => return false,
-            }
+            return matches!(
+                io_err.kind(),
+                ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted
+            );
         }
         return false;
     }

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -133,10 +133,29 @@ fn is_retryable(err: &reqwest::Error) -> bool {
     if err.is_connect() {
         return true;
     }
-    match err.status() {
-        Some(code) => is_retryable_code(code),
-        None => false,
+    if err.is_request() {
+        // This implementation is inspired by the ideas from:
+        // http://github.com/TrueLayer/reqwest-middleware/blob/main/reqwest-retry/src/retryable_strategy.rs#L138-L184
+
+        let Some(hyper_err) = as_inner::<hyper::Error, _>(err) else {
+            return false;
+        };
+        if hyper_err.is_incomplete_message() || hyper_err.is_canceled() {
+            return true;
+        }
+        if let Some(io_err) = as_inner::<std::io::Error, _>(hyper_err) {
+            use std::io::ErrorKind;
+            match io_err.kind() {
+                ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted => return true,
+                _ => return false,
+            }
+        }
+        return false;
     }
+    if let Some(code) = err.status() {
+        return is_retryable_code(code);
+    }
+    false
 }
 
 fn is_retryable_code(code: StatusCode) -> bool {
@@ -149,6 +168,25 @@ fn is_retryable_code(code: StatusCode) -> bool {
         | StatusCode::TOO_MANY_REQUESTS => true,
         _ => false,
     }
+}
+
+/// Extract the first source error of type `T`.
+fn as_inner<T, E>(error: &E) -> Option<&T>
+where
+    T: std::error::Error + 'static,
+    E: std::error::Error,
+{
+    let mut e = error.source()?;
+    // Prevent infinite loops due to cycles in the `source()` errors. This seems
+    // unlikely, and it would require effort to create, but it is easy to
+    // prevent.
+    for _ in 0..32 {
+        if let Some(value) = e.downcast_ref::<T>() {
+            return Some(value);
+        }
+        e = e.source()?;
+    }
+    None
 }
 
 #[cfg(test)]

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -126,36 +126,17 @@ pub(crate) fn is_gax_error_retryable(err: &GaxError) -> bool {
 }
 
 fn is_retryable(err: &reqwest::Error) -> bool {
-    // Connection errors are transient more often than not. A bad configuration
-    // can point to a non-existing service, and that will never recover.
-    // However: (1) we expect this to be rare, and (2) this is what limiting
-    // retry policies and backoff policies handle.
     if err.is_connect() {
+        // Connection errors are transient more often than not. A bad
+        // configuration can point to a non-existing service, and that will
+        // never recover. However: (1) we expect this to be rare, and (2) this
+        // is what limiting retry policies and backoff policies handle.
         return true;
     }
     if err.is_request() {
-        // This implementation is inspired by the ideas from:
-        // http://github.com/TrueLayer/reqwest-middleware/blob/main/reqwest-retry/src/retryable_strategy.rs#L138-L184
-
-        let Some(hyper_err) = as_inner::<hyper::Error, _>(err) else {
-            return false;
-        };
-        if hyper_err.is_incomplete_message() || hyper_err.is_canceled() {
-            return true;
-        }
-        if let Some(io_err) = as_inner::<std::io::Error, _>(hyper_err) {
-            use std::io::ErrorKind;
-            return matches!(
-                io_err.kind(),
-                ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted
-            );
-        }
-        return false;
+        return true;
     }
-    if let Some(code) = err.status() {
-        return is_retryable_code(code);
-    }
-    false
+    err.status().is_some_and(is_retryable_code)
 }
 
 fn is_retryable_code(code: StatusCode) -> bool {
@@ -168,25 +149,6 @@ fn is_retryable_code(code: StatusCode) -> bool {
         | StatusCode::TOO_MANY_REQUESTS => true,
         _ => false,
     }
-}
-
-/// Extract the first source error of type `T`.
-fn as_inner<T, E>(error: &E) -> Option<&T>
-where
-    T: std::error::Error + 'static,
-    E: std::error::Error,
-{
-    let mut e = error.source()?;
-    // Prevent infinite loops due to cycles in the `source()` errors. This seems
-    // unlikely, and it would require effort to create, but it is easy to
-    // prevent.
-    for _ in 0..32 {
-        if let Some(value) = e.downcast_ref::<T>() {
-            return Some(value);
-        }
-        e = e.source()?;
-    }
-    None
 }
 
 #[cfg(test)]

--- a/src/auth/tests/transient.rs
+++ b/src/auth/tests/transient.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/auth/tests/transient.rs
+++ b/src/auth/tests/transient.rs
@@ -1,0 +1,141 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use google_cloud_auth::credentials::mds::Builder;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn hyper_incomplete_message() -> Result<()> {
+        let endpoint = spawn_incomplete_message_server().await;
+        let creds = Builder::default()
+            .with_endpoint(endpoint)
+            .build_access_token_credentials()?;
+        let token = creds.access_token().await;
+        let err = token.expect_err("token request should fail");
+        assert!(err.is_transient());
+
+        let hyper_err = as_inner::<hyper::Error, _>(&err).expect("should contain a hyper error");
+        assert!(hyper_err.is_incomplete_message(), "{hyper_err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn io_connection_reset() -> Result<()> {
+        let endpoint = spawn_connection_reset_server().await;
+        let creds = Builder::default()
+            .with_endpoint(endpoint)
+            .build_access_token_credentials()?;
+        let token = creds.access_token().await;
+        let err = token.expect_err("token request should fail");
+        assert!(err.is_transient());
+
+        let io_err = as_inner::<std::io::Error, _>(&err).expect("should contain an io error");
+        assert!(
+            matches!(io_err.kind(), std::io::ErrorKind::ConnectionReset),
+            "{io_err:?}"
+        );
+
+        Ok(())
+    }
+
+    /// Spawns a background TCP server that gracefully hangs up mid-response.
+    ///
+    /// The client-side error should be transient, and classified as a
+    /// `hyper::Error::Kind::IncompleteMessage`.
+    ///
+    /// Returns the `host:port` string it bound to.
+    async fn spawn_incomplete_message_server() -> String {
+        // Bind to port 0 to let the OS pick a free port
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind TCP listener");
+        let addr = listener.local_addr().expect("Failed to get local address");
+
+        tokio::spawn(async move {
+            // Loop to handle potential retries from the client
+            loop {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    tokio::spawn(async move {
+                        let mut buf = [0; 1024];
+
+                        // Read the incoming HTTP GET request
+                        let _ = socket.read(&mut buf).await;
+
+                        // Send an incomplete HTTP status line without \r\n\r\n
+                        let _ = socket.write_all(b"HTTP/1.1 200 O").await;
+                        let _ = socket.flush().await;
+
+                        // The socket goes out of scope and drops here.
+                        // This sends a TCP FIN, cleanly closing the connection
+                        // while hyper is still waiting for the rest of the headers.
+                    });
+                }
+            }
+        });
+
+        format!("http://{}", addr.to_string())
+    }
+
+    /// Spawns a background TCP server that abruptly sends a `RST` frame.
+    ///
+    /// The client-side error should be transient, and classified as a
+    /// `std::io::ErrorKind::ConnectionReset`.
+    ///
+    /// Returns the `host:port` string it bound to.
+    async fn spawn_connection_reset_server() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("Failed to bind TCP listener");
+        let addr = listener.local_addr().expect("Failed to get local address");
+
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    tokio::spawn(async move {
+                        let mut buf = [0; 1024];
+                        let _ = socket.read(&mut buf).await;
+
+                        // Force a TCP RST (Connection reset by peer)
+                        let _ = socket.set_zero_linger();
+                    });
+                }
+            }
+        });
+
+        format!("http://{}", addr.to_string())
+    }
+
+    /// Extract the first source error of type `T`.
+    fn as_inner<T, E>(error: &E) -> Option<&T>
+    where
+        T: std::error::Error + 'static,
+        E: std::error::Error,
+    {
+        let mut e = error.source()?;
+        // Prevent infinite loops due to cycles in the `source()` errors. This seems
+        // unlikely, and it would require effort to create, but it is easy to
+        // prevent.
+        for _ in 0..32 {
+            if let Some(value) = e.downcast_ref::<T>() {
+                return Some(value);
+            }
+            e = e.source()?;
+        }
+        None
+    }
+}

--- a/src/auth/tests/transient.rs
+++ b/src/auth/tests/transient.rs
@@ -88,7 +88,7 @@ mod tests {
             }
         });
 
-        format!("http://{}", addr.to_string())
+        format!("http://{}", addr)
     }
 
     /// Spawns a background TCP server that abruptly sends a `RST` frame.
@@ -117,7 +117,7 @@ mod tests {
             }
         });
 
-        format!("http://{}", addr.to_string())
+        format!("http://{}", addr)
     }
 
     /// Extract the first source error of type `T`.


### PR DESCRIPTION
Classify more auth errors as transient, as a single permanent error can poison the token cache.

Note that this PR only affects auth. We should do a similar thing in our `gaxi::http::ReqwestClient`.

### Implementation nits:

I duplicated the `as_inner` function from `gaxi` twice in this PR. I liked the idea of an e2e test outside of the crate. And I wanted to verify the errors produced by the bad servers, not just that we classify them as transient.

Fixes #5864, related to #4677