### PR TITLE
ci: always build new library docs

### DIFF
--- a/.gcb/scripts/docs-rs.sh
+++ b/.gcb/scripts/docs-rs.sh
@@ -25,16 +25,20 @@ cargo install --locked cargo-workspaces
 cargo version
 rustup show active-toolchain -v
 
-mapfile -t all_packages < <(cargo workspaces plan 2>/dev/null)
-packages=("${all_packages[@]:0:20}")
-if [[ "${TRIGGER_NAME:-}" == "gcb-pm-*" ]]; then
-    packages=("${all_packages[@]}")
+# Seed the basic common packages serially.
+export RUSTDOCFLAGS='-D warnings'
+.gcb/scripts/cargo-fetch.sh
+
+cargo +nightly docs-rs --frozen -p google-cloud-wkt
+cargo +nightly docs-rs --frozen -p google-cloud-rpc
+cargo +nightly docs-rs --frozen -p google-cloud-gax
+cargo +nightly docs-rs --frozen -p google-cloud-auth
+cargo +nightly docs-rs --frozen -p google-cloud-gax-internal
+cargo +nightly docs-rs --frozen -p google-cloud-lro
+
+mapfile -t packages < <(cargo workspaces plan 2>/dev/null)
+if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
+    packages=("${packages[@]:0:20}")
 fi
-
-for package in "${packages[@]}"; do
-    env RUSTDOCFLAGS='-D warnings' cargo +nightly docs-rs -p "${package}"
-done
-
-echo "==== DONE ===="
-
-/workspace/.bin/sccache --show-stats
+printf "%s\n" "${packages[@]}" | \
+    xargs -P $(nproc) -I{} cargo +nightly --frozen docs-rs -p {}

--- a/.gcb/scripts/docs-rs.sh
+++ b/.gcb/scripts/docs-rs.sh
@@ -36,6 +36,11 @@ cargo +nightly docs-rs --frozen -p google-cloud-auth
 cargo +nightly docs-rs --frozen -p google-cloud-gax-internal
 cargo +nightly docs-rs --frozen -p google-cloud-lro
 
+# On PRs we build a subset of the packages because the full build is too slow.
+# The `docs.sh` script builds new libraries on PRs. I (coryan@) think that
+# buiding new libraries in both `docs.sh` and `docs-rs.sh` is not worth it: the
+# most common problem caught by these is bad markdown at the source, that would
+# be detected by both builds.
 mapfile -t packages < <(cargo workspaces plan 2>/dev/null)
 if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
     packages=("${packages[@]:0:20}")

--- a/.gcb/scripts/docs.sh
+++ b/.gcb/scripts/docs.sh
@@ -15,17 +15,31 @@
 
 set -ev
 
-rustup component add clippy
 cargo version
 rustup show active-toolchain -v
 
-args=()
-if [[ "${TRIGGER_NAME:-}" == "gcb-pm-*" ]]; then
-    args+=("--workspace")
+export RUSTDOCFLAGS='-D warnings'
+.gcb/scripts/cargo-fetch.sh
+
+cargo doc --no-deps --frozen --all-features -p google-cloud-wkt
+cargo doc --no-deps --frozen --all-features -p google-cloud-rpc
+cargo doc --no-deps --frozen --all-features -p google-cloud-gax
+cargo doc --no-deps --frozen --all-features -p google-cloud-auth
+cargo doc --no-deps --frozen --all-features -p google-cloud-gax-internal
+cargo doc --no-deps --frozen --all-features -p google-cloud-location
+
+# On PRs, detect any new libraries and compile their documentation. Without this
+# step the post-merge build may break, and we prefer to avoid this problem.
+if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
+    git fetch --unshallow
+    mapfile -t new_manifests < <(git diff "origin/main...HEAD" --name-only --diff-filter=A | grep /Cargo.toml)
+    for manifest in "${new_manifests[@]}"; do
+        cargo doc --no-deps --frozen --all-features --manifest-path "${manifest}"
+    done
 fi
 
-env RUSTDOCFLAGS='-D warnings' cargo doc --all-features "${args[@]}"
-
-echo "==== DONE ===="
-
-/workspace/.bin/sccache --show-stats
+args=()
+if [[ "${GCB_TRIGGER_NAME:-}" == "gcb-pm-*" ]]; then
+    args+=("--workspace")
+fi
+cargo doc --no-deps --frozen --all-features "${args[@]}"


### PR DESCRIPTION
The build time to compile all the documentation is too long for a PR build,
well over 30m. New libraries are not too bad, and it is important to check
their docs. We can detect a new library because it gets a new `Cargo.toml`
file.

Fixes #5986 but I need to confirm the build times before declaring success
