### PR TITLE
chore(bigquery): prepare for preview release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "0.0.0"
+version = "0.16.0-preview"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-bigquery-derive"
-version = "0.0.0"
+version = "0.1.0-preview"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -481,9 +481,9 @@ libraries:
     version: 2.0.0
     copyright_year: "2025"
   - name: google-cloud-bigquery
+    version: 0.16.0-preview
     copyright_year: "2026"
     output: src/bigquery
-    skip_release: true
     rust:
       modules:
         - output: src/bigquery/src/generated

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -491,7 +491,8 @@ libraries:
           template: bigquery
   - name: google-cloud-bigquery-derive
     version: 0.1.0-preview
-    copyright_year: "2026"    
+    copyright_year: "2026"
+    output: src/bigquery-derive
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.13.0
     copyright_year: "2025"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -489,6 +489,9 @@ libraries:
         - output: src/bigquery/src/generated
           api_path: google/cloud/bigquery/v2
           template: bigquery
+  - name: google-cloud-bigquery-derive
+    version: 0.1.0-preview
+    copyright_year: "2026"    
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.13.0
     copyright_year: "2025"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -489,10 +489,6 @@ libraries:
         - output: src/bigquery/src/generated
           api_path: google/cloud/bigquery/v2
           template: bigquery
-  - name: google-cloud-bigquery-derive
-    version: 0.1.0-preview
-    copyright_year: "2026"
-    output: src/bigquery-derive
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.13.0
     copyright_year: "2025"
@@ -508,6 +504,10 @@ libraries:
   - name: google-cloud-bigquery-datatransfer-v1
     version: 1.11.0
     copyright_year: "2025"
+  - name: google-cloud-bigquery-derive
+    version: 0.1.0-preview
+    copyright_year: "2026"
+    output: src/bigquery-derive
   - name: google-cloud-bigquery-migration-v2
     version: 1.11.0
     copyright_year: "2025"

--- a/src/bigquery-derive/Cargo.toml
+++ b/src/bigquery-derive/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name                   = "google-cloud-bigquery-derive"
-version                = "0.0.0"
+version                = "0.1.0-preview"
 description            = "Derive macros for the Google Cloud BigQuery client."
 edition.workspace      = true
 authors.workspace      = true
@@ -23,7 +23,7 @@ repository.workspace   = true
 keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
-publish                = false
+publish                = true
 
 [lib]
 proc-macro = true

--- a/src/bigquery/Cargo.toml
+++ b/src/bigquery/Cargo.toml
@@ -14,8 +14,8 @@
 
 [package]
 name        = "google-cloud-bigquery"
-publish     = false
-version     = "0.0.0"
+publish     = true
+version     = "0.16.0-preview"
 description = "Google Cloud Client Libraries for Rust - BigQuery"
 # Inherit other attributes from the workspace.
 edition.workspace      = true

--- a/src/bigquery/README.md
+++ b/src/bigquery/README.md
@@ -2,9 +2,10 @@
 
 This crate implements the [BigQuery] client library.
 
-**WARNING:** this crate is under active development. We expect multiple breaking
-changes in the upcoming releases. Testing is also incomplete, we do **not**
-recommend that you use this crate in production. We welcome feedback about the
-APIs, documentation, missing features, bugs, etc.
+**WARNING:** this is a preview release of the crate. We believe the APIs to be
+stable. We also are seeking feedback about the APIs and may need to make
+breaking changes if we discover that some parts are hard to use.
+
+We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 
 [bigquery]: https://cloud.google.com/bigquery

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -14,10 +14,11 @@
 
 //! Google Cloud Client Libraries for Rust - BigQuery
 //!
-//! **WARNING:** this crate is under active development. We expect multiple
-//! breaking changes in the upcoming releases. Testing is also incomplete, we do
-//! **not** recommend that you use this crate in production. We welcome feedback
-//! about the APIs, documentation, missing features, bugs, etc.
+//! **WARNING:** this is a preview release of the crate. We believe the APIs to be
+//! stable. We also are seeking feedback about the APIs and may need to make
+//! breaking changes if we discover that some parts are hard to use.
+//!
+//! We welcome feedback about the APIs, documentation, missing features, bugs, etc.
 //!
 //! This crate contains traits, types, and functions to interact with
 //! [BigQuery].


### PR DESCRIPTION
Update the version number to be higher than the existing `google-cloud-bigquery` crate.

Use *-preview to minimize the impact of breaking changes.

Update the README and lib.rs documentation to describe the status.

Towards #5844 