### PR TITLE
impl(gax): add RequestSender and ResponseReceiver streaming types

### DIFF
--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -45,7 +45,7 @@ rand                  = { workspace = true, features = ["thread_rng"] }
 serde.workspace       = true
 serde_json.workspace  = true
 thiserror.workspace   = true
-tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
 # Local crates
 google-cloud-rpc = { workspace = true }
 wkt.workspace    = true

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -29,11 +29,14 @@ impl<Req> RequestSender<Req> {
     }
 
     /// Sends a request item over the stream.
-    pub async fn send(&self, item: Req) -> Result<(), crate::error::Error> {
+    pub async fn send(&self, item: Req) -> Result<(), crate::error::Error>
+    where
+        Req: Send + Sync + 'static,
+    {
         self.req_tx
             .send(item)
             .await
-            .map_err(|_| crate::error::Error::io("stream closed"))
+            .map_err(crate::error::Error::io)
     }
 }
 
@@ -75,5 +78,18 @@ mod tests {
 
         drop(resp_tx);
         assert!(receiver.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_request_sender_send_error() {
+        use std::error::Error as _;
+
+        let (req_tx, req_rx) = mpsc::channel::<String>(16);
+        let sender = RequestSender::new(req_tx);
+
+        drop(req_rx);
+        let err = sender.send("hello".to_string()).await.unwrap_err();
+        assert!(err.is_io());
+        assert!(err.source().is_some());
     }
 }

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -12,4 +12,68 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Types and helpers for gRPC streaming requests and responses.
+//! Types for gRPC streaming requests and responses.
+
+use tokio::sync::mpsc;
+
+/// A handle for sending outbound request items over a gRPC stream.
+#[derive(Clone, Debug)]
+pub struct RequestSender<Req> {
+    req_tx: mpsc::Sender<Req>,
+}
+
+impl<Req> RequestSender<Req> {
+    /// Creates a new [`RequestSender`].
+    pub fn new(req_tx: mpsc::Sender<Req>) -> Self {
+        Self { req_tx }
+    }
+
+    /// Sends a request item over the stream.
+    pub async fn send(&self, item: Req) -> Result<(), crate::error::Error> {
+        self.req_tx
+            .send(item)
+            .await
+            .map_err(|_| crate::error::Error::io("stream closed"))
+    }
+}
+
+/// A handle for receiving inbound response items from a gRPC stream.
+#[derive(Debug)]
+pub struct ResponseReceiver<Resp> {
+    rx: mpsc::Receiver<crate::Result<Resp>>,
+}
+
+impl<Resp> ResponseReceiver<Resp> {
+    /// Creates a new [`ResponseReceiver`].
+    pub fn new(rx: mpsc::Receiver<crate::Result<Resp>>) -> Self {
+        Self { rx }
+    }
+
+    /// Receives the next response item from the stream.
+    pub async fn recv(&mut self) -> Option<crate::Result<Resp>> {
+        self.rx.recv().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_request_sender_and_response_receiver() {
+        let (req_tx, mut req_rx) = mpsc::channel::<String>(16);
+        let (resp_tx, resp_rx) = mpsc::channel::<crate::Result<String>>(16);
+
+        let sender = RequestSender::new(req_tx);
+        let mut receiver = ResponseReceiver::new(resp_rx);
+
+        sender.send("hello".to_string()).await.unwrap();
+        assert_eq!(req_rx.recv().await.unwrap(), "hello");
+
+        resp_tx.send(Ok("world".to_string())).await.unwrap();
+        assert_eq!(receiver.recv().await.unwrap().unwrap(), "world");
+
+        drop(resp_tx);
+        assert!(receiver.recv().await.is_none());
+    }
+}


### PR DESCRIPTION
Implement `RequestSender<Req>` and `ResponseReceiver<Resp>` wrapper types in `google-cloud-gax` for gRPC streaming handle management. For now, these are very simple wrappers around Tokio `mpsc` channel types, so that we can start generating code that uses them.

For #2318