### PR TITLE
chore: compute skip release

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -577,6 +577,7 @@ libraries:
       - discovery
       - googleapis
     specification_format: discovery
+    skip_release: true
     rust:
       package_dependencies:
         - name: google-cloud-lro

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -576,8 +576,8 @@ libraries:
     roots:
       - discovery
       - googleapis
-    specification_format: discovery
     skip_release: true
+    specification_format: discovery
     rust:
       package_dependencies:
         - name: google-cloud-lro

--- a/src/generated/cloud/compute/v1/Cargo.toml
+++ b/src/generated/cloud/compute/v1/Cargo.toml
@@ -25,6 +25,7 @@ repository.workspace   = true
 keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
+publish                = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
Skip Compute release.

#5930 contains an accidental breaking change that is being rolled back.

This can be reverted after the next `discovery` sources update happens carrying the fix.