### PR TITLE
fix(spanner): make types module public for typed param construction

### DIFF
--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -32,6 +32,8 @@ pub mod read;
 pub mod result;
 /// SQL statement builders and parameter bindings.
 pub mod statement;
+/// Spanner primitive type constructors for typed parameter binding.
+pub mod types;
 /// Type and value representations and conversion traits.
 pub mod value;
 
@@ -89,7 +91,6 @@ pub(crate) mod timestamp_bound;
 pub(crate) mod to_value;
 pub(crate) mod transaction_retry_policy;
 pub(crate) mod transaction_runner;
-pub(crate) mod types;
 pub(crate) mod write_only_transaction;
 
 mod status;

--- a/src/spanner/tests/types_module_visibility.rs
+++ b/src/spanner/tests/types_module_visibility.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests that exercise the public `google_cloud_spanner::types`
+//! module from an external-crate perspective.
+//!
+//! If the `types` module is ever declared `pub(crate)` again, these tests
+//! fail to compile with `error[E0603]: module 'types' is private`. That
+//! compile-time failure is the regression guard: it locks the public
+//! constructors (`types::timestamp()`, `types::string()`, `types::int64()`,
+//! etc.) reachable from external crates that depend on
+//! `google-cloud-spanner`.
+
+use google_cloud_spanner::statement::Statement;
+use google_cloud_spanner::types;
+
+#[test]
+fn external_uses_typed_param_constructors() {
+    let stmt = Statement::builder("SELECT @ts, @s, @n")
+        .add_typed_param("ts", &time::OffsetDateTime::now_utc(), types::timestamp())
+        .add_typed_param("s", &"hello".to_string(), types::string())
+        .add_typed_param("n", &42i64, types::int64())
+        .build();
+
+    assert!(stmt.sql().contains("SELECT @ts, @s, @n"));
+}
+
+#[test]
+fn external_reaches_all_primitive_constructors() {
+    // Touch each documented primitive constructor so any future visibility
+    // regression that hides even one of them fails compilation here.
+    let _ = types::int64();
+    let _ = types::string();
+    let _ = types::timestamp();
+    let _ = types::bool();
+    let _ = types::bytes();
+    let _ = types::date();
+    let _ = types::float32();
+    let _ = types::float64();
+    let _ = types::json();
+    let _ = types::numeric();
+    let _ = types::uuid();
+    let _ = types::interval();
+    let _ = types::pg_numeric();
+    let _ = types::pg_jsonb();
+    let _ = types::pg_oid();
+    let _ = types::array(types::int64());
+}


### PR DESCRIPTION
The `google_cloud_spanner::types` module was declared `pub(crate)`, so the
documented primitive constructors (`int64()`, `string()`, `timestamp()`, `bool()`, `bytes()`, `date()`, `float32()`, `float64()`, `json()`, `numeric()`, `uuid()`, `interval()`, plus the PostgreSQL variants `pg_numeric()`, `pg_jsonb()`, `pg_oid()`) were unreachable from external crates. Downstream code calling `StatementBuilder::add_typed_param` was forced to construct values via the generated
`google_cloud_spanner::model::Type`
protobuf struct and field mutation, coupling external code to a `#[non_exhaustive]` generated type.

The module visibility was the only thing wrong: every constructor is already
`pub fn` inside the module, already documented at its declaration site in
`src/spanner/src/types.rs`, and already used internally by the SDK's own tests at `src/spanner/src/statement.rs:390-394` via `crate::types::string()`.
This was a classic Rust visibility gotcha where items declared `pub` were
hidden by a `pub(crate)` module.

Changed `pub(crate) mod types` to `pub mod types` at `src/spanner/src/lib.rs:92`.
Added an integration test (`tests/types_module_visibility.rs`) that exercises
the constructors from an external-crate perspective, so any future regression
that re-hides the module fails compilation with the same `E0603` error downstream users reported.

Fixes #5911