### PR TITLE
docs(bigquery): add basic query execution samples

### DIFF
--- a/src/bigquery/examples/src/query.rs
+++ b/src/bigquery/examples/src/query.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod batch;
+mod dry_run;
+mod job_optional;
+mod legacy;
+mod no_cache;
 #[allow(clippy::module_inception)]
 mod query;
 
@@ -21,7 +26,22 @@ pub async fn run_samples() -> anyhow::Result<()> {
     let project_id = project_id()?;
 
     println!("Running sample for `bigquery_query`...");
-    query::sample(&project_id).await?;
+    Box::pin(query::sample(&project_id)).await?;
+
+    println!("Running sample for `bigquery_query_no_cache`...");
+    Box::pin(no_cache::sample(&project_id)).await?;
+
+    println!("Running sample for `bigquery_query_batch`...");
+    Box::pin(batch::sample(&project_id)).await?;
+
+    println!("Running sample for `bigquery_query_dry_run`...");
+    Box::pin(dry_run::sample(&project_id)).await?;
+
+    println!("Running sample for `bigquery_query_legacy`...");
+    Box::pin(legacy::sample(&project_id)).await?;
+
+    println!("Running sample for `bigquery_query_job_optional`...");
+    Box::pin(job_optional::sample(&project_id)).await?;
 
     Ok(())
 }

--- a/src/bigquery/examples/src/query.rs
+++ b/src/bigquery/examples/src/query.rs
@@ -21,27 +21,24 @@ mod no_cache;
 mod query;
 
 use google_cloud_test_utils::runtime_config::project_id;
+use std::future::Future;
+use std::pin::Pin;
 
 pub async fn run_samples() -> anyhow::Result<()> {
     let project_id = project_id()?;
 
-    println!("Running sample for `bigquery_query`...");
-    Box::pin(query::sample(&project_id)).await?;
-
-    println!("Running sample for `bigquery_query_no_cache`...");
-    Box::pin(no_cache::sample(&project_id)).await?;
-
-    println!("Running sample for `bigquery_query_batch`...");
-    Box::pin(batch::sample(&project_id)).await?;
-
-    println!("Running sample for `bigquery_query_dry_run`...");
-    Box::pin(dry_run::sample(&project_id)).await?;
-
-    println!("Running sample for `bigquery_query_legacy`...");
-    Box::pin(legacy::sample(&project_id)).await?;
-
-    println!("Running sample for `bigquery_query_job_optional`...");
-    Box::pin(job_optional::sample(&project_id)).await?;
+    let pending: Vec<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>> = vec![
+        Box::pin(query::sample(&project_id)),
+        Box::pin(no_cache::sample(&project_id)),
+        Box::pin(batch::sample(&project_id)),
+        Box::pin(dry_run::sample(&project_id)),
+        Box::pin(legacy::sample(&project_id)),
+        Box::pin(job_optional::sample(&project_id)),
+    ];
+    let _: Vec<_> = futures::future::join_all(pending)
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(())
 }

--- a/src/bigquery/examples/src/query.rs
+++ b/src/bigquery/examples/src/query.rs
@@ -35,7 +35,7 @@ pub async fn run_samples() -> anyhow::Result<()> {
         Box::pin(legacy::sample(&project_id)),
         Box::pin(job_optional::sample(&project_id)),
     ];
-    let _: Vec<_> = futures::future::join_all(pending)
+    let _ = futures::future::join_all(pending)
         .await
         .into_iter()
         .collect::<anyhow::Result<Vec<_>>>()?;

--- a/src/bigquery/examples/src/query/batch.rs
+++ b/src/bigquery/examples/src/query/batch.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_batch]
+use google_cloud_bigquery::client::BigQuery;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = 'TX' \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_priority("BATCH")
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_batch]

--- a/src/bigquery/examples/src/query/dry_run.rs
+++ b/src/bigquery/examples/src/query/dry_run.rs
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_dry_run]
+use google_cloud_bigquery::client::BigQuery;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let complete_query = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = 'TX' \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_dry_run(true)
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?;
+
+    let bytes = complete_query.metadata().total_bytes_processed.unwrap_or(0);
+    println!("This query will process {bytes} bytes.");
+    Ok(())
+}
+// [END bigquery_query_dry_run]

--- a/src/bigquery/examples/src/query/job_optional.rs
+++ b/src/bigquery/examples/src/query/job_optional.rs
@@ -14,30 +14,50 @@
 
 // [START bigquery_query_job_optional]
 use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::QueryReference;
 use google_cloud_bigquery::model::query_request::JobCreationMode;
 
 pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let client = BigQuery::builder().build().await?;
 
-    let mut rows = client
+    let query = client
         .query(
             "SELECT \
-        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
-        WHERE state = 'TX' \
-        LIMIT 100",
+        name, gender, SUM(number) AS total \
+        FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        GROUP BY name, gender \
+        ORDER BY total DESC \
+        LIMIT 10",
         )
         .with_project_id(project_id)
         .set_job_creation_mode(JobCreationMode::JobCreationOptional)
         .set_location("US")
         .run()
-        .await?
-        .until_done()
-        .await?
-        .read();
+        .await?;
+
+    match query.query_reference() {
+        QueryReference::Stateless { query_id } => {
+            println!("Query was run in optional job mode.  Query ID: \"{query_id}\"");
+        }
+        QueryReference::Job(job) => {
+            let qualified_job_id = format!(
+                "{}:{}.{}",
+                job.project_id,
+                job.location.as_deref().unwrap_or_default(),
+                job.job_id
+            );
+            println!("Query was run with job state.  Job ID: \"{qualified_job_id}\"");
+        }
+        _ => {}
+    }
+
+    let mut rows = query.until_done().await?.read();
 
     while let Some(row) = rows.next().await.transpose()? {
         let name: String = row.get("name");
-        println!("Name: {name}");
+        let gender: String = row.get("gender");
+        let total: i64 = row.get("total");
+        println!("Name: {name}, Gender: {gender}, Total: {total}");
     }
     Ok(())
 }

--- a/src/bigquery/examples/src/query/job_optional.rs
+++ b/src/bigquery/examples/src/query/job_optional.rs
@@ -1,0 +1,44 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_job_optional]
+use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::query_request::JobCreationMode;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = 'TX' \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_job_creation_mode(JobCreationMode::JobCreationOptional)
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_job_optional]

--- a/src/bigquery/examples/src/query/legacy.rs
+++ b/src/bigquery/examples/src/query/legacy.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_legacy]
+use google_cloud_bigquery::client::BigQuery;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM [bigquery-public-data:usa_names.usa_1910_2013] \
+        WHERE state = 'TX' \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_use_legacy_sql(true)
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_legacy]

--- a/src/bigquery/examples/src/query/no_cache.rs
+++ b/src/bigquery/examples/src/query/no_cache.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_no_cache]
+use google_cloud_bigquery::client::BigQuery;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = 'TX' \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_use_query_cache(false)
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_no_cache]


### PR DESCRIPTION
Adds sample code for the following DevRel region tags:
- `bigquery_query_no_cache`: disable query caching
- `bigquery_query_batch`: batch priority execution
- `bigquery_query_dry_run`: query evaluation and byte estimation
- `bigquery_query_legacy`: legacy SQL dialect execution
- `bigquery_query_job_optional`: lightweight fast-path querying without forcing job creation

Towards #5741 