### PR TITLE
chore(actions): address zizmor findings

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -46,8 +46,11 @@ jobs:
           key: ${{ github.job }}-${{ runner.os }}-${{ matrix.rust-version }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/sdk.yaml') }}
         if: matrix.os != 'macos-14' && github.event_name != 'release'
       - name: Setup Rust ${{ matrix.rust-version }}
-        run: rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
-      - run: rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+        env:
+          RUST_VERSION: ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+        run: |
+          rustup toolchain install ${RUST_VERSION}
+          rustup default ${RUST_VERSION}
       - name: Display Cargo version
         run: cargo version
       - name: Display rustc version
@@ -69,9 +72,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Rust ${{ matrix.rust-version }}
+        env:
+          RUST_VERSION: ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
         run: |
-          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
-          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup toolchain install ${RUST_VERSION}
+          rustup default ${RUST_VERSION}
       - name: Verify library versions
         run: cargo run --package check-versions
 
@@ -170,10 +175,12 @@ jobs:
           # user guide.
           if: github.event_name != 'release'
       - name: Setup Rust ${{ matrix.rust-version }}
+        env:
+          RUST_VERSION: ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
         run: |
           set -e
-          rustup toolchain install ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
-          rustup default ${{ fromJson(env.GHA_RUST_VERSIONS)[matrix.rust-version] }}
+          rustup toolchain install ${RUST_VERSION}
+          rustup default ${RUST_VERSION}
           cargo install mdbook --version ^0.5 --locked
       - run: mdbook build guide
       - run: mdbook test guide


### PR DESCRIPTION
This PR is an auto-generated attempt to address zizmor findings. It may not catch everything, and should be reviewed by repository owners.

These changes were generated by running `zizmor --fix=all --gh-token=$(gh auth token) ./.github/workflows`, and then applying some fixes for any remaining issues reported by zizmor. See go/github-zizmor-help for instructions to install and run. 

Additionally, it updates renovate configuration (if present) to extend [best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes pinning action digests and image digests, among other things.

If this PR is unhelpful, feel free to close the PR and address separately. If it is helpful, feel free to approve and merge, or edit/modify as needed to get it to the right state. Repository owners must ultimately ensure compliance by 2026-07-13. The purpose of this PR is to provide some assistance with achieving that as a first pass. This will become a blocking check for new changes to github workflows on 2026-07-13 within the `googleapis` org.

There may be some ignored findings (with the comment `# zizmor: ignore[...]`), which you may fix if feasible.
