### PR TITLE
impl(bigquery-write): default rustls provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "bigquery-write-grpc-mock",
  "bytes",
  "google-cloud-auth",
+ "google-cloud-bigquery-write",
  "google-cloud-gax",
  "google-cloud-gax-internal",
  "google-cloud-rpc",

--- a/src/bigquery-write/Cargo.toml
+++ b/src/bigquery-write/Cargo.toml
@@ -26,6 +26,14 @@ keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
 
+[features]
+default = ["default-rustls-provider"]
+# Enabled by default. Use the default rustls crypto provider ([aws-lc-rs]) for
+# TLS and authentication. Applications with specific requirements for
+# cryptography (such as exclusively using the [ring] crate) should disable this
+# default and call `rustls::CryptoProvider::install_default()`.
+default-rustls-provider = ["gaxi/_default-rustls-provider"]
+
 [dependencies]
 async-trait.workspace      = true
 bytes.workspace            = true
@@ -46,8 +54,9 @@ gaxi                       = { workspace = true, features = ["_internal-common",
 
 [dev-dependencies]
 anyhow.workspace            = true
-google-cloud-auth.workspace = true
 bigquery-write-grpc-mock    = { path = "grpc-mock" }
+google-cloud-auth.workspace = true
+google-cloud-bigquery-write = { path = ".", features = ["default-rustls-provider"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Preemptively add a default rustls feature, like we have in every other client.

This is necessary if we want our clients to (1) work out of the box and (2) allow for custom crypto providers.

Part of the work for #5311