### PR TITLE
chore(bigquery): do not publish crates

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -484,12 +484,12 @@ libraries:
     version: 0.16.0-preview
     copyright_year: "2026"
     output: src/bigquery
+    skip_release: true
     rust:
       modules:
         - output: src/bigquery/src/generated
           api_path: google/cloud/bigquery/v2
           template: bigquery
-    skip_release: true
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.13.0
     copyright_year: "2025"
@@ -521,6 +521,7 @@ libraries:
     copyright_year: "2025"
     keep:
       - src/operation.rs
+    skip_release: true
     rust:
       package_dependencies:
         - name: tokio
@@ -529,7 +530,6 @@ libraries:
         - name: uuid
           package: uuid
           force_used: true
-    skip_release: true
   - name: google-cloud-bigquery-write
     copyright_year: "2026"
     output: src/bigquery-write

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -489,6 +489,7 @@ libraries:
         - output: src/bigquery/src/generated
           api_path: google/cloud/bigquery/v2
           template: bigquery
+    skip_release: true
   - name: google-cloud-bigquery-analyticshub-v1
     version: 1.13.0
     copyright_year: "2025"
@@ -508,6 +509,7 @@ libraries:
     version: 0.1.0-preview
     copyright_year: "2026"
     output: src/bigquery-derive
+    skip_release: true
   - name: google-cloud-bigquery-migration-v2
     version: 1.11.0
     copyright_year: "2025"
@@ -527,7 +529,7 @@ libraries:
         - name: uuid
           package: uuid
           force_used: true
-      package_name_override: google-cloud-bigquery-v2
+    skip_release: true
   - name: google-cloud-bigquery-write
     copyright_year: "2026"
     output: src/bigquery-write

--- a/src/bigquery-derive/Cargo.toml
+++ b/src/bigquery-derive/Cargo.toml
@@ -23,7 +23,7 @@ repository.workspace   = true
 keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
-publish                = true
+publish                = false
 
 [lib]
 proc-macro = true

--- a/src/bigquery/Cargo.toml
+++ b/src/bigquery/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-bigquery"
-publish     = true
+publish     = false
 version     = "0.16.0-preview"
 description = "Google Cloud Client Libraries for Rust - BigQuery"
 # Inherit other attributes from the workspace.

--- a/src/generated/cloud/bigquery/v2/Cargo.toml
+++ b/src/generated/cloud/bigquery/v2/Cargo.toml
@@ -25,6 +25,7 @@ repository.workspace   = true
 keywords.workspace     = true
 categories.workspace   = true
 rust-version.workspace = true
+publish                = false
 
 [lints]
 workspace = true


### PR DESCRIPTION
We can be extra conservative with these crates and publish them in the August release.