### PR TITLE
impl(bigquery): add write client

### DIFF
--- a/src/bigquery-write/Cargo.toml
+++ b/src/bigquery-write/Cargo.toml
@@ -35,22 +35,23 @@ default = ["default-rustls-provider"]
 default-rustls-provider = ["gaxi/_default-rustls-provider"]
 
 [dependencies]
-async-trait.workspace      = true
-bytes.workspace            = true
-http.workspace             = true
-prost.workspace            = true
-prost-types.workspace      = true
-serde.workspace            = true
-serde_json.workspace       = true
-serde_with.workspace       = true
-thiserror.workspace        = true
-tokio.workspace            = true
-tokio-stream.workspace     = true
-tracing.workspace          = true
-google-cloud-gax.workspace = true
-google-cloud-rpc.workspace = true
-wkt.workspace              = true
-gaxi                       = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
+async-trait.workspace       = true
+bytes.workspace             = true
+http.workspace              = true
+prost.workspace             = true
+prost-types.workspace       = true
+serde.workspace             = true
+serde_json.workspace        = true
+serde_with.workspace        = true
+thiserror.workspace         = true
+tokio.workspace             = true
+tokio-stream.workspace      = true
+tracing.workspace           = true
+google-cloud-auth.workspace = true
+google-cloud-gax.workspace  = true
+google-cloud-rpc.workspace  = true
+wkt.workspace               = true
+gaxi                        = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
 
 [dev-dependencies]
 anyhow.workspace            = true

