### PR TITLE
chore: bump all versions 2026-07-30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-api-servicecontrol-v2"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -299,7 +299,7 @@ libraries:
       - path: google/api/servicecontrol/v1
     copyright_year: "2025"
   - name: google-cloud-api-servicecontrol-v2
-    version: 1.11.0
+    version: 1.12.0
     apis:
       - path: google/api/servicecontrol/v2
     copyright_year: "2025"

--- a/src/generated/api/servicecontrol/v2/Cargo.toml
+++ b/src/generated/api/servicecontrol/v2/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name                   = "google-cloud-api-servicecontrol-v2"
-version                = "1.11.0"
+version                = "1.12.0"
 description            = "Google Cloud Client Libraries for Rust - Service Control API"
 edition.workspace      = true
 authors.workspace      = true

--- a/src/generated/api/servicecontrol/v2/README.md
+++ b/src/generated/api/servicecontrol/v2/README.md
@@ -27,8 +27,8 @@ The main types to work with this crate are the clients:
 
 ## More Information
 
-- Read the [crate's documentation](https://docs.rs/google-cloud-api-servicecontrol-v2/1.11.0)
+- Read the [crate's documentation](https://docs.rs/google-cloud-api-servicecontrol-v2/1.12.0)
 
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 [ring]: https://crates.io/crates/ring
-[ServiceController]: https://docs.rs/google-cloud-api-servicecontrol-v2/1.11.0/google_cloud_api_servicecontrol_v2/client/struct.ServiceController.html
+[ServiceController]: https://docs.rs/google-cloud-api-servicecontrol-v2/1.12.0/google_cloud_api_servicecontrol_v2/client/struct.ServiceController.html


### PR DESCRIPTION
Bump all versions again

```
go run github.com/googleapis/librarian/cmd/librarian@${V} bump -all 
go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all  
```