### PR TITLE
chore: add DML samples for Getting Started Guide

### DIFF
--- a/src/spanner/examples/src/dml/dml_insert.rs
+++ b/src/spanner/examples/src/dml/dml_insert.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_dml_getting_started_insert]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let runner = client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |transaction| {
+            let sql = r#"INSERT INTO Singers (SingerId, FirstName, LastName) VALUES
+                       (12, 'Melissa', 'Garcia'),
+                       (13, 'Russell', 'Morales'),
+                       (14, 'Jacqueline', 'Long'),
+                       (15, 'Dylan', 'Shaw')"#;
+            let statement = Statement::builder(sql).build();
+            let row_count = transaction.execute_update(statement).await?;
+            println!("{row_count} records inserted.");
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+// [END spanner_dml_getting_started_insert]

--- a/src/spanner/examples/src/dml/dml_update.rs
+++ b/src/spanner/examples/src/dml/dml_update.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_dml_getting_started_update]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let runner = client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |transaction| {
+            // Transfer marketing budget from one album to another. We do it in a transaction to
+            // ensure that the transfer is atomic.
+            let select_statement1 = Statement::builder(
+                r#"SELECT MarketingBudget
+                 FROM Albums
+                 WHERE SingerId = 2 AND AlbumId = 2"#,
+            )
+            .build();
+            let mut result_set1 = transaction.execute_query(select_statement1).await?;
+            let mut album2_budget = 0i64;
+            if let Some(row) = result_set1.next().await.transpose()? {
+                album2_budget = row.get("MarketingBudget");
+            }
+
+            let transfer = 200000i64;
+            if album2_budget < transfer {
+                return Ok(());
+            }
+
+            let select_statement2 = Statement::builder(
+                r#"SELECT MarketingBudget
+                 FROM Albums
+                 WHERE SingerId = 1 AND AlbumId = 1"#,
+            )
+            .build();
+            let mut result_set2 = transaction.execute_query(select_statement2).await?;
+            let mut album1_budget = 0i64;
+            if let Some(row) = result_set2.next().await.transpose()? {
+                album1_budget = row.get("MarketingBudget");
+            }
+
+            album1_budget += transfer;
+            album2_budget -= transfer;
+
+            let update_statement1 = Statement::builder(
+                r#"UPDATE Albums
+                 SET MarketingBudget = @AlbumBudget
+                 WHERE SingerId = 1 AND AlbumId = 1"#,
+            )
+            .add_param("AlbumBudget", &album1_budget)
+            .build();
+            transaction.execute_update(update_statement1).await?;
+
+            let update_statement2 = Statement::builder(
+                r#"UPDATE Albums
+                 SET MarketingBudget = @AlbumBudget
+                 WHERE SingerId = 2 AND AlbumId = 2"#,
+            )
+            .add_param("AlbumBudget", &album2_budget)
+            .build();
+            transaction.execute_update(update_statement2).await?;
+
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+// [END spanner_dml_getting_started_update]

--- a/src/spanner/examples/src/dml/mod.rs
+++ b/src/spanner/examples/src/dml/mod.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod client;
-pub mod database;
-pub mod dml;
-pub mod mutation;
-pub mod query;
-pub mod read;
+pub mod dml_insert;
+pub mod dml_update;
+pub mod pg_dml_insert;
+pub mod pg_dml_update;

--- a/src/spanner/examples/src/dml/pg_dml_insert.rs
+++ b/src/spanner/examples/src/dml/pg_dml_insert.rs
@@ -1,0 +1,38 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_postgresql_dml_getting_started_insert]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let runner = client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |transaction| {
+            let sql = r#"INSERT INTO Singers (SingerId, FirstName, LastName) VALUES
+                       (12, 'Melissa', 'Garcia'),
+                       (13, 'Russell', 'Morales'),
+                       (14, 'Jacqueline', 'Long'),
+                       (15, 'Dylan', 'Shaw')"#;
+            let statement = Statement::builder(sql).build();
+            let row_count = transaction.execute_update(statement).await?;
+            println!("{row_count} records inserted.");
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+// [END spanner_postgresql_dml_getting_started_insert]

--- a/src/spanner/examples/src/dml/pg_dml_update.rs
+++ b/src/spanner/examples/src/dml/pg_dml_update.rs
@@ -1,0 +1,82 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_postgresql_dml_getting_started_update]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let runner = client.read_write_transaction().build().await?;
+
+    runner
+        .run(async |transaction| {
+            // Transfer marketing budget from one album to another. We do it in a transaction to
+            // ensure that the transfer is atomic.
+            let select_statement1 = Statement::builder(
+                r#"SELECT MarketingBudget as "MarketingBudget"
+                 FROM Albums
+                 WHERE SingerId = 2 AND AlbumId = 2"#,
+            )
+            .build();
+            let mut result_set1 = transaction.execute_query(select_statement1).await?;
+            let mut album2_budget = 0i64;
+            if let Some(row) = result_set1.next().await.transpose()? {
+                album2_budget = row.get("MarketingBudget");
+            }
+
+            let transfer = 200000i64;
+            if album2_budget < transfer {
+                return Ok(());
+            }
+
+            let select_statement2 = Statement::builder(
+                r#"SELECT MarketingBudget as "MarketingBudget"
+                 FROM Albums
+                 WHERE SingerId = 1 AND AlbumId = 1"#,
+            )
+            .build();
+            let mut result_set2 = transaction.execute_query(select_statement2).await?;
+            let mut album1_budget = 0i64;
+            if let Some(row) = result_set2.next().await.transpose()? {
+                album1_budget = row.get("MarketingBudget");
+            }
+
+            album1_budget += transfer;
+            album2_budget -= transfer;
+
+            let update_statement1 = Statement::builder(
+                r#"UPDATE Albums
+                 SET MarketingBudget = $1
+                 WHERE SingerId = 1 AND AlbumId = 1"#,
+            )
+            .add_param("p1", &album1_budget)
+            .build();
+            transaction.execute_update(update_statement1).await?;
+
+            let update_statement2 = Statement::builder(
+                r#"UPDATE Albums
+                 SET MarketingBudget = $1
+                 WHERE SingerId = 2 AND AlbumId = 2"#,
+            )
+            .add_param("p1", &album2_budget)
+            .build();
+            transaction.execute_update(update_statement2).await?;
+
+            Ok(())
+        })
+        .await?;
+
+    Ok(())
+}
+// [END spanner_postgresql_dml_getting_started_update]

--- a/src/spanner/examples/tests/integration.rs
+++ b/src/spanner/examples/tests/integration.rs
@@ -22,7 +22,7 @@ mod tests {
     use google_cloud_spanner::statement::Statement;
     use google_cloud_spanner_admin_database_v1::model::DatabaseDialect;
     use google_cloud_test_utils::errors::anydump;
-    use spanner_samples::{database, mutation, query, read};
+    use spanner_samples::{database, dml, mutation, query, read};
 
     /// Macro to define sample integration tests, managing database
     /// provisioning and automatic teardown.
@@ -61,6 +61,11 @@ mod tests {
                 .await
                 .inspect_err(anydump)?;
 
+            // 1b. Test spanner_dml_getting_started_insert sample
+            dml::dml_insert::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
             // 2. Test spanner_query_data sample
             query::query_data::sample(client)
                 .await
@@ -86,6 +91,11 @@ mod tests {
                 .await
                 .inspect_err(anydump)?;
 
+            // 6b. Test spanner_dml_getting_started_update sample
+            dml::dml_update::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
             // 7. Test spanner_query_data_with_new_column sample
             query::query_new_column::sample(client)
                 .await
@@ -97,6 +107,11 @@ mod tests {
         async fn postgresql_samples(client: &DatabaseClient, ctx: &TestDatabaseContext) -> anyhow::Result<()> [dialect = DatabaseDialect::Postgresql] {
             // 1. Test spanner_insert_data sample (mutations are dialect-agnostic)
             mutation::insert_data::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
+            // 1b. Test spanner_postgresql_dml_getting_started_insert sample
+            dml::pg_dml_insert::sample(client)
                 .await
                 .inspect_err(anydump)?;
 
@@ -112,6 +127,11 @@ mod tests {
 
             // 4. Test spanner_update_data sample
             mutation::update_data::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
+            // 4b. Test spanner_postgresql_dml_getting_started_update sample
+            dml::pg_dml_update::sample(client)
                 .await
                 .inspect_err(anydump)?;
 


### PR DESCRIPTION
Add DML samples for the Getting Started Guide.

Note: These samples align with the same samples [here](https://docs.cloud.google.com/spanner/docs/getting-started/java#write-data), as we will integrate the Rust client into the Getting Started Guide.