### PR TITLE
feat(spanner): implement ToValue for str

### DIFF
--- a/src/spanner/src/to_value.rs
+++ b/src/spanner/src/to_value.rs
@@ -65,17 +65,21 @@ impl ToValue for ProtoValue {
 
 impl ToValue for String {
     fn to_value(&self) -> Value {
+        self.as_str().to_value()
+    }
+}
+
+impl ToValue for str {
+    fn to_value(&self) -> Value {
         Value(ProtoValue {
-            kind: Some(prost_types::value::Kind::StringValue(self.clone())),
+            kind: Some(prost_types::value::Kind::StringValue(self.to_string())),
         })
     }
 }
 
 impl ToValue for &str {
     fn to_value(&self) -> Value {
-        Value(ProtoValue {
-            kind: Some(prost_types::value::Kind::StringValue(self.to_string())),
-        })
+        (**self).to_value()
     }
 }
 
@@ -209,6 +213,22 @@ mod tests {
         let v = "world".to_value();
         assert_eq!(v.kind(), Kind::String);
         assert_eq!(v.as_string(), "world");
+    }
+
+    #[test]
+    fn test_to_value_str_trait_bound() {
+        fn bind_param<T: ToValue + ?Sized>(val: &T) -> Value {
+            val.to_value()
+        }
+
+        let v = bind_param("hello");
+        assert_eq!(v.kind(), Kind::String);
+        assert_eq!(v.as_string(), "hello");
+
+        let owned: String = "hello".to_string();
+        assert_eq!(bind_param(&owned), v);
+        let borrowed: &str = &owned;
+        assert_eq!(bind_param(&borrowed), v);
     }
 
     #[test]

--- a/src/spanner/src/to_value.rs
+++ b/src/spanner/src/to_value.rs
@@ -79,7 +79,7 @@ impl ToValue for str {
 
 impl ToValue for &str {
     fn to_value(&self) -> Value {
-        (**self).to_value()
+        <str as ToValue>::to_value(*self)
     }
 }
 

--- a/src/spanner/src/to_value.rs
+++ b/src/spanner/src/to_value.rs
@@ -65,7 +65,7 @@ impl ToValue for ProtoValue {
 
 impl ToValue for String {
     fn to_value(&self) -> Value {
-        self.as_str().to_value()
+        <str as ToValue>::to_value(self)
     }
 }
 


### PR DESCRIPTION
`ToValue` was implemented for `&str` but not for the unsized `str`, meaning that callers had to pass an extra reference (`&"hello"`).

Fixes #6084.