### PR TITLE
impl(gax): register google_cloud_unstable_gapic_streaming cfg flag

### DIFF
--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -40,6 +40,7 @@ locals {
     "--cfg google_cloud_unstable_grpc_server_streaming",
     "--cfg google_cloud_unstable_tracing",
     "--cfg google_cloud_unstable_grpc_rust",
+    "--cfg google_cloud_unstable_gapic_streaming",
   ])
 
   tokio_unstable_flags = "--cfg tokio_unstable"

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -25,7 +25,7 @@ env:
   GHA_RUST_VERSIONS: '{ "rust:current": "1.96" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
-  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing'
+  UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing --cfg google_cloud_unstable_gapic_streaming'
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -558,6 +558,7 @@ storage-grpc-mock         = { path = "src/storage/grpc-mock" }
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = [
+  'cfg(google_cloud_unstable_gapic_streaming)',
   'cfg(google_cloud_unstable_grpc_rust)',
   'cfg(google_cloud_unstable_grpc_server_streaming)',
   'cfg(google_cloud_unstable_storage_bidi)',

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -39,6 +39,9 @@ pub mod paginator;
 
 pub mod response;
 
+#[cfg(google_cloud_unstable_gapic_streaming)]
+pub mod streaming;
+
 pub mod backoff_policy;
 pub mod client_builder;
 pub mod exponential_backoff;

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -1,0 +1,15 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Types and helpers for gRPC streaming requests and responses.


### PR DESCRIPTION
This change registers the google_cloud_unstable_gapic_streaming compiler cfg flag across the workspace lint configuration, CI build definitions, and GAX module declarations. This provides the compiler gating mechanism for experimental gRPC streaming surface area. Implementation to come in a follow up PR and will be contained within the
gated module.

For #2318