### PR TITLE
ci: update Rust to 1.97

### DIFF
--- a/.gcb/complex.yaml
+++ b/.gcb/complex.yaml
@@ -58,7 +58,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.96'
+  _RUST_VERSION: '1.97'
 # The workspace-minimal-versions build can take over 1h (the default). This is
 # harmless (other than wasting CPU time) for other builds.
 timeout: 7200s

--- a/.gcb/coverage.yaml
+++ b/.gcb/coverage.yaml
@@ -85,7 +85,7 @@ substitutions:
   _CODECOV_SHA256: '80b5e6f898d6080be523f53ff169702a008a1c91b20c63c49df1175ed794d822'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.96'
+  _RUST_VERSION: '1.97'
 availableSecrets:
   secretManager:
     - versionName: projects/${PROJECT_ID}/secrets/CODECOV_TOKEN/versions/latest

--- a/.gcb/cryptoproviders.yaml
+++ b/.gcb/cryptoproviders.yaml
@@ -69,7 +69,7 @@ steps:
       done
 
 substitutions:
-  _RUST_VERSION: '1.96'
+  _RUST_VERSION: '1.97'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -176,7 +176,7 @@ substitutions:
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1
   _POOL_ID: rust-sdk-pool
-  _RUST_VERSION: '1.96'
+  _RUST_VERSION: '1.97'
   _GO_VERSION: '1.25.6'
   _PYTHON_VERSION: '3.14'
   _TERRAFORM_VERSION: '1.14.0'

--- a/.gcb/integration.yaml
+++ b/.gcb/integration.yaml
@@ -66,7 +66,7 @@ steps:
       cargo test --features run-integration-tests --tests
 
 substitutions:
-  _RUST_VERSION: '1.96'
+  _RUST_VERSION: '1.97'
   _SCCACHE_VERSION: 'v0.12.0'
   _SCCACHE_SHA256: 'b0e89ead6899224a4ba2b90e9073bf1ce036d95bab30f3dc33c1e1468bc4ad44'
   _POOL_REGION: us-central1

--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -22,7 +22,7 @@ on:
   release:
     types: [published]
 env:
-  GHA_RUST_VERSIONS: '{ "rust:current": "1.96" }'
+  GHA_RUST_VERSIONS: '{ "rust:current": "1.97" }'
   GHA_GO_VERSIONS: '{ "go:current": "1.25.6" }'
   # Define the unstable flags once
   UNSTABLE_CFGS: &unstable_cfgs '--cfg google_cloud_unstable_trust_boundaries --cfg google_cloud_unstable_storage_bidi --cfg google_cloud_unstable_grpc_server_streaming --cfg google_cloud_unstable_tracing --cfg google_cloud_unstable_gapic_streaming'


### PR DESCRIPTION
All builds, except the MSRV builds, should be running with Rust 1.97