### PR TITLE
fix(gax-internal): escape URL path in requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5942,6 +5942,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "test-case",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,7 +479,7 @@ tokio-stream      = { default-features = false, version = "0.1.16" }
 # Local packages used as dependencies.
 google-cloud-auth        = { default-features = false, version = "1.13.0", path = "src/auth" }
 google-cloud-gax         = { default-features = false, version = "1.11.0", path = "src/gax" }
-gaxi                     = { default-features = false, version = "0.7.14", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                     = { default-features = false, version = "0.7.15", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 wkt                      = { default-features = false, version = "1.5.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-wkt         = { default-features = false, version = "1.5.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-api         = { default-features = false, version = "1.6.0", path = "src/generated/api/types" }

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -849,7 +849,7 @@ libraries:
     copyright_year: "2025"
     output: src/gax
   - name: google-cloud-gax-internal
-    version: 0.7.14
+    version: 0.7.15
     copyright_year: "2025"
     output: src/gax-internal
     rust:

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.7.14"
+version     = "0.7.15"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -850,14 +850,14 @@ mod tests {
     // This behavior is not documented, and it may change in the future. Nonethless, we want to
     // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
     // preserve.
-    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
     #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
     #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
-    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
-    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
     #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
     #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
-    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
     #[tokio::test]
     async fn builder_appends(endpoint: &str, path: &str, want_path: &str) -> anyhow::Result<()> {
         let mut config = ClientConfig::default();

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -807,6 +807,33 @@ mod tests {
         Ok(())
     }
 
+    // Verify `builder()` appends the path to any path in the endpoint URL.
+    //
+    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
+    // preserve.
+    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[tokio::test]
+    async fn builder_appends(endpoint: &str, path: &str, want_path: &str) -> anyhow::Result<()> {
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        let client = ReqwestClient::new(config, endpoint).await?;
+        let builder = client.builder(Method::GET, path.to_string());
+        let request = client
+            .request(builder, &RequestOptions::default(), None)
+            .await?;
+        assert_eq!(request.url().path(), want_path, "{request:?}");
+        assert!(request.url().query().is_none(), "{request:?}");
+        Ok(())
+    }
+
     #[tokio::test]
     #[test_case(None, "test.my-custom-universe.com"; "default")]
     #[test_case(Some("http://www.my-custom-universe.com"), "test.my-custom-universe.com"; "global")]

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -62,7 +62,7 @@ const X_GOOG_USER_PROJECT: &str = "x-goog-user-project";
 pub struct ReqwestClient {
     inner: ::reqwest::Client,
     cred: Credentials,
-    url: ::reqwest::Url,
+    url: Url,
     host: String,
     retry_policy: Arc<dyn RetryPolicy>,
     backoff_policy: Arc<dyn BackoffPolicy>,
@@ -149,8 +149,7 @@ impl ReqwestClient {
     }
 
     pub fn builder(&self, method: Method, path: String) -> reqwest::RequestBuilder {
-        let mut url = self.url.clone();
-        url.set_path(&path);
+        let url = self.endpoint_with_path(&path);
         self.inner
             .request(method, url)
             .header(::reqwest::header::HOST, &self.host)
@@ -195,13 +194,22 @@ impl ReqwestClient {
     /// }
     /// ```
     pub fn http_builder(&self, method: Method, path: &str) -> HttpRequestBuilder {
-        let mut url = self.url.clone();
-        url.set_path(path);
+        let url = self.endpoint_with_path(path);
         let builder = self
             .inner
             .request(method, url)
             .header(::reqwest::header::HOST, &self.host);
         HttpRequestBuilder::new(self.clone(), builder)
+    }
+
+    fn endpoint_with_path(&self, path: &str) -> Url {
+        let mut url = self.url.clone();
+        match (url.path().ends_with('/'), path.starts_with('/')) {
+            (false, false) => url.set_path(&format!("{}/{}", url.path(), path)),
+            (true, true) => url.set_path(&format!("{}{}", url.path(), &path[1..])),
+            _ => url.set_path(&format!("{}{}", url.path(), path)),
+        }
+        url
     }
 
     /// Creates a builder for a plain HTTP request.

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -28,6 +28,7 @@ use crate::as_inner::as_inner;
 use crate::attempt_info::AttemptInfo;
 use crate::observability::{HttpResultExt, RequestRecorder, create_http_attempt_span};
 use crate::universe_domain::DEFAULT_UNIVERSE_DOMAIN;
+use ::reqwest::Url;
 use google_cloud_auth::credentials::{
     Builder as CredentialsBuilder, CacheableResource, Credentials,
 };
@@ -61,7 +62,7 @@ const X_GOOG_USER_PROJECT: &str = "x-goog-user-project";
 pub struct ReqwestClient {
     inner: ::reqwest::Client,
     cred: Credentials,
-    endpoint: String,
+    url: ::reqwest::Url,
     host: String,
     retry_policy: Arc<dyn RetryPolicy>,
     backoff_policy: Arc<dyn BackoffPolicy>,
@@ -102,11 +103,12 @@ impl ReqwestClient {
         .map_err(|e| e.client_builder())?;
         let service_endpoint = default_endpoint.replace(DEFAULT_UNIVERSE_DOMAIN, &universe_domain);
         let tracing_enabled = crate::options::tracing_enabled(&config);
-        let endpoint = config.endpoint.unwrap_or(service_endpoint);
+        let endpoint = config.endpoint.as_deref().unwrap_or(&service_endpoint);
+        let url = Url::parse(endpoint).map_err(BuilderError::transport)?;
         Ok(Self {
             inner,
             cred,
-            endpoint,
+            url,
             host,
             retry_policy: config.retry_policy.unwrap_or_else(|| {
                 Arc::new(
@@ -147,18 +149,22 @@ impl ReqwestClient {
     }
 
     pub fn builder(&self, method: Method, path: String) -> reqwest::RequestBuilder {
+        let mut url = self.url.clone();
+        url.set_path(&path);
         self.inner
-            .request(method, format!("{}{path}", &self.endpoint))
+            .request(method, url)
             .header(::reqwest::header::HOST, &self.host)
     }
 
-    /// Creates a builder for a complete URL.
+    /// Creates a builder for a full URL.
     ///
     /// Most clients use a single endpoint for all requests. Therefore, the
     /// [builder()][Self::builder()] prepends the endpoint to a request path.
     /// The most notable exception is the storage client, which receives the URL
     /// for uploads dynamically, and needs to make requests to arbitrary URLs.
+    #[deprecated = "this is unsafe, as the URL may include path traversal tricks"]
     pub fn builder_with_url(&self, method: Method, url: &str) -> reqwest::RequestBuilder {
+        let url = reqwest::Url::parse(url).expect("a valid URL");
         self.inner.request(method, url)
     }
 
@@ -189,9 +195,11 @@ impl ReqwestClient {
     /// }
     /// ```
     pub fn http_builder(&self, method: Method, path: &str) -> HttpRequestBuilder {
+        let mut url = self.url.clone();
+        url.set_path(path);
         let builder = self
             .inner
-            .request(method, format!("{}{path}", &self.endpoint))
+            .request(method, url)
             .header(::reqwest::header::HOST, &self.host);
         HttpRequestBuilder::new(self.clone(), builder)
     }
@@ -232,11 +240,12 @@ impl ReqwestClient {
         url: &str,
         default_endpoint: &str,
     ) -> Result<HttpRequestBuilder> {
+        let parsed_url = Url::parse(url).map_err(Error::binding)?;
         let host = crate::host::header(Some(url), default_endpoint, &self.universe_domain)
             .map_err(|e| e.gax())?;
         let builder = self
             .inner
-            .request(method, url)
+            .request(method, parsed_url)
             .header(::reqwest::header::HOST, &host);
 
         Ok(HttpRequestBuilder::new(self.clone(), builder))
@@ -764,6 +773,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reqwest_client_new_bad_endpoint() {
+        let mut config = ClientConfig::default();
+        config.endpoint = Some("bad-bad-bad".into());
+        let result = ReqwestClient::new(config, "https://test.googleapis.com").await;
+        assert!(
+            matches!(result, Err(ref e) if e.is_transport()),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reqwest_client_new_bad_default_endpoint() {
+        let config = ClientConfig::default();
+        let result = ReqwestClient::new(config, "bad-bad-bad").await;
+        assert!(
+            matches!(result, Err(ref e) if e.is_transport()),
+            "{result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn reqwest_client_with_instrumentation() {
         let config = ClientConfig::default();
         let client = ReqwestClient::new(config, "https://test.googleapis.com")
@@ -902,6 +932,18 @@ mod tests {
 
         config.disable_automatic_decompression = false;
         let _client = ReqwestClient::new(config, "https://test.googleapis.com").await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn builder_escapes_path() -> anyhow::Result<()> {
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        let client = ReqwestClient::new(config, "https://localhost:1").await?;
+        let builder = client.builder(Method::GET, "path?$httpMethod=DELETE".to_string());
+        let request = builder.build()?;
+        let url = request.url();
+        assert_eq!(url.path(), "/path%3F$httpMethod=DELETE", "{url:?}");
         Ok(())
     }
 

--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -171,6 +171,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn escape_path() -> anyhow::Result<()> {
+        let client = ReqwestClient::new(test_config(), "http://example.com").await?;
+        let request = client
+            .http_builder(Method::GET, "/path?$httpMethod=DELETE")
+            .build_for_tests()
+            .await?;
+        assert_eq!(
+            request.url().path(),
+            "/path%3F$httpMethod=DELETE",
+            "{request:?}"
+        );
+        assert!(request.url().query().is_none(), "{request:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn bad_url() -> anyhow::Result<()> {
+        let client = ReqwestClient::new(test_config(), "http://example.com").await?;
+        let request =
+            client.http_builder_with_url(Method::GET, "bad-bad-bad", "http://localhost:1");
+        assert!(
+            matches!(request, Err(ref e) if e.is_binding()),
+            "{request:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn query() -> anyhow::Result<()> {
         let client = ReqwestClient::new(test_config(), "http://example.com").await?;
         let request = client

--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -146,14 +146,14 @@ mod tests {
     // This behavior is not documented, and it may change in the future. Nonethless, we want to
     // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
     // preserve.
-    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
     #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
     #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
-    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
-    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
     #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
     #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
-    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
     #[tokio::test]
     async fn http_builder_appends(
         endpoint: &str,

--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -133,11 +133,41 @@ mod tests {
     use crate::http::reqwest::{HeaderMap, HeaderValue, Method};
     use crate::options::ClientConfig;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use test_case::test_case;
 
     fn test_config() -> ClientConfig {
         let mut config = ClientConfig::default();
         config.cred = Some(Anonymous::default().build());
         config
+    }
+
+    // Verify `http_builder()` appends the path to any path in the endpoint URL.
+    //
+    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
+    // preserve.
+    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[tokio::test]
+    async fn http_builder_appends(
+        endpoint: &str,
+        path: &str,
+        want_path: &str,
+    ) -> anyhow::Result<()> {
+        let client = ReqwestClient::new(test_config(), endpoint).await?;
+        let request = client
+            .http_builder(Method::GET, path)
+            .build_for_tests()
+            .await?;
+        assert_eq!(request.url().path(), want_path, "{request:?}");
+        assert!(request.url().query().is_none(), "{request:?}");
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/gax-internal/src/http/reqwest.rs
+++ b/src/gax-internal/src/http/reqwest.rs
@@ -22,6 +22,7 @@ pub use reqwest::Request;
 pub use reqwest::RequestBuilder;
 pub use reqwest::Response;
 pub use reqwest::StatusCode;
+pub use reqwest::Url;
 pub use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 #[cfg(feature = "_internal-http-multipart")]
 pub use reqwest::multipart;

--- a/src/storage/src/storage/read_object/parse_http_response.rs
+++ b/src/storage/src/storage/read_object/parse_http_response.rs
@@ -128,7 +128,7 @@ mod tests {
         let server = Server::run();
         server.expect(
             Expectation::matching(all_of![
-                request::method_path("GET", "//storage/v1/b/test-bucket/o/test-object"),
+                request::method_path("GET", "/storage/v1/b/test-bucket/o/test-object"),
                 request::query(url_decoded(contains(("alt", "media")))),
             ])
             .respond_with(

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -46,6 +46,7 @@ anyhow.workspace   = true
 httptest.workspace = true
 serde.workspace    = true
 tokio.workspace    = true
+test-case          = { workspace = true }
 
 [lints]
 workspace = true

--- a/tests/integration/src/lib.rs
+++ b/tests/integration/src/lib.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub mod error_details;
+mod traversal;

--- a/tests/integration/src/traversal.rs
+++ b/tests/integration/src/traversal.rs
@@ -1,0 +1,60 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Verify generated clients prevent traversal attacks.
+
+#[cfg(test)]
+mod tests {
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_workflows_v1::client::Workflows;
+    use httptest::{Expectation, Server, matchers::*, responders::*};
+    use serde_json::json;
+
+    const INPUT_PATH: &str = "projects/p/locations/l/operations/o?$httpMethod=DELETE";
+    // Note the percent-encoding for the ? character. The `reqwest::Url` class only encodes the path
+    // characters that require encoding, in this case `?`. That is enough to disable any
+    // path-traversal shenanigans.
+    const WANT_PATH: &str = "/v1/projects/p/locations/l/operations/o%3F$httpMethod=DELETE";
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn traversal_is_prevented() -> anyhow::Result<()> {
+        let server = start();
+        let endpoint = server.url_str("/");
+        let endpoint = endpoint.strip_suffix("/").expect("ends in /");
+
+        let client = Workflows::builder()
+            .with_endpoint(endpoint)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        let _ = client.get_operation().set_name(INPUT_PATH).send().await?;
+        Ok(())
+    }
+
+    fn start() -> Server {
+        let server = Server::run();
+
+        server.expect(
+            Expectation::matching(all_of![
+                request::method("GET"),
+                request::path(WANT_PATH),
+                request::query(url_decoded(contains(("$alt", "json;enum-encoding=int"))))
+            ])
+            .respond_with(json_encoded(json!({}))),
+        );
+
+        server
+    }
+}

--- a/tests/integration/src/traversal.rs
+++ b/tests/integration/src/traversal.rs
@@ -20,16 +20,22 @@ mod tests {
     use google_cloud_workflows_v1::client::Workflows;
     use httptest::{Expectation, Server, matchers::*, responders::*};
     use serde_json::json;
+    use test_case::test_case;
 
-    const INPUT_PATH: &str = "projects/p/locations/l/operations/o?$httpMethod=DELETE";
-    // Note the percent-encoding for the ? character. The `reqwest::Url` class only encodes the path
-    // characters that require encoding, in this case `?`. That is enough to disable any
-    // path-traversal shenanigans.
-    const WANT_PATH: &str = "/v1/projects/p/locations/l/operations/o%3F$httpMethod=DELETE";
-
+    // A `?` character should be percent-encoded to avoid treating it like a query parameter.
+    #[test_case(
+        "projects/p/locations/l/operations/o?$httpMethod=DELETE",
+        "/v1/projects/p/locations/l/operations/o%3F$httpMethod=DELETE"
+    )]
+    // A `%` character is passed through. The service is supposed to treat that as part of
+    // the path.
+    #[test_case(
+        "projects/p/locations/l/operations/o%3F$httpMethod=DELETE",
+        "/v1/projects/p/locations/l/operations/o%3F$httpMethod=DELETE"
+    )]
     #[tokio::test(flavor = "multi_thread")]
-    async fn traversal_is_prevented() -> anyhow::Result<()> {
-        let server = start();
+    async fn path_is_escaped(name: &str, want_path: &'static str) -> anyhow::Result<()> {
+        let server = start(want_path);
         let endpoint = server.url_str("/");
         let endpoint = endpoint.strip_suffix("/").expect("ends in /");
 
@@ -39,17 +45,34 @@ mod tests {
             .build()
             .await?;
 
-        let _ = client.get_operation().set_name(INPUT_PATH).send().await?;
+        let _ = client.get_operation().set_name(name).send().await?;
         Ok(())
     }
 
-    fn start() -> Server {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn additional_components_are_rejected() -> anyhow::Result<()> {
+        let client = Workflows::builder()
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+
+        // The generated code rejects any name with more components than expected.
+        let result = client
+            .list_operations()
+            .set_name("projects/p/locations/l/operations/too-much")
+            .send()
+            .await;
+        assert!(matches!(result, Err(ref e) if e.is_binding()), "{result:?}");
+        Ok(())
+    }
+
+    fn start(path: &'static str) -> Server {
         let server = Server::run();
 
         server.expect(
             Expectation::matching(all_of![
                 request::method("GET"),
-                request::path(WANT_PATH),
+                request::path(path),
                 request::query(url_decoded(contains(("$alt", "json;enum-encoding=int"))))
             ])
             .respond_with(json_encoded(json!({}))),


### PR DESCRIPTION
We must percent-encode the URL path, otherwise the path is subject to path traveral attacks, including the dreaded `$httpMethod` query parameter.