### PR TITLE
ci(gemini): hone review bot

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -50,7 +50,6 @@ When reviewing or generating code, apply rigorous scrutiny:
   preferable to returning an error that can't arise. In tests, prefer `?`. If
   that is not possible use `.expect()`. Only use `.unwrap()` as a last resort.
 
-
 ## Async & Concurrency
 
 - **Send & Sync:** New public `async fn` and Future types MUST be `Send` and

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -45,11 +45,10 @@ When reviewing or generating code, apply rigorous scrutiny:
   meaningful distinctions for the user. Error variants should be actionable.
 - **Panics:** `unwrap()` and `expect()` should typically be avoided in
   production code and examples (use `?` or handle errors). If an invariant is
-  known, (e.g. a builer always returns a valid configuration, or the service
-  always returns a message with presence), it is fine to `expect()`, and
-  often preferable to returning an error that can't arise. In tests, prefer `?`.
-  If that is not possible use `.expect()`. Only use `.unwrap()` as a last
-  resort.
+  known, (e.g. a builder always returns a valid configuration, or the service
+  always returns a message with presence), it is fine to `expect()`, and often
+  preferable to returning an error that can't arise. In tests, prefer `?`. If
+  that is not possible use `.expect()`. Only use `.unwrap()` as a last resort.
 
 
 ## Async & Concurrency

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -47,7 +47,10 @@ When reviewing or generating code, apply rigorous scrutiny:
   production code and examples (use `?` or handle errors). If an invariant is
   known, (e.g. a builer always returns a valid configuration, or the service
   always returns a message with presence), it is fine to `expect()`, and
-  often preferable to returning an error that can't arise.
+  often preferable to returning an error that can't arise. In tests, prefer `?`.
+  If that is not possible use `.expect()`. Only use `.unwrap()` as a last
+  resort.
+
 
 ## Async & Concurrency
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -26,16 +26,28 @@ When reviewing or generating code, apply rigorous scrutiny:
 - **Demand Explosive Correctness:** Never swallow errors or ignore `Result`
   types. Fail loudly and explicitly when appropriate.
 
+## Optimizations
+
+- **Unnecessary clones**: Scrutinize expensive uses of `clone()` (i.e. for
+  `String`s, not for `Arc`s). Look out for subtle copies, e.g. from `chunks()`
+  or a `to_*()` instead of `into_*()`. Is it necessary to copy the data? Can we
+  move the data instead?
+- **Unnecessary locks**: Scrutinize any use of `Mutex<>`. Do multiple threads
+  really need to access this data? Could we avoid locks with a different model?
+
 ## Safety & Error Handling
 
 - **Unsafe Code:** Avoid `unsafe` unless absolutely necessary. Any `unsafe`
   block must have a `// SAFETY:` comment explaining why it is safe.
-- **Panics:** No `unwrap()` or `expect()` in production code or examples (use
-  `?` or handle errors). No `panic!` macro calls in library code. `unwrap()` is
-  acceptable in tests.
 - **Error Handling:** Public functions should return `Result<T, Error>`. Use the
-  `?` operator for propagation. Custom error types should imply meaningful
-  distinctions for the user.
+  `?` operator for propagation. The library should almost always prefer to
+  return a `Result<>` over an internal `panic!`. Custom error types should imply
+  meaningful distinctions for the user. Error variants should be actionable.
+- **Panics:** `unwrap()` and `expect()` should typically be avoided in
+  production code and examples (use `?` or handle errors). If an invariant is
+  known, (e.g. a builer always returns a valid configuration, or the service
+  always returns a message with presence), it is fine to `expect()`, and
+  often preferable to returning an error that can't arise.
 
 ## Async & Concurrency
 


### PR DESCRIPTION
(1) The bot is flagging too many valid `expect()`s because our language is too strict. Sometimes `expect()` is correct and preferred. So refine that standard.

(2) Tell the bot to look for unnecessary data copies, unnecessary locks. I swear this is like 50% of the "value" I add in a review.