### PR TITLE
fix(o11y): fix `record_discovery_polling_result` macro compilation failure

### DIFF
--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -62,6 +62,20 @@ pub trait DiscoveryOperation {
     }
 }
 
+impl<T: DiscoveryOperation + ?Sized> DiscoveryOperation for &T {
+    fn done(&self) -> bool {
+        (*self).done()
+    }
+
+    fn name(&self) -> Option<&String> {
+        (*self).name()
+    }
+
+    fn error(&self) -> Option<Status> {
+        (*self).error()
+    }
+}
+
 // Instrumented LRO futures can get very large and cause stack overflows
 // (especially when nested decorators are used for tracing), so we box them.
 // The performance impact of moving these to the heap is negligible because

--- a/src/lro/src/internal/tracing.rs
+++ b/src/lro/src/internal/tracing.rs
@@ -92,11 +92,8 @@ macro_rules! record_discovery_polling_result {
             if let Some(status) = error {
                 span.record("otel.status_code", "ERROR");
                 span.record("otel.status_description", &status.message);
-                let err = $crate::Error::service(status);
-                span.record(
-                    "error.type",
-                    ::gaxi::observability::errors::error_type(&err),
-                );
+                span.record("rpc.response.status_code", status.code as i32);
+                span.record("error.type", status.code.to_string());
             }
         }
     };


### PR DESCRIPTION
Update `record_discovery_polling_result!` macro to extract status code, message, and `error.type` using only public types, resolving compilation failures in generated crates.