### PR TITLE
refactor(gax): extract make_headers to grpc_helpers

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -19,8 +19,6 @@ mod grpc_helpers;
 pub mod status;
 pub mod tonic;
 
-use grpc_helpers::make_headers;
-
 use crate::observability::attributes::{self, keys::*, otel_status_codes};
 use crate::universe_domain::DEFAULT_UNIVERSE_DOMAIN;
 use ::tonic::client::Grpc;
@@ -47,6 +45,7 @@ use google_cloud_gax::retry_policy::{
     Aip194Strict as RetryAip194Strict, RetryPolicy, RetryPolicyExt as _,
 };
 use google_cloud_gax::retry_throttler::SharedRetryThrottler;
+use grpc_helpers::make_headers;
 use http::HeaderMap;
 use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
 use std::sync::Arc;

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -15,8 +15,11 @@
 //! Implements the common features of all gRPC-based client.
 
 pub mod from_status;
+mod grpc_helpers;
 pub mod status;
 pub mod tonic;
+
+use grpc_helpers::make_headers;
 
 use crate::observability::attributes::{self, keys::*, otel_status_codes};
 use crate::universe_domain::DEFAULT_UNIVERSE_DOMAIN;
@@ -51,7 +54,6 @@ use std::time::Duration;
 
 // A tonic::transport::Channel always has a Buffer layer.
 const DEFAULT_REQUEST_BUFFER_CAPACITY: usize = 1024;
-const X_GOOG_USER_PROJECT: &str = "x-goog-user-project";
 
 pub type GrpcService = Channel;
 
@@ -159,7 +161,7 @@ impl Client {
         Request: prost::Message + Clone + 'static,
         Response: prost::Message + Default + 'static,
     {
-        let headers = Self::make_headers(api_client_header, request_params, &options).await?;
+        let headers = make_headers(api_client_header, request_params, &options)?;
         self.retry_loop::<Request, Response>(extensions, path, request, options, headers)
             .await
     }
@@ -209,7 +211,7 @@ impl Client {
         Response: prost::Message + Default + 'static,
     {
         use ::tonic::IntoStreamingRequest;
-        let headers = Self::make_headers(api_client_header, request_params, &options).await?;
+        let headers = make_headers(api_client_header, request_params, &options)?;
         let headers = self.add_auth_headers(headers).await?;
         let metadata = tonic::MetadataMap::from_headers(headers);
         let request = ::tonic::Request::from_parts(metadata, extensions, request);
@@ -274,7 +276,7 @@ impl Client {
         Response: prost::Message + Default + 'static,
     {
         use ::tonic::IntoRequest;
-        let headers = Self::make_headers(api_client_header, request_params, &options).await?;
+        let headers = make_headers(api_client_header, request_params, &options)?;
         let headers = self.add_auth_headers(headers).await?;
         let metadata = tonic::MetadataMap::from_headers(headers);
         let mut request = ::tonic::Request::from_parts(metadata, extensions, request);
@@ -552,48 +554,6 @@ impl Client {
         Ok(data)
     }
 
-    async fn make_headers(
-        api_client_header: &'static str,
-        request_params: &str,
-        options: &RequestOptions,
-    ) -> Result<http::header::HeaderMap> {
-        use google_cloud_gax::options::internal::RequestOptionsExt as _;
-
-        let mut headers = HeaderMap::new();
-        if let Some(user_agent) = options.user_agent() {
-            headers.insert(
-                http::header::USER_AGENT,
-                http::header::HeaderValue::from_str(user_agent).map_err(Error::ser)?,
-            );
-        }
-        if let Some(quota_project) = options.quota_project() {
-            headers.insert(
-                http::header::HeaderName::from_static(X_GOOG_USER_PROJECT),
-                http::header::HeaderValue::from_str(quota_project).map_err(Error::ser)?,
-            );
-        }
-        headers.append(
-            http::header::HeaderName::from_static("x-goog-api-client"),
-            http::header::HeaderValue::from_static(api_client_header),
-        );
-        if !request_params.is_empty() {
-            // When using routing info to populate the request parameters it is
-            // possible that none of the path template matches. AIP-4222 says:
-            //
-            //     If none of the routing parameters matched their respective
-            //     fields, the routing header **must not** be sent.
-            //
-            headers.append(
-                http::header::HeaderName::from_static("x-goog-request-params"),
-                http::header::HeaderValue::from_str(request_params).map_err(Error::ser)?,
-            );
-        }
-        if let Some(custom_headers) = options.get_extension::<HeaderMap>() {
-            headers.extend(custom_headers.clone());
-        }
-        Ok(headers)
-    }
-
     fn get_retry_policy(&self, options: &RequestOptions) -> Arc<dyn RetryPolicy> {
         options
             .retry_policy()
@@ -721,25 +681,5 @@ mod tests {
             .unwrap();
         // We can't easily assert the internal state without exposing more internals,
         // but this verifies the method exists and runs.
-    }
-
-    #[tokio::test]
-    async fn test_make_headers_with_custom_headers() {
-        use google_cloud_gax::options::internal::RequestOptionsExt as _;
-        let mut custom_headers = http::HeaderMap::new();
-        custom_headers.insert(
-            "x-custom-header",
-            http::HeaderValue::from_static("custom-value"),
-        );
-
-        let options = RequestOptions::default().insert_extension(custom_headers);
-
-        let headers = Client::make_headers("test-client/1.0", "param=1", &options)
-            .await
-            .unwrap();
-
-        assert_eq!(headers.get("x-custom-header").unwrap(), "custom-value");
-        assert_eq!(headers.get("x-goog-api-client").unwrap(), "test-client/1.0");
-        assert_eq!(headers.get("x-goog-request-params").unwrap(), "param=1");
     }
 }

--- a/src/gax-internal/src/grpc/grpc_helpers.rs
+++ b/src/gax-internal/src/grpc/grpc_helpers.rs
@@ -1,0 +1,166 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use google_cloud_gax::Result;
+use google_cloud_gax::error::Error;
+use google_cloud_gax::options::RequestOptions;
+use google_cloud_gax::options::internal::RequestOptionsExt as _;
+use http::{HeaderMap, header::HeaderName};
+
+const X_GOOG_API_CLIENT: HeaderName = HeaderName::from_static("x-goog-api-client");
+const X_GOOG_REQUEST_PARAMS: HeaderName = HeaderName::from_static("x-goog-request-params");
+const X_GOOG_USER_PROJECT: HeaderName = HeaderName::from_static("x-goog-user-project");
+
+/// Constructs the headers required for Google Cloud API requests.
+/// Custom headers can be provided through `RequestOptions`.
+/// Returns an error if any of the header values fail to parse.
+pub(crate) fn make_headers(
+    api_client_header: &'static str,
+    request_params: &str,
+    options: &RequestOptions,
+) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+
+    if let Some(user_agent) = options.user_agent() {
+        headers.insert(
+            http::header::USER_AGENT,
+            http::header::HeaderValue::from_str(user_agent).map_err(Error::ser)?,
+        );
+    }
+
+    if let Some(quota_project) = options.quota_project() {
+        headers.insert(
+            X_GOOG_USER_PROJECT,
+            http::header::HeaderValue::from_str(quota_project).map_err(Error::ser)?,
+        );
+    }
+
+    headers.append(
+        X_GOOG_API_CLIENT,
+        http::header::HeaderValue::from_static(api_client_header),
+    );
+
+    if !request_params.is_empty() {
+        // When using routing info to populate the request parameters it is
+        // possible that none of the path template matches. AIP-4222 says:
+        //
+        //     If none of the routing parameters matched their respective
+        //     fields, the routing header **must not** be sent.
+        //
+        headers.append(
+            X_GOOG_REQUEST_PARAMS,
+            http::header::HeaderValue::from_str(request_params).map_err(Error::ser)?,
+        );
+    }
+
+    if let Some(custom_headers) = options.get_extension::<HeaderMap>() {
+        headers.extend(custom_headers.clone());
+    }
+
+    Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::header::HeaderValue;
+    use pretty_assertions::assert_eq;
+
+    type TestResult = anyhow::Result<()>;
+
+    const API_CLIENT_HEADER: &str = "test-client/1.0";
+
+    #[test]
+    fn make_headers_with_standard_headers() -> TestResult {
+        // Arrange
+        const USER_AGENT: &str = "custom-user-agent/v1.2.3";
+        const QUOTA_PROJECT: &str = "user-quota-project";
+        const REQUEST_PARAMS: &str = "resource=projects%2Ftest";
+
+        let mut options = RequestOptions::default();
+        options.set_user_agent(USER_AGENT);
+        options.set_quota_project(QUOTA_PROJECT);
+
+        // Act
+        let headers = make_headers(API_CLIENT_HEADER, REQUEST_PARAMS, &options)?;
+
+        // Assert
+        assert_eq!(headers.get(X_GOOG_API_CLIENT).unwrap(), API_CLIENT_HEADER);
+        assert_eq!(headers.get(X_GOOG_REQUEST_PARAMS).unwrap(), REQUEST_PARAMS);
+        assert_eq!(headers.get(X_GOOG_USER_PROJECT).unwrap(), QUOTA_PROJECT);
+        assert_eq!(headers.get(http::header::USER_AGENT).unwrap(), USER_AGENT);
+        Ok(())
+    }
+
+    #[test]
+    fn make_headers_omits_unset_params() -> TestResult {
+        // Act
+        let headers = make_headers(API_CLIENT_HEADER, "", &RequestOptions::default())?;
+
+        // Assert
+        assert_eq!(headers.get(X_GOOG_API_CLIENT).unwrap(), API_CLIENT_HEADER);
+        assert!(headers.get(X_GOOG_REQUEST_PARAMS).is_none(), "{headers:?}");
+        assert!(headers.get(X_GOOG_USER_PROJECT).is_none(), "{headers:?}");
+        assert!(
+            headers.get(http::header::USER_AGENT).is_none(),
+            "{headers:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn make_headers_with_custom_headers() -> TestResult {
+        // Arrange
+        const CUSTOM_HEADER_NAME: &str = "x-custom-header";
+        const CUSTOM_HEADER: &str = "custom-value";
+        const CUSTOM_REQUEST_PARAMS: &str = "param=1";
+
+        let mut custom_headers = HeaderMap::new();
+        custom_headers.insert(CUSTOM_HEADER_NAME, HeaderValue::from_static(CUSTOM_HEADER));
+
+        let options = RequestOptions::default().insert_extension(custom_headers);
+
+        // Act
+        let headers = make_headers(API_CLIENT_HEADER, CUSTOM_REQUEST_PARAMS, &options)?;
+
+        // Assert
+        assert_eq!(headers.get(X_GOOG_API_CLIENT).unwrap(), API_CLIENT_HEADER);
+        assert_eq!(
+            headers.get(X_GOOG_REQUEST_PARAMS).unwrap(),
+            CUSTOM_REQUEST_PARAMS
+        );
+        assert_eq!(headers.get(CUSTOM_HEADER_NAME).unwrap(), CUSTOM_HEADER);
+        Ok(())
+    }
+
+    #[test]
+    fn make_headers_with_invalid_header_values() {
+        // Invalid user agent
+        let mut options = RequestOptions::default();
+        options.set_user_agent("invalid\nagent");
+        let res = make_headers(API_CLIENT_HEADER, "param=1", &options);
+        assert!(res.is_err());
+
+        // Invalid quota project
+        let mut options = RequestOptions::default();
+        options.set_quota_project("invalid\nproject");
+        let res = make_headers(API_CLIENT_HEADER, "param=1", &options);
+        assert!(res.is_err());
+
+        // Invalid request params
+        let options = RequestOptions::default();
+        let res = make_headers(API_CLIENT_HEADER, "invalid\nparams", &options);
+        assert!(res.is_err());
+    }
+}

--- a/src/gax-internal/src/grpc/grpc_helpers.rs
+++ b/src/gax-internal/src/grpc/grpc_helpers.rs
@@ -150,17 +150,17 @@ mod tests {
         let mut options = RequestOptions::default();
         options.set_user_agent("invalid\nagent");
         let res = make_headers(API_CLIENT_HEADER, "param=1", &options);
-        assert!(res.is_err());
+        assert!(res.is_err(), "{res:?}");
 
         // Invalid quota project
         let mut options = RequestOptions::default();
         options.set_quota_project("invalid\nproject");
         let res = make_headers(API_CLIENT_HEADER, "param=1", &options);
-        assert!(res.is_err());
+        assert!(res.is_err(), "{res:?}");
 
         // Invalid request params
         let options = RequestOptions::default();
         let res = make_headers(API_CLIENT_HEADER, "invalid\nparams", &options);
-        assert!(res.is_err());
+        assert!(res.is_err(), "{res:?}");
     }
 }


### PR DESCRIPTION
For #5991

If the `Arrange/Act/Assert`comments in the tests are too noisy/unidiomatic, I'm happy to remove them.