### PR TITLE
test(auth): assert metadata-flavor header is in access token requests

### DIFF
--- a/src/auth/src/mds/client.rs
+++ b/src/auth/src/mds/client.rs
@@ -373,6 +373,7 @@ mod tests {
             Expectation::matching(all_of![
                 request::method("GET"),
                 request::path(format!("{}/token", MDS_DEFAULT_URI)),
+                request::headers(contains(("metadata-flavor", "Google"))),
                 request::query(url_decoded(contains((
                     "scopes",
                     "scope1,scope2".to_string()
@@ -405,6 +406,7 @@ mod tests {
             Expectation::matching(all_of![
                 request::method("GET"),
                 request::path(format!("{}/token", MDS_DEFAULT_URI)),
+                request::headers(contains(("metadata-flavor", "Google"))),
             ])
             .respond_with(status_code(404).body("Not Found")),
         );


### PR DESCRIPTION
The Rust mock server expectations for access_token fetch calls did not verify the presence of the mandatory metadata-flavor: Google header, unlike Java, Python, Node, and C++ which enforce header validation on all mock metadata requests.