### PR TITLE
impl(bigquery): implement job-level retry loop

### DIFF
--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -14,6 +14,10 @@
 
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::{ErrorProto, InsertJobRequest, Job, JobReference, JobStatus};
+use google_cloud_bigquery_v2::stub::JobService as JobServiceStub;
+use google_cloud_gax::Result as GaxResult;
+use google_cloud_gax::options::RequestOptions;
+use google_cloud_gax::response::Response;
 use mockall::{Sequence, mock};
 use std::future::Future;
 
@@ -21,28 +25,39 @@ mock! {
     #[derive(Debug)]
     pub TestJobService {}
 
-    impl google_cloud_bigquery_v2::stub::JobService for TestJobService {
+    impl JobServiceStub for TestJobService {
         fn insert_job(
             &self,
             req: InsertJobRequest,
-            options: google_cloud_gax::options::RequestOptions,
-        ) -> impl Future<Output = google_cloud_gax::Result<google_cloud_gax::response::Response<Job>>> + Send;
+            options: RequestOptions,
+        ) -> impl Future<Output = GaxResult<Response<Job>>> + Send;
     }
+}
+
+fn transient_job_failure() -> Job {
+    Job::new().set_status(
+        JobStatus::new()
+            .set_state("DONE")
+            .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
+    )
 }
 
 #[tokio::test]
 async fn job_poller_until_done_with_mock_stub() -> Result<(), Box<dyn std::error::Error>> {
-    let mock_job = Job::new().set_status(JobStatus::new().set_state("DONE"));
     let mut mock = MockTestJobService::new();
-    mock.expect_insert_job().times(1).returning(move |_, _| {
-        let job = mock_job.clone();
-        Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+    mock.expect_insert_job().return_once(|_, _| {
+        Box::pin(async move {
+            Ok(Response::from(
+                Job::new().set_status(JobStatus::new().set_state("DONE")),
+            ))
+        })
     });
 
     let client = JobService::from_stub(mock);
     let poller = client.insert_job().into_job_poller();
     let job = poller.until_done().await?;
     assert_eq!(job.status.as_ref().map(|s| s.state.as_str()), Some("DONE"));
+    assert!(job.status.unwrap().error_result.is_none());
     Ok(())
 }
 
@@ -63,11 +78,10 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
     let mut mock = MockTestJobService::new();
     let mut seq = Sequence::new();
 
-    let failed_job_clone = failed_job.clone();
     mock.expect_insert_job()
         .times(1)
         .in_sequence(&mut seq)
-        .returning(move |req, _| {
+        .return_once(move |req, _| {
             assert_eq!(
                 req.job
                     .as_ref()
@@ -78,29 +92,37 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
                     .job_id,
                 "job-1"
             );
-            let job = failed_job_clone.clone();
-            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+            Box::pin(async move { Ok(Response::from(failed_job)) })
         });
 
-    let success_job_clone = success_job.clone();
     mock.expect_insert_job()
         .times(1)
         .in_sequence(&mut seq)
-        .returning(move |req, _| {
+        .return_once(move |req, _| {
             let retried_job = req.job.as_ref().unwrap();
             assert!(retried_job.status.is_none());
             assert_ne!(retried_job.job_reference.as_ref().unwrap().job_id, "job-1");
-            let job = success_job_clone.clone();
-            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+            Box::pin(async move { Ok(Response::from(success_job)) })
         });
 
     let client = JobService::from_stub(mock);
-    let poller = client.insert_job().set_job(failed_job).into_job_poller();
+    let initial_job = Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
+        .set_status(
+            JobStatus::new()
+                .set_state("DONE")
+                .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
+        );
+    let poller = client.insert_job().set_job(initial_job).into_job_poller();
 
     let result = poller.until_done().await?;
 
     // Should succeed on 2nd attempt
-    assert!(result.status.as_ref().unwrap().error_result.is_none());
+    assert_eq!(
+        result.status.as_ref().map(|s| s.state.as_str()),
+        Some("DONE")
+    );
+    assert!(result.status.unwrap().error_result.is_none());
     Ok(())
 }
 
@@ -115,13 +137,9 @@ async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn s
         );
 
     let mut mock = MockTestJobService::new();
-    let _seq = Sequence::new();
 
-    let failed_job_clone = failed_job.clone();
-    mock.expect_insert_job().times(1).returning(move |_, _| {
-        let job = failed_job_clone.clone();
-        Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
-    });
+    mock.expect_insert_job()
+        .return_once(move |_, _| Box::pin(async move { Ok(Response::from(failed_job)) }));
 
     let client = JobService::from_stub(mock);
     let poller = client.insert_job().into_job_poller();
@@ -129,54 +147,20 @@ async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn s
 
     // Should return immediately after 1st attempt
     assert_eq!(
-        result
-            .status
-            .as_ref()
-            .unwrap()
-            .error_result
-            .as_ref()
-            .unwrap()
-            .reason
-            .as_str(),
+        result.status.unwrap().error_result.unwrap().reason.as_str(),
         "invalidQuery"
     );
     Ok(())
 }
 
 #[tokio::test]
-async fn job_poller_stops_when_retry_limit_reached() -> Result<(), Box<dyn std::error::Error>> {
-    let failed_job1 = Job::new().set_status(
-        JobStatus::new()
-            .set_state("DONE")
-            .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
-    );
-    let failed_job2 = failed_job1.clone();
-    let failed_job3 = failed_job1.clone();
-
+async fn retry_exhausted() -> Result<(), Box<dyn std::error::Error>> {
     let mut mock = MockTestJobService::new();
-    let mut seq = Sequence::new();
 
-    mock.expect_insert_job()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(move |_, _| {
-            let job = failed_job1.clone();
-            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
-        });
-    mock.expect_insert_job()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(move |_, _| {
-            let job = failed_job2.clone();
-            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
-        });
-    mock.expect_insert_job()
-        .times(1)
-        .in_sequence(&mut seq)
-        .returning(move |_, _| {
-            let job = failed_job3.clone();
-            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
-        });
+    mock.expect_insert_job().times(3).returning(move |_, _| {
+        let job = transient_job_failure();
+        Box::pin(async move { Ok(Response::from(job)) })
+    });
 
     let client = JobService::from_stub(mock);
     let poller = client
@@ -188,15 +172,7 @@ async fn job_poller_stops_when_retry_limit_reached() -> Result<(), Box<dyn std::
 
     // Should stop retrying after limit of 3
     assert_eq!(
-        result
-            .status
-            .as_ref()
-            .unwrap()
-            .error_result
-            .as_ref()
-            .unwrap()
-            .reason
-            .as_str(),
+        result.status.unwrap().error_result.unwrap().reason.as_str(),
         "jobBackendError"
     );
     Ok(())

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ fn transient_job_failure() -> Job {
 }
 
 #[tokio::test]
-async fn job_poller_until_done_with_mock_stub() -> Result<(), Box<dyn std::error::Error>> {
+async fn success() -> anyhow::Result<()> {
     let mut mock = MockTestJobService::new();
     mock.expect_insert_job().return_once(|_, _| {
         Ok(Response::from(
@@ -59,8 +59,7 @@ async fn job_poller_until_done_with_mock_stub() -> Result<(), Box<dyn std::error
 }
 
 #[tokio::test]
-async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn std::error::Error>>
-{
+async fn job_poller_retries_transient_error_and_succeeds() -> anyhow::Result<()> {
     let failed_job = Job::new()
         .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
         .set_status(
@@ -79,16 +78,7 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
         .times(1)
         .in_sequence(&mut seq)
         .return_once(move |req, _| {
-            assert_eq!(
-                req.job
-                    .as_ref()
-                    .unwrap()
-                    .job_reference
-                    .as_ref()
-                    .unwrap()
-                    .job_id,
-                "job-1"
-            );
+            assert_eq!(req.job.unwrap().job_reference.unwrap().job_id, "job-1");
             Ok(Response::from(failed_job))
         });
 
@@ -96,9 +86,9 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
         .times(1)
         .in_sequence(&mut seq)
         .return_once(move |req, _| {
-            let retried_job = req.job.as_ref().unwrap();
+            let retried_job = req.job.unwrap();
             assert!(retried_job.status.is_none());
-            assert_ne!(retried_job.job_reference.as_ref().unwrap().job_id, "job-1");
+            assert_ne!(retried_job.job_reference.unwrap().job_id, "job-1");
             Ok(Response::from(success_job))
         });
 
@@ -124,7 +114,7 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
 }
 
 #[tokio::test]
-async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn std::error::Error>> {
+async fn job_poller_does_not_retry_non_retryable_error() -> anyhow::Result<()> {
     let failed_job = Job::new()
         .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
         .set_status(
@@ -151,13 +141,12 @@ async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn s
 }
 
 #[tokio::test]
-async fn retry_exhausted() -> Result<(), Box<dyn std::error::Error>> {
+async fn retry_exhausted() -> anyhow::Result<()> {
     let mut mock = MockTestJobService::new();
 
-    mock.expect_insert_job().times(3).returning(move |_, _| {
-        let job = transient_job_failure();
-        Ok(Response::from(job))
-    });
+    mock.expect_insert_job()
+        .times(3)
+        .returning(move |_, _| Ok(Response::from(transient_job_failure())));
 
     let client = JobService::from_stub(mock);
     let poller = client

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -1,0 +1,203 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::model::{ErrorProto, InsertJobRequest, Job, JobReference, JobStatus};
+use mockall::{Sequence, mock};
+use std::future::Future;
+
+mock! {
+    #[derive(Debug)]
+    pub TestJobService {}
+
+    impl google_cloud_bigquery_v2::stub::JobService for TestJobService {
+        fn insert_job(
+            &self,
+            req: InsertJobRequest,
+            options: google_cloud_gax::options::RequestOptions,
+        ) -> impl Future<Output = google_cloud_gax::Result<google_cloud_gax::response::Response<Job>>> + Send;
+    }
+}
+
+#[tokio::test]
+async fn job_poller_until_done_with_mock_stub() -> Result<(), Box<dyn std::error::Error>> {
+    let mock_job = Job::new().set_status(JobStatus::new().set_state("DONE"));
+    let mut mock = MockTestJobService::new();
+    mock.expect_insert_job().times(1).returning(move |_, _| {
+        let job = mock_job.clone();
+        Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+    });
+
+    let client = JobService::from_stub(mock);
+    let poller = client.insert_job().into_job_poller();
+    let job = poller.until_done().await?;
+    assert_eq!(job.status.as_ref().map(|s| s.state.as_str()), Some("DONE"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn std::error::Error>>
+{
+    let failed_job = Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
+        .set_status(
+            JobStatus::new()
+                .set_state("DONE")
+                .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
+        );
+    let success_job = Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-2"))
+        .set_status(JobStatus::new().set_state("DONE"));
+
+    let mut mock = MockTestJobService::new();
+    let mut seq = Sequence::new();
+
+    let failed_job_clone = failed_job.clone();
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(move |req, _| {
+            assert_eq!(
+                req.job
+                    .as_ref()
+                    .unwrap()
+                    .job_reference
+                    .as_ref()
+                    .unwrap()
+                    .job_id,
+                "job-1"
+            );
+            let job = failed_job_clone.clone();
+            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+        });
+
+    let success_job_clone = success_job.clone();
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(move |req, _| {
+            let retried_job = req.job.as_ref().unwrap();
+            assert!(retried_job.status.is_none());
+            assert_ne!(retried_job.job_reference.as_ref().unwrap().job_id, "job-1");
+            let job = success_job_clone.clone();
+            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+        });
+
+    let client = JobService::from_stub(mock);
+    let poller = client.insert_job().set_job(failed_job).into_job_poller();
+
+    let result = poller.until_done().await?;
+
+    // Should succeed on 2nd attempt
+    assert!(result.status.as_ref().unwrap().error_result.is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn std::error::Error>> {
+    let failed_job = Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
+        .set_status(
+            JobStatus::new()
+                .set_state("DONE")
+                .set_error_result(ErrorProto::new().set_reason("invalidQuery")),
+        );
+
+    let mut mock = MockTestJobService::new();
+    let _seq = Sequence::new();
+
+    let failed_job_clone = failed_job.clone();
+    mock.expect_insert_job().times(1).returning(move |_, _| {
+        let job = failed_job_clone.clone();
+        Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+    });
+
+    let client = JobService::from_stub(mock);
+    let poller = client.insert_job().into_job_poller();
+    let result = poller.until_done().await?;
+
+    // Should return immediately after 1st attempt
+    assert_eq!(
+        result
+            .status
+            .as_ref()
+            .unwrap()
+            .error_result
+            .as_ref()
+            .unwrap()
+            .reason
+            .as_str(),
+        "invalidQuery"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn job_poller_stops_when_retry_limit_reached() -> Result<(), Box<dyn std::error::Error>> {
+    let failed_job1 = Job::new().set_status(
+        JobStatus::new()
+            .set_state("DONE")
+            .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
+    );
+    let failed_job2 = failed_job1.clone();
+    let failed_job3 = failed_job1.clone();
+
+    let mut mock = MockTestJobService::new();
+    let mut seq = Sequence::new();
+
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(move |_, _| {
+            let job = failed_job1.clone();
+            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+        });
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(move |_, _| {
+            let job = failed_job2.clone();
+            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+        });
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .returning(move |_, _| {
+            let job = failed_job3.clone();
+            Box::pin(async move { Ok(google_cloud_gax::response::Response::from(job)) })
+        });
+
+    let client = JobService::from_stub(mock);
+    let poller = client
+        .insert_job()
+        .into_job_poller()
+        .with_job_attempt_limit(3);
+
+    let result = poller.until_done().await?;
+
+    // Should stop retrying after limit of 3
+    assert_eq!(
+        result
+            .status
+            .as_ref()
+            .unwrap()
+            .error_result
+            .as_ref()
+            .unwrap()
+            .reason
+            .as_str(),
+        "jobBackendError"
+    );
+    Ok(())
+}

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -33,12 +33,24 @@ mock! {
     }
 }
 
-fn transient_job_failure() -> Job {
-    Job::new().set_status(
-        JobStatus::new()
-            .set_state("DONE")
-            .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
-    )
+fn transient_job_failure(job_id: &str) -> Job {
+    Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id(job_id))
+        .set_status(
+            JobStatus::new()
+                .set_state("DONE")
+                .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
+        )
+}
+
+fn non_retryable_job_failure(job_id: &str) -> Job {
+    Job::new()
+        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id(job_id))
+        .set_status(
+            JobStatus::new()
+                .set_state("DONE")
+                .set_error_result(ErrorProto::new().set_reason("invalidQuery")),
+        )
 }
 
 #[tokio::test]
@@ -53,20 +65,15 @@ async fn success() -> anyhow::Result<()> {
     let client = JobService::from_stub(mock);
     let poller = client.insert_job().into_job_poller();
     let job = poller.until_done().await?;
-    assert_eq!(job.status.as_ref().map(|s| s.state.as_str()), Some("DONE"));
-    assert!(job.status.unwrap().error_result.is_none());
+    let status = job.status.unwrap();
+    assert_eq!(status.state.as_str(), "DONE");
+    assert!(status.error_result.is_none());
     Ok(())
 }
 
 #[tokio::test]
-async fn job_poller_retries_transient_error_and_succeeds() -> anyhow::Result<()> {
-    let failed_job = Job::new()
-        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
-        .set_status(
-            JobStatus::new()
-                .set_state("DONE")
-                .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
-        );
+async fn retry_success() -> anyhow::Result<()> {
+    let failed_job = transient_job_failure("job-1");
     let success_job = Job::new()
         .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-2"))
         .set_status(JobStatus::new().set_state("DONE"));
@@ -93,35 +100,20 @@ async fn job_poller_retries_transient_error_and_succeeds() -> anyhow::Result<()>
         });
 
     let client = JobService::from_stub(mock);
-    let initial_job = Job::new()
-        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
-        .set_status(
-            JobStatus::new()
-                .set_state("DONE")
-                .set_error_result(ErrorProto::new().set_reason("jobBackendError")),
-        );
+    let initial_job = transient_job_failure("job-1");
     let poller = client.insert_job().set_job(initial_job).into_job_poller();
 
     let result = poller.until_done().await?;
 
-    // Should succeed on 2nd attempt
-    assert_eq!(
-        result.status.as_ref().map(|s| s.state.as_str()),
-        Some("DONE")
-    );
-    assert!(result.status.unwrap().error_result.is_none());
+    let status = result.status.unwrap();
+    assert_eq!(status.state.as_str(), "DONE");
+    assert!(status.error_result.is_none());
     Ok(())
 }
 
 #[tokio::test]
-async fn job_poller_does_not_retry_non_retryable_error() -> anyhow::Result<()> {
-    let failed_job = Job::new()
-        .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-1"))
-        .set_status(
-            JobStatus::new()
-                .set_state("DONE")
-                .set_error_result(ErrorProto::new().set_reason("invalidQuery")),
-        );
+async fn non_retryable_error() -> anyhow::Result<()> {
+    let failed_job = non_retryable_job_failure("job-1");
 
     let mut mock = MockTestJobService::new();
 
@@ -146,13 +138,13 @@ async fn retry_exhausted() -> anyhow::Result<()> {
 
     mock.expect_insert_job()
         .times(3)
-        .returning(move |_, _| Ok(Response::from(transient_job_failure())));
+        .returning(move |_, _| Ok(Response::from(transient_job_failure("job-unknown"))));
 
     let client = JobService::from_stub(mock);
     let poller = client
         .insert_job()
         .into_job_poller()
-        .with_job_attempt_limit(3);
+        .set_job_level_attempt_limit(3);
 
     let result = poller.until_done().await?;
 

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -19,18 +19,17 @@ use google_cloud_gax::Result as GaxResult;
 use google_cloud_gax::options::RequestOptions;
 use google_cloud_gax::response::Response;
 use mockall::{Sequence, mock};
-use std::future::Future;
 
 mock! {
     #[derive(Debug)]
     pub TestJobService {}
 
     impl JobServiceStub for TestJobService {
-        fn insert_job(
+        async fn insert_job(
             &self,
             req: InsertJobRequest,
             options: RequestOptions,
-        ) -> impl Future<Output = GaxResult<Response<Job>>> + Send;
+        ) -> GaxResult<Response<Job>>;
     }
 }
 
@@ -46,11 +45,9 @@ fn transient_job_failure() -> Job {
 async fn job_poller_until_done_with_mock_stub() -> Result<(), Box<dyn std::error::Error>> {
     let mut mock = MockTestJobService::new();
     mock.expect_insert_job().return_once(|_, _| {
-        Box::pin(async move {
-            Ok(Response::from(
-                Job::new().set_status(JobStatus::new().set_state("DONE")),
-            ))
-        })
+        Ok(Response::from(
+            Job::new().set_status(JobStatus::new().set_state("DONE")),
+        ))
     });
 
     let client = JobService::from_stub(mock);
@@ -92,7 +89,7 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
                     .job_id,
                 "job-1"
             );
-            Box::pin(async move { Ok(Response::from(failed_job)) })
+            Ok(Response::from(failed_job))
         });
 
     mock.expect_insert_job()
@@ -102,7 +99,7 @@ async fn job_poller_retries_transient_error_and_succeeds() -> Result<(), Box<dyn
             let retried_job = req.job.as_ref().unwrap();
             assert!(retried_job.status.is_none());
             assert_ne!(retried_job.job_reference.as_ref().unwrap().job_id, "job-1");
-            Box::pin(async move { Ok(Response::from(success_job)) })
+            Ok(Response::from(success_job))
         });
 
     let client = JobService::from_stub(mock);
@@ -139,7 +136,7 @@ async fn job_poller_does_not_retry_non_retryable_error() -> Result<(), Box<dyn s
     let mut mock = MockTestJobService::new();
 
     mock.expect_insert_job()
-        .return_once(move |_, _| Box::pin(async move { Ok(Response::from(failed_job)) }));
+        .return_once(move |_, _| Ok(Response::from(failed_job)));
 
     let client = JobService::from_stub(mock);
     let poller = client.insert_job().into_job_poller();
@@ -159,7 +156,7 @@ async fn retry_exhausted() -> Result<(), Box<dyn std::error::Error>> {
 
     mock.expect_insert_job().times(3).returning(move |_, _| {
         let job = transient_job_failure();
-        Box::pin(async move { Ok(Response::from(job)) })
+        Ok(Response::from(job))
     });
 
     let client = JobService::from_stub(mock);

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -14,8 +14,11 @@
 
 use crate::builder::job_service::InsertJob;
 use crate::model::Job;
+use google_cloud_gax::Result as GaxResult;
+use google_cloud_gax::backoff_policy::BackoffPolicy;
 use google_cloud_gax::error::rpc::{Code, Status};
 use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+use google_cloud_gax::retry_state::RetryState;
 use google_cloud_lro::Poller;
 
 impl google_cloud_lro::internal::DiscoveryOperation for Job {
@@ -114,12 +117,11 @@ impl JobPoller {
     }
 
     /// Polls the job until it is done, returning the final Job status.
-    pub async fn until_done(self) -> google_cloud_gax::Result<Job> {
+    pub async fn until_done(self) -> GaxResult<Job> {
         let mut attempts = 0;
         let mut builder = self.builder;
         let backoff = self.policy.backoff;
         let start_time = std::time::Instant::now();
-        use google_cloud_gax::backoff_policy::BackoffPolicy;
 
         loop {
             attempts += 1;
@@ -134,7 +136,7 @@ impl JobPoller {
                 let retry_job = prepare_job_for_retry(job_result);
                 builder = builder.set_job(retry_job);
 
-                let retry_state = google_cloud_gax::retry_state::RetryState::new(true)
+                let retry_state = RetryState::new(true)
                     .set_start(start_time)
                     .set_attempt_count(attempts as u32);
                 let delay = backoff.on_failure(&retry_state);

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -105,7 +105,7 @@ impl JobPoller {
     }
 
     /// Sets the maximum number of job-level attempts.
-    pub fn with_job_attempt_limit(mut self, limit: usize) -> Self {
+    pub fn set_job_level_attempt_limit(mut self, limit: usize) -> Self {
         self.policy.job_level_attempt_limit = limit;
         self
     }

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::builder::job_service::InsertJob;
 use crate::model::Job;
 use google_cloud_gax::error::rpc::{Code, Status};
+use google_cloud_gax::exponential_backoff::ExponentialBackoff;
+use google_cloud_lro::Poller;
 
 impl google_cloud_lro::internal::DiscoveryOperation for Job {
     fn name(&self) -> Option<&String> {
@@ -65,11 +68,109 @@ pub(crate) fn prepare_job_for_retry(mut job: Job) -> Job {
     job
 }
 
+/// Configuration policy for BigQuery job-level retries.
+#[derive(Debug)]
+pub(crate) struct JobRetryPolicy {
+    /// Maximum number of general job-level attempts for retryable job errors.
+    pub job_level_attempt_limit: usize,
+    /// Backoff strategy between retry attempts.
+    pub backoff: ExponentialBackoff,
+}
+
+impl Default for JobRetryPolicy {
+    fn default() -> Self {
+        Self {
+            job_level_attempt_limit: 3,
+            backoff: ExponentialBackoff::default(),
+        }
+    }
+}
+
+/// A poller that monitors the status of an inserted BigQuery job and handles retries.
+#[derive(Debug)]
+pub struct JobPoller {
+    policy: JobRetryPolicy,
+    builder: InsertJob,
+}
+
+impl JobPoller {
+    pub(crate) fn new(builder: InsertJob) -> Self {
+        Self {
+            policy: JobRetryPolicy::default(),
+            builder,
+        }
+    }
+
+    /// Sets the maximum number of job-level attempts.
+    pub fn with_job_attempt_limit(mut self, limit: usize) -> Self {
+        self.policy.job_level_attempt_limit = limit;
+        self
+    }
+
+    /// Sets the exponential backoff policy for job-level retries.
+    pub fn with_job_retry_backoff(mut self, backoff: ExponentialBackoff) -> Self {
+        self.policy.backoff = backoff;
+        self
+    }
+
+    /// Polls the job until it is done, returning the final Job status.
+    pub async fn until_done(self) -> google_cloud_gax::Result<Job> {
+        let mut attempts = 0;
+        let mut builder = self.builder;
+        let backoff = self.policy.backoff;
+        let start_time = std::time::Instant::now();
+        use google_cloud_gax::backoff_policy::BackoffPolicy;
+
+        loop {
+            attempts += 1;
+
+            let job_result = builder.clone().poller().until_done().await?;
+
+            if let Some(status) = &job_result.status
+                && let Some(err) = &status.error_result
+                && is_retryable_job_error(&err.reason)
+                && attempts < self.policy.job_level_attempt_limit
+            {
+                let retry_job = prepare_job_for_retry(job_result);
+                builder = builder.set_job(retry_job);
+
+                let retry_state = google_cloud_gax::retry_state::RetryState::new(true)
+                    .set_start(start_time)
+                    .set_attempt_count(attempts as u32);
+                let delay = backoff.on_failure(&retry_state);
+                tokio::time::sleep(delay).await;
+                continue;
+            }
+            return Ok(job_result);
+        }
+    }
+}
+
+impl InsertJob {
+    /// Returns a `JobPoller`, which can retry on [job-level errors].
+    ///
+    /// If the job fails with an internal error, the `JobPoller` will retry the
+    /// `InsertJob` operation. Note that the client library will supply a
+    /// synthetic job ID for any retries.
+    ///
+    /// ```no_run
+    /// # async fn example(builder: google_cloud_bigquery_v2::builder::job_service::InsertJob) -> Result<(), Box<dyn std::error::Error>> {
+    /// let job = builder.into_job_poller().until_done().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [job-level errors]: https://docs.cloud.google.com/bigquery/docs/error-messages#errortable
+    pub fn into_job_poller(self) -> JobPoller {
+        JobPoller::new(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::{
-        ErrorProto, Job, JobConfiguration, JobConfigurationQuery, JobReference, JobStatus,
+        ErrorProto, JobConfiguration, JobConfigurationQuery, JobReference, JobStatus,
     };
     use google_cloud_lro::internal::DiscoveryOperation;
 
@@ -114,14 +215,11 @@ mod tests {
 
     #[test]
     fn error_some() {
-        let job = Job::new().set_status(
-            JobStatus::new()
-                .set_state("DONE")
-                .set_error_result(ErrorProto::new().set_message("test error")),
-        );
+        let job = Job::new()
+            .set_status(JobStatus::new().set_error_result(ErrorProto::new().set_message("failed")));
         let err = job.error().expect("should have error");
         assert_eq!(err.code, Code::Unknown);
-        assert_eq!(err.message, "test error");
+        assert_eq!(err.message, "failed");
     }
 
     #[test]
@@ -141,7 +239,7 @@ mod tests {
     #[test]
     fn job_retry_policy_defaults() {
         let policy = JobRetryPolicy::default();
-        assert_eq!(policy.job_level_retry_limit, 3);
+        assert_eq!(policy.job_level_attempt_limit, 3);
     }
 
     #[test]
@@ -244,85 +342,9 @@ mod tests {
     #[test]
     fn custom_retry_policy_builder() {
         let mut policy = JobRetryPolicy::default();
-        assert_eq!(policy.job_level_retry_limit, 3);
+        assert_eq!(policy.job_level_attempt_limit, 3);
 
-        policy.job_level_retry_limit = 5;
-        assert_eq!(policy.job_level_retry_limit, 5);
-    }
-}
-
-use crate::builder::job_service::InsertJob;
-use google_cloud_gax::exponential_backoff::ExponentialBackoff;
-use google_cloud_lro::Poller;
-
-/// Configuration policy for BigQuery job-level retries.
-#[derive(Debug)]
-pub(crate) struct JobRetryPolicy {
-    /// Maximum number of job-level retry attempts for retryable job errors.
-    pub job_level_retry_limit: usize,
-    /// Backoff strategy between retry attempts.
-    pub backoff: ExponentialBackoff,
-}
-
-impl Default for JobRetryPolicy {
-    fn default() -> Self {
-        Self {
-            job_level_retry_limit: 3,
-            backoff: ExponentialBackoff::default(),
-        }
-    }
-}
-
-/// A poller that monitors the status of an inserted BigQuery job and handles retries.
-#[derive(Debug)]
-pub struct JobPoller {
-    policy: JobRetryPolicy,
-    builder: InsertJob,
-}
-
-impl JobPoller {
-    pub(crate) fn new(builder: InsertJob) -> Self {
-        Self {
-            policy: JobRetryPolicy::default(),
-            builder,
-        }
-    }
-
-    /// Sets the maximum number of job-level retry attempts.
-    pub fn with_job_retry_limit(mut self, limit: usize) -> Self {
-        self.policy.job_level_retry_limit = limit;
-        self
-    }
-
-    /// Sets the exponential backoff policy for job-level retries.
-    pub fn with_job_retry_backoff(mut self, backoff: ExponentialBackoff) -> Self {
-        self.policy.backoff = backoff;
-        self
-    }
-
-    /// Polls the job until it is done, returning the final Job status.
-    pub async fn until_done(self) -> google_cloud_gax::Result<Job> {
-        // Scaffolding: just pass through to standard poller for now
-        self.builder.poller().until_done().await
-    }
-}
-
-impl InsertJob {
-    /// Returns a `JobPoller`, which can retry on [job-level errors].
-    ///
-    /// If the job fails with an internal error, the `JobPoller` will retry the
-    /// `InsertJob` operation. Note that the client library will supply a
-    /// synthetic job ID for any retries.
-    ///
-    /// ```no_run
-    /// # async fn example(builder: google_cloud_bigquery_v2::builder::job_service::InsertJob) -> Result<(), Box<dyn std::error::Error>> {
-    /// let job = builder.into_job_poller().until_done().await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// [job-level errors]: https://docs.cloud.google.com/bigquery/docs/error-messages#errortable
-    pub fn into_job_poller(self) -> JobPoller {
-        JobPoller::new(self)
+        policy.job_level_attempt_limit = 5;
+        assert_eq!(policy.job_level_attempt_limit, 5);
     }
 }


### PR DESCRIPTION
Implement the automatic job-level retry loop in `until_done()`.

When a submitted BigQuery job finishes with a transient error in `status.error_result`, `JobPoller` will:
1. Prepare a new `Job` instance with a synthetic UUID `job_id` (preserving original project ID, location, and configuration settings).
2. Reset execution status to `None`.
3. Apply configured backoff delay (`JobRetryPolicy`).
4. Resubmit `InsertJob` up to the configured `job_level_retry_limit`.