### PR TITLE
chore: update librarian to v0.28.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.27.2-0.20260720195823-e59cd3c4206c
+version: v0.28.0
 repo: googleapis/google-cloud-rust
 sources:
   conformance:


### PR DESCRIPTION


```
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ go run github.com/googleapis/librarian/cmd/librarian@latest update version
go: downloading github.com/googleapis/librarian v0.28.0
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
suztomo@suztomo:~/librarian-2026/google-cloud-rust$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
time=2026-07-21T15:38:38.165Z level=WARN source=/usr/local/google/home/suztomo/go/pkg/mod/github.com/googleapis/librarian@v0.28.0/internal/sidekick/parser/protobuf_annotations.go:83 msg="mismatched body in additional binding (see AIP-127)" message=.google.devtools.cloudbuild.v1.RunBuildTriggerRequest topLevelBody=source additionalBindingBody=*
```