### PR TITLE
impl(bigquery): bubble up `JobPoller` errors instead of returning `Ok`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,6 +2171,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -309,10 +309,9 @@ libraries:
           match: |2
                 - `folders/<folder-number>`
                 - `organizations/<organization-number>`
-          replace: |+
+          replace: |
             - `folders/<folder-number>`
             - `organizations/<organization-number>`
-
   - name: google-cloud-api-servicemanagement-v1
     version: 1.13.0
     apis:
@@ -524,6 +523,9 @@ libraries:
     skip_release: true
     rust:
       package_dependencies:
+        - name: thiserror
+          package: thiserror
+          force_used: true
         - name: tokio
           package: tokio
           force_used: true

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -132,12 +132,11 @@ async fn non_retryable_error() -> anyhow::Result<()> {
     let result = poller.until_done().await;
 
     // Should return immediately after 1st attempt
-    let JobPollerError::Job(failed_job) = result.unwrap_err() else {
-        panic!("expected JobPollerError::Job");
+    let JobPollerError::ErrorProto(err) = result.unwrap_err() else {
+        panic!("expected JobPollerError::ErrorProto");
     };
 
-    let status = failed_job.status.unwrap();
-    assert_eq!(status.error_result.unwrap().reason.as_str(), "invalidQuery");
+    assert_eq!(err.reason.as_str(), "invalidQuery");
     Ok(())
 }
 
@@ -155,15 +154,11 @@ async fn retry_exhausted() -> anyhow::Result<()> {
     let result = poller.until_done().await;
 
     // Should stop retrying after limit of 3
-    let JobPollerError::Job(failed_job) = result.unwrap_err() else {
-        panic!("expected JobPollerError::Job");
+    let JobPollerError::ErrorProto(err) = result.unwrap_err() else {
+        panic!("expected JobPollerError::ErrorProto");
     };
 
-    let status = failed_job.status.unwrap();
-    assert_eq!(
-        status.error_result.unwrap().reason.as_str(),
-        "jobBackendError"
-    );
+    assert_eq!(err.reason.as_str(), "jobBackendError");
     Ok(())
 }
 

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -14,6 +14,7 @@
 
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::{ErrorProto, InsertJobRequest, Job, JobReference, JobStatus};
+use google_cloud_bigquery_v2::operation::JobPollerError;
 use google_cloud_bigquery_v2::stub::JobService as JobServiceStub;
 use google_cloud_gax::Result as GaxResult;
 use google_cloud_gax::options::RequestOptions;
@@ -28,6 +29,12 @@ mock! {
         async fn insert_job(
             &self,
             req: InsertJobRequest,
+            options: RequestOptions,
+        ) -> GaxResult<Response<Job>>;
+
+        async fn get_job(
+            &self,
+            req: google_cloud_bigquery_v2::model::GetJobRequest,
             options: RequestOptions,
         ) -> GaxResult<Response<Job>>;
     }
@@ -122,13 +129,15 @@ async fn non_retryable_error() -> anyhow::Result<()> {
 
     let client = JobService::from_stub(mock);
     let poller = client.insert_job().into_job_poller();
-    let result = poller.until_done().await?;
+    let result = poller.until_done().await;
 
     // Should return immediately after 1st attempt
-    assert_eq!(
-        result.status.unwrap().error_result.unwrap().reason.as_str(),
-        "invalidQuery"
-    );
+    let JobPollerError::Job(failed_job) = result.unwrap_err() else {
+        panic!("expected JobPollerError::Job");
+    };
+
+    let status = failed_job.status.unwrap();
+    assert_eq!(status.error_result.unwrap().reason.as_str(), "invalidQuery");
     Ok(())
 }
 
@@ -144,14 +153,57 @@ async fn retry_exhausted() -> anyhow::Result<()> {
     let poller = client
         .insert_job()
         .into_job_poller()
-        .set_job_level_attempt_limit(3);
+        .with_attempt_limit(3);
+
+    let result = poller.until_done().await;
+
+    // Should stop retrying after limit of 3
+    let JobPollerError::Job(failed_job) = result.unwrap_err() else {
+        panic!("expected JobPollerError::Job");
+    };
+
+    let status = failed_job.status.unwrap();
+    assert_eq!(
+        status.error_result.unwrap().reason.as_str(),
+        "jobBackendError"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn polling_success() -> anyhow::Result<()> {
+    let mut mock = MockTestJobService::new();
+    let mut seq = Sequence::new();
+
+    mock.expect_insert_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .return_once(move |_, _| {
+            Ok(Response::from(
+                Job::new()
+                    .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-running"))
+                    .set_status(JobStatus::new().set_state("RUNNING")),
+            ))
+        });
+
+    mock.expect_get_job()
+        .times(1)
+        .in_sequence(&mut seq)
+        .return_once(move |req, _| {
+            assert_eq!(req.job_id, "job-running");
+            Ok(Response::from(
+                Job::new()
+                    .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-running"))
+                    .set_status(JobStatus::new().set_state("DONE")),
+            ))
+        });
+
+    let client = JobService::from_stub(mock);
+    let poller = client.insert_job().into_job_poller();
 
     let result = poller.until_done().await?;
 
-    // Should stop retrying after limit of 3
-    assert_eq!(
-        result.status.unwrap().error_result.unwrap().reason.as_str(),
-        "jobBackendError"
-    );
+    let status = result.status.unwrap();
+    assert_eq!(status.state.as_str(), "DONE");
     Ok(())
 }

--- a/src/bigquery/tests/job_poller_tests.rs
+++ b/src/bigquery/tests/job_poller_tests.rs
@@ -150,10 +150,7 @@ async fn retry_exhausted() -> anyhow::Result<()> {
         .returning(move |_, _| Ok(Response::from(transient_job_failure("job-unknown"))));
 
     let client = JobService::from_stub(mock);
-    let poller = client
-        .insert_job()
-        .into_job_poller()
-        .with_attempt_limit(3);
+    let poller = client.insert_job().into_job_poller().with_attempt_limit(3);
 
     let result = poller.until_done().await;
 
@@ -181,7 +178,11 @@ async fn polling_success() -> anyhow::Result<()> {
         .return_once(move |_, _| {
             Ok(Response::from(
                 Job::new()
-                    .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-running"))
+                    .set_job_reference(
+                        JobReference::new()
+                            .set_project_id("p1")
+                            .set_job_id("job-running"),
+                    )
                     .set_status(JobStatus::new().set_state("RUNNING")),
             ))
         });
@@ -193,7 +194,11 @@ async fn polling_success() -> anyhow::Result<()> {
             assert_eq!(req.job_id, "job-running");
             Ok(Response::from(
                 Job::new()
-                    .set_job_reference(JobReference::new().set_project_id("p1").set_job_id("job-running"))
+                    .set_job_reference(
+                        JobReference::new()
+                            .set_project_id("p1")
+                            .set_job_id("job-running"),
+                    )
                     .set_status(JobStatus::new().set_state("DONE")),
             ))
         });

--- a/src/generated/api/servicecontrol/v2/src/model.rs
+++ b/src/generated/api/servicecontrol/v2/src/model.rs
@@ -192,9 +192,8 @@ pub struct ResourceInfo {
     ///
     /// - `folders/<folder-number>`
     /// - `organizations/<organization-number>`
-    ///
-    /// Required for the policy enforcement on the container level (e.g. VPCSC,
-    /// Location Policy check, Org Policy check).
+    ///   Required for the policy enforcement on the container level (e.g. VPCSC,
+    ///   Location Policy check, Org Policy check).
     pub container: std::string::String,
 
     /// Optional. The location of the resource, it must be a valid zone, region or

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -51,6 +51,7 @@ google-cloud-type.workspace = true
 serde.workspace             = true
 serde_json.workspace        = true
 serde_with.workspace        = true
+thiserror.workspace         = true
 tokio.workspace             = true
 tracing.workspace           = true
 uuid.workspace              = true

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -29,6 +29,7 @@ extern crate serde;
 extern crate serde_json;
 extern crate serde_with;
 extern crate std;
+extern crate thiserror;
 extern crate tokio;
 extern crate tracing;
 extern crate uuid;

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -95,9 +95,9 @@ pub enum JobPollerError {
     /// An error occurred during the RPC or LRO polling.
     #[error(transparent)]
     Rpc(#[from] GaxError),
-    /// The job completed, but the BigQuery service reported an error in `status.error_result`.
+    /// The job completed, but the BigQuery service reported an internal error.
     #[error("BigQuery job failed ({}): {}", .0.reason, .0.message)]
-    Job(crate::model::ErrorProto),
+    ErrorProto(crate::model::ErrorProto),
 }
 
 /// A poller that monitors the status of an inserted BigQuery job and handles retries.
@@ -156,7 +156,7 @@ impl JobPoller {
                     tokio::time::sleep(delay).await;
                     continue;
                 }
-                return Err(JobPollerError::Job(err.clone()));
+                return Err(JobPollerError::ErrorProto(err.clone()));
             }
             return Ok(job_result);
         }

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -15,8 +15,8 @@
 use crate::builder::job_service::InsertJob;
 use crate::model::Job;
 use google_cloud_gax::backoff_policy::BackoffPolicy;
-use google_cloud_gax::error::rpc::{Code, Status};
 use google_cloud_gax::error::Error as GaxError;
+use google_cloud_gax::error::rpc::{Code, Status};
 use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 use google_cloud_gax::retry_state::RetryState;
 use google_cloud_lro::Poller;
@@ -179,7 +179,7 @@ impl JobPoller {
 
                     let retry_state = RetryState::new(true)
                         .set_start(start_time)
-                        .set_attempt_count(attempts as u32);
+                        .set_attempt_count(attempts);
                     let delay = backoff.on_failure(&retry_state);
                     tokio::time::sleep(delay).await;
                     continue;

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -90,42 +90,14 @@ impl Default for JobRetryPolicy {
 }
 
 /// Errors returned by the JobPoller.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum JobPollerError {
     /// An error occurred during the RPC or LRO polling.
-    Gax(GaxError),
+    #[error(transparent)]
+    Rpc(#[from] GaxError),
     /// The job completed, but the BigQuery service reported an error in `status.error_result`.
-    Job(Box<Job>),
-}
-
-impl std::fmt::Display for JobPollerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Gax(e) => write!(f, "{}", e),
-            Self::Job(job) => {
-                if let Some(err) = job.status.as_ref().and_then(|s| s.error_result.as_ref()) {
-                    write!(f, "BigQuery job failed ({}): {}", err.reason, err.message)
-                } else {
-                    write!(f, "BigQuery job failed: unknown error")
-                }
-            }
-        }
-    }
-}
-
-impl std::error::Error for JobPollerError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Gax(e) => Some(e),
-            Self::Job(_) => None,
-        }
-    }
-}
-
-impl From<GaxError> for JobPollerError {
-    fn from(e: GaxError) -> Self {
-        Self::Gax(e)
-    }
+    #[error("BigQuery job failed ({}): {}", .0.reason, .0.message)]
+    Job(crate::model::ErrorProto),
 }
 
 /// A poller that monitors the status of an inserted BigQuery job and handles retries.
