### PR TITLE
feat(o11y): extract error details and type for Discovery LROs

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.22.0
+version: bb509a740d375c1ca1709e624e404b69924fdfa7
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -165,7 +165,6 @@ libraries:
   - name: google-cloud-agentregistry-v1
     version: 1.0.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-aiplatform-v1
     version: 1.13.0
     copyright_year: "2025"
@@ -548,7 +547,6 @@ libraries:
   - name: google-cloud-ces-v1
     version: 1.3.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-chronicle-v1
     version: 1.12.0
     copyright_year: "2025"
@@ -866,7 +864,6 @@ libraries:
   - name: google-cloud-geminidataanalytics-v1
     version: 1.1.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-gkebackup-v1
     version: 1.12.0
     copyright_year: "2025"
@@ -945,7 +942,6 @@ libraries:
   - name: google-cloud-hypercomputecluster-v1
     version: 1.3.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-iam-admin-v1
     version: 1.10.0
     apis:
@@ -1347,7 +1343,6 @@ libraries:
   - name: google-cloud-securitycentermanagement-v1
     version: 1.2.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-securityposture-v1
     version: 1.12.0
     copyright_year: "2025"
@@ -1638,7 +1633,6 @@ libraries:
   - name: google-cloud-vectorsearch-v1
     version: 1.3.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-video-livestream-v1
     version: 1.12.0
     copyright_year: "2025"
@@ -1657,7 +1651,6 @@ libraries:
   - name: google-cloud-visionai-v1
     version: 1.3.0
     copyright_year: "2026"
-    rust: {}
   - name: google-cloud-vmmigration-v1
     version: 1.12.0
     copyright_year: "2025"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: bb509a740d375c1ca1709e624e404b69924fdfa7
