### PR TITLE
Revert "test(o11y): fix flaky client_signals test"

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -165,7 +165,7 @@ mod tests {
     };
     pub(crate) static TEST_URL_TEMPLATE: &str = "/v1/projects/{}:test_method";
     pub(crate) static TEST_METHOD: &str = "google.test.v1.Service/TestMethod";
-    pub(crate) const TEST_REQUEST_DURATION: Duration = Duration::from_millis(120);
+    pub(crate) const TEST_REQUEST_DURATION: Duration = Duration::from_millis(750);
     const COMMON_ATTRIBUTES: [(&str, &str); 3] = [
         ("rpc.system.name", "http"),
         ("url.domain", "example.com"),
@@ -175,11 +175,7 @@ mod tests {
     // Simulate the transport HTTP client for a request that fills the `RequestRecorder` data.
     async fn recorded_request_transport_client(url: &str) -> Result<String, Error> {
         let recorder = RequestRecorder::current().expect("current recorder should be available");
-        let client = reqwest::Client::builder()
-            .connect_timeout(Duration::from_secs(2))
-            .timeout(Duration::from_secs(5))
-            .build()
-            .map_err(Error::io)?;
+        let client = reqwest::Client::new();
         let request = client
             .get(url)
             .build()
@@ -213,7 +209,7 @@ mod tests {
         recorded_request_transport_client(url).await
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn client_request() -> anyhow::Result<()> {
         const PATH: &str = "/v1/projects/test-only:test_method";
 
@@ -515,6 +511,7 @@ mod tests {
     #[cfg(feature = "_internal-grpc-client")]
     #[tokio::test]
     async fn grpc_client_request() -> anyhow::Result<()> {
+        tokio::time::pause();
         let (endpoint, _server) = grpc_server::start_echo_server().await?;
         let signals = SignalProviders::new();
 
@@ -607,7 +604,9 @@ mod tests {
 
     #[cfg(feature = "_internal-grpc-client")]
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn grpc_client_request_retry() -> anyhow::Result<()> {
+        tokio::time::pause();
         let (endpoint, _server) = grpc_server::start_fixed_responses(vec![
             Err(tonic::Status::unavailable("try again")),
             Ok(tonic::Response::new(EchoResponse {
@@ -654,8 +653,10 @@ mod tests {
 
     #[cfg(feature = "_internal-grpc-client")]
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn grpc_client_request_success() -> anyhow::Result<()> {
         let (endpoint, _server) = grpc_server::start_echo_server().await?;
+        tokio::time::pause();
         let signals = SignalProviders::new();
 
         let metric = DurationMetric::new_with_provider(
@@ -914,8 +915,8 @@ mod tests {
                 )
             });
         assert!(
-            bucket.is_some_and(|(c, b)| want_count.contains(&c) && b >= low),
-            "mismatched bucket {bucket:?}, bucket >= {low}\nfound=[{low}, {high})\n{point:?}"
+            bucket.is_some_and(|(c, b)| want_count.contains(&c) && b == low),
+            "mismatched bucket {bucket:?} want (1, {low})\nfound=[{low}, {high})\n{point:?}"
         );
     }
 

--- a/src/gax-internal/src/observability/client_signals/duration_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/duration_metric.rs
@@ -181,14 +181,17 @@ impl DurationMetric {
 #[cfg(test)]
 mod tests {
     use super::super::tests::{
-        TEST_INFO, TEST_METHOD, TEST_REQUEST_DURATION, TEST_URL_TEMPLATE, check_metric_data,
-        check_metric_scope,
+        TEST_INFO, TEST_METHOD, TEST_URL_TEMPLATE, check_metric_data, check_metric_scope,
     };
     use super::*;
     use crate::observability::ClientRequestAttributes;
     use google_cloud_gax::error::rpc::Status;
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
     use std::sync::Arc;
+    use std::time::Duration;
+
+    // This is in the middle of the [0.5, 1.0) bucket defined in `boundaries`.
+    const DELAY: Duration = Duration::from_millis(750);
 
     #[tokio::test(start_paused = true)]
     async fn global_record_error() -> anyhow::Result<()> {
@@ -215,7 +218,7 @@ mod tests {
                 .set_rpc_method(TEST_METHOD),
         );
         // Use a long pause so it gets recorded as such.
-        tokio::time::sleep(TEST_REQUEST_DURATION).await;
+        tokio::time::sleep(DELAY).await;
         let _ = recorder
             .scope(async {
                 metric.with_recorder_ok();
@@ -265,7 +268,7 @@ mod tests {
                 .set_rpc_method(TEST_METHOD),
         );
         // Use a long pause so it gets recorded as such.
-        tokio::time::sleep(TEST_REQUEST_DURATION).await;
+        tokio::time::sleep(DELAY).await;
         let error = Error::service(
             Status::default()
                 .set_code(Code::NotFound)
@@ -321,7 +324,7 @@ mod tests {
                 .set_rpc_method(TEST_METHOD),
         );
         // Use a long pause so it gets recorded as such.
-        tokio::time::sleep(TEST_REQUEST_DURATION).await;
+        tokio::time::sleep(DELAY).await;
         let error = Error::http(429, http::HeaderMap::new(), bytes::Bytes::new());
         let _ = recorder
             .scope(async {

--- a/src/gax-internal/src/observability/client_signals/with_client_logging.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_logging.rs
@@ -157,7 +157,8 @@ mod tests {
     use tracing::subscriber::DefaultGuard;
     use tracing_subscriber::fmt::format::FmtSpan;
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn no_recorder() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 
@@ -169,7 +170,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn ok() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 
@@ -188,6 +190,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn error_with_partial_recorder() -> anyhow::Result<()> {
         const BAD_URL: &str = "https://127.0.0.1:1";
 
@@ -238,6 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn error_with_full_recorder() -> anyhow::Result<()> {
         let (_guard, buffer) = capture_logs();
 

--- a/src/gax-internal/src/observability/client_signals/with_client_metric.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_metric.rs
@@ -92,7 +92,7 @@ mod tests {
     use httptest::{Expectation, Server};
     use std::sync::Arc;
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn ok_no_recorder() -> anyhow::Result<()> {
         let signals = SignalProviders::new();
         let metric = DurationMetric::new_with_provider(
@@ -109,7 +109,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn err_no_recorder() -> anyhow::Result<()> {
         let signals = SignalProviders::new();
         let metric = DurationMetric::new_with_provider(
@@ -172,7 +173,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6023) - disable flaky test"]
     async fn err_with_annotations() -> anyhow::Result<()> {
         let signals = SignalProviders::new();
         let metric = DurationMetric::new_with_provider(

--- a/src/gax-internal/src/observability/client_signals/with_client_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_span.rs
@@ -207,7 +207,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn poll_err() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 

--- a/src/gax-internal/src/observability/client_signals/with_transport_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_transport_span.rs
@@ -160,7 +160,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::collections::BTreeSet;
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn poll_ok() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 
@@ -224,7 +224,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn poll_err() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 
@@ -280,7 +280,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn poll_ok_retry() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 


### PR DESCRIPTION
Reverts googleapis/google-cloud-rust#6030

The tests continue to hang indefinitely and time out after 60s in CI. I attempted to reproduce the issue locally by stress testing with `cargo nextest`, but found that local nextest runs do not accurately reflect the CI environment. 

These tests will remain `#[ignore]` to stabilize CI until a reliable local reproduction and fix can be found.

Fixes #6035