### PR TITLE
chore(spanner): add read-only transaction samples

### DIFF
--- a/src/spanner/examples/src/query/mod.rs
+++ b/src/spanner/examples/src/query/mod.rs
@@ -14,6 +14,8 @@
 
 pub mod pg_query_new_column;
 pub mod pg_query_parameter;
+pub mod pg_read_only_transaction;
 pub mod query_data;
 pub mod query_new_column;
 pub mod query_parameter;
+pub mod read_only_transaction;

--- a/src/spanner/examples/src/query/pg_read_only_transaction.rs
+++ b/src/spanner/examples/src/query/pg_read_only_transaction.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_postgresql_read_only_transaction]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::key::KeySet;
+use google_cloud_spanner::read::ReadRequest;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let transaction = client.read_only_transaction().build().await?;
+
+    // 1. Execute a query using the read-only transaction
+    let statement = Statement::builder("SELECT SingerId, AlbumId, AlbumTitle FROM Albums").build();
+    let mut result_set = transaction.execute_query(statement).await?;
+    println!("Results from query:");
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id: i64 = row.get(0);
+        let album_id: i64 = row.get(1);
+        let album_title: String = row.get(2);
+        println!("{singer_id} {album_id} {album_title}");
+    }
+
+    // 2. Execute a read using the same read-only transaction
+    let read_request = ReadRequest::builder("Albums", ["SingerId", "AlbumId", "AlbumTitle"])
+        .with_keys(KeySet::all())
+        .build();
+    let mut result_set = transaction.execute_read(read_request).await?;
+    println!("Results from read:");
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id: i64 = row.get(0);
+        let album_id: i64 = row.get(1);
+        let album_title: String = row.get(2);
+        println!("{singer_id} {album_id} {album_title}");
+    }
+
+    Ok(())
+}
+// [END spanner_postgresql_read_only_transaction]

--- a/src/spanner/examples/src/query/read_only_transaction.rs
+++ b/src/spanner/examples/src/query/read_only_transaction.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_read_only_transaction]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::key::KeySet;
+use google_cloud_spanner::read::ReadRequest;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let transaction = client.read_only_transaction().build().await?;
+
+    // 1. Execute a query using the read-only transaction
+    let statement = Statement::builder("SELECT SingerId, AlbumId, AlbumTitle FROM Albums").build();
+    let mut result_set = transaction.execute_query(statement).await?;
+    println!("Results from query:");
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id: i64 = row.get(0);
+        let album_id: i64 = row.get(1);
+        let album_title: String = row.get(2);
+        println!("{singer_id} {album_id} {album_title}");
+    }
+
+    // 2. Execute a read using the same read-only transaction
+    let read_request = ReadRequest::builder("Albums", ["SingerId", "AlbumId", "AlbumTitle"])
+        .with_keys(KeySet::all())
+        .build();
+    let mut result_set = transaction.execute_read(read_request).await?;
+    println!("Results from read:");
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id: i64 = row.get(0);
+        let album_id: i64 = row.get(1);
+        let album_title: String = row.get(2);
+        println!("{singer_id} {album_id} {album_title}");
+    }
+
+    Ok(())
+}
+// [END spanner_read_only_transaction]

--- a/src/spanner/examples/tests/integration.rs
+++ b/src/spanner/examples/tests/integration.rs
@@ -101,6 +101,11 @@ mod tests {
                 .await
                 .inspect_err(anydump)?;
 
+            // 8. Test spanner_read_only_transaction sample
+            query::read_only_transaction::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
             Ok(())
         }
 
@@ -137,6 +142,11 @@ mod tests {
 
             // 5. Test spanner_postgresql_query_data_with_new_column sample
             query::pg_query_new_column::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
+            // 6. Test spanner_postgresql_read_only_transaction sample
+            query::pg_read_only_transaction::sample(client)
                 .await
                 .inspect_err(anydump)?;
 


### PR DESCRIPTION
Adds read-only transaction samples for the Spanner Getting Started Guide.