### PR TITLE
feat(pubsub): configure universe domain

### DIFF
--- a/src/pubsub/src/publisher/builder.rs
+++ b/src/pubsub/src/publisher/builder.rs
@@ -133,6 +133,24 @@ impl PublisherBuilder {
         self
     }
 
+    /// Configure the universe domain.
+    ///
+    /// The universe domain is the default service domain for a given cloud universe.
+    /// The default value is "googleapis.com".
+    ///
+    /// ```
+    /// # use google_cloud_pubsub::client::Publisher;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Publisher::builder("projects/my-project/topics/my-topic")
+    ///     .with_universe_domain("googleapis.com")
+    ///     .build().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_universe_domain<V: Into<String>>(mut self, v: V) -> Self {
+        self.base_builder = self.base_builder.with_universe_domain(v);
+        self
+    }
+
     /// Enables tracing.
     ///
     /// The client libraries can be dynamically instrumented with the Tokio
@@ -468,6 +486,7 @@ mod tests {
         base_config: &gaxi::options::ClientConfig,
     ) {
         assert_eq!(pub_config.endpoint, base_config.endpoint);
+        assert_eq!(pub_config.universe_domain, base_config.universe_domain);
         assert_eq!(pub_config.cred.is_some(), base_config.cred.is_some());
         assert_eq!(pub_config.tracing, base_config.tracing);
         assert_eq!(
@@ -502,6 +521,7 @@ mod tests {
         let throttler = google_cloud_gax::retry_throttler::CircuitBreaker::default();
         let pub_builder = Publisher::builder("projects/my-project/topics/my-topic")
             .with_endpoint("test-endpoint.com")
+            .with_universe_domain("test-ud.com")
             .with_credentials(Anonymous::new().build())
             .with_tracing()
             .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
@@ -512,6 +532,7 @@ mod tests {
             .with_grpc_subchannel_count(16);
         let base_builder = BasePublisher::builder()
             .with_endpoint("test-endpoint.com")
+            .with_universe_domain("test-ud.com")
             .with_credentials(Anonymous::new().build())
             .with_tracing()
             .with_retry_policy(AlwaysRetry.with_attempt_limit(3))

--- a/src/pubsub/src/publisher/client_builder.rs
+++ b/src/pubsub/src/publisher/client_builder.rs
@@ -79,6 +79,26 @@ impl BasePublisherBuilder {
         self
     }
 
+    /// Configure the universe domain.
+    ///
+    /// The universe domain is the default service domain for a given cloud universe.
+    /// The default value is "googleapis.com".
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::BasePublisher;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = BasePublisher::builder()
+    ///     .with_universe_domain("googleapis.com")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_universe_domain<V: Into<String>>(mut self, v: V) -> Self {
+        self.config.universe_domain = Some(v.into());
+        self
+    }
+
     /// Enables tracing.
     ///
     /// The client libraries can be dynamically instrumented with the Tokio
@@ -238,6 +258,7 @@ mod tests {
         let builder = BasePublisherBuilder::new();
         assert!(builder.config.endpoint.is_none(), "{builder:?}");
         assert!(builder.config.cred.is_none(), "{builder:?}");
+        assert!(builder.config.universe_domain.is_none(), "{builder:?}");
         assert!(!builder.config.tracing);
         assert!(
             format!("{:?}", builder.config).contains("AdaptiveThrottler"),
@@ -269,6 +290,7 @@ mod tests {
         use google_cloud_gax::retry_policy::{AlwaysRetry, RetryPolicyExt};
         let builder = BasePublisherBuilder::new()
             .with_endpoint("test-endpoint.com")
+            .with_universe_domain("test-ud.com")
             .with_credentials(Anonymous::new().build())
             .with_tracing()
             .with_retry_policy(AlwaysRetry.with_attempt_limit(3))
@@ -280,6 +302,10 @@ mod tests {
         assert_eq!(
             builder.config.endpoint,
             Some("test-endpoint.com".to_string())
+        );
+        assert_eq!(
+            builder.config.universe_domain,
+            Some("test-ud.com".to_string())
         );
         assert!(builder.config.cred.is_some(), "{builder:?}");
         assert!(builder.config.tracing);

--- a/src/pubsub/src/subscriber/client_builder.rs
+++ b/src/pubsub/src/subscriber/client_builder.rs
@@ -74,6 +74,26 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure the universe domain.
+    ///
+    /// The universe domain is the default service domain for a given cloud universe.
+    /// The default value is "googleapis.com".
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_pubsub::client::Subscriber;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Subscriber::builder()
+    ///     .with_universe_domain("googleapis.com")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn with_universe_domain<V: Into<String>>(mut self, v: V) -> Self {
+        self.config.universe_domain = Some(v.into());
+        self
+    }
+
     /// Configures the authentication credentials.
     ///
     /// More information about valid credentials types can be found in the
@@ -138,6 +158,11 @@ mod tests {
         assert!(builder.config.endpoint.is_none(), "{:?}", builder.config);
         assert!(builder.config.cred.is_none(), "{:?}", builder.config);
         assert!(
+            builder.config.universe_domain.is_none(),
+            "{:?}",
+            builder.config
+        );
+        assert!(
             builder.config.grpc_subchannel_count.is_none(),
             "{:?}",
             builder.config
@@ -152,11 +177,16 @@ mod tests {
     fn setters() {
         let builder = ClientBuilder::new()
             .with_endpoint("test-endpoint.com")
+            .with_universe_domain("test-ud.com")
             .with_credentials(Anonymous::new().build())
             .with_grpc_subchannel_count(16);
         assert_eq!(
             builder.config.endpoint,
             Some("test-endpoint.com".to_string())
+        );
+        assert_eq!(
+            builder.config.universe_domain,
+            Some("test-ud.com".to_string())
         );
         assert!(builder.config.cred.is_some(), "{:?}", builder.config);
         assert_eq!(builder.config.grpc_subchannel_count, Some(16));


### PR DESCRIPTION
Let applications configure the universe domain for the thick pubsub clients.

Fixes #6161 