@@ -184,7 +156,7 @@ impl JobPoller {
                     tokio::time::sleep(delay).await;
                     continue;
                 }
-                return Err(JobPollerError::Job(Box::new(job_result)));
+                return Err(JobPollerError::Job(err.clone()));
             }
             return Ok(job_result);
         }
@@ -197,9 +169,6 @@ impl InsertJob {
     /// If the job fails with an internal error, the `JobPoller` will retry the
     /// `InsertJob` operation. Note that the client library will supply a
     /// synthetic job ID for any retries.
-    ///
-    /// WARNING: Unlike `poller()`, the `JobPoller` will return an error if the
-    /// final job completes with an `error_result` in its status.
     ///
     /// ```no_run
     /// # async fn example(builder: google_cloud_bigquery_v2::builder::job_service::InsertJob) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/generated/cloud/bigquery/v2/src/operation.rs
+++ b/src/generated/cloud/bigquery/v2/src/operation.rs
@@ -14,9 +14,9 @@
 
 use crate::builder::job_service::InsertJob;
 use crate::model::Job;
-use google_cloud_gax::Result as GaxResult;
 use google_cloud_gax::backoff_policy::BackoffPolicy;
 use google_cloud_gax::error::rpc::{Code, Status};
+use google_cloud_gax::error::Error as GaxError;
 use google_cloud_gax::exponential_backoff::ExponentialBackoff;
 use google_cloud_gax::retry_state::RetryState;
 use google_cloud_lro::Poller;
@@ -75,7 +75,7 @@ pub(crate) fn prepare_job_for_retry(mut job: Job) -> Job {
 #[derive(Debug)]
 pub(crate) struct JobRetryPolicy {
     /// Maximum number of general job-level attempts for retryable job errors.
-    pub job_level_attempt_limit: usize,
+    pub job_level_attempt_limit: u32,
     /// Backoff strategy between retry attempts.
     pub backoff: ExponentialBackoff,
 }
@@ -86,6 +86,45 @@ impl Default for JobRetryPolicy {
             job_level_attempt_limit: 3,
             backoff: ExponentialBackoff::default(),
         }
+    }
+}
+
+/// Errors returned by the JobPoller.
+#[derive(Debug)]
+pub enum JobPollerError {
+    /// An error occurred during the RPC or LRO polling.
+    Gax(GaxError),
+    /// The job completed, but the BigQuery service reported an error in `status.error_result`.
+    Job(Box<Job>),
+}
+
+impl std::fmt::Display for JobPollerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Gax(e) => write!(f, "{}", e),
+            Self::Job(job) => {
+                if let Some(err) = job.status.as_ref().and_then(|s| s.error_result.as_ref()) {
+                    write!(f, "BigQuery job failed ({}): {}", err.reason, err.message)
+                } else {
+                    write!(f, "BigQuery job failed: unknown error")
+                }
+            }
+        }
+    }
+}
+
+impl std::error::Error for JobPollerError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Gax(e) => Some(e),
+            Self::Job(_) => None,
+        }
+    }
+}
+
+impl From<GaxError> for JobPollerError {
+    fn from(e: GaxError) -> Self {
+        Self::Gax(e)
     }
 }
 
