### PR TITLE
feat(bigquery): add LRO `Poller` for `InsertJob`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
  "bytes",
  "google-cloud-gax",
  "google-cloud-gax-internal",
+ "google-cloud-lro",
  "google-cloud-type",
  "google-cloud-wkt",
  "serde",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -500,6 +500,8 @@ libraries:
   - name: google-cloud-bigquery-v2
     version: 1.0.0
     copyright_year: "2025"
+    keep:
+      - src/operation.rs
     skip_release: true
     rust:
       package_name_override: google-cloud-bigquery-v2

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.26.0
+version: v0.26.1-0.20260716180500-d5ce8a9d2faa
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -46,6 +46,7 @@ async-trait.workspace       = true
 bytes.workspace             = true
 gaxi                        = { workspace = true, features = ["_internal-http-client"] }
 google-cloud-gax.workspace  = true
+google-cloud-lro.workspace  = true
 google-cloud-type.workspace = true
 serde.workspace             = true
 serde_json.workspace        = true

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -1029,20 +1029,32 @@ pub mod job_service {
                 google_cloud_gax::exponential_backoff::ExponentialBackoff::default(),
             );
 
+            let shared_location = std::sync::Arc::new(std::sync::OnceLock::<String>::new());
+            let shared_location_for_start = shared_location.clone();
+            let shared_location_for_query = shared_location.clone();
+
             let query = move |name: String| {
                 let stub_clone = stub.clone();
                 let options_clone = options.clone();
                 let req_clone = req.clone();
+                let shared_location_clone = shared_location_for_query.clone();
                 async move {
+                    let loc = shared_location_clone
+                        .get()
+                        .cloned()
+                        .or_else(|| {
+                            req_clone
+                                .job
+                                .as_ref()
+                                .and_then(|j| j.job_reference.as_ref())
+                                .and_then(|jr| jr.location.clone())
+                        })
+                        .unwrap_or_default();
+
                     let get_req = crate::model::GetJobRequest {
                         project_id: req_clone.project_id.clone(),
                         job_id: name,
-                        location: req_clone
-                            .job
-                            .as_ref()
-                            .and_then(|j| j.job_reference.as_ref())
-                            .and_then(|jr| jr.location.clone())
-                            .unwrap_or_default(),
+                        location: loc,
                         _unknown_fields: std::default::Default::default(),
                     };
                     let job = stub_clone
@@ -1054,7 +1066,19 @@ pub mod job_service {
                 }
             };
 
-            let start = move || async move { self.send().await };
+            let start = move || {
+                let shared_location_clone = shared_location_for_start.clone();
+                async move {
+                    let res = self.send().await;
+                    if let Ok(ref job) = res
+                        && let Some(ref jr) = job.job_reference
+                        && let Some(ref loc) = jr.location
+                    {
+                        let _ = shared_location_clone.set(loc.clone());
+                    }
+                    res
+                }
+            };
 
             google_cloud_lro::internal::new_discovery_poller(
                 polling_error_policy,

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -1020,7 +1020,8 @@ pub mod job_service {
         pub fn poller(self) -> impl google_cloud_lro::Poller<crate::model::Job, crate::model::Job> {
             let req = self.0.request.clone();
             let stub = self.0.stub.clone();
-            let options = self.0.options.clone();
+            let mut options = self.0.options.clone();
+            options.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
 
             let polling_error_policy =
                 std::sync::Arc::new(google_cloud_gax::polling_error_policy::AlwaysContinue);
@@ -1030,9 +1031,8 @@ pub mod job_service {
 
             let query = move |name: String| {
                 let stub_clone = stub.clone();
-                let mut options_clone = options.clone();
+                let options_clone = options.clone();
                 let req_clone = req.clone();
-                options_clone.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
                 async move {
                     let get_req = crate::model::GetJobRequest {
                         project_id: req_clone.project_id.clone(),
@@ -1046,7 +1046,7 @@ pub mod job_service {
                         _unknown_fields: std::default::Default::default(),
                     };
                     let job = stub_clone
-                        .get_job(get_req, options_clone.clone())
+                        .get_job(get_req, options_clone)
                         .await
                         .map(crate::Response::into_body)?;
 

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -1016,6 +1016,54 @@ pub mod job_service {
                 .map(crate::Response::into_body)
         }
 
+        /// Creates a [Poller][google_cloud_lro::Poller] to work with `InsertJob`.
+        pub fn poller(self) -> impl google_cloud_lro::Poller<crate::model::Job, crate::model::Job> {
+            let req = self.0.request.clone();
+            let stub = self.0.stub.clone();
+            let options = self.0.options.clone();
+
+            let polling_error_policy =
+                std::sync::Arc::new(google_cloud_gax::polling_error_policy::AlwaysContinue);
+            let polling_backoff_policy = std::sync::Arc::new(
+                google_cloud_gax::exponential_backoff::ExponentialBackoff::default(),
+            );
+
+            let query = move |name: String| {
+                let stub_clone = stub.clone();
+                let mut options_clone = options.clone();
+                let req_clone = req.clone();
+                options_clone.set_retry_policy(google_cloud_gax::retry_policy::NeverRetry);
+                async move {
+                    let get_req = crate::model::GetJobRequest {
+                        project_id: req_clone.project_id.clone(),
+                        job_id: name,
+                        location: req_clone
+                            .job
+                            .as_ref()
+                            .and_then(|j| j.job_reference.as_ref())
+                            .and_then(|jr| jr.location.clone())
+                            .unwrap_or_default(),
+                        _unknown_fields: std::default::Default::default(),
+                    };
+                    let job = stub_clone
+                        .get_job(get_req, options_clone.clone())
+                        .await
+                        .map(crate::Response::into_body)?;
+
+                    Ok(job)
+                }
+            };
+
+            let start = move || async move { self.send().await };
+
+            google_cloud_lro::internal::new_discovery_poller(
+                polling_error_policy,
+                polling_backoff_policy,
+                start,
+                query,
+            )
+        }
+
         /// Sets the value of [project_id][crate::model::InsertJobRequest::project_id].
         pub fn set_project_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
             self.0.request.project_id = v.into();

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -110,3 +110,6 @@ pub(crate) use google_cloud_gax::client_builder::internal::new_builder as new_cl
 pub(crate) use google_cloud_gax::options::RequestOptions;
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
+
+#[allow(missing_docs)]
+pub mod operation;

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -23,6 +23,7 @@ extern crate async_trait;
 extern crate bytes;
 extern crate gaxi;
 extern crate google_cloud_gax;
+extern crate google_cloud_lro;
 extern crate google_cloud_type;
 extern crate serde;
 extern crate serde_json;

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -37,3 +37,91 @@ impl google_cloud_lro::internal::DiscoveryOperation for Job {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Job, JobReference, JobStatus, ErrorProto};
+    use google_cloud_lro::internal::DiscoveryOperation;
+
+    #[test]
+    fn name_none() {
+        let job = Job::default();
+        assert_eq!(job.name(), None);
+    }
+
+    #[test]
+    fn name_some() {
+        let job = Job {
+            job_reference: Some(JobReference {
+                job_id: "test-id".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(job.name().map(|s| s.as_str()), Some("test-id"));
+    }
+
+    #[test]
+    fn done_none() {
+        let job = Job::default();
+        assert!(!job.done());
+    }
+
+    #[test]
+    fn done_false() {
+        let job = Job {
+            status: Some(JobStatus {
+                state: "RUNNING".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!job.done());
+    }
+
+    #[test]
+    fn done_true() {
+        let job = Job {
+            status: Some(JobStatus {
+                state: "DONE".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(job.done());
+    }
+
+    #[test]
+    fn error_none() {
+        let job = Job::default();
+        assert!(job.error().is_none());
+
+        let job_no_error = Job {
+            status: Some(JobStatus {
+                state: "DONE".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(job_no_error.error().is_none());
+    }
+
+    #[test]
+    fn error_some() {
+        let job = Job {
+            status: Some(JobStatus {
+                state: "DONE".to_string(),
+                error_result: Some(ErrorProto {
+                    message: "test error".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let err = job.error().expect("should have error");
+        assert_eq!(err.code, Code::Unknown);
+        assert_eq!(err.message, "test error");
+    }
+}

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::model::Job;
+use google_cloud_gax::error::rpc::{Code, Status};
+
+impl google_cloud_lro::internal::DiscoveryOperation for Job {
+    fn name(&self) -> Option<&String> {
+        self.job_reference.as_ref().map(|r| &r.job_id)
+    }
+
+    fn done(&self) -> bool {
+        self.status
+            .as_ref()
+            .map(|s| s.state == "DONE")
+            .unwrap_or(false)
+    }
+
+    fn error(&self) -> Option<Status> {
+        self.status.as_ref().and_then(|s| {
+            s.error_result.as_ref().map(|e| {
+                Status::default()
+                    .set_code(Code::Unknown)
+                    .set_message(e.message.clone())
+            })
+        })
+    }
+}

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -41,7 +41,7 @@ impl google_cloud_lro::internal::DiscoveryOperation for Job {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::{Job, JobReference, JobStatus, ErrorProto};
+    use crate::model::{ErrorProto, Job, JobReference, JobStatus};
     use google_cloud_lro::internal::DiscoveryOperation;
 
     #[test]


### PR DESCRIPTION
Regenerate `google-cloud-bigquery-v2` to introduce a standard `.poller()` method for `InsertJob`.