### PR TITLE
fix(o11y): disable flaky lro-tracing observability tests

### DIFF
--- a/src/gax-internal/src/observability/client_signals.rs
+++ b/src/gax-internal/src/observability/client_signals.rs
@@ -210,6 +210,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6077) - disabled because it is flaky"]
     async fn client_request() -> anyhow::Result<()> {
         const PATH: &str = "/v1/projects/test-only:test_method";
 

--- a/src/gax-internal/src/observability/client_signals/with_client_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_client_span.rs
@@ -137,6 +137,7 @@ mod tests {
     use std::future::ready;
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6077) - disabled because it is flaky"]
     async fn poll_ok() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 

--- a/src/gax-internal/src/observability/client_signals/with_transport_span.rs
+++ b/src/gax-internal/src/observability/client_signals/with_transport_span.rs
@@ -161,6 +161,7 @@ mod tests {
     use std::collections::BTreeSet;
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6077) - disabled because it is flaky"]
     async fn poll_ok() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 
@@ -225,6 +226,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6077) - disabled because it is flaky"]
     async fn poll_err() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 
@@ -281,6 +283,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    #[ignore = "TODO(#6077) - disabled because it is flaky"]
     async fn poll_ok_retry() -> anyhow::Result<()> {
         let providers = SignalProviders::new();
 


### PR DESCRIPTION
Disables tests in observability client signals due to flakiness (TODO #6077).