### PR TITLE
chore: update librarian to v0.26.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.25.1-0.20260709214352-8266ce39cdfc
+version: v0.26.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION
Update `librarian` version to `v0.26.0`. 

`librarian generate --all` produced no diffs.