### PR TITLE
fix(spanner): include seqno with queries in r/w transactions

### DIFF
--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -164,7 +164,7 @@ impl SingleUseReadOnlyTransaction {
         &self,
         statement: T,
     ) -> crate::Result<ResultSet> {
-        self.context.execute_query(statement).await
+        self.context.execute_query(statement, None).await
     }
 
     /// Reads rows from the database using key lookups and scans, as a simple key/value style alternative to execute_query.
@@ -508,7 +508,7 @@ impl MultiUseReadOnlyTransaction {
         &self,
         statement: T,
     ) -> crate::Result<ResultSet> {
-        self.context.execute_query(statement).await
+        self.context.execute_query(statement, None).await
     }
 
     /// Reads rows from the database using key lookups and scans, as a simple key/value style alternative to execute_query.
@@ -1060,13 +1060,15 @@ impl ReadContext {
     pub(crate) async fn execute_query<T: Into<Statement>>(
         &self,
         statement: T,
+        seqno: Option<i64>,
     ) -> crate::Result<ResultSet> {
         let statement = statement.into();
         let gax_options = statement.gax_options().clone();
         let mut request = statement
             .into_request()
             .set_session(self.session_name.clone())
-            .set_transaction(self.transaction_selector.selector().await?);
+            .set_transaction(self.transaction_selector.selector().await?)
+            .set_seqno(seqno.unwrap_or(0));
         request.request_options = self.amend_request_options(request.request_options);
 
         execute_stream_with_retry!(

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -427,7 +427,8 @@ impl ReadWriteTransaction {
         let mut gax_options = stmt.gax_options().clone();
         self.amend_gax_options(&mut gax_options);
         let stmt = stmt.with_gax_options(gax_options);
-        self.context.execute_query(stmt).await
+        let seqno = self.seqno.fetch_add(1, Ordering::SeqCst);
+        self.context.execute_query(stmt, Some(seqno)).await
     }
 
     /// Reads rows from the database using key lookups and scans, as a simple key/value style alternative to execute_query.
@@ -1837,9 +1838,9 @@ mod tests {
 
         mock.expect_execute_streaming_sql().once().returning(|req| {
             let req = req.into_inner();
-            assert_eq!(req.sql, "SELECT 1");
-            // Queries do not need to include a sequence number.
-            assert_eq!(req.seqno, 0);
+            assert_eq!(req.sql, "SELECT 1", "SQL statement mismatch");
+            // Queries in read/write transactions should always include a sequence number.
+            assert_eq!(req.seqno, 1, "ExecuteSqlRequest seqno mismatch");
 
             assert_eq!(
                 req.transaction,

--- a/tests/spanner/src/dml_returning.rs
+++ b/tests/spanner/src/dml_returning.rs
@@ -158,3 +158,55 @@ pub async fn dml_then_return_unconsumed_query(db_client: &DatabaseClient) -> Res
 
     Ok(())
 }
+
+pub async fn dml_then_return_multiple_execute_queries(db_client: &DatabaseClient) -> Result<()> {
+    let run_id = LowercaseAlphanumeric.random_string(10);
+    let id1 = format!("dml-ret-multi1-{}", run_id);
+    let id2 = format!("dml-ret-multi2-{}", run_id);
+
+    // Execute multiple DMLs with THEN RETURN via execute_query in a single Read-Write transaction
+    let runner = db_client.read_write_transaction().build().await?;
+    let result = runner
+        .run(async |tx| {
+            let id1 = id1.clone();
+            let id2 = id2.clone();
+
+            let stmt1 = Statement::builder(
+                "INSERT INTO AllTypes (Id, ColBool) VALUES (@id, @bool) THEN RETURN Id",
+            )
+            .add_param("id", &id1)
+            .add_param("bool", &true)
+            .build();
+
+            let mut result_set1 = tx.execute_query(stmt1).await?;
+            let row1 = result_set1
+                .next()
+                .await
+                .transpose()?
+                .expect("Expected to find returned row 1");
+            let returned_id1: String = row1.get("Id");
+            assert_eq!(returned_id1, id1, "Returned ID 1 mismatch");
+
+            let stmt2 = Statement::builder(
+                "INSERT INTO AllTypes (Id, ColBool) VALUES (@id, @bool) THEN RETURN Id",
+            )
+            .add_param("id", &id2)
+            .add_param("bool", &false)
+            .build();
+
+            let mut result_set2 = tx.execute_query(stmt2).await?;
+            let row2 = result_set2
+                .next()
+                .await
+                .transpose()?
+                .expect("Expected to find returned row 2");
+            let returned_id2: String = row2.get("Id");
+            assert_eq!(returned_id2, id2, "Returned ID 2 mismatch");
+
+            Ok(())
+        })
+        .await;
+
+    result?;
+    Ok(())
+}

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -144,6 +144,7 @@ mod spanner {
             integration_tests_spanner::dml_returning::dml_then_return_execute_query(db_client).await?;
             integration_tests_spanner::dml_returning::dml_then_return_execute_update(db_client).await?;
             integration_tests_spanner::dml_returning::dml_then_return_unconsumed_query(db_client).await?;
+            integration_tests_spanner::dml_returning::dml_then_return_multiple_execute_queries(db_client).await?;
             integration_tests_spanner::read_write_transaction::consecutive_reads(db_client).await?;
             integration_tests_spanner::read_write_transaction::mixed_reads_and_queries(db_client)
                 .await?;


### PR DESCRIPTION
The execute_query method did not include a seqno when it was used in a read/write transaction. This is not a problem for queries, but it is a problem if the execute_query method is used to execute a DML statement with a THEN RETURN clause.