### PR TITLE
test(gax-internal): verify existing behavior

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -807,6 +807,33 @@ mod tests {
         Ok(())
     }
 
+    // Verify `builder()` appends the path to any path in the endpoint URL.
+    //
+    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
+    // preserve.
+    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[tokio::test]
+    async fn builder_appends(endpoint: &str, path: &str, want_path: &str) -> anyhow::Result<()> {
+        let mut config = ClientConfig::default();
+        config.cred = Some(Anonymous::new().build());
+        let client = ReqwestClient::new(config, endpoint).await?;
+        let builder = client.builder(Method::GET, path.to_string());
+        let request = client
+            .request(builder, &RequestOptions::default(), None)
+            .await?;
+        assert_eq!(request.url().path(), want_path, "{request:?}");
+        assert!(request.url().query().is_none(), "{request:?}");
+        Ok(())
+    }
+
     #[tokio::test]
     #[test_case(None, "test.my-custom-universe.com"; "default")]
     #[test_case(Some("http://www.my-custom-universe.com"), "test.my-custom-universe.com"; "global")]

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -809,7 +809,7 @@ mod tests {
 
     // Verify `builder()` appends the path to any path in the endpoint URL.
     //
-    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // This behavior is not documented, and it may change in the future. Nonetheless, we want to
     // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
     // preserve.
     // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]

--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -133,11 +133,41 @@ mod tests {
     use crate::http::reqwest::{HeaderMap, HeaderValue, Method};
     use crate::options::ClientConfig;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use test_case::test_case;
 
     fn test_config() -> ClientConfig {
         let mut config = ClientConfig::default();
         config.cred = Some(Anonymous::default().build());
         config
+    }
+
+    // Verify `http_builder()` appends the path to any path in the endpoint URL.
+    //
+    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
+    // preserve.
+    // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t1.com/", "v1/projects/p", "/v1/projects/p")]
+    #[test_case("http://t2.com", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t3.com/", "/v1/projects/p", "/v1/projects/p")]
+    // #[test_case("http://t4.com/p1/p2", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t5.com/p1/p2/", "v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[test_case("http://t6.com/p1/p2", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    // #[test_case("http://t7.com/p1/p2/", "/v1/projects/p", "/p1/p2/v1/projects/p")]
+    #[tokio::test]
+    async fn http_builder_appends(
+        endpoint: &str,
+        path: &str,
+        want_path: &str,
+    ) -> anyhow::Result<()> {
+        let client = ReqwestClient::new(test_config(), endpoint).await?;
+        let request = client
+            .http_builder(Method::GET, path)
+            .build_for_tests()
+            .await?;
+        assert_eq!(request.url().path(), want_path, "{request:?}");
+        assert!(request.url().query().is_none(), "{request:?}");
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/gax-internal/src/http/http_request_builder.rs
+++ b/src/gax-internal/src/http/http_request_builder.rs
@@ -143,7 +143,7 @@ mod tests {
 
     // Verify `http_builder()` appends the path to any path in the endpoint URL.
     //
-    // This behavior is not documented, and it may change in the future. Nonethless, we want to
+    // This behavior is not documented, and it may change in the future. Nonetheless, we want to
     // avoid behavioral breaking changes unless we have good reason to, and this is easy enough to
     // preserve.
     // #[test_case("http://t0.com", "v1/projects/p", "/v1/projects/p")]


### PR DESCRIPTION
Add tests to verify existing behavior and avoid accidental breaks. The behavior is undocumented, and we may decide to change it, but that should be for a good reason, not because of an accident.