### PR TITLE
feat(spanner): add request-options and change-stream-exclusion setters to BatchWriteTransactionBuilder

### DIFF
--- a/src/spanner/src/batch_write_transaction.rs
+++ b/src/spanner/src/batch_write_transaction.rs
@@ -15,6 +15,8 @@
 use crate::client::DatabaseClient;
 use crate::model::BatchWriteRequest;
 use crate::model::BatchWriteResponse;
+use crate::model::RequestOptions;
+use crate::model::request_options::Priority;
 use crate::mutation::MutationGroup;
 use crate::server_streaming::stream::BatchWriteStream;
 use gaxi::prost::FromProto;
@@ -23,13 +25,95 @@ use gaxi::prost::FromProto;
 use futures::Stream;
 
 /// A builder for [BatchWriteTransaction].
+///
+/// Note that the `request_tag` field of [RequestOptions] is not exposed here:
+/// per-request tags apply only to queries and reads, and are ignored by the
+/// `BatchWrite` RPC. Use [set_transaction_tag][BatchWriteTransactionBuilder::set_transaction_tag]
+/// to tag the transactions of a batch write.
 pub struct BatchWriteTransactionBuilder {
     client: DatabaseClient,
+    transaction_tag: Option<String>,
+    priority: Priority,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl BatchWriteTransactionBuilder {
     pub(crate) fn new(client: DatabaseClient) -> Self {
-        Self { client }
+        Self {
+            client,
+            transaction_tag: None,
+            priority: Priority::Unspecified,
+            exclude_txn_from_change_streams: false,
+        }
+    }
+
+    /// Sets a transaction tag to be used for the batch write.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.batch_write_transaction()
+    ///     .set_transaction_tag("my-tag")
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The tag applies to all of the transactions created to apply the mutation
+    /// groups of the batch write.
+    ///
+    /// See also: [Troubleshooting with tags](https://docs.cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags)
+    pub fn set_transaction_tag(mut self, tag: impl Into<String>) -> Self {
+        self.transaction_tag = Some(tag.into());
+        self
+    }
+
+    /// Sets the RPC priority to use for the batch write request.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # use google_cloud_spanner::model::request_options::Priority;
+    /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.batch_write_transaction()
+    ///     .set_priority(Priority::Low)
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_priority(mut self, priority: Priority) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Sets whether to exclude the batch write from change streams.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::Spanner;
+    /// # async fn build_tx(spanner: Spanner) -> Result<(), google_cloud_spanner::Error> {
+    /// let db_client = spanner.database_client("projects/p/instances/i/databases/d").build().await?;
+    /// let transaction = db_client.batch_write_transaction()
+    ///     .set_exclude_txn_from_change_streams(true)
+    ///     .build();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// When set to `true`, it prevents modifications from all transactions in this batch write
+    /// operation from being tracked in change streams.
+    /// Note that this only affects change streams that have been created with the DDL option `allow_txn_exclusion = true`.
+    /// If `allow_txn_exclusion` is not set or set to `false` for a change stream, updates made within this batch write
+    /// are recorded in that change stream regardless of this setting.
+    ///
+    /// When set to `false` or not specified, modifications from this batch write are recorded in all change streams
+    /// tracking columns modified by these transactions.
+    pub fn set_exclude_txn_from_change_streams(mut self, exclude: bool) -> Self {
+        self.exclude_txn_from_change_streams = exclude;
+        self
     }
 
     /// Builds the [BatchWriteTransaction].
@@ -40,6 +124,9 @@ impl BatchWriteTransactionBuilder {
             session_name,
             client: self.client,
             channel_hint,
+            transaction_tag: self.transaction_tag,
+            priority: self.priority,
+            exclude_txn_from_change_streams: self.exclude_txn_from_change_streams,
         }
     }
 }
@@ -52,6 +139,9 @@ pub struct BatchWriteTransaction {
     session_name: String,
     client: DatabaseClient,
     channel_hint: usize,
+    transaction_tag: Option<String>,
+    priority: Priority,
+    exclude_txn_from_change_streams: bool,
 }
 
 impl BatchWriteTransaction {
@@ -98,9 +188,14 @@ impl BatchWriteTransaction {
     where
         I: IntoIterator<Item = MutationGroup>,
     {
+        let req_options = RequestOptions::default()
+            .set_transaction_tag(self.transaction_tag.unwrap_or_default())
+            .set_priority(self.priority);
         let req = BatchWriteRequest::new()
-            .set_session(self.session_name.clone())
-            .set_mutation_groups(groups.into_iter().map(|g| g.build_proto()));
+            .set_session(self.session_name)
+            .set_mutation_groups(groups.into_iter().map(|g| g.build_proto()))
+            .set_request_options(req_options)
+            .set_exclude_txn_from_change_streams(self.exclude_txn_from_change_streams);
 
         let stream = self
             .client
@@ -216,6 +311,68 @@ mod tests {
         let group = MutationGroup::new(vec![mutation]);
 
         let tx = db_client.batch_write_transaction().build();
+        let mut stream = tx.execute_streaming(vec![group]).await?;
+
+        let result = stream
+            .next()
+            .await
+            .expect("stream should have yielded a message")?;
+        assert_eq!(
+            result.indexes,
+            vec![0],
+            "indexes should match the mocked response"
+        );
+
+        Ok(())
+    }
+
+    #[tokio_test_no_panics]
+    async fn execute_streaming_with_request_options() -> Result<()> {
+        let mut mock = MockSpanner::new();
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "projects/p/instances/i/databases/d/sessions/123".to_string(),
+                ..Default::default()
+            }))
+        });
+
+        mock.expect_batch_write().once().returning(|req| {
+            let req = req.into_inner();
+
+            // Validate the custom request options contain the transaction tag and priority
+            let req_opts = req
+                .request_options
+                .as_ref()
+                .expect("request_options should be present");
+            assert_eq!(req_opts.transaction_tag, "my_tag");
+            assert_eq!(Priority::from(req_opts.priority), Priority::High);
+            assert_eq!(req_opts.request_tag, "");
+
+            assert!(req.exclude_txn_from_change_streams);
+
+            let response = mock_v1::BatchWriteResponse {
+                indexes: vec![0],
+                status: None,
+                commit_timestamp: None,
+            };
+
+            Ok(Response::from(adapt([Ok(response)])))
+        });
+
+        let (db_client, _server) = setup_db_client(mock).await;
+
+        let mutation = Mutation::new_insert_builder("Users")
+            .set("UserId")
+            .to(&1)
+            .build();
+        let group = MutationGroup::new(vec![mutation]);
+
+        let tx = db_client
+            .batch_write_transaction()
+            .set_transaction_tag("my_tag")
+            .set_priority(Priority::High)
+            .set_exclude_txn_from_change_streams(true)
+            .build();
         let mut stream = tx.execute_streaming(vec![group]).await?;
 
         let result = stream


### PR DESCRIPTION
The `BatchWriteRequest` proto carries `request_options` and `exclude_txn_from_change_streams`, but `BatchWriteTransactionBuilder` exposed no setters for them, so callers could not apply a priority, a transaction tag, or change-stream exclusion to batch writes.

Add `set_priority`, `set_transaction_tag` and `set_exclude_txn_from_change_streams` to the builder, mirroring the sibling `WriteOnlyTransactionBuilder`.