--- a/src/bigquery-write/src/client.rs
+++ b/src/bigquery-write/src/client.rs
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ClientBuilderResult as BuilderResult;
+use crate::client_builder::ClientBuilder;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A client for BigQuery Storage Write API.
+pub struct Client {
+    #[allow(unused)]
+    inner: Arc<Transport>,
+}
+
+impl Client {
+    /// Creates a new [ClientBuilder].
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
+
+    pub(crate) async fn new(builder: ClientBuilder) -> BuilderResult<Self> {
+        let transport = Transport::new(builder.config).await?;
+        Ok(Self {
+            inner: Arc::new(transport),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+
+    #[tokio::test]
+    async fn test_client_builder() -> anyhow::Result<()> {
+        let _ = Client::builder()
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        Ok(())
+    }
+}

--- a/src/bigquery-write/src/client.rs
+++ b/src/bigquery-write/src/client.rs
@@ -18,12 +18,13 @@ use crate::transport::Transport;
 use std::sync::Arc;
 
 /// A client for BigQuery Storage Write API.
-pub struct Client {
+#[derive(Debug)]
+pub struct Write {
     #[allow(unused)]
     inner: Arc<Transport>,
 }
 
-impl Client {
+impl Write {
     /// Creates a new [ClientBuilder].
     pub fn builder() -> ClientBuilder {
         ClientBuilder::new()
@@ -44,7 +45,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_client_builder() -> anyhow::Result<()> {
-        let _ = Client::builder()
+        let _ = Write::builder()
             .with_credentials(Anonymous::new().build())
             .build()
             .await?;

--- a/src/bigquery-write/src/client_builder.rs
+++ b/src/bigquery-write/src/client_builder.rs
@@ -1,0 +1,157 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::ClientBuilderResult as BuilderResult;
+use crate::client::Client;
+use gaxi::options::ClientConfig;
+use google_cloud_auth::credentials::Credentials;
+
+/// A builder for [Client].
+///
+/// # Example
+/// ```
+/// # use google_cloud_bigquery_write::client::Client;
+/// # async fn sample() -> anyhow::Result<()> {
+/// let builder = Client::builder();
+/// let client = builder
+///     .with_endpoint("https://bigquerystoragewrite.googleapis.com")
+///     .build()
+///     .await?;
+/// # Ok(()) }
+/// ```
+pub struct ClientBuilder {
+    pub(super) config: ClientConfig,
+}
+
+impl ClientBuilder {
+    pub(super) fn new() -> Self {
+        Self {
+            config: ClientConfig::default(),
+        }
+    }
+
+    /// Creates a new client.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Client;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Client::builder().build().await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn build(self) -> BuilderResult<Client> {
+        Client::new(self).await
+    }
+
+    /// Sets the endpoint.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Client;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Client::builder()
+    ///     .with_endpoint("https://private.googleapis.com")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_endpoint<V: Into<String>>(mut self, v: V) -> Self {
+        self.config.endpoint = Some(v.into());
+        self
+    }
+
+    /// Configures the authentication credentials.
+    ///
+    /// More information about valid credentials types can be found in the
+    /// [google-cloud-auth] crate documentation.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Client;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// use google_cloud_auth::credentials::mds;
+    /// let client = Client::builder()
+    ///     .with_credentials(
+    ///         mds::Builder::default()
+    ///             .with_scopes(["https://www.googleapis.com/auth/cloud-platform.read-only"])
+    ///             .build()?)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [google-cloud-auth]: https://docs.rs/google-cloud-auth
+    pub fn with_credentials<V: Into<Credentials>>(mut self, v: V) -> Self {
+        self.config.cred = Some(v.into());
+        self
+    }
+
+    /// Configure the number of subchannels used by the client.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Client;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let count = std::thread::available_parallelism()?.get();
+    /// let client = Client::builder()
+    ///     .with_grpc_subchannel_count(count)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// gRPC-based clients may exhibit high latency if many requests need to be
+    /// demuxed over a single HTTP/2 connection (often called a *subchannel* in
+    /// gRPC).
+    ///
+    /// Consider using more subchannels if your application opens many message
+    /// streams. Consider using fewer subchannels if your application needs the
+    /// file descriptors for other purposes.
+    pub fn with_grpc_subchannel_count(mut self, v: usize) -> Self {
+        self.config.grpc_subchannel_count = Some(v);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+
+    #[test]
+    fn defaults() {
+        let builder = ClientBuilder::new();
+        assert!(builder.config.endpoint.is_none(), "{:?}", builder.config);
+        assert!(builder.config.cred.is_none(), "{:?}", builder.config);
+        assert!(
+            builder.config.grpc_subchannel_count.is_none(),
+            "{:?}",
+            builder.config
+        );
+    }
+
+    #[test]
+    fn setters() {
+        let builder = ClientBuilder::new()
+            .with_endpoint("test-endpoint.com")
+            .with_credentials(Anonymous::new().build())
+            .with_grpc_subchannel_count(16);
+        assert_eq!(
+            builder.config.endpoint,
+            Some("test-endpoint.com".to_string())
+        );
+        assert!(builder.config.cred.is_some(), "{:?}", builder.config);
+        assert_eq!(builder.config.grpc_subchannel_count, Some(16));
+    }
+}

--- a/src/bigquery-write/src/client_builder.rs
+++ b/src/bigquery-write/src/client_builder.rs
@@ -13,23 +13,24 @@
 // limitations under the License.
 
 use crate::ClientBuilderResult as BuilderResult;
-use crate::client::Client;
+use crate::client::Write;
 use gaxi::options::ClientConfig;
 use google_cloud_auth::credentials::Credentials;
 
-/// A builder for [Client].
+/// A builder for [Write].
 ///
 /// # Example
 /// ```
-/// # use google_cloud_bigquery_write::client::Client;
+/// # use google_cloud_bigquery_write::client::Write;
 /// # async fn sample() -> anyhow::Result<()> {
-/// let builder = Client::builder();
+/// let builder = Write::builder();
 /// let client = builder
 ///     .with_endpoint("https://bigquerystoragewrite.googleapis.com")
 ///     .build()
 ///     .await?;
 /// # Ok(()) }
 /// ```
+#[derive(Debug)]
 pub struct ClientBuilder {
     pub(super) config: ClientConfig,
 }
@@ -45,22 +46,22 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_bigquery_write::client::Client;
+    /// # use google_cloud_bigquery_write::client::Write;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// let client = Client::builder().build().await?;
+    /// let client = Write::builder().build().await?;
     /// # Ok(()) }
     /// ```
-    pub async fn build(self) -> BuilderResult<Client> {
-        Client::new(self).await
+    pub async fn build(self) -> BuilderResult<Write> {
+        Write::new(self).await
     }
 
     /// Sets the endpoint.
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_bigquery_write::client::Client;
+    /// # use google_cloud_bigquery_write::client::Write;
     /// # async fn sample() -> anyhow::Result<()> {
-    /// let client = Client::builder()
+    /// let client = Write::builder()
     ///     .with_endpoint("https://private.googleapis.com")
     ///     .build()
     ///     .await?;
@@ -78,10 +79,10 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_bigquery_write::client::Client;
+    /// # use google_cloud_bigquery_write::client::Write;
     /// # async fn sample() -> anyhow::Result<()> {
     /// use google_cloud_auth::credentials::mds;
-    /// let client = Client::builder()
+    /// let client = Write::builder()
     ///     .with_credentials(
     ///         mds::Builder::default()
     ///             .with_scopes(["https://www.googleapis.com/auth/cloud-platform.read-only"])
@@ -101,10 +102,10 @@ impl ClientBuilder {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_bigquery_write::client::Client;
+    /// # use google_cloud_bigquery_write::client::Write;
     /// # async fn sample() -> anyhow::Result<()> {
     /// let count = std::thread::available_parallelism()?.get();
-    /// let client = Client::builder()
+    /// let client = Write::builder()
     ///     .with_grpc_subchannel_count(count)
     ///     .build()
     ///     .await?;
@@ -115,8 +116,8 @@ impl ClientBuilder {
     /// demuxed over a single HTTP/2 connection (often called a *subchannel* in
     /// gRPC).
     ///
-    /// Consider using more subchannels if your application opens many message
-    /// streams. Consider using fewer subchannels if your application needs the
+    /// Consider using more subchannels if your application creates many
+    /// writers. Consider using fewer subchannels if your application needs the
     /// file descriptors for other purposes.
     pub fn with_grpc_subchannel_count(mut self, v: usize) -> Self {
         self.config.grpc_subchannel_count = Some(v);

--- a/src/bigquery-write/src/client_builder.rs
+++ b/src/bigquery-write/src/client_builder.rs
@@ -72,6 +72,26 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure the universe domain.
+    ///
+    /// The universe domain is the default service domain for a given cloud universe.
+    /// The default value is "googleapis.com".
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Write;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Write::builder()
+    ///     .with_universe_domain("googleapis.com")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_universe_domain<V: Into<String>>(mut self, v: V) -> Self {
+        self.config.universe_domain = Some(v.into());
+        self
+    }
+
     /// Configures the authentication credentials.
     ///
     /// More information about valid credentials types can be found in the
@@ -136,6 +156,11 @@ mod tests {
         assert!(builder.config.endpoint.is_none(), "{:?}", builder.config);
         assert!(builder.config.cred.is_none(), "{:?}", builder.config);
         assert!(
+            builder.config.universe_domain.is_none(),
+            "{:?}",
+            builder.config
+        );
+        assert!(
             builder.config.grpc_subchannel_count.is_none(),
             "{:?}",
             builder.config
@@ -146,11 +171,16 @@ mod tests {
     fn setters() {
         let builder = ClientBuilder::new()
             .with_endpoint("test-endpoint.com")
+            .with_universe_domain("test-ud.com")
             .with_credentials(Anonymous::new().build())
             .with_grpc_subchannel_count(16);
         assert_eq!(
             builder.config.endpoint,
             Some("test-endpoint.com".to_string())
+        );
+        assert_eq!(
+            builder.config.universe_domain,
+            Some("test-ud.com".to_string())
         );
         assert!(builder.config.cred.is_some(), "{:?}", builder.config);
         assert_eq!(builder.config.grpc_subchannel_count, Some(16));

--- a/src/bigquery-write/src/lib.rs
+++ b/src/bigquery-write/src/lib.rs
@@ -34,6 +34,17 @@ pub(crate) use google_cloud_gax::options::RequestOptions;
 pub(crate) use google_cloud_gax::options::internal::RequestBuilder;
 pub(crate) use google_cloud_gax::response::Response;
 
+/// Clients to interact with Cloud BigQuery Storage Write API
+pub mod client;
+/// Builders to interact with Cloud BigQuery Storage Write API
+pub mod builder {
+    /// Request and client builders for the Data [Client][crate::client::Client].
+    pub mod data {
+        pub use crate::client_builder::ClientBuilder;
+    }
+    // TODO(#6152) - add admin client.
+}
+mod client_builder;
 mod error;
 mod proto_schema;
 #[cfg_attr(not(test), expect(dead_code))]

--- a/src/bigquery-write/src/lib.rs
+++ b/src/bigquery-write/src/lib.rs
@@ -38,7 +38,7 @@ pub(crate) use google_cloud_gax::response::Response;
 pub mod client;
 /// Builders to interact with Cloud BigQuery Storage Write API
 pub mod builder {
-    /// Request and client builders for the [Write][crate::client::Client] client
+    /// Request and client builders for the [Write][crate::client::Write] client
     pub mod write {
         pub use crate::client_builder::ClientBuilder;
     }

--- a/src/bigquery-write/src/lib.rs
+++ b/src/bigquery-write/src/lib.rs
@@ -38,11 +38,11 @@ pub(crate) use google_cloud_gax::response::Response;
 pub mod client;
 /// Builders to interact with Cloud BigQuery Storage Write API
 pub mod builder {
-    /// Request and client builders for the Data [Client][crate::client::Client].
-    pub mod data {
+    /// Request and client builders for the [Write][crate::client::Client] client
+    pub mod write {
         pub use crate::client_builder::ClientBuilder;
     }
-    // TODO(#6152) - add admin client.
+    // TODO(#6152) - add admin client
 }
 mod client_builder;
 mod error;


### PR DESCRIPTION
Add a BigQuery Write client. At the moment, it can't do anything. It's just there.

I don't want the organization (naming of types and modules) to block this PR, but if you have opinions, please leave them for me to consider.

Part of the work for #5664