@@ -105,7 +144,7 @@ impl JobPoller {
     }
 
     /// Sets the maximum number of job-level attempts.
-    pub fn set_job_level_attempt_limit(mut self, limit: usize) -> Self {
+    pub fn with_attempt_limit(mut self, limit: u32) -> Self {
         self.policy.job_level_attempt_limit = limit;
         self
     }
@@ -117,31 +156,35 @@ impl JobPoller {
     }
 
     /// Polls the job until it is done, returning the final Job status.
-    pub async fn until_done(self) -> GaxResult<Job> {
-        let mut attempts = 0;
+    pub async fn until_done(self) -> Result<Job, JobPollerError> {
+        let mut attempts = 0_u32;
         let mut builder = self.builder;
         let backoff = self.policy.backoff;
         let start_time = std::time::Instant::now();
 
         loop {
-            attempts += 1;
-
+            // NOTE: the client library intercepts errors and retries internally
+            // according to the policies set on `builder`.
             let job_result = builder.clone().poller().until_done().await?;
+            attempts += 1;
 
             if let Some(status) = &job_result.status
                 && let Some(err) = &status.error_result
-                && is_retryable_job_error(&err.reason)
-                && attempts < self.policy.job_level_attempt_limit
             {
-                let retry_job = prepare_job_for_retry(job_result);
-                builder = builder.set_job(retry_job);
+                if is_retryable_job_error(&err.reason)
+                    && attempts < self.policy.job_level_attempt_limit
+                {
+                    let retry_job = prepare_job_for_retry(job_result);
+                    builder = builder.set_job(retry_job);
 
-                let retry_state = RetryState::new(true)
-                    .set_start(start_time)
-                    .set_attempt_count(attempts as u32);
-                let delay = backoff.on_failure(&retry_state);
-                tokio::time::sleep(delay).await;
-                continue;
+                    let retry_state = RetryState::new(true)
+                        .set_start(start_time)
+                        .set_attempt_count(attempts as u32);
+                    let delay = backoff.on_failure(&retry_state);
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                return Err(JobPollerError::Job(Box::new(job_result)));
             }
             return Ok(job_result);
         }
@@ -154,6 +197,9 @@ impl InsertJob {
     /// If the job fails with an internal error, the `JobPoller` will retry the
     /// `InsertJob` operation. Note that the client library will supply a
     /// synthetic job ID for any retries.
+    ///
+    /// WARNING: Unlike `poller()`, the `JobPoller` will return an error if the
+    /// final job completes with an `error_result` in its status.
     ///
     /// ```no_run
     /// # async fn example(builder: google_cloud_bigquery_v2::builder::job_service::InsertJob) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Update `JobPoller::until_done` to surface errors when a job completes with a failure in its `status.error_result`.

Previously, `until_done` would return `Ok(job)` even if the job ultimately completed with an error state (as long as the underlying RPC succeeded). This updates the behavior to return a dedicated error type.

Fixes #6199