### PR TITLE
test(bigquery): add integration tests for job polling

### DIFF
--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -129,6 +129,87 @@ async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()>
     Ok(())
 }
 
+pub async fn job_service_poller() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().with_tracing().build().await?;
+    cleanup_stale_jobs(&client, &project_id).await?;
+
+    let job_id = random_job_id();
+    println!("CREATING JOB (WITH POLLER) ID: {job_id}");
+
+    let query = "SELECT 1 as one";
+
+    // Use the job poller extension to insert and poll the job until completion.
+    let job = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(JobConfigurationQuery::new().set_query(query)),
+                ),
+        )
+        .into_job_poller()
+        .until_done()
+        .await?;
+
+    println!("CREATE JOB (POLLED) = {job:?}");
+
+    assert!(job.job_reference.is_some(), "{job:?}");
+    let status = job.status.as_ref().expect("job should have status");
+    assert_eq!(status.state.as_str(), "DONE", "job state should be DONE");
+    assert!(
+        status.error_result.is_none(),
+        "job completed with unexpected error_result: {:?}",
+        status.error_result
+    );
+
+    Ok(())
+}
+
+pub async fn job_service_poller_error() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().with_tracing().build().await?;
+
+    let job_id = random_job_id();
+    let query = "SELECT * FROM `non_existent_dataset_12345.non_existent_table_67890`";
+
+    let result = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(JobConfigurationQuery::new().set_query(query)),
+                ),
+        )
+        .into_job_poller()
+        .until_done()
+        .await;
+
+    let err = result.expect_err("expected job polling to return error");
+    match err {
+        google_cloud_bigquery_v2::operation::JobPollerError::ErrorProto(proto) => {
+            assert!(
+                !proto.reason.is_empty(),
+                "expected non-empty error reason in ErrorProto"
+            );
+        }
+        google_cloud_bigquery_v2::operation::JobPollerError::Rpc(rpc_err) => {
+            panic!(
+                "expected JobPollerError::ErrorProto from BigQuery job, got RPC error: {rpc_err:?}"
+            );
+        }
+    }
+
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -131,7 +131,7 @@ async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()>
 
 pub async fn job_service_poller() -> Result<()> {
     let project_id = project_id()?;
-    let client = JobService::builder().with_tracing().build().await?;
+    let client = JobService::builder().build().await?;
     cleanup_stale_jobs(&client, &project_id).await?;
 
     let job_id = random_job_id();
@@ -172,7 +172,7 @@ pub async fn job_service_poller() -> Result<()> {
 
 pub async fn job_service_poller_error() -> Result<()> {
     let project_id = project_id()?;
-    let client = JobService::builder().with_tracing().build().await?;
+    let client = JobService::builder().build().await?;
 
     let job_id = random_job_id();
     let query = "SELECT * FROM `non_existent_dataset_12345.non_existent_table_67890`";

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -160,7 +160,7 @@ pub async fn job_service_poller() -> Result<()> {
 
     assert!(job.job_reference.is_some(), "{job:?}");
     let status = job.status.as_ref().expect("job should have status");
-    assert_eq!(status.state.as_str(), "DONE", "job state should be DONE");
+    assert_eq!(status.state.as_str(), "DONE");
     assert!(
         status.error_result.is_none(),
         "job completed with unexpected error_result: {:?}",

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -223,6 +223,88 @@ pub async fn job_service() -> Result<()> {
     Ok(())
 }
 
+pub async fn job_service_poller() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().with_tracing().build().await?;
+    cleanup_stale_jobs(&client, &project_id).await?;
+
+    let job_id = random_job_id();
+    println!("CREATING JOB (WITH POLLER) ID: {job_id}");
+
+    let query = "SELECT 1 as one";
+
+    // Use the job poller extension to insert and poll the job until completion.
+    let job = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(JobConfigurationQuery::new().set_query(query)),
+                ),
+        )
+        .into_job_poller()
+        .until_done()
+        .await?;
+
+    println!("CREATE JOB (POLLED) = {job:?}");
+
+    assert!(job.job_reference.is_some(), "{job:?}");
+    let status = job.status.as_ref().expect("job should have status");
+    assert_eq!(status.state.as_str(), "DONE", "job state should be DONE");
+    assert!(
+        status.error_result.is_none(),
+        "job completed with unexpected error_result: {:?}",
+        status.error_result
+    );
+
+    Ok(())
+}
+
+pub async fn job_service_poller_error() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().with_tracing().build().await?;
+
+    let job_id = random_job_id();
+    let query = "SELECT * FROM `non_existent_dataset_12345.non_existent_table_67890`";
+
+    let result = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(JobConfigurationQuery::new().set_query(query)),
+                ),
+        )
+        .into_job_poller()
+        .until_done()
+        .await;
+
+    let err = result.expect_err("expected job polling to return error");
+    match err {
+        google_cloud_bigquery_v2::operation::JobPollerError::ErrorProto(proto) => {
+            assert!(
+                !proto.reason.is_empty(),
+                "expected non-empty error reason in ErrorProto"
+            );
+        }
+        google_cloud_bigquery_v2::operation::JobPollerError::Rpc(rpc_err) => {
+            panic!(
+                "expected JobPollerError::ErrorProto from BigQuery job, got RPC error: {rpc_err:?}"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn query_client() -> Result<()> {
     let project_id = project_id()?;
     let bq = BigQuery::builder().build().await?;

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -22,7 +22,7 @@ use rand::{RngExt, distr::Alphanumeric};
 const INSTANCE_LABEL: &str = "rust-sdk-integration-test";
 
 pub use dataset::dataset_admin;
-pub use job::job_service;
+pub use job::{job_service, job_service_poller, job_service_poller_error};
 pub use query::{
     query_client, query_client_datatypes, query_client_job, query_client_multi_page,
     query_client_nested_types, query_client_numeric_limits,

--- a/tests/bigquery/tests/driver.rs
+++ b/tests/bigquery/tests/driver.rs
@@ -80,4 +80,20 @@ mod bigquery {
             .await
             .inspect_err(anydump)
     }
+
+    #[tokio::test]
+    async fn run_job_service_poller() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::job_service_poller()
+            .await
+            .inspect_err(anydump)
+    }
+
+    #[tokio::test]
+    async fn run_job_service_poller_error() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::job_service_poller_error()
+            .await
+            .inspect_err(anydump)
+    }
 }

--- a/tests/bigquery/tests/driver.rs
+++ b/tests/bigquery/tests/driver.rs
@@ -88,4 +88,20 @@ mod bigquery {
             .await
             .inspect_err(anydump)
     }
+
+    #[tokio::test]
+    async fn run_job_service_poller() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::job_service_poller()
+            .await
+            .inspect_err(anydump)
+    }
+
+    #[tokio::test]
+    async fn run_job_service_poller_error() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::job_service_poller_error()
+            .await
+            .inspect_err(anydump)
+    }
 }


### PR DESCRIPTION
Add live integration tests for `JobPoller` in `google-cloud-bigquery-v2`, covering successful query polling and error handling paths against live BigQuery APIs.

Fixes #5754 