### PR TITLE
fix(deps): specify version for google-cloud-monitoring-v3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -541,6 +541,7 @@ google-cloud-identity-accesscontextmanager-type = { default-features = false, ve
 google-cloud-identity-accesscontextmanager-v1   = { default-features = false, version = "1.12.0", path = "src/generated/identity/accesscontextmanager/v1" }
 google-cloud-kms-v1                             = { default-features = false, version = "1.13.0", path = "src/generated/cloud/kms/v1" }
 google-cloud-logging-type                       = { default-features = false, version = "1.6.0", path = "src/generated/logging/type" }
+google-cloud-monitoring-v3                      = { default-features = false, version = "1.11.0", path = "src/generated/monitoring/v3" }
 google-cloud-orgpolicy-v1                       = { default-features = false, version = "1.6.0", path = "src/generated/cloud/orgpolicy/v1" }
 google-cloud-orgpolicy-v2                       = { default-features = false, version = "1.11.0", path = "src/generated/cloud/orgpolicy/v2" }
 google-cloud-osconfig-v1                        = { default-features = false, version = "1.12.0", path = "src/generated/cloud/osconfig/v1" }
@@ -566,7 +567,6 @@ google-cloud-iam-credentials-v1      = { default-features = false, path = "src/g
 google-cloud-language-v2             = { default-features = false, path = "src/generated/cloud/language/v2" }
 google-cloud-dns-v1                  = { default-features = false, path = "src/generated/cloud/dns/v1" }
 google-cloud-firestore               = { default-features = false, path = "src/firestore" }
-google-cloud-monitoring-v3           = { default-features = false, path = "src/generated/monitoring/v3" }
 google-cloud-showcase-v1beta1        = { default-features = false, path = "src/generated/showcase" }
 google-cloud-telcoautomation-v1      = { default-features = false, path = "src/generated/cloud/telcoautomation/v1" }
 google-cloud-trace-v1                = { default-features = false, path = "src/generated/devtools/cloudtrace/v1" }


### PR DESCRIPTION
Specifies the version requirement for `google-cloud-monitoring-v3` in the workspace dependencies.

This is required because `google-cloud-spanner` has an optional dependency on `google-cloud-monitoring-v3` (via the `_experimental-builtin-metrics` feature). When publishing `google-cloud-spanner`, Cargo requires all of its dependencies to have a version specified, otherwise it fails manifest verification.
