### PR TITLE
ci(.github): resolve zizmor static analysis warnings

### DIFF
--- a/.github/workflows/advisory-check.yaml
+++ b/.github/workflows/advisory-check.yaml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # ratchet:dtolnay/rust-toolchain@master

--- a/.github/workflows/gcb-monitor.yaml
+++ b/.github/workflows/gcb-monitor.yaml
@@ -69,7 +69,7 @@ jobs:
             gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "The build failed again in GCB. Details: $CHECK_SUITE_URL (Commit: $COMMIT_SHA). $PR_TEXT"
           else
             echo "Creating new issue."
-            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)
+            ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${GITHUB_ACTOR} -R $GH_REPO)
             ISSUE_NUM=${ISSUE_LINK##*/}
             gh issue comment $ISSUE_NUM --repo $GH_REPO --body "@googleapis/cloud-sdk-rust-team A critical issue has been created, please respond immediately."
           fi

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -37,13 +37,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # rachet:actions/cache@v5
+        with:
+          persist-credentials: false
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # rachet:actions/cache@v5 # zizmor: ignore[cache-poisoning] - bypassed during release runs
         with:
           path: |
             ~/.cargo
           key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
-        # TODO(#3887) - restore the cache
-        if: matrix.os != 'macos-14'
+        if: matrix.os != 'macos-14' && github.event_name != 'release'
       - name: Setup Rust ${{ matrix.rust-version }}
         run: rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
       - run: rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
@@ -65,6 +66,8 @@ jobs:
         rust-version: ['rust:current']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup Rust ${{ matrix.rust-version }}
         run: |
           rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
@@ -82,11 +85,14 @@ jobs:
         rust-version: ['rust:current']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
+        with:
+          persist-credentials: false
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5 # zizmor: ignore[cache-poisoning] - bypassed during release runs
         with:
           path: |
             ~/.cargo
           key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
+        if: github.event_name != 'release'
       - name: Check for major breaks in key libraries
         # TODO(#3265) - replace with a standard tool or a program in Go or Rust.
         run: |
@@ -151,7 +157,9 @@ jobs:
         rust-version: ['rust:current']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
+        with:
+          persist-credentials: false
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5 # zizmor: ignore[cache-poisoning] - bypassed during release runs
         with:
           path: |
             ~/.cargo


### PR DESCRIPTION
Remediates Zizmor static analysis alerts using automated fixes (such as disabling persist-credentials and using GITHUB_ACTOR environment variables).

Also added step-level release guards to completely bypass caching during release events and ignored the linter warnings inline. The risk of poisoning would have been limited to the deployed user guide, but by skipping the caching we are eliminating that threat altogether.

Also remove a stale TODO that references a closed bug.

Fixes #5942