### PR TITLE
ci: alert on PM failure per build

### DIFF
--- a/.github/workflows/gcb-monitor.yaml
+++ b/.github/workflows/gcb-monitor.yaml
@@ -14,7 +14,7 @@
 
 name: Google Cloud Build Monitor
 on:
-  check_suite:
+  check_run:
     types: [completed]
 
 permissions:
@@ -24,39 +24,46 @@ permissions:
 jobs:
   create-issue-on-failure:
     runs-on: ubuntu-24.04
-    # Only run for GCB check suites that failed/timed out/cancelled on the main branch.
+    # Only alert for a failed GCB build on the main branch.
     if: >
-      github.repository == 'googleapis/google-cloud-rust' && github.event.check_suite.app.name == 'Google Cloud Build' && (github.event.check_suite.conclusion == 'failure' ||
-       github.event.check_suite.conclusion == 'timed_out' ||
-       github.event.check_suite.conclusion == 'cancelled') &&
-      github.event.check_suite.head_branch == 'main'
+      github.repository == 'googleapis/google-cloud-rust' &&
+      github.event.check_run.app.name == 'Google Cloud Build' &&
+      github.event.check_run.check_suite.head_branch == 'main' &&
+      (github.event.check_run.conclusion == 'failure' ||
+      github.event.check_run.conclusion == 'timed_out' ||
+      github.event.check_run.conclusion == 'cancelled')
     steps:
+      # TODO(#5941) - delete this step.
+      - name: Debug context
+        shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github.event.check_run) }}
+        run: |
+          echo "$GITHUB_CONTEXT"
       - name: Create or update CI failure issue
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          CHECK_SUITE_URL: ${{ github.event.check_suite.url }}
-          COMMIT_SHA: ${{ github.event.check_suite.head_sha }}
-          PR_LIST: ${{ toJson(github.event.check_suite.pull_requests) }}
+          BUILD_URL: ${{ github.event.check_run.details_url }}
+          BUILD_NAME: ${{ github.event.check_run.name }}
+          COMMIT_SHA: ${{ github.event.check_run.head_sha }}
         run: |
-          ISSUE_TITLE="google-cloud-rust: CI failure on main branch"
+          ISSUE_TITLE="Post-merge failure for \`$BUILD_NAME\`"
 
-          # Format the PR list for the body
+          # Query GitHub for any PRs associated with this commit
+          PRS=$(gh api repos/$GH_REPO/commits/$COMMIT_SHA/pulls --jq '.[].number')
           PR_TEXT=""
-          if [[ "$PR_LIST" != "[]" ]]; then
+          if [[ -n "$PRS" ]]; then
             PR_TEXT="**Associated Pull Requests:**"
-            # Extract PR numbers and turn them into links
-            PRS=$(echo "$PR_LIST" | jq -r '.[] | "#" + (.number | toString)')
             for pr in $PRS; do
-              PR_TEXT="$PR_TEXT"$'\n'"- $pr"
+              PR_TEXT="$PR_TEXT"$'\n'"- #$pr"
             done
           fi
 
-          BODY="The Rust CI failed on the \`main\` branch.
-
-          **Failure in Google Cloud Build:**
-          - **Check Suite:** $CHECK_SUITE_URL
+          BODY="**Failure in Google Cloud Build on \`main\`:**
+          - **Build:** \`$BUILD_NAME\`
+          - **Build Log:** $BUILD_URL
           - **Commit:** $COMMIT_SHA
 
           $PR_TEXT"
@@ -66,7 +73,7 @@ jobs:
 
           if [[ -n "$EXISTING_ISSUE" && "$EXISTING_ISSUE" != "null" ]]; then
             echo "Found existing open issue #$EXISTING_ISSUE. Adding comment."
-            gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "The build failed again in GCB. Details: $CHECK_SUITE_URL (Commit: $COMMIT_SHA). $PR_TEXT"
+            gh issue comment "$EXISTING_ISSUE" --repo $GH_REPO --body "$BODY"
           else
             echo "Creating new issue."
             ISSUE_LINK=$(gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label ":rotating_light: critical" --assignee ${{ github.actor }} -R $GH_REPO)

--- a/.github/workflows/gcb-monitor.yaml
+++ b/.github/workflows/gcb-monitor.yaml
@@ -26,12 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     # Only alert for a failed GCB build on the main branch.
     if: >
-      github.repository == 'googleapis/google-cloud-rust' &&
-      github.event.check_run.app.name == 'Google Cloud Build' &&
-      github.event.check_run.check_suite.head_branch == 'main' &&
-      (github.event.check_run.conclusion == 'failure' ||
-      github.event.check_run.conclusion == 'timed_out' ||
-      github.event.check_run.conclusion == 'cancelled')
+      github.repository == 'googleapis/google-cloud-rust' && github.event.check_run.app.name == 'Google Cloud Build' && github.event.check_run.check_suite.head_branch == 'main' && (github.event.check_run.conclusion == 'failure' || github.event.check_run.conclusion == 'timed_out' || github.event.check_run.conclusion == 'cancelled')
     steps:
       # TODO(#5941) - delete this step.
       - name: Debug context


### PR DESCRIPTION
Do a pass on the GCB issue alert workflow.

- Identify the failed build (GCB trigger).
  - This means we need to act per build instead of per build suite.
  - Which means triggering on `check_run` instead of `check_suite`.
- Link to the failed build log directly. (which is the point of this PR)
- Link the PR associated with the commit. (The `github.event.check_*.pull_requests` field is apparently empty for post-merge actions. So we use `gh api` to query the associated PR instead)
- Add debug logging because I don't expect to get this right the first time. If I do, it will be easy to clean up in a follow up PR.

For #5941 