### PR TITLE
feat(spanner): export SpannerRetryPolicy

### DIFF
--- a/src/spanner/src/lib.rs
+++ b/src/spanner/src/lib.rs
@@ -30,6 +30,8 @@ pub mod mutation;
 pub mod read;
 /// Spanner execution result streams and rows.
 pub mod result;
+/// RPC retry policies used by the Spanner client.
+pub mod retry_policy;
 /// SQL statement builders and parameter bindings.
 pub mod statement;
 /// Spanner primitive type constructors for typed parameter binding.
@@ -83,7 +85,6 @@ pub(crate) mod read_only_transaction;
 pub(crate) mod read_write_transaction;
 pub(crate) mod result_set;
 pub(crate) mod result_set_metadata;
-pub(crate) mod retry_policy;
 pub(crate) mod row;
 pub(crate) mod server_streaming;
 pub(crate) mod session_maintainer;

--- a/src/spanner/src/retry_policy.rs
+++ b/src/spanner/src/retry_policy.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! RPC retry policies used by the Spanner client.
+
 use google_cloud_gax::error::Error;
 use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicy};
 use google_cloud_gax::retry_result::RetryResult;
@@ -19,17 +21,45 @@ use google_cloud_gax::retry_state::RetryState;
 use google_cloud_gax::throttle_result::ThrottleResult;
 use std::time::Duration;
 
-/// A custom retry policy for Cloud Spanner that decorates/extends `Aip194Strict`.
+/// The retry policy the Spanner client applies to RPCs that do not configure
+/// their own. It decorates/extends [google_cloud_gax::retry_policy::Aip194Strict].
 ///
-/// Spanner allows transport/connection errors to be retried on idempotent operations.
-/// This policy explicitly allows retries on these transport/network errors if the request is idempotent.
+/// Like `Aip194Strict`, this policy retries `UNAVAILABLE` errors and transient
+/// failures that occur before the request reaches the service, but only for
+/// idempotent requests. In addition — because Spanner allows transport and
+/// connection errors to be retried on idempotent operations — it also retries
+/// transport/network and I/O errors that `Aip194Strict` would classify as
+/// permanent (such as a connection dropped after the request was sent), again
+/// only if the request is idempotent.
+///
+/// The policy places no limit on the number of attempts or the elapsed time.
+/// Applications that want to bound the client's default retry behavior can
+/// decorate this policy with
+/// [RetryPolicyExt][google_cloud_gax::retry_policy::RetryPolicyExt] instead of
+/// re-implementing its error classification:
+///
+/// # Example
+/// ```
+/// # use std::time::Duration;
+/// # use google_cloud_spanner::retry_policy::SpannerRetryPolicy;
+/// # use google_cloud_spanner::statement::Statement;
+/// # use google_cloud_gax::retry_policy::RetryPolicyExt;
+/// let statement = Statement::builder("SELECT * FROM Users")
+///     .with_retry_policy(
+///         SpannerRetryPolicy::new()
+///             .with_attempt_limit(5)
+///             .with_time_limit(Duration::from_secs(30)),
+///     )
+///     .build();
+/// ```
 #[derive(Clone, Debug)]
-pub(crate) struct SpannerRetryPolicy {
+pub struct SpannerRetryPolicy {
     inner: Aip194Strict,
 }
 
 impl SpannerRetryPolicy {
-    pub(crate) fn new() -> Self {
+    /// Creates a new Spanner retry policy.
+    pub fn new() -> Self {
         Self {
             inner: Aip194Strict,
         }


### PR DESCRIPTION
The Spanner client installs `SpannerRetryPolicy` as the default retry policy for RPCs that do not configure their own, but the type was `pub(crate)`.

Downstream users who wanted to bound the client's default behavior (e.g. cap attempts or elapsed time with `RetryPolicyExt::with_attempt_limit` / `with_time_limit`) while keeping the Spanner-specific error classification - retrying transport/IO errors on idempotent requests on top of the strict [AIP-194](https://google.aip.dev/194) checks - had to maintain a byte-for-byte behavioral copy of the policy, which can silently drift when the crate changes.

Make the `retry_policy` module and `SpannerRetryPolicy` (+ its `new` constructor) public, with rustdoc describing the policy's behavior and an example decorating it with `RetryPolicyExt`. No behavior changes.

## Precedent in other language clients

The other official Spanner clients treat the default retry configuration as public, user-tunable API rather than an internal detail; this PR brings the Rust preview client in line.

- **Go** (`cloud.google.com/go/spanner`): the Spanner-specific default backoff is an exported package variable, [`spanner.DefaultRetryBackoff`](https://github.com/googleapis/google-cloud-go/blob/main/spanner/retry.go), and the handwritten client's [`ClientConfig.CallOptions *vkit.CallOptions`](https://github.com/googleapis/google-cloud-go/blob/main/spanner/client.go) exists precisely "for providing custom retry settings that override the default values". The generated `apiv1.Client` additionally exposes its `CallOptions` field publicly, pre-populated with the per-RPC default retryers ([spanner/apiv1/spanner_client.go](https://github.com/googleapis/google-cloud-go/blob/main/spanner/apiv1/spanner_client.go)), so callers can inspect and rebound the defaults directly.
- **Java** (`googleapis/java-spanner`): [`SpannerOptions.Builder.getSpannerStubSettingsBuilder()`](https://github.com/googleapis/java-spanner/blob/main/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java) is public and documented for setting custom `RetrySettings` per gRPC method (including the documented `applyToAllUnaryMethods` idiom); the builder starts from the public generated `SpannerStubSettings` defaults, so the default per-method `RetrySettings` are obtainable via public API (e.g. `executeSqlSettings().getRetrySettings()`) and can be modified with `toBuilder()` rather than re-implemented.
- **Python** (`googleapis/python-spanner`): every generated and handwritten data method takes a public `retry=` parameter accepting a `google.api_core.retry.Retry` (e.g. [`Snapshot.execute_sql`](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/snapshot.py)), and the handwritten layer exports a module-level default, [`DEFAULT_RETRY_BACKOFF = Retry(initial=0.02, maximum=32, multiplier=1.3)` in `spanner_v1/database.py`](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/database.py). One nuance: the per-RPC generated defaults live as `default_retry` values inside the generated transport ([transports/base.py](https://github.com/googleapis/python-spanner/blob/main/google/cloud/spanner_v1/services/spanner/transports/base.py)) — visible source but not exported constants — though any of them can be replaced per call.
- **Node.js** (`googleapis/nodejs-spanner`): the default per-method retry codes and backoff parameters ship as data in the published package ([`src/v1/spanner_client_config.json`](https://github.com/googleapis/nodejs-spanner/blob/main/src/v1/spanner_client_config.json)), and the generated client's constructor accepts a documented `clientConfig` override merged over those defaults via gax `constructSettings`, plus per-call gax `CallOptions` retry settings ([src/v1/spanner_client.ts](https://github.com/googleapis/nodejs-spanner/blob/main/src/v1/spanner_client.ts)). The default here is packaged data rather than an exported symbol, but it is still user-visible and overridable without re-implementation.
