### PR TITLE
chore(spanner): configure instance type via builder extension

### DIFF
--- a/src/spanner/src/builder.rs
+++ b/src/spanner/src/builder.rs
@@ -18,6 +18,7 @@ pub use crate::batch_dml::BatchDmlBuilder;
 pub use crate::batch_read_only_transaction::BatchReadOnlyTransactionBuilder;
 pub use crate::batch_write_transaction::BatchWriteTransactionBuilder;
 pub use crate::client::ClientBuilder as SpannerBuilder;
+pub use crate::client::SpannerBuilderExt;
 pub use crate::database_client::DatabaseClientBuilder;
 pub use crate::key::KeySetBuilder;
 pub use crate::mutation::WriteBuilder;

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -97,18 +97,48 @@ impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
             channels.push(Channel::create(&config).await?);
         }
 
+        let instance_type = config
+            .extensions
+            .get::<InstanceType>()
+            .copied()
+            .unwrap_or_default();
+
         Ok(Spanner {
             channels,
             counter: std::sync::Arc::new(AtomicUsize::new(0)),
             config,
             is_emulator,
-            instance_type: InstanceType::Cloud,
+            instance_type,
         })
     }
 }
 
 /// A builder for the Spanner client.
 pub type ClientBuilder = google_cloud_gax::client_builder::ClientBuilder<Factory, Credentials>;
+
+/// Extension trait for [`ClientBuilder`] (also exported as `SpannerBuilder`) to configure Spanner-specific options.
+pub trait SpannerBuilderExt {
+    /// Sets the target [`InstanceType`] (`Cloud` vs `Omni`) for the Spanner client.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_spanner::client::{Spanner, SpannerBuilderExt};
+    /// # use google_cloud_spanner::omni::InstanceType;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = Spanner::builder()
+    ///     .with_instance_type(InstanceType::Omni)
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
+    fn with_instance_type(self, instance_type: InstanceType) -> Self;
+}
+
+impl SpannerBuilderExt for ClientBuilder {
+    fn with_instance_type(self, instance_type: InstanceType) -> Self {
+        self.with_extension(instance_type)
+    }
+}
 
 fn parse_emulator_endpoint(endpoint: &str) -> String {
     match url::Url::parse(endpoint) {
@@ -213,28 +243,6 @@ impl Spanner {
     /// environment variable is set.
     pub fn builder() -> ClientBuilder {
         new_builder(Factory)
-    }
-
-    /// Sets the target instance deployment type (`Cloud` or `Omni`).
-    ///
-    /// # Warning
-    ///
-    /// **Experimental:** This method is experimental and may be updated or replaced in a future release.
-    ///
-    /// # Example
-    /// ```
-    /// # use google_cloud_spanner::client::Spanner;
-    /// # use google_cloud_spanner::omni::InstanceType;
-    /// # async fn sample() -> anyhow::Result<()> {
-    /// let client = Spanner::builder()
-    ///     .build()
-    ///     .await?
-    ///     .with_instance_type(InstanceType::Omni);
-    /// # Ok(()) }
-    /// ```
-    pub fn with_instance_type(mut self, instance_type: InstanceType) -> Self {
-        self.instance_type = instance_type;
-        self
     }
 
     /// Returns a builder for the [DatabaseAdmin] client.

--- a/src/spanner/src/omni.rs
+++ b/src/spanner/src/omni.rs
@@ -14,6 +14,8 @@
 
 //! Spanner Omni instance types and configuration utilities.
 
+pub use crate::client::SpannerBuilderExt;
+
 /// Specifies the type of Spanner instance to connect to (`Cloud` or `Omni`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[non_exhaustive]
@@ -106,10 +108,10 @@ mod tests {
     #[tokio::test]
     async fn test_spanner_with_instance_type() {
         let spanner = Spanner::builder()
+            .with_instance_type(InstanceType::Omni)
             .build()
             .await
-            .expect("build client")
-            .with_instance_type(InstanceType::Omni);
+            .expect("build client");
         assert_eq!(spanner.instance_type(), InstanceType::Omni);
     }
 
@@ -118,10 +120,10 @@ mod tests {
     async fn test_query_local_omni_instance() {
         let spanner = Spanner::builder()
             .with_endpoint("http://localhost:15000")
+            .with_instance_type(InstanceType::Omni)
             .build()
             .await
-            .expect("build client")
-            .with_instance_type(InstanceType::Omni);
+            .expect("build client");
 
         let db_client = spanner
             .database_client("retail-sample")


### PR DESCRIPTION
Replace the post-build `Spanner::with_instance_type` mutator method with a `Spanner::builder()` configuration option using GAX extensions.