### PR TITLE
impl(o11y): record `error.type` attribute on LRO span

### DIFF
--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -52,6 +52,7 @@ google-cloud-wkt         = { workspace = true }
 
 [target.'cfg(google_cloud_unstable_tracing)'.dependencies]
 tracing = { workspace = true }
+gaxi    = { workspace = true, features = ["_internal-common"] }
 
 [target.'cfg(google_cloud_unstable_tracing)'.dev-dependencies]
 tracing-subscriber      = { workspace = true, features = ["registry"] }

--- a/src/lro/src/internal/ext.rs
+++ b/src/lro/src/internal/ext.rs
@@ -53,7 +53,8 @@ where
                 "gcp.rpc.method" = method_name,
                 "gcp.resource.destination.id" = tracing::field::Empty,
                 "otel.status_code" = tracing::field::Empty,
-                "otel.status_description" = tracing::field::Empty
+                "otel.status_description" = tracing::field::Empty,
+                "error.type" = tracing::field::Empty
             );
             let traced = Tracing::new(self, span);
             return Either::Right(traced);

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::{Poller, PollingResult, Result, sealed};
+use gaxi::observability::errors::error_type;
 use google_cloud_gax::polling_state::PollingState;
 use tracing::{Instrument, Span, info_span};
 
@@ -122,6 +123,7 @@ impl LroRecorder {
     pub fn record_error(&self, err: &crate::Error) {
         self.span.record("otel.status_code", "ERROR");
         self.span.record("otel.status_description", err.to_string());
+        self.span.record("error.type", error_type(err));
     }
 
     pub async fn record_action<F, Fut, T>(&self, f: F) -> T


### PR DESCRIPTION
Add `error.type` attribute to the LRO (T2) span and populate it from the status code if the long-running operation fails with a status code. This allows observability tools to track error rates by error type for long-running operations.

This lack of T2 error type recording is surfaced in the `error.type` assertions requested for LRO tracing integration tests (https://github.com/googleapis/google-cloud-rust/pull/5886).