### PR TITLE
fix(storage): bound stale bucket cleanup

### DIFF
--- a/src/storage/examples/Cargo.toml
+++ b/src/storage/examples/Cargo.toml
@@ -38,7 +38,7 @@ google-cloud-test-utils       = { workspace = true }
 http.workspace                = true
 rand.workspace                = true
 tempfile.workspace            = true
-tokio                         = { workspace = true, features = ["macros"] }
+tokio                         = { workspace = true, features = ["macros", "rt", "time"] }
 tracing-subscriber            = { workspace = true, features = ["fmt", "std"] }
 tracing.workspace             = true
 

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -666,7 +666,7 @@ async fn create_bucket_kms_key(
 pub async fn create_test_bucket() -> anyhow::Result<(StorageControl, Bucket)> {
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
     let client = client_for_create_bucket().await?;
-    cleanup_stale_buckets(&client, &project_id).await?;
+    cleanup_stale_buckets(&client, &project_id).await;
 
     let bucket_id = crate::random_bucket_id();
 
@@ -691,7 +691,7 @@ pub async fn create_test_bucket() -> anyhow::Result<(StorageControl, Bucket)> {
 pub async fn create_test_hns_bucket() -> anyhow::Result<(StorageControl, Bucket)> {
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
     let client = client_for_create_bucket().await?;
-    cleanup_stale_buckets(&client, &project_id).await?;
+    cleanup_stale_buckets(&client, &project_id).await;
 
     let bucket_id = crate::random_bucket_id();
 
@@ -719,7 +719,7 @@ pub async fn create_test_hns_bucket() -> anyhow::Result<(StorageControl, Bucket)
 pub async fn create_test_rapid_bucket() -> anyhow::Result<(StorageControl, Bucket)> {
     let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")?;
     let client = client_for_create_bucket().await?;
-    cleanup_stale_buckets(&client, &project_id).await?;
+    cleanup_stale_buckets(&client, &project_id).await;
 
     let bucket_id = crate::random_bucket_id();
 
@@ -768,10 +768,7 @@ async fn client_for_create_bucket() -> anyhow::Result<StorageControl> {
     Ok(client)
 }
 
-pub async fn cleanup_stale_buckets(
-    client: &StorageControl,
-    project_id: &str,
-) -> anyhow::Result<()> {
+pub async fn cleanup_stale_buckets(client: &StorageControl, project_id: &str) {
     run_stale_bucket_cleanup(
         STALE_BUCKET_CLEANUP_TIMEOUT,
         cleanup_stale_buckets_inner(client, project_id),
@@ -779,22 +776,20 @@ pub async fn cleanup_stale_buckets(
     .await
 }
 
-async fn run_stale_bucket_cleanup<F>(timeout: Duration, cleanup: F) -> anyhow::Result<()>
+async fn run_stale_bucket_cleanup<F>(timeout: Duration, cleanup: F)
 where
     F: std::future::Future<Output = anyhow::Result<()>>,
 {
     match tokio::time::timeout(timeout, cleanup).await {
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(())) => {}
         Ok(Err(e)) => {
             tracing::warn!("stale bucket cleanup failed; continuing: {e:?}");
-            Ok(())
         }
         Err(_) => {
             tracing::warn!(
                 "stale bucket cleanup timed out after {:.1}s; continuing",
                 timeout.as_secs_f64()
             );
-            Ok(())
         }
     }
 }
@@ -1090,24 +1085,24 @@ mod tests {
         assert_eq!(clean_project_id("1234567890"), "1234567890");
     }
 
+    // Verifies that when the inner cleanup future returns an error,
+    // run_stale_bucket_cleanup handles it cleanly without panicking.
     #[tokio::test]
     async fn stale_bucket_cleanup_ignores_errors() {
-        let result = run_stale_bucket_cleanup(Duration::from_secs(1), async {
+        run_stale_bucket_cleanup(Duration::from_secs(1), async {
             anyhow::bail!("test-only cleanup error")
         })
         .await;
-
-        assert!(result.is_ok(), "{result:?}");
     }
 
+    // Verifies that when the inner cleanup future hangs,
+    // run_stale_bucket_cleanup enforces the timeout and completes cleanly instead of blocking.
     #[tokio::test]
     async fn stale_bucket_cleanup_stops_at_timeout() {
-        let result = run_stale_bucket_cleanup(
+        run_stale_bucket_cleanup(
             Duration::from_millis(1),
             std::future::pending::<anyhow::Result<()>>(),
         )
         .await;
-
-        assert!(result.is_ok(), "{result:?}");
     }
 }

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -758,11 +758,7 @@ async fn client_for_create_bucket() -> anyhow::Result<StorageControl> {
                 .build()
                 .unwrap(),
         )
-        .with_retry_policy(
-            RetryableErrors
-                .with_attempt_limit(16)
-                .with_time_limit(Duration::from_secs(32)),
-        )
+        .with_retry_policy(RetryableErrors.with_attempt_limit(5))
         .build()
         .await?;
     Ok(client)

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -38,6 +38,8 @@ use google_cloud_test_utils::resource_names::random_bucket_id;
 use google_cloud_wkt::FieldMask;
 use std::time::Duration;
 
+const STALE_BUCKET_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub async fn run_anywhere_cache_examples(buckets: &mut Vec<String>) -> anyhow::Result<()> {
     let _guard = enable_info_tracing();
 
@@ -757,7 +759,7 @@ async fn client_for_create_bucket() -> anyhow::Result<StorageControl> {
                 .unwrap(),
         )
         .with_retry_policy(
-            google_cloud_gax::retry_policy::AlwaysRetry
+            RetryableErrors
                 .with_attempt_limit(16)
                 .with_time_limit(Duration::from_secs(32)),
         )
@@ -770,7 +772,38 @@ pub async fn cleanup_stale_buckets(
     client: &StorageControl,
     project_id: &str,
 ) -> anyhow::Result<()> {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    run_stale_bucket_cleanup(
+        STALE_BUCKET_CLEANUP_TIMEOUT,
+        cleanup_stale_buckets_inner(client, project_id),
+    )
+    .await
+}
+
+async fn run_stale_bucket_cleanup<F>(timeout: Duration, cleanup: F) -> anyhow::Result<()>
+where
+    F: std::future::Future<Output = anyhow::Result<()>>,
+{
+    match tokio::time::timeout(timeout, cleanup).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            tracing::warn!("stale bucket cleanup failed; continuing: {e:?}");
+            Ok(())
+        }
+        Err(_) => {
+            tracing::warn!(
+                "stale bucket cleanup timed out after {:.1}s; continuing",
+                timeout.as_secs_f64()
+            );
+            Ok(())
+        }
+    }
+}
+
+async fn cleanup_stale_buckets_inner(
+    client: &StorageControl,
+    project_id: &str,
+) -> anyhow::Result<()> {
+    use std::time::{SystemTime, UNIX_EPOCH};
     let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
     let stale_deadline = google_cloud_wkt::Timestamp::clamp(stale_deadline.as_secs() as i64, 0);
@@ -1055,5 +1088,26 @@ mod tests {
         assert_eq!(clean_project_id("projects/my-project-id"), "my-project-id");
         assert_eq!(clean_project_id("my-project-id"), "my-project-id");
         assert_eq!(clean_project_id("1234567890"), "1234567890");
+    }
+
+    #[tokio::test]
+    async fn stale_bucket_cleanup_ignores_errors() {
+        let result = run_stale_bucket_cleanup(Duration::from_secs(1), async {
+            anyhow::bail!("test-only cleanup error")
+        })
+        .await;
+
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn stale_bucket_cleanup_stops_at_timeout() {
+        let result = run_stale_bucket_cleanup(
+            Duration::from_millis(1),
+            std::future::pending::<anyhow::Result<()>>(),
+        )
+        .await;
+
+        assert!(result.is_ok(), "{result:?}");
     }
 }

--- a/src/storage/examples/src/lib.rs
+++ b/src/storage/examples/src/lib.rs
@@ -38,7 +38,7 @@ use google_cloud_test_utils::resource_names::random_bucket_id;
 use google_cloud_wkt::FieldMask;
 use std::time::Duration;
 
-const STALE_BUCKET_CLEANUP_TIMEOUT: Duration = Duration::from_secs(30);
+const STALE_BUCKET_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 pub async fn run_anywhere_cache_examples(buckets: &mut Vec<String>) -> anyhow::Result<()> {
     let _guard = enable_info_tracing();
@@ -1085,20 +1085,18 @@ mod tests {
         assert_eq!(clean_project_id("1234567890"), "1234567890");
     }
 
-    // Verifies that when the inner cleanup future returns an error,
-    // run_stale_bucket_cleanup handles it cleanly without panicking.
     #[tokio::test]
     async fn stale_bucket_cleanup_ignores_errors() {
+        // Should not panic
         run_stale_bucket_cleanup(Duration::from_secs(1), async {
             anyhow::bail!("test-only cleanup error")
         })
         .await;
     }
 
-    // Verifies that when the inner cleanup future hangs,
-    // run_stale_bucket_cleanup enforces the timeout and completes cleanly instead of blocking.
     #[tokio::test]
     async fn stale_bucket_cleanup_stops_at_timeout() {
+        // Should not block
         run_stale_bucket_cleanup(
             Duration::from_millis(1),
             std::future::pending::<anyhow::Result<()>>(),

--- a/tests/storage/src/lib.rs
+++ b/tests/storage/src/lib.rs
@@ -307,7 +307,7 @@ pub async fn buckets() -> Result<()> {
     let project_id = project_id()?;
 
     let control = StorageControl::builder().build().await?;
-    cleanup_stale_buckets(&control, &project_id).await?;
+    cleanup_stale_buckets(&control, &project_id).await;
 
     let bucket_id = random_bucket_id();
     let bucket_name = format!("projects/_/buckets/{bucket_id}");


### PR DESCRIPTION
For #6104.

Switch from AlwaysRetry to RetryableErrors to avoid retrying permanent cleanup failures. Also cap stale bucket cleanup at 5 minutes.