+version: v0.24.1-0.20260706153224-e26270201c2b
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/cloud/compute/v1/src/operation.rs
+++ b/src/generated/cloud/compute/v1/src/operation.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::model::Operation;
+use google_cloud_gax::error::rpc::{Code, Status};
 
 impl google_cloud_lro::internal::DiscoveryOperation for Operation {
     fn name(&self) -> Option<&String> {
@@ -21,7 +22,7 @@ impl google_cloud_lro::internal::DiscoveryOperation for Operation {
     fn done(&self) -> bool {
         self.status == Some(crate::model::operation::Status::Done)
     }
-    fn error(&self) -> Option<google_cloud_gax::error::rpc::Status> {
+    fn error(&self) -> Option<Status> {
         if self.error.is_none()
             && self.http_error_status_code.is_none()
             && self.http_error_message.is_none()
@@ -29,44 +30,43 @@ impl google_cloud_lro::internal::DiscoveryOperation for Operation {
             return None;
         }
 
-        let mut status = google_cloud_gax::error::rpc::Status::default();
+        let mut status = Status::default();
 
         let http_status = self.http_error_status_code.unwrap_or(200);
         let mut code = match http_status {
-            200 => google_cloud_gax::error::rpc::Code::Ok,
-            400 => google_cloud_gax::error::rpc::Code::InvalidArgument,
-            401 => google_cloud_gax::error::rpc::Code::Unauthenticated,
-            403 => google_cloud_gax::error::rpc::Code::PermissionDenied,
-            404 => google_cloud_gax::error::rpc::Code::NotFound,
-            409 => google_cloud_gax::error::rpc::Code::AlreadyExists,
-            429 => google_cloud_gax::error::rpc::Code::ResourceExhausted,
-            499 => google_cloud_gax::error::rpc::Code::Cancelled,
-            500 => google_cloud_gax::error::rpc::Code::Internal,
-            501 => google_cloud_gax::error::rpc::Code::Unimplemented,
-            503 => google_cloud_gax::error::rpc::Code::Unavailable,
-            504 => google_cloud_gax::error::rpc::Code::DeadlineExceeded,
-            _ => google_cloud_gax::error::rpc::Code::Unknown,
+            200 => Code::Ok,
+            400 => Code::InvalidArgument,
+            401 => Code::Unauthenticated,
+            403 => Code::PermissionDenied,
+            404 => Code::NotFound,
+            409 => Code::AlreadyExists,
+            429 => Code::ResourceExhausted,
+            499 => Code::Cancelled,
+            500 => Code::Internal,
+            501 => Code::Unimplemented,
+            503 => Code::Unavailable,
+            504 => Code::DeadlineExceeded,
+            _ => Code::Unknown,
         };
 
         let mut message = self.http_error_message.clone().unwrap_or_default();
 
         if let Some(first_err) = self.error.as_ref().and_then(|err| err.errors.first()) {
-            if code == google_cloud_gax::error::rpc::Code::Ok {
-                code = google_cloud_gax::error::rpc::Code::Unknown;
+            if code == Code::Ok {
+                code = Code::Unknown;
             }
             if let Some(err_code) = &first_err.code {
-                if let Ok(c) = google_cloud_gax::error::rpc::Code::try_from(err_code.as_str()) {
-                    code = c;
-                } else if err_code == "QUOTA_EXCEEDED" {
-                    code = google_cloud_gax::error::rpc::Code::ResourceExhausted;
-                }
+                code = match err_code.as_str() {
+                    "QUOTA_EXCEEDED" => Code::ResourceExhausted,
+                    other => Code::try_from(other).unwrap_or(code),
+                };
             }
             if let Some(err_msg) = &first_err.message {
                 message = err_msg.clone();
             }
         }
 
-        if code == google_cloud_gax::error::rpc::Code::Ok && http_status == 200 {
+        if code == Code::Ok && http_status == 200 {
             return None;
         }
 

--- a/src/generated/cloud/compute/v1/src/operation.rs
+++ b/src/generated/cloud/compute/v1/src/operation.rs
@@ -55,19 +55,11 @@ impl google_cloud_lro::internal::DiscoveryOperation for Operation {
                 code = google_cloud_gax::error::rpc::Code::Unknown;
             }
             if let Some(err_code) = &first_err.code {
-                code = match err_code.as_str() {
-                    "QUOTA_EXCEEDED" => google_cloud_gax::error::rpc::Code::ResourceExhausted,
-                    "RESOURCE_EXHAUSTED" => google_cloud_gax::error::rpc::Code::ResourceExhausted,
-                    "NOT_FOUND" => google_cloud_gax::error::rpc::Code::NotFound,
-                    "PERMISSION_DENIED" => google_cloud_gax::error::rpc::Code::PermissionDenied,
-                    "INVALID_ARGUMENT" => google_cloud_gax::error::rpc::Code::InvalidArgument,
-                    "ALREADY_EXISTS" => google_cloud_gax::error::rpc::Code::AlreadyExists,
-                    "FAILED_PRECONDITION" => google_cloud_gax::error::rpc::Code::FailedPrecondition,
-                    "ABORTED" => google_cloud_gax::error::rpc::Code::Aborted,
-                    "UNAVAILABLE" => google_cloud_gax::error::rpc::Code::Unavailable,
-                    "DEADLINE_EXCEEDED" => google_cloud_gax::error::rpc::Code::DeadlineExceeded,
-                    _ => code,
-                };
+                if let Ok(c) = google_cloud_gax::error::rpc::Code::try_from(err_code.as_str()) {
+                    code = c;
+                } else if err_code == "QUOTA_EXCEEDED" {
+                    code = google_cloud_gax::error::rpc::Code::ResourceExhausted;
+                }
             }
             if let Some(err_msg) = &first_err.message {
                 message = err_msg.clone();

--- a/src/generated/cloud/compute/v1/src/operation.rs
+++ b/src/generated/cloud/compute/v1/src/operation.rs
@@ -21,4 +21,64 @@ impl google_cloud_lro::internal::DiscoveryOperation for Operation {
     fn done(&self) -> bool {
         self.status == Some(crate::model::operation::Status::Done)
     }
+    fn error(&self) -> Option<google_cloud_gax::error::rpc::Status> {
+        if self.error.is_none()
+            && self.http_error_status_code.is_none()
+            && self.http_error_message.is_none()
+        {
+            return None;
+        }
+
+        let mut status = google_cloud_gax::error::rpc::Status::default();
+
+        let http_status = self.http_error_status_code.unwrap_or(200);
+        let mut code = match http_status {
+            200 => google_cloud_gax::error::rpc::Code::Ok,
+            400 => google_cloud_gax::error::rpc::Code::InvalidArgument,
+            401 => google_cloud_gax::error::rpc::Code::Unauthenticated,
+            403 => google_cloud_gax::error::rpc::Code::PermissionDenied,
+            404 => google_cloud_gax::error::rpc::Code::NotFound,
+            409 => google_cloud_gax::error::rpc::Code::AlreadyExists,
+            429 => google_cloud_gax::error::rpc::Code::ResourceExhausted,
+            499 => google_cloud_gax::error::rpc::Code::Cancelled,
+            500 => google_cloud_gax::error::rpc::Code::Internal,
+            501 => google_cloud_gax::error::rpc::Code::Unimplemented,
+            503 => google_cloud_gax::error::rpc::Code::Unavailable,
+            504 => google_cloud_gax::error::rpc::Code::DeadlineExceeded,
+            _ => google_cloud_gax::error::rpc::Code::Unknown,
+        };
+
+        let mut message = self.http_error_message.clone().unwrap_or_default();
+
+        if let Some(first_err) = self.error.as_ref().and_then(|err| err.errors.first()) {
+            if code == google_cloud_gax::error::rpc::Code::Ok {
+                code = google_cloud_gax::error::rpc::Code::Unknown;
+            }
+            if let Some(err_code) = &first_err.code {
+                code = match err_code.as_str() {
+                    "QUOTA_EXCEEDED" => google_cloud_gax::error::rpc::Code::ResourceExhausted,
+                    "RESOURCE_EXHAUSTED" => google_cloud_gax::error::rpc::Code::ResourceExhausted,
+                    "NOT_FOUND" => google_cloud_gax::error::rpc::Code::NotFound,
+                    "PERMISSION_DENIED" => google_cloud_gax::error::rpc::Code::PermissionDenied,
+                    "INVALID_ARGUMENT" => google_cloud_gax::error::rpc::Code::InvalidArgument,
+                    "ALREADY_EXISTS" => google_cloud_gax::error::rpc::Code::AlreadyExists,
+                    "FAILED_PRECONDITION" => google_cloud_gax::error::rpc::Code::FailedPrecondition,
+                    "ABORTED" => google_cloud_gax::error::rpc::Code::Aborted,
+                    "UNAVAILABLE" => google_cloud_gax::error::rpc::Code::Unavailable,
+                    "DEADLINE_EXCEEDED" => google_cloud_gax::error::rpc::Code::DeadlineExceeded,
+                    _ => code,
+                };
+            }
+            if let Some(err_msg) = &first_err.message {
+                message = err_msg.clone();
+            }
+        }
+
+        if code == google_cloud_gax::error::rpc::Code::Ok && http_status == 200 {
+            return None;
+        }
+
+        status = status.set_code(code).set_message(message);
+        Some(status)
+    }
 }

--- a/src/generated/cloud/compute/v1/src/tracing.rs
+++ b/src/generated/cloud/compute/v1/src/tracing.rs
@@ -375,9 +375,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -621,9 +619,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -907,9 +903,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1235,9 +1229,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1395,9 +1387,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -1837,9 +1827,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2011,9 +1999,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2353,9 +2339,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2541,9 +2525,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2743,9 +2725,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -2931,9 +2911,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3119,9 +3097,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3307,9 +3283,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3495,9 +3469,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -3827,9 +3799,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4001,9 +3971,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4203,9 +4171,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4391,9 +4357,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4579,9 +4543,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -4867,9 +4829,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5027,9 +4987,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5455,9 +5413,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5685,9 +5641,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -5803,9 +5757,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6005,9 +5957,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6809,9 +6759,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -6997,9 +6945,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7213,9 +7159,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7431,9 +7375,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7619,9 +7561,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -7849,9 +7789,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8167,9 +8105,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8455,9 +8391,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8657,9 +8591,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -8945,9 +8877,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9105,9 +9035,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9321,9 +9249,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -9705,9 +9631,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10035,9 +9959,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10335,9 +10257,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10537,9 +10457,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -10926,9 +10844,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11114,9 +11030,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11246,9 +11160,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11532,9 +11444,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11720,9 +11630,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -11922,9 +11830,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12110,9 +12016,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12326,9 +12230,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12584,9 +12486,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12744,9 +12644,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -12946,9 +12844,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13346,9 +13242,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13534,9 +13428,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13722,9 +13614,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -13910,9 +13800,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14112,9 +14000,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14274,9 +14160,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14688,9 +14572,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14848,9 +14730,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -14994,9 +14874,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15098,9 +14976,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15286,9 +15162,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15488,9 +15362,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -15676,9 +15548,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16006,9 +15876,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16180,9 +16048,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16496,9 +16362,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16614,9 +16478,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16830,9 +16692,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -16976,9 +16836,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17150,9 +17008,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17310,9 +17166,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17498,9 +17352,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17644,9 +17496,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -17832,9 +17682,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18108,9 +17956,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18254,9 +18100,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18456,9 +18300,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18700,9 +18542,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -18916,9 +18756,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19062,9 +18900,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19250,9 +19086,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19578,9 +19412,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19738,9 +19570,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -19998,9 +19828,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20214,9 +20042,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20332,9 +20158,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20548,9 +20372,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20708,9 +20530,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -20896,9 +20716,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21198,9 +21016,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21456,9 +21272,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21616,9 +21430,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -21804,9 +21616,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22048,9 +21858,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22236,9 +22044,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22508,9 +22314,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22738,9 +22542,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -22940,9 +22742,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23114,9 +22914,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23344,9 +23142,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23546,9 +23342,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23720,9 +23514,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -23880,9 +23672,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");
@@ -24126,9 +23916,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");

--- a/src/generated/cloud/dns/v1/src/client.rs
+++ b/src/generated/cloud/dns/v1/src/client.rs
@@ -696,10 +696,15 @@ impl ManagedZones {
     /// # Example
     /// ```
     /// # use google_cloud_dns_v1::client::ManagedZones;
+    /// use google_cloud_lro::Poller;
     /// use google_cloud_dns_v1::Result;
     /// async fn sample(
     ///    client: &ManagedZones
     /// ) -> Result<()> {
+    ///     let response = client.patch()
+    ///         /* set fields */
+    ///         .poller().until_done().await?;
+    ///     println!("response {:?}", response);
     ///     Ok(())
     /// }
     /// ```
@@ -752,10 +757,15 @@ impl ManagedZones {
     /// # Example
     /// ```
     /// # use google_cloud_dns_v1::client::ManagedZones;
+    /// use google_cloud_lro::Poller;
     /// use google_cloud_dns_v1::Result;
     /// async fn sample(
     ///    client: &ManagedZones
     /// ) -> Result<()> {
+    ///     let response = client.update()
+    ///         /* set fields */
+    ///         .poller().until_done().await?;
+    ///     println!("response {:?}", response);
     ///     Ok(())
     /// }
     /// ```

--- a/src/generated/cloud/dns/v1/src/tracing.rs
+++ b/src/generated/cloud/dns/v1/src/tracing.rs
@@ -366,9 +366,7 @@ where
                 match &result {
                     Ok(response) => {
                         let op = response.body();
-                        // TODO(https://github.com/googleapis/librarian/issues/6286): Track recording error info for Discovery LROs
-                        let done = google_cloud_lro::internal::DiscoveryOperation::done(op);
-                        _span.record("gcp.longrunning.done", done);
+                        google_cloud_lro::record_discovery_polling_result!(&_span, op);
                     }
                     Err(e) => {
                         _span.record("otel.status_code", "ERROR");

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -609,6 +609,7 @@ mod tests {
         done: bool,
         name: Option<String>,
         value: Option<i32>,
+        error: Option<Status>,
     }
 
     impl DiscoveryOperation for TestOperation {
@@ -617,6 +618,9 @@ mod tests {
         }
         fn name(&self) -> Option<&String> {
             self.name.as_ref()
+        }
+        fn error(&self) -> Option<Status> {
+            self.error.clone()
         }
     }
 
@@ -703,6 +707,94 @@ mod tests {
                     .get("gcp.resource.destination.id")
                     .and_then(|v| v.as_string()),
                 Some("discovery-operation-123".to_string())
+            );
+        }
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    #[tokio::test]
+    async fn test_discovery_poller_tracing_error() {
+        let guard = google_cloud_test_utils::test_layer::TestLayer::initialize();
+
+        let start = || async move {
+            let op = TestOperation {
+                name: Some("discovery-operation-err".into()),
+                ..TestOperation::default()
+            };
+            Ok(op)
+        };
+
+        let query = |_: String| async move {
+            let status = Status::default()
+                .set_code(Code::AlreadyExists)
+                .set_message("operation-error-message");
+            let op = TestOperation {
+                done: true,
+                error: Some(status),
+                ..TestOperation::default()
+            };
+            Ok(op)
+        };
+
+        let mut poller = new_discovery_poller(
+            Arc::new(AlwaysContinue),
+            Arc::new(test_backoff()),
+            start,
+            query,
+        );
+
+        let make_test_span = |name: &'static str| {
+            tracing::info_span!(
+                "test_span",
+                "otel.name" = name,
+                "gcp.resource.destination.id" = tracing::field::Empty,
+                "otel.status_code" = tracing::field::Empty,
+                "otel.status_description" = tracing::field::Empty,
+                "error.type" = tracing::field::Empty,
+            )
+        };
+
+        let span = make_test_span("test_span_1");
+        let poller_ref = &mut poller;
+        let recorder = crate::internal::LroRecorder::new(span.clone());
+        let _ = recorder
+            .scope(async move { poller_ref.poll().instrument(span).await })
+            .await;
+
+        let span = make_test_span("test_span_2");
+        let poller_ref2 = &mut poller;
+        let recorder2 = crate::internal::LroRecorder::new(span.clone());
+        let _ = recorder2
+            .scope(async move { poller_ref2.poll().instrument(span).await })
+            .await;
+
+        {
+            let captured = google_cloud_test_utils::test_layer::TestLayer::capture(&guard);
+            let got = captured
+                .iter()
+                .find(|s| {
+                    s.attributes
+                        .get("otel.name")
+                        .and_then(|v| v.as_string())
+                        .as_deref()
+                        == Some("test_span_2")
+                })
+                .unwrap_or_else(|| panic!("missing `test_span_2` in captured spans: {captured:?}"));
+            assert_eq!(
+                got.attributes
+                    .get("otel.status_code")
+                    .and_then(|v| v.as_string()),
+                Some("ERROR".to_string())
+            );
+            assert_eq!(
+                got.attributes
+                    .get("otel.status_description")
+                    .and_then(|v| v.as_string()),
+                Some("operation-error-message".to_string())
+            );
+            assert_eq!(
+                got.attributes.get("error.type").and_then(|v| v.as_string()),
+                Some("ALREADY_EXISTS".to_string())
             );
         }
     }

--- a/src/lro/src/internal/discovery.rs
+++ b/src/lro/src/internal/discovery.rs
@@ -576,6 +576,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn discovery_operation_blanket_and_default() {
+        struct DefaultOperation {
+            done: bool,
+            name: Option<String>,
+        }
+        impl DiscoveryOperation for DefaultOperation {
+            fn done(&self) -> bool {
+                self.done
+            }
+            fn name(&self) -> Option<&String> {
+                self.name.as_ref()
+            }
+        }
+
+        let op = DefaultOperation {
+            done: true,
+            name: Some("test-default".to_string()),
+        };
+
+        // 1. Default implementation of error()
+        assert!(op.error().is_none());
+
+        // 2. Blanket impl for &T
+        let op_ref = &op;
+        assert!(<&DefaultOperation as DiscoveryOperation>::done(&op_ref));
+        assert_eq!(
+            <&DefaultOperation as DiscoveryOperation>::name(&op_ref),
+            Some(&"test-default".to_string())
+        );
+        assert!(<&DefaultOperation as DiscoveryOperation>::error(&op_ref).is_none());
+    }
+
     fn is_transient(error: &Error) -> bool {
         error.status().is_some_and(|s| s == &transient_status())
     }

--- a/tests/discovery/tests/driver.rs
+++ b/tests/discovery/tests/driver.rs
@@ -35,10 +35,89 @@ mod compute {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_compute_lro_errors() -> anyhow::Result<()> {
+        #[cfg(google_cloud_unstable_tracing)]
+        let _guard = google_cloud_test_utils::test_layer::TestLayer::initialize();
+        #[cfg(not(google_cloud_unstable_tracing))]
         let _guard = enable_tracing();
+
         integration_tests_discovery::lro_errors()
             .await
-            .inspect_err(anydump)
+            .inspect_err(anydump)?;
+
+        #[cfg(google_cloud_unstable_tracing)]
+        {
+            let spans = google_cloud_test_utils::test_layer::TestLayer::capture(&_guard);
+
+            // 1. Assert on the "LRO Wait" (T2) span
+            let lro_wait_span = spans
+                .iter()
+                .find(|s| s.name == "LRO Wait")
+                .ok_or_else(|| anyhow::anyhow!("missing LRO Wait span in {spans:#?}"))?;
+
+            assert_eq!(
+                attribute_value_str(lro_wait_span, "otel.status_code"),
+                Some("ERROR".to_string())
+            );
+            assert!(
+                attribute_value_str(lro_wait_span, "otel.status_description")
+                    .unwrap_or_default()
+                    .contains("Quota 'CPUS_PER_VM_FAMILY' exceeded")
+            );
+            assert_eq!(
+                attribute_value_str(lro_wait_span, "error.type"),
+                Some("RESOURCE_EXHAUSTED".to_string())
+            );
+
+            // 2. Assert on the "client_request" (T3) span for get_operation
+            let get_op_span = spans
+                .iter()
+                .rfind(|s| {
+                    s.name == "client_request"
+                        && attribute_value_str(s, "rpc.method")
+                            == Some("google.cloud.compute.v1.instances/getOperation".to_string())
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!("missing getOperation client_request span in {spans:#?}")
+                })?;
+
+            assert_eq!(
+                attribute_value_str(get_op_span, "gcp.longrunning.done"),
+                Some("true".to_string())
+            );
+            assert_eq!(
+                attribute_value_str(get_op_span, "gcp.longrunning.status_code"),
+                Some("8".to_string())
+            );
+            assert_eq!(
+                attribute_value_str(get_op_span, "otel.status_code"),
+                Some("ERROR".to_string())
+            );
+            assert!(
+                attribute_value_str(get_op_span, "otel.status_description")
+                    .unwrap_or_default()
+                    .contains("Quota 'CPUS_PER_VM_FAMILY' exceeded")
+            );
+            assert_eq!(
+                attribute_value_str(get_op_span, "error.type"),
+                Some("RESOURCE_EXHAUSTED".to_string())
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(google_cloud_unstable_tracing)]
+    fn attribute_value_str(
+        span: &google_cloud_test_utils::test_layer::CapturedSpan,
+        key: &str,
+    ) -> Option<String> {
+        use google_cloud_test_utils::test_layer::AttributeValue;
+        span.attributes.get(key).map(|v| match v {
+            AttributeValue::String(s) => s.to_string(),
+            AttributeValue::Boolean(b) => b.to_string(),
+            AttributeValue::Int64(i) => i.to_string(),
+            AttributeValue::UInt64(u) => u.to_string(),
+            AttributeValue::Double(d) => d.to_string(),
+        })
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
Now that the generator template and the LRO macro are fixed, we implement the actual telemetry error mapping for Compute Engine LROs and adds integration test assertions.