### PR TITLE
fix(o11y): fix incorrect done status in LRO tracing

### DIFF
--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -143,7 +143,6 @@ macro_rules! record_polling_attributes {
             if let Some(attempt) = recorder.attempt_count() {
                 let span = &$span;
                 span.record("gcp.longrunning.poll_attempt_count", attempt);
-                span.record("gcp.longrunning.done", false);
             }
             if let Some(dest_id) = recorder.destination_id() {
                 let span = &$span;
@@ -399,10 +398,6 @@ mod tests {
             Some(&google_cloud_test_utils::test_layer::AttributeValue::UInt64(42))
         );
         assert_eq!(
-            got.attributes.get("gcp.longrunning.done"),
-            Some(&google_cloud_test_utils::test_layer::AttributeValue::Boolean(false))
-        );
-        assert_eq!(
             got.attributes.get("gcp.resource.destination.id"),
             Some(
                 &google_cloud_test_utils::test_layer::AttributeValue::String(
@@ -435,7 +430,6 @@ mod tests {
                 .get("gcp.longrunning.poll_attempt_count")
                 .is_none()
         );
-        assert!(got.attributes.get("gcp.longrunning.done").is_none());
     }
 
     #[cfg(google_cloud_unstable_tracing)]
@@ -467,7 +461,6 @@ mod tests {
                 .get("gcp.longrunning.poll_attempt_count")
                 .is_none()
         );
-        assert!(got.attributes.get("gcp.longrunning.done").is_none());
     }
 
     #[derive(Default)]


### PR DESCRIPTION
Fix a bug where last poll span for an LRO was marked with `gcp.longrunning.done = false` even after successful completion.

The `record_polling_attributes!` macro was recording `"gcp.longrunning.done" = false` on the active span before launching the polling RPC. For the `tracing-opentelemetry` subscriber, once a span attribute is recorded with a non-empty value (`false` boolean), subsequent calls to `.record` targeting the same key are ignored by the exporter. 

As a result, when the completed RPC response arrived and the wrapper recorded `op.done` (which was `true`), the update was dropped, and the trace displayed the status as `false`.