### PR TITLE
feat(spanner): support the last_statement flag

### DIFF
--- a/src/spanner/src/batch_dml.rs
+++ b/src/spanner/src/batch_dml.rs
@@ -28,6 +28,7 @@ use std::time::Duration;
 pub struct BatchDmlBuilder {
     statements: Vec<Statement>,
     request_options: Option<RequestOptions>,
+    last_statements: bool,
     gax_options: GaxRequestOptions,
 }
 
@@ -82,11 +83,32 @@ impl BatchDmlBuilder {
         self
     }
 
+    /// Sets whether this batch is the last statement in a read/write transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::statement::Statement;
+    /// # use google_cloud_spanner::batch::BatchDml;
+    /// let statement1 = Statement::builder("UPDATE users SET active = true WHERE id = 1").build();
+    /// let batch = BatchDml::builder()
+    ///     .add_statement(statement1)
+    ///     .set_last_statements(true)
+    ///     .build();
+    /// ```
+    ///
+    /// If true, indicates that this request marks the end of the transaction, which
+    /// allows Spanner to optimize execution.
+    pub fn set_last_statements(mut self, last_statements: bool) -> Self {
+        self.last_statements = last_statements;
+        self
+    }
+
     /// Builds and returns the finalized BatchDml object.
     pub fn build(self) -> BatchDml {
         BatchDml {
             statements: self.statements,
             request_options: self.request_options,
+            last_statements: self.last_statements,
             gax_options: self.gax_options,
         }
     }
@@ -97,6 +119,7 @@ impl BatchDmlBuilder {
 pub struct BatchDml {
     pub(crate) statements: Vec<Statement>,
     pub(crate) request_options: Option<RequestOptions>,
+    pub(crate) last_statements: bool,
     pub(crate) gax_options: GaxRequestOptions,
 }
 
@@ -118,6 +141,7 @@ impl<T: Into<Statement>> From<Vec<T>> for BatchDml {
         BatchDml {
             statements: statements.into_iter().map(Into::into).collect(),
             request_options: None,
+            last_statements: false,
             gax_options: GaxRequestOptions::default(),
         }
     }
@@ -178,11 +202,13 @@ mod tests {
         let batch = BatchDml::builder()
             .add_statement(stmt1)
             .add_statement(stmt2)
+            .set_last_statements(true)
             .build();
 
         assert_eq!(batch.statements.len(), 2);
         assert_eq!(batch.statements[0].sql, "UPDATE t SET c = 1 WHERE id = 1");
         assert_eq!(batch.statements[1].sql, "UPDATE t SET c = 2 WHERE id = 2");
+        assert!(batch.last_statements);
         assert!(
             batch.request_options.is_none(),
             "Unexpected request_options set: {:#?}",

--- a/src/spanner/src/read_write_transaction.rs
+++ b/src/spanner/src/read_write_transaction.rs
@@ -569,9 +569,8 @@ impl ReadWriteTransaction {
             .set_transaction(self.context.transaction_selector.selector().await?)
             .set_seqno(seqno)
             .set_statements(statements)
-            .set_or_clear_request_options(
-                self.context.amend_request_options(batch.request_options),
-            );
+            .set_or_clear_request_options(self.context.amend_request_options(batch.request_options))
+            .set_last_statements(batch.last_statements);
 
         let response = execute_with_retry!(
             self,
@@ -1201,18 +1200,38 @@ mod tests {
     }
 
     #[tokio_test_no_panics]
+    async fn read_write_transaction_execute_update_last_statement() {
+        let stmt = Statement::builder("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .set_last_statement(true)
+            .build();
+        run_read_write_transaction_execute_update(BeginTransactionOption::ExplicitBegin, stmt)
+            .await;
+    }
+
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_explicit() {
-        run_read_write_transaction_execute_update(BeginTransactionOption::ExplicitBegin).await;
+        run_read_write_transaction_execute_update(
+            BeginTransactionOption::ExplicitBegin,
+            "UPDATE Users SET Name = 'Alice' WHERE Id = 1",
+        )
+        .await;
     }
 
     #[tokio_test_no_panics]
     async fn read_write_transaction_execute_update_inline() {
-        run_read_write_transaction_execute_update(BeginTransactionOption::InlineBegin).await;
+        run_read_write_transaction_execute_update(
+            BeginTransactionOption::InlineBegin,
+            "UPDATE Users SET Name = 'Alice' WHERE Id = 1",
+        )
+        .await;
     }
 
     async fn run_read_write_transaction_execute_update(
         begin_transaction_option: BeginTransactionOption,
+        statement: impl Into<Statement>,
     ) {
+        let statement = statement.into();
+        let expected_last_statement = statement.last_statement;
         let mut mock = create_session_mock();
 
         if begin_transaction_option == BeginTransactionOption::ExplicitBegin {
@@ -1233,6 +1252,7 @@ mod tests {
             let req = req.into_inner();
             assert_eq!(req.sql, "UPDATE Users SET Name = 'Alice' WHERE Id = 1");
             assert_eq!(req.seqno, 1);
+            assert_eq!(req.last_statement, expected_last_statement);
 
             if begin_transaction_option == BeginTransactionOption::InlineBegin {
                 let transaction = req
@@ -1296,7 +1316,7 @@ mod tests {
             .await
             .expect("Failed to build transaction");
         let count = tx
-            .execute_update("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .execute_update(statement)
             .await
             .expect("Failed to execute update");
         assert_eq!(count, 1);
@@ -1478,6 +1498,20 @@ mod tests {
     }
 
     #[tokio_test_no_panics]
+    async fn read_write_transaction_execute_batch_update_last_statements() -> anyhow::Result<()> {
+        let batch = BatchDml::builder()
+            .add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
+            .add_statement("UPDATE Users SET Name = 'Bob' WHERE Id = 2")
+            .set_last_statements(true)
+            .build();
+        run_read_write_transaction_execute_batch_update(
+            BeginTransactionOption::ExplicitBegin,
+            batch,
+        )
+        .await
+    }
+
+    #[tokio_test_no_panics]
     async fn read_write_transaction_execute_batch_update_explicit() -> anyhow::Result<()> {
         let batch = BatchDml::builder()
             .add_statement("UPDATE Users SET Name = 'Alice' WHERE Id = 1")
@@ -1529,6 +1563,8 @@ mod tests {
         begin_transaction_option: BeginTransactionOption,
         batch: impl Into<BatchDml>,
     ) -> anyhow::Result<()> {
+        let batch = batch.into();
+        let expected_last_statements = batch.last_statements;
         let mut mock = create_session_mock();
 
         if begin_transaction_option == BeginTransactionOption::ExplicitBegin {
@@ -1544,6 +1580,7 @@ mod tests {
             .once()
             .returning(move |req| {
                 let req = req.into_inner();
+                assert_eq!(req.last_statements, expected_last_statements);
                 assert_eq!(req.statements.len(), 2);
                 assert_eq!(
                     req.statements[0].sql,

--- a/src/spanner/src/statement.rs
+++ b/src/spanner/src/statement.rs
@@ -43,6 +43,7 @@ pub struct StatementBuilder {
     directed_read_options: Option<DirectedReadOptions>,
     query_options: Option<QueryOptions>,
     query_mode: Option<QueryMode>,
+    last_statement: bool,
     gax_options: GaxRequestOptions,
 }
 
@@ -56,6 +57,7 @@ impl StatementBuilder {
             directed_read_options: None,
             query_options: None,
             query_mode: None,
+            last_statement: false,
             gax_options: GaxRequestOptions::default(),
         }
     }
@@ -179,6 +181,34 @@ impl StatementBuilder {
         self
     }
 
+    /// Sets whether this statement is the last statement in a read/write transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_spanner::statement::Statement;
+    /// # async fn run_tx(client: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let runner = db_client.read_write_transaction().build().await?;
+    ///
+    /// let result = runner.run(async |transaction| {
+    ///     let statement = Statement::builder("UPDATE MyTable SET MyColumn = 'MyValue' WHERE Id = 1")
+    ///         .set_last_statement(true)
+    ///         .build();
+    ///     transaction.execute_update(statement).await?;
+    ///     Ok(42)
+    /// }).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// If true, indicates that this is the last statement in a transaction, which allows
+    /// Spanner to optimize execution.
+    pub fn set_last_statement(mut self, last_statement: bool) -> Self {
+        self.last_statement = last_statement;
+        self
+    }
+
     /// Sets the retry policy for this statement.
     pub fn with_retry_policy(mut self, policy: impl Into<RetryPolicyArg>) -> Self {
         self.gax_options.set_retry_policy(policy);
@@ -201,6 +231,7 @@ impl StatementBuilder {
             directed_read_options: self.directed_read_options,
             query_options: self.query_options,
             query_mode: self.query_mode,
+            last_statement: self.last_statement,
             gax_options: self.gax_options,
         }
     }
@@ -238,7 +269,8 @@ pub struct Statement {
     pub(crate) directed_read_options: Option<DirectedReadOptions>,
     pub(crate) query_options: Option<QueryOptions>,
     pub(crate) query_mode: Option<QueryMode>,
-    gax_options: GaxRequestOptions,
+    pub(crate) last_statement: bool,
+    pub(crate) gax_options: GaxRequestOptions,
 }
 
 impl Statement {
@@ -284,6 +316,34 @@ impl Statement {
         self
     }
 
+    /// Sets whether this statement is the last statement in a read/write transaction.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_spanner::statement::Statement;
+    /// # async fn run_tx(client: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = client.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let runner = db_client.read_write_transaction().build().await?;
+    ///
+    /// let result = runner.run(async |transaction| {
+    ///     let statement = Statement::builder("UPDATE MyTable SET MyColumn = 'MyValue' WHERE Id = 1")
+    ///         .build()
+    ///         .set_last_statement(true);
+    ///     transaction.execute_update(statement).await?;
+    ///     Ok(42)
+    /// }).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// If true, indicates that this is the last statement in a transaction, which allows
+    /// Spanner to optimize execution.
+    pub fn set_last_statement(mut self, last_statement: bool) -> Self {
+        self.last_statement = last_statement;
+        self
+    }
+
     fn into_parts(
         self,
     ) -> (
@@ -314,6 +374,7 @@ impl Statement {
         let directed_read_options = self.directed_read_options.clone();
         let query_options = self.query_options.clone();
         let query_mode = self.query_mode.clone();
+        let last_statement = self.last_statement;
         let (sql, params, param_types) = self.into_parts();
         crate::model::ExecuteSqlRequest::default()
             .set_sql(sql)
@@ -323,6 +384,7 @@ impl Statement {
             .set_or_clear_directed_read_options(directed_read_options)
             .set_or_clear_query_options(query_options)
             .set_query_mode(query_mode.unwrap_or_default())
+            .set_last_statement(last_statement)
     }
 
     pub(crate) fn into_batch_statement(self) -> crate::model::execute_batch_dml_request::Statement {
@@ -567,6 +629,33 @@ mod tests {
         );
         assert!(stmt.gax_options.retry_policy().is_some());
         assert!(stmt.gax_options.backoff_policy().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn set_last_statement() -> anyhow::Result<()> {
+        let stmt = Statement::builder("SELECT * FROM users").build();
+        assert!(!stmt.last_statement);
+
+        let req = stmt.into_request();
+        assert!(!req.last_statement);
+
+        let stmt = Statement::builder("SELECT * FROM users")
+            .set_last_statement(true)
+            .build();
+        assert!(stmt.last_statement);
+
+        let req = stmt.into_request();
+        assert!(req.last_statement);
+
+        let stmt = Statement::builder("SELECT * FROM users")
+            .build()
+            .set_last_statement(true);
+        assert!(stmt.last_statement);
+
+        let req = stmt.into_request();
+        assert!(req.last_statement);
 
         Ok(())
     }

--- a/tests/spanner/src/read_write_transaction.rs
+++ b/tests/spanner/src/read_write_transaction.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use google_cloud_spanner::batch::BatchDml;
 use google_cloud_spanner::client::DatabaseClient;
 use google_cloud_spanner::key;
 use google_cloud_spanner::mutation::Mutation;
@@ -1148,6 +1149,102 @@ pub async fn continue_after_initial_query_error(db_client: &DatabaseClient) -> a
         777,
         "Insert should have succeeded despite earlier query error"
     );
+
+    Ok(())
+}
+
+pub async fn read_write_transaction_last_statement(
+    db_client: &DatabaseClient,
+) -> anyhow::Result<()> {
+    let id = format!("rw-last-stmt-{}", LowercaseAlphanumeric.random_string(10));
+
+    // Insert a row
+    let mutation = Mutation::new_insert_builder("AllTypes")
+        .set("Id")
+        .to(&id)
+        .set("ColInt64")
+        .to(&100_i64)
+        .build();
+    db_client
+        .write_only_transaction()
+        .build()
+        .write(vec![mutation])
+        .await?;
+
+    let runner = db_client.read_write_transaction().build().await?;
+    runner
+        .run(async |transaction| {
+            let update_statement =
+                Statement::builder("UPDATE AllTypes SET ColInt64 = 200 WHERE Id = @id")
+                    .add_param("id", &id)
+                    .set_last_statement(true)
+                    .build();
+            transaction.execute_update(update_statement).await?;
+            Ok(())
+        })
+        .await?;
+
+    // Verify update was committed
+    let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+        .add_param("id", &id)
+        .build();
+    let mut result_set = db_client
+        .single_use()
+        .build()
+        .execute_query(statement)
+        .await?;
+    let row = result_set.next().await.transpose()?.expect("Row exists");
+    let final_val: i64 = row.get("ColInt64");
+    assert_eq!(final_val, 200);
+
+    Ok(())
+}
+
+pub async fn read_write_transaction_batch_last_statements(
+    db_client: &DatabaseClient,
+) -> anyhow::Result<()> {
+    let id = format!("rw-last-stmts-{}", LowercaseAlphanumeric.random_string(10));
+
+    // Insert a row
+    let mutation = Mutation::new_insert_builder("AllTypes")
+        .set("Id")
+        .to(&id)
+        .set("ColInt64")
+        .to(&100_i64)
+        .build();
+    db_client
+        .write_only_transaction()
+        .build()
+        .write(vec![mutation])
+        .await?;
+
+    let runner = db_client.read_write_transaction().build().await?;
+    runner
+        .run(async |transaction| {
+            let stmt = Statement::builder("UPDATE AllTypes SET ColInt64 = 300 WHERE Id = @id")
+                .add_param("id", &id)
+                .build();
+            let batch = BatchDml::builder()
+                .add_statement(stmt)
+                .set_last_statements(true)
+                .build();
+            transaction.execute_batch_update(batch).await?;
+            Ok(())
+        })
+        .await?;
+
+    // Verify update was committed
+    let statement = Statement::builder("SELECT ColInt64 FROM AllTypes WHERE Id = @id")
+        .add_param("id", &id)
+        .build();
+    let mut result_set = db_client
+        .single_use()
+        .build()
+        .execute_query(statement)
+        .await?;
+    let row = result_set.next().await.transpose()?.expect("Row exists");
+    let final_val: i64 = row.get("ColInt64");
+    assert_eq!(final_val, 300);
 
     Ok(())
 }

--- a/tests/spanner/tests/driver.rs
+++ b/tests/spanner/tests/driver.rs
@@ -121,6 +121,14 @@ mod spanner {
                 db_client,
             )
             .await?;
+            integration_tests_spanner::read_write_transaction::read_write_transaction_last_statement(
+                db_client,
+            )
+            .await?;
+            integration_tests_spanner::read_write_transaction::read_write_transaction_batch_last_statements(
+                db_client,
+            )
+            .await?;
             integration_tests_spanner::read_write_transaction::rolled_back_read_write_transaction(
                 db_client,
             )


### PR DESCRIPTION
Spanner allows an application to indicate when a statement will be the last statement in a read/write transaction. Spanner can use this flag to optimize the execution of the last statement, as it means that Spanner can safely defer some of the internal verifications until the Commit call for the transaction.