### PR TITLE
docs(bigquery): add parameterized query samples

### DIFF
--- a/src/bigquery/examples/src/query.rs
+++ b/src/bigquery/examples/src/query.rs
@@ -33,7 +33,7 @@ pub async fn run_samples() -> anyhow::Result<()> {
         Box::pin(params_arrays::sample(&project_id)),
         Box::pin(params_timestamps::sample(&project_id)),
     ];
-    let _: Vec<_> = futures::future::join_all(pending)
+    let _ = futures::future::join_all(pending)
         .await
         .into_iter()
         .collect::<anyhow::Result<Vec<_>>>()?;

--- a/src/bigquery/examples/src/query.rs
+++ b/src/bigquery/examples/src/query.rs
@@ -12,16 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod params_arrays;
+mod params_named;
+mod params_positional;
+mod params_timestamps;
 #[allow(clippy::module_inception)]
 mod query;
 
 use google_cloud_test_utils::runtime_config::project_id;
+use std::future::Future;
+use std::pin::Pin;
 
 pub async fn run_samples() -> anyhow::Result<()> {
     let project_id = project_id()?;
 
-    println!("Running sample for `bigquery_query`...");
-    query::sample(&project_id).await?;
+    let pending: Vec<Pin<Box<dyn Future<Output = anyhow::Result<()>>>>> = vec![
+        Box::pin(query::sample(&project_id)),
+        Box::pin(params_positional::sample(&project_id)),
+        Box::pin(params_named::sample(&project_id)),
+        Box::pin(params_arrays::sample(&project_id)),
+        Box::pin(params_timestamps::sample(&project_id)),
+    ];
+    let _: Vec<_> = futures::future::join_all(pending)
+        .await
+        .into_iter()
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(())
 }

--- a/src/bigquery/examples/src/query/params_arrays.rs
+++ b/src/bigquery/examples/src/query/params_arrays.rs
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_params_arrays]
+use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::{QueryParameter, QueryParameterType, QueryParameterValue};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let param = QueryParameter::new()
+        .set_name("states")
+        .set_parameter_type(
+            QueryParameterType::new()
+                .set_type("ARRAY")
+                .set_array_type(QueryParameterType::new().set_type("STRING")),
+        )
+        .set_parameter_value(QueryParameterValue::new().set_array_values(vec![
+            QueryParameterValue::new().set_value("TX"),
+            QueryParameterValue::new().set_value("CA"),
+        ]));
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state IN UNNEST(@states) \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_parameter_mode("NAMED")
+        .set_query_parameters(vec![param])
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_params_arrays]

--- a/src/bigquery/examples/src/query/params_named.rs
+++ b/src/bigquery/examples/src/query/params_named.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_params_named]
+use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::{QueryParameter, QueryParameterType, QueryParameterValue};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let param = QueryParameter::new()
+        .set_name("state")
+        .set_parameter_type(QueryParameterType::new().set_type("STRING"))
+        .set_parameter_value(QueryParameterValue::new().set_value("TX"));
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = @state \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_parameter_mode("NAMED")
+        .set_query_parameters(vec![param])
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_params_named]

--- a/src/bigquery/examples/src/query/params_positional.rs
+++ b/src/bigquery/examples/src/query/params_positional.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_params_positional]
+use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::{QueryParameter, QueryParameterType, QueryParameterValue};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let param = QueryParameter::new()
+        .set_parameter_type(QueryParameterType::new().set_type("STRING"))
+        .set_parameter_value(QueryParameterValue::new().set_value("TX"));
+
+    let mut rows = client
+        .query(
+            "SELECT \
+        name FROM `bigquery-public-data.usa_names.usa_1910_2013` \
+        WHERE state = ? \
+        LIMIT 100",
+        )
+        .with_project_id(project_id)
+        .set_parameter_mode("POSITIONAL")
+        .set_query_parameters(vec![param])
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    while let Some(row) = rows.next().await.transpose()? {
+        let name: String = row.get("name");
+        println!("Name: {name}");
+    }
+    Ok(())
+}
+// [END bigquery_query_params_positional]

--- a/src/bigquery/examples/src/query/params_timestamps.rs
+++ b/src/bigquery/examples/src/query/params_timestamps.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_query_params_timestamps]
+use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::model::{QueryParameter, QueryParameterType, QueryParameterValue};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let client = BigQuery::builder().build().await?;
+
+    let param = QueryParameter::new()
+        .set_name("ts")
+        .set_parameter_type(QueryParameterType::new().set_type("TIMESTAMP"))
+        .set_parameter_value(QueryParameterValue::new().set_value("2020-01-01T00:00:00.000000Z"));
+
+    let mut rows = client
+        .query("SELECT TIMESTAMP_ADD(@ts, INTERVAL 1 HOUR) AS next_hour")
+        .with_project_id(project_id)
+        .set_parameter_mode("NAMED")
+        .set_query_parameters(vec![param])
+        .set_location("US")
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    if let Some(row) = rows.next().await.transpose()? {
+        let next_hour: String = row.get("next_hour");
+        println!("Next hour: {next_hour}");
+    }
+    Ok(())
+}
+// [END bigquery_query_params_timestamps]


### PR DESCRIPTION
Adds sample code demonstrating parameterized queries in BigQuery for the following region tags:
- `bigquery_query_params_positional`: positional query parameters (`?`)
- `bigquery_query_params_named`: named query parameters (`@param_name`)
- `bigquery_query_params_arrays`: array parameter passing and filtering with `UNNEST`
- `bigquery_query_params_timestamps`: timestamp parameters formatting and evaluation

Towards #5741 