### PR TITLE
impl(bigquery): introduce `AppendError`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/src/bigquery-write/Cargo.toml
+++ b/src/bigquery-write/Cargo.toml
@@ -35,6 +35,7 @@ prost-types.workspace      = true
 serde.workspace            = true
 serde_json.workspace       = true
 serde_with.workspace       = true
+thiserror.workspace        = true
 tokio.workspace            = true
 tokio-stream.workspace     = true
 tracing.workspace          = true

--- a/src/bigquery-write/src/error.rs
+++ b/src/bigquery-write/src/error.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Error;
+
+/// Represents an error that can occur when appending rows.
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum AppendError {
+    /// The underlying RPC failed.
+    #[non_exhaustive]
+    #[error("the operation failed. RPC error: {source}")]
+    Rpc {
+        /// The error returned by the service for the request.
+        #[source]
+        source: Error,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_gax::error::rpc::{Code, Status};
+
+    #[test]
+    fn append_error_rpc_debug() {
+        let e = AppendError::Rpc {
+            source: Error::service(
+                Status::default()
+                    .set_code(Code::FailedPrecondition)
+                    .set_message("inner fail"),
+            ),
+        };
+        let fmt = format!("{e}");
+        assert!(fmt.contains("operation failed."), "{fmt}");
+        assert!(fmt.contains("inner fail"), "{fmt}");
+    }
+}

--- a/src/bigquery-write/src/lib.rs
+++ b/src/bigquery-write/src/lib.rs
@@ -34,6 +34,8 @@ pub(crate) use google_cloud_gax::options::RequestOptions;
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
+#[cfg_attr(not(test), expect(dead_code))]
+mod error;
 mod proto_schema;
 #[cfg_attr(not(test), expect(dead_code))]
 mod stream;


### PR DESCRIPTION
Define a custom error to return when we append rows. The error is crate private while we do not have a public client.

We need a custom error. There will at least be another variant for `UnexpectedEndOfStream` for when the stream ends in an error without having responded to some of the requests.

I am sure there will be more variants we will need as we write the implementation.

Part of the work for #5833 