### PR TITLE
feat: add public grpc feature flag for hybrid clients (#6095)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -580,6 +580,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
   # Enables re-generation of protos. Only needed on major version updates to
   # Prost and/or Tonic.
   'cfg(google_cloud_generate_protos)',
+  'cfg(google_cloud_unstable_grpc)',
   'cfg(tokio_unstable)',
 ] }
 

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -92,6 +92,9 @@ _internal-common = [
 
 # Enables the default rustls crypto provider for whatever client(s) are enabled.
 _default-rustls-provider = ["google-cloud-auth?/default-rustls-provider", "tonic?/tls-aws-lc"]
+# Enable gRPC transport support. This is a public feature flag that enables
+# gRPC streaming capabilities in client libraries.
+grpc = ["_internal-grpc-client"]
 # Enables the unstable server streaming functionality in the gRPC client.
 _internal-grpc-server-streaming = []
 

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -94,7 +94,7 @@ _internal-common = [
 _default-rustls-provider = ["google-cloud-auth?/default-rustls-provider", "tonic?/tls-aws-lc"]
 # Enable gRPC transport support. This is a public feature flag that enables
 # gRPC streaming capabilities in client libraries.
-grpc = ["_internal-grpc-client"]
+grpc = ["_internal-grpc-client", "google-cloud-gax/grpc"]
 # Enables the unstable server streaming functionality in the gRPC client.
 _internal-grpc-server-streaming = []
 

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -30,8 +30,8 @@ repository.workspace   = true
 rust-version.workspace = true
 
 [package.metadata.docs.rs]
-# We want to generate documentation for streaming APIs, gated by this feature.
-features = ["unstable-stream"]
+# We want to generate documentation for streaming APIs, gated by these features.
+features = ["grpc", "unstable-stream"]
 
 [lints]
 workspace = true
@@ -64,6 +64,9 @@ tokio               = { workspace = true, features = ["test-util"] }
 #
 # [futures::stream::Stream]: https://docs.rs/futures/latest/futures/stream/trait.Stream.html
 unstable-stream = []
+# Enable gRPC transport support. This is a public feature flag that enables
+# gRPC streaming capabilities in client libraries.
+grpc = []
 # DO NOT USE: this allows us to detect semver changes in types used in the
 # implementation of client libraries. None of the types or functions gated
 # by this feature are intended for general use. We do not plan to document these

--- a/src/gax/src/lib.rs
+++ b/src/gax/src/lib.rs
@@ -39,7 +39,7 @@ pub mod paginator;
 
 pub mod response;
 
-#[cfg(google_cloud_unstable_gapic_streaming)]
+#[cfg(all(feature = "grpc", google_cloud_unstable_gapic_streaming))]
 pub mod streaming;
 
 pub mod backoff_policy;


### PR DESCRIPTION
- Add public  feature flag to gax and gax-internal crates
- Gate gax streaming module under #[cfg(all(feature = grpc, google_cloud_unstable_gapic_streaming))]
- Update docs.rs metadata to include grpc feature
- Add cfg(google_cloud_unstable_grpc) to workspace check-cfg

fix #6095