### PR TITLE
ci: fix doc post-merge builds

### DIFF
--- a/.gcb/scripts/docs-rs.sh
+++ b/.gcb/scripts/docs-rs.sh
@@ -25,10 +25,10 @@ cargo install --locked cargo-workspaces
 cargo version
 rustup show active-toolchain -v
 
-# Seed the basic common packages serially.
 export RUSTDOCFLAGS='-D warnings'
 .gcb/scripts/cargo-fetch.sh
 
+# Seed the basic common packages serially to warm up the build cache.
 cargo +nightly docs-rs --frozen -p google-cloud-wkt
 cargo +nightly docs-rs --frozen -p google-cloud-rpc
 cargo +nightly docs-rs --frozen -p google-cloud-gax
@@ -42,8 +42,9 @@ cargo +nightly docs-rs --frozen -p google-cloud-lro
 # most common problem caught by these is bad markdown at the source, that would
 # be detected by both builds.
 mapfile -t packages < <(cargo workspaces plan 2>/dev/null)
-if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
+if [[ "${GCB_TRIGGER_NAME:-}" != gcb-pm-* ]]; then
     packages=("${packages[@]:0:20}")
 fi
+echo "Generating documents for ${#packages[@]} crates"
 printf "%s\n" "${packages[@]}" | \
     xargs -P $(nproc) -I{} cargo +nightly --frozen docs-rs -p {}

--- a/.gcb/scripts/docs.sh
+++ b/.gcb/scripts/docs.sh
@@ -30,7 +30,7 @@ cargo doc --no-deps --frozen --all-features -p google-cloud-location
 
 # On PRs, detect any new libraries and compile their documentation. Without this
 # step the post-merge build may break, and we prefer to avoid this problem.
-if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
+if [[ "${GCB_TRIGGER_NAME:-}" != gcb-pm-* ]]; then
     git fetch --unshallow
     mapfile -t new_manifests < <(git diff "origin/main...HEAD" --name-only --diff-filter=A | grep /Cargo.toml)
     for manifest in "${new_manifests[@]}"; do
@@ -39,7 +39,7 @@ if [[ "${GCB_TRIGGER_NAME:-}" != "gcb-pm-*" ]]; then
 fi
 
 args=()
-if [[ "${GCB_TRIGGER_NAME:-}" == "gcb-pm-*" ]]; then
+if [[ "${GCB_TRIGGER_NAME:-}" == gcb-pm-* ]]; then
     args+=("--workspace")
 fi
 cargo doc --no-deps --frozen --all-features "${args[@]}"


### PR DESCRIPTION
Using quotes with globs switches to literal matching. I guess I learnt the "always quote" lesson too well.