### PR TITLE
ci(o11y): disable flaky client_signals tests

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -604,6 +604,7 @@ mod tests {
 
     #[cfg(feature = "_internal-grpc-client")]
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn grpc_client_request_retry() -> anyhow::Result<()> {
         tokio::time::pause();
         let (endpoint, _server) = grpc_server::start_fixed_responses(vec![
@@ -652,6 +653,7 @@ mod tests {
 
     #[cfg(feature = "_internal-grpc-client")]
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn grpc_client_request_success() -> anyhow::Result<()> {
         let (endpoint, _server) = grpc_server::start_echo_server().await?;
         tokio::time::pause();

--- a/src/gax-internal/src/observability/client_signals/with_client_logging.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_logging.rs
@@ -158,6 +158,7 @@ mod tests {
     use tracing_subscriber::fmt::format::FmtSpan;
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn no_recorder() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 
@@ -170,6 +171,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn ok() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 
@@ -188,6 +190,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn error_with_partial_recorder() -> anyhow::Result<()> {
         const BAD_URL: &str = "https://127.0.0.1:1";
 
@@ -238,6 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn error_with_full_recorder() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 

--- a/src/gax-internal/src/observability/client_signals/with_client_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_metric.rs
@@ -110,6 +110,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn err_no_recorder() -> anyhow::Result<()> {
         let signals = SignalProviders::new();
         let metric = DurationMetric::new_with_provider(
@@ -173,6 +174,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn err_with_annotations() -> anyhow::Result<()> {
         let signals = SignalProviders::new();
         let metric = DurationMetric::new_with_provider(


### PR DESCRIPTION
Disable observability tests in `client_signals` that have been consistently timing out (running for > 60 seconds) in CI.

Fixes #6020