### PR TITLE
feat(gax): retry on timeouts policy decorator

### DIFF
--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -53,6 +53,7 @@
 //!
 //! [idempotent]: https://en.wikipedia.org/wiki/Idempotence
 
+mod client_timeout;
 mod too_many_requests;
 
 use crate::error::Error;
@@ -62,6 +63,7 @@ use crate::throttle_result::ThrottleResult;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub use client_timeout::ClientTimeout;
 pub use too_many_requests::TooManyRequests;
 
 /// Determines how errors are handled in the retry loop.
@@ -224,6 +226,36 @@ pub trait RetryPolicyExt: RetryPolicy + Sized {
     /// [ResourceExhausted]: crate::error::rpc::Code::ResourceExhausted
     fn continue_on_too_many_requests(self) -> TooManyRequests<Self> {
         TooManyRequests::new(self)
+    }
+
+    /// Decorate a [RetryPolicy] to continue on client-side timeouts.
+    ///
+    /// This policy decorates an inner policy and retries any client-side timeout errors for
+    /// idempotent request. For other errors it returns the same value as the inner policy.
+    ///
+    /// This policy is useful if you want to ignore connection timeouts, or retry if the service is
+    /// taking too long to respond. Be aware that a client-side timeout may occur even after the
+    /// service receives the request. If your request has side-effects, such as creating or deleting
+    /// resources, it may be unsafe to retry the operation.
+    ///
+    /// # Example
+    /// ```
+    /// use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicy, RetryPolicyExt};
+    /// use google_cloud_gax::retry_state::RetryState;
+    /// let policy = Aip194Strict;
+    /// assert!(policy.on_error(&RetryState::new(false).set_attempt_count(0_u32), timeout()).is_permanent());
+    /// let policy = Aip194Strict.continue_on_client_timeout();
+    /// assert!(policy.on_error(&RetryState::new(true).set_attempt_count(0_u32), timeout()).is_continue());
+    ///
+    /// # use google_cloud_gax::error::Error;
+    /// fn timeout() -> Error {
+    /// # Error::timeout("test-only")
+    /// }
+    /// ```
+    ///
+    /// [ResourceExhausted]: crate::error::rpc::Code::ResourceExhausted
+    fn continue_on_client_timeout(self) -> ClientTimeout<Self> {
+        ClientTimeout::new(self)
     }
 }
 

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -231,7 +231,7 @@ pub trait RetryPolicyExt: RetryPolicy + Sized {
     /// Decorate a [RetryPolicy] to continue on client-side timeouts.
     ///
     /// This policy decorates an inner policy and retries any client-side timeout errors for
-    /// idempotent request. For other errors it returns the same value as the inner policy.
+    /// idempotent requests. For other errors it returns the same value as the inner policy.
     ///
     /// This policy is useful if you want to ignore connection timeouts, or retry if the service is
     /// taking too long to respond. Be aware that a client-side timeout may occur even after the
@@ -252,8 +252,6 @@ pub trait RetryPolicyExt: RetryPolicy + Sized {
     /// # Error::timeout("test-only")
     /// }
     /// ```
-    ///
-    /// [ResourceExhausted]: crate::error::rpc::Code::ResourceExhausted
     fn continue_on_client_timeout(self) -> ClientTimeout<Self> {
         ClientTimeout::new(self)
     }

--- a/src/gax/src/retry_policy/client_timeout.rs
+++ b/src/gax/src/retry_policy/client_timeout.rs
@@ -81,7 +81,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::{MockPolicy, idempotent_state};
+    use super::super::tests::{MockPolicy, idempotent_state, non_idempotent_state};
     use super::*;
     use crate::error::rpc::{Code, Status};
     use crate::retry_policy::NeverRetry;
@@ -104,6 +104,8 @@ mod tests {
         let policy = ClientTimeout::new(NeverRetry);
         let result = policy.on_error(&idempotent_state(Instant::now()), timeout());
         assert!(matches!(result, RetryResult::Continue(_)), "{result:?}");
+        let result = policy.on_error(&non_idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
         let result = policy.on_error(&idempotent_state(Instant::now()), permanent());
         assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
     }
@@ -114,6 +116,8 @@ mod tests {
         let policy = NeverRetry.continue_on_client_timeout();
         let result = policy.on_error(&idempotent_state(Instant::now()), timeout());
         assert!(matches!(result, RetryResult::Continue(_)), "{result:?}");
+        let result = policy.on_error(&non_idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
         let result = policy.on_error(&idempotent_state(Instant::now()), permanent());
         assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
     }

--- a/src/gax/src/retry_policy/client_timeout.rs
+++ b/src/gax/src/retry_policy/client_timeout.rs
@@ -1,0 +1,146 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{Error, RetryPolicy, RetryResult, RetryState, ThrottleResult};
+use std::time::Duration;
+
+/// A retry policy decorator that continues on client timeouts.
+///
+/// This policy returns [RetryResult::Continue] when the error is a client-side timeout and the
+/// request is idempotent. Otherwise it returns the result from the inner retry policy.
+///
+/// # Parameters
+/// * `P` - the inner retry policy.
+#[derive(Debug)]
+pub struct ClientTimeout<P>
+where
+    P: RetryPolicy,
+{
+    inner: P,
+}
+
+impl<P> ClientTimeout<P>
+where
+    P: RetryPolicy,
+{
+    /// Decorate an existing retry policy to ignore client-side timeouts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::retry_policy::{ClientTimeout, RetryPolicy};
+    /// use google_cloud_gax::retry_policy::Aip194Strict;
+    /// use google_cloud_gax::retry_state::RetryState;
+    /// let policy = ClientTimeout::new(Aip194Strict);
+    /// assert!(policy.on_error(&RetryState::new(true).set_attempt_count(1_u32), timeout()).is_continue());
+    /// assert!(policy.on_error(&RetryState::new(true).set_attempt_count(2_u32), permanent()).is_permanent());
+    ///
+    /// use google_cloud_gax::error::Error;
+    /// # use google_cloud_gax::error::rpc::{Code, Status};
+    /// fn timeout() -> Error {
+    /// # Error::timeout("test-only")
+    /// }
+    /// fn permanent() -> Error {
+    /// # Error::service(Status::default().set_code(Code::PermissionDenied))
+    /// }
+    /// ```
+    pub fn new(inner: P) -> Self {
+        Self { inner }
+    }
+}
+
+impl<P> RetryPolicy for ClientTimeout<P>
+where
+    P: RetryPolicy,
+{
+    fn on_error(&self, state: &RetryState, error: Error) -> RetryResult {
+        if state.idempotent && error.is_timeout() {
+            return RetryResult::Continue(error);
+        }
+        self.inner.on_error(state, error)
+    }
+
+    fn on_throttle(&self, state: &RetryState, error: Error) -> ThrottleResult {
+        self.inner.on_throttle(state, error)
+    }
+
+    fn remaining_time(&self, state: &RetryState) -> Option<Duration> {
+        self.inner.remaining_time(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{MockPolicy, idempotent_state};
+    use super::*;
+    use crate::error::rpc::{Code, Status};
+    use crate::retry_policy::NeverRetry;
+    use std::time::Instant;
+
+    fn timeout() -> Error {
+        Error::timeout("test-only")
+    }
+
+    fn permanent() -> Error {
+        Error::service(Status::default().set_code(Code::PermissionDenied))
+    }
+
+    fn transient() -> Error {
+        Error::service(Status::default().set_code(Code::Unavailable))
+    }
+
+    #[test]
+    fn on_error() {
+        let policy = ClientTimeout::new(NeverRetry);
+        let result = policy.on_error(&idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, RetryResult::Continue(_)), "{result:?}");
+        let result = policy.on_error(&idempotent_state(Instant::now()), permanent());
+        assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
+    }
+
+    #[test]
+    fn ext() {
+        use super::super::RetryPolicyExt;
+        let policy = NeverRetry.continue_on_client_timeout();
+        let result = policy.on_error(&idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, RetryResult::Continue(_)), "{result:?}");
+        let result = policy.on_error(&idempotent_state(Instant::now()), permanent());
+        assert!(matches!(result, RetryResult::Exhausted(_)), "{result:?}");
+    }
+
+    #[test]
+    fn forwards() {
+        let mut mock = MockPolicy::new();
+        mock.expect_on_error()
+            .times(1..)
+            .returning(|_, e| RetryResult::Permanent(e));
+        mock.expect_on_throttle()
+            .times(1..)
+            .returning(|_, e| ThrottleResult::Exhausted(e));
+        mock.expect_remaining_time().times(1).returning(|_| None);
+
+        let policy = ClientTimeout::new(mock);
+        let result = policy.on_error(&idempotent_state(Instant::now()), transient());
+        assert!(matches!(result, RetryResult::Permanent(_)), "{result:?}");
+        let result = policy.on_error(&idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, RetryResult::Continue(_)), "{result:?}");
+
+        let result = policy.on_throttle(&idempotent_state(Instant::now()), transient());
+        assert!(matches!(result, ThrottleResult::Exhausted(_)));
+        let result = policy.on_throttle(&idempotent_state(Instant::now()), timeout());
+        assert!(matches!(result, ThrottleResult::Exhausted(_)));
+
+        let result = policy.remaining_time(&idempotent_state(Instant::now()));
+        assert!(result.is_none(), "{result:?}");
+    }
+}


### PR DESCRIPTION
Introduce a retry policy decorator that retries on timeouts. Applications may want to retry when the client cannot establish a connection or get a response quickly enough.

Towards #2927 and #5973