### PR TITLE
docs(spanner): add samples for indexes with storing columns

### DIFF
--- a/src/spanner/examples/src/database/create_storing_index.rs
+++ b/src/spanner/examples/src/database/create_storing_index.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START spanner_postgresql_add_column]
+// [START spanner_create_storing_index]
 use google_cloud_lro::Poller;
 use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
 
 pub async fn sample(admin_client: &DatabaseAdmin, database_name: &str) -> anyhow::Result<()> {
-    let statements = vec!["ALTER TABLE Albums ADD COLUMN MarketingBudget bigint"];
+    let statements =
+        vec!["CREATE INDEX AlbumsByAlbumTitle2 ON Albums(AlbumTitle) STORING (MarketingBudget)"];
 
-    println!("Adding MarketingBudget column to Albums...");
+    println!("Creating AlbumsByAlbumTitle2 storing index...");
     admin_client
         .update_database_ddl()
         .set_database(database_name)
@@ -28,7 +29,7 @@ pub async fn sample(admin_client: &DatabaseAdmin, database_name: &str) -> anyhow
         .until_done()
         .await?;
 
-    println!("Added MarketingBudget column");
+    println!("Added AlbumsByAlbumTitle2 index");
     Ok(())
 }
-// [END spanner_postgresql_add_column]
+// [END spanner_create_storing_index]

--- a/src/spanner/examples/src/database/mod.rs
+++ b/src/spanner/examples/src/database/mod.rs
@@ -15,6 +15,8 @@
 pub mod add_column;
 pub mod create_database;
 pub mod create_index;
+pub mod create_storing_index;
 pub mod pg_add_column;
 pub mod pg_create_database;
 pub mod pg_create_index;
+pub mod pg_create_storing_index;

--- a/src/spanner/examples/src/database/pg_create_storing_index.rs
+++ b/src/spanner/examples/src/database/pg_create_storing_index.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START spanner_postgresql_add_column]
+// [START spanner_postgresql_create_storing_index]
 use google_cloud_lro::Poller;
 use google_cloud_spanner_admin_database_v1::client::DatabaseAdmin;
 
 pub async fn sample(admin_client: &DatabaseAdmin, database_name: &str) -> anyhow::Result<()> {
-    let statements = vec!["ALTER TABLE Albums ADD COLUMN MarketingBudget bigint"];
+    let statements =
+        vec!["CREATE INDEX AlbumsByAlbumTitle2 ON Albums(AlbumTitle) INCLUDE (MarketingBudget)"];
 
-    println!("Adding MarketingBudget column to Albums...");
+    println!("Creating AlbumsByAlbumTitle2 storing index...");
     admin_client
         .update_database_ddl()
         .set_database(database_name)
@@ -28,7 +29,7 @@ pub async fn sample(admin_client: &DatabaseAdmin, database_name: &str) -> anyhow
         .until_done()
         .await?;
 
-    println!("Added MarketingBudget column");
+    println!("Added AlbumsByAlbumTitle2 index");
     Ok(())
 }
-// [END spanner_postgresql_add_column]
+// [END spanner_postgresql_create_storing_index]

--- a/src/spanner/examples/src/query/mod.rs
+++ b/src/spanner/examples/src/query/mod.rs
@@ -15,9 +15,11 @@
 pub mod pg_query_new_column;
 pub mod pg_query_parameter;
 pub mod pg_read_data_with_index;
+pub mod pg_read_data_with_storing_index;
 pub mod pg_read_only_transaction;
 pub mod query_data;
 pub mod query_new_column;
 pub mod query_parameter;
 pub mod read_data_with_index;
+pub mod read_data_with_storing_index;
 pub mod read_only_transaction;

--- a/src/spanner/examples/src/query/pg_read_data_with_storing_index.rs
+++ b/src/spanner/examples/src/query/pg_read_data_with_storing_index.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_postgresql_read_data_with_storing_index]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::key::KeySet;
+use google_cloud_spanner::read::ReadRequest;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let read_request = ReadRequest::builder("Albums", ["AlbumId", "AlbumTitle", "MarketingBudget"])
+        .with_index("AlbumsByAlbumTitle2", KeySet::all())
+        .build();
+
+    let transaction = client.single_use().build();
+    let mut result_set = transaction.execute_read(read_request).await?;
+
+    while let Some(row) = result_set.next().await.transpose()? {
+        let album_id: i64 = row.get(0);
+        let album_title: String = row.get(1);
+        let marketing_budget: Option<i64> = row.get(2);
+
+        match marketing_budget {
+            Some(budget) => println!("{album_id} {album_title} {budget}"),
+            None => println!("{album_id} {album_title} NULL"),
+        }
+    }
+
+    Ok(())
+}
+// [END spanner_postgresql_read_data_with_storing_index]

--- a/src/spanner/examples/src/query/read_data_with_storing_index.rs
+++ b/src/spanner/examples/src/query/read_data_with_storing_index.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_read_data_with_storing_index]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::key::KeySet;
+use google_cloud_spanner::read::ReadRequest;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let read_request = ReadRequest::builder("Albums", ["AlbumId", "AlbumTitle", "MarketingBudget"])
+        .with_index("AlbumsByAlbumTitle2", KeySet::all())
+        .build();
+
+    let transaction = client.single_use().build();
+    let mut result_set = transaction.execute_read(read_request).await?;
+
+    while let Some(row) = result_set.next().await.transpose()? {
+        let album_id: i64 = row.get(0);
+        let album_title: String = row.get(1);
+        let marketing_budget: Option<i64> = row.get(2);
+
+        match marketing_budget {
+            Some(budget) => println!("{album_id} {album_title} {budget}"),
+            None => println!("{album_id} {album_title} NULL"),
+        }
+    }
+
+    Ok(())
+}
+// [END spanner_read_data_with_storing_index]

--- a/src/spanner/examples/tests/integration.rs
+++ b/src/spanner/examples/tests/integration.rs
@@ -111,6 +111,16 @@ mod tests {
                 .await
                 .inspect_err(anydump)?;
 
+            // 7b. Test spanner_create_storing_index sample
+            database::create_storing_index::sample(&ctx.admin_client, &ctx.database_name)
+                .await
+                .inspect_err(anydump)?;
+
+            // 7c. Test spanner_read_data_with_storing_index sample
+            query::read_data_with_storing_index::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
             // 8. Test spanner_read_only_transaction sample
             query::read_only_transaction::sample(client)
                 .await
@@ -162,6 +172,16 @@ mod tests {
 
             // 5. Test spanner_postgresql_query_data_with_new_column sample
             query::pg_query_new_column::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
+            // 5b. Test spanner_postgresql_create_storing_index sample
+            database::pg_create_storing_index::sample(&ctx.admin_client, &ctx.database_name)
+                .await
+                .inspect_err(anydump)?;
+
+            // 5c. Test spanner_postgresql_read_data_with_storing_index sample
+            query::pg_read_data_with_storing_index::sample(client)
                 .await
                 .inspect_err(anydump)?;
 


### PR DESCRIPTION
Adds samples for creating secondary indexes with storing columns and for using these indexes to execute read operations.