### PR TITLE
test(o11y): relax assertions in compute LRO error tracing test

### DIFF
--- a/tests/discovery/tests/driver.rs
+++ b/tests/discovery/tests/driver.rs
@@ -54,14 +54,17 @@ mod compute {
                 attribute_value_str(lro_wait_span, "otel.status_code"),
                 Some("ERROR".to_string())
             );
+            let lro_status_desc =
+                attribute_value_str(lro_wait_span, "otel.status_description").unwrap_or_default();
             assert!(
-                attribute_value_str(lro_wait_span, "otel.status_description")
-                    .unwrap_or_default()
-                    .contains("Quota 'CPUS_PER_VM_FAMILY' exceeded")
+                !lro_status_desc.is_empty(),
+                "otel.status_description should be populated from the LRO error, got: {lro_status_desc}"
             );
-            assert_eq!(
-                attribute_value_str(lro_wait_span, "error.type"),
-                Some("RESOURCE_EXHAUSTED".to_string())
+            let lro_error_type =
+                attribute_value_str(lro_wait_span, "error.type").unwrap_or_default();
+            assert!(
+                lro_error_type == "RESOURCE_EXHAUSTED" || lro_error_type == "UNAVAILABLE",
+                "error.type should be RESOURCE_EXHAUSTED or UNAVAILABLE, got: {lro_error_type}"
             );
 
             // 2. Assert on the "client_request" (T3) span for get_operation
@@ -82,22 +85,27 @@ mod compute {
                 attribute_value_str(get_op_span, "gcp.longrunning.done"),
                 Some("true".to_string())
             );
-            assert_eq!(
-                attribute_value_str(get_op_span, "gcp.longrunning.status_code"),
-                Some("8".to_string())
+            let get_op_status_code =
+                attribute_value_str(get_op_span, "gcp.longrunning.status_code").unwrap_or_default();
+            assert!(
+                get_op_status_code == "8" || get_op_status_code == "14",
+                "gcp.longrunning.status_code should be 8 (RESOURCE_EXHAUSTED) or 14 (UNAVAILABLE), got: {get_op_status_code}"
             );
             assert_eq!(
                 attribute_value_str(get_op_span, "otel.status_code"),
                 Some("ERROR".to_string())
             );
+            let get_op_status_desc =
+                attribute_value_str(get_op_span, "otel.status_description").unwrap_or_default();
             assert!(
-                attribute_value_str(get_op_span, "otel.status_description")
-                    .unwrap_or_default()
-                    .contains("Quota 'CPUS_PER_VM_FAMILY' exceeded")
+                !get_op_status_desc.is_empty(),
+                "otel.status_description should be populated, got: {get_op_status_desc}"
             );
-            assert_eq!(
-                attribute_value_str(get_op_span, "error.type"),
-                Some("RESOURCE_EXHAUSTED".to_string())
+            let get_op_error_type =
+                attribute_value_str(get_op_span, "error.type").unwrap_or_default();
+            assert!(
+                get_op_error_type == "RESOURCE_EXHAUSTED" || get_op_error_type == "UNAVAILABLE",
+                "error.type should be RESOURCE_EXHAUSTED or UNAVAILABLE, got: {get_op_error_type}"
             );
         }
         Ok(())


### PR DESCRIPTION
Relax the assertions to accommodate varying live GCP responses.

`run_compute_lro_errors` forces an LRO failure by requesting a massive VM. Before, it asserted on a `Quota Exceeded` error `(RESOURCE_EXHAUSTED / 8)`. However, when the target zone (`us-central1-a`) is low on physical capacity, GCP returns a `Resource Unavailable` error (`UNAVAILABLE / 14`), failing the test.

Rather than asserting on exact error strings, we now assert that the error attributes match one of the expected capacity-related failures. This validates that the o11y feature correctly extracts and propagates the REST error fields to the spans, while making sure the test is resilient to GCP backend capacity without masking unrelated bugs (like `PERMISSION_DENIED`).

This is a temporary fix to unblock CI until we agree on a broader strategy for live integration tests.

Fixes #6025 
Fixes #6026