### PR TITLE
chore(spanner): configure built-in metrics reader

### DIFF
--- a/src/spanner/src/database_client.rs
+++ b/src/spanner/src/database_client.rs
@@ -376,6 +376,7 @@ impl DatabaseClientBuilder {
             Observability::init(
                 &self.spanner.config,
                 self.spanner.instance_type(),
+                self.spanner.is_emulator(),
                 project_id,
             )
             .await,

--- a/src/spanner/src/observability/exporter.rs
+++ b/src/spanner/src/observability/exporter.rs
@@ -160,11 +160,10 @@ async fn send_time_series_batches(
         }
     }
 
-    if let Some(e) = last_error {
-        Err(e)
-    } else {
-        Ok(())
+    if let Some(error) = last_error {
+        return Err(error);
     }
+    Ok(())
 }
 
 fn is_permission_denied(err: &crate::Error) -> bool {

--- a/src/spanner/src/observability/metrics.rs
+++ b/src/spanner/src/observability/metrics.rs
@@ -31,6 +31,17 @@ use {
 use gaxi::options::ClientConfig;
 
 #[cfg(feature = "_experimental-builtin-metrics")]
+pub(crate) const DEFAULT_EXPORT_INTERVAL: Duration = Duration::from_secs(60);
+
+#[cfg(feature = "_experimental-builtin-metrics")]
+pub(crate) const BUCKET_BOUNDARIES: [f64; 50] = [
+    0.0, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+    16.0, 17.0, 18.0, 19.0, 20.0, 25.0, 30.0, 40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0,
+    250.0, 300.0, 400.0, 500.0, 650.0, 800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0,
+    100000.0, 200000.0, 400000.0, 800000.0, 1600000.0, 3200000.0,
+];
+
+#[cfg(feature = "_experimental-builtin-metrics")]
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct SpannerMetrics {
@@ -49,18 +60,22 @@ impl SpannerMetrics {
             operation_latencies: meter
                 .f64_histogram("spanner.googleapis.com/internal/client/operation_latencies")
                 .with_unit("ms")
+                .with_boundaries(BUCKET_BOUNDARIES.to_vec())
                 .build(),
             attempt_latencies: meter
                 .f64_histogram("spanner.googleapis.com/internal/client/attempt_latencies")
                 .with_unit("ms")
+                .with_boundaries(BUCKET_BOUNDARIES.to_vec())
                 .build(),
             gfe_latencies: meter
                 .f64_histogram("spanner.googleapis.com/internal/client/gfe_latencies")
                 .with_unit("ms")
+                .with_boundaries(BUCKET_BOUNDARIES.to_vec())
                 .build(),
             afe_latencies: meter
                 .f64_histogram("spanner.googleapis.com/internal/client/afe_latencies")
                 .with_unit("ms")
+                .with_boundaries(BUCKET_BOUNDARIES.to_vec())
                 .build(),
             operation_count: meter
                 .u64_counter("spanner.googleapis.com/internal/client/operation_count")
@@ -91,12 +106,13 @@ impl Observability {
     pub(crate) async fn init(
         config: &ClientConfig,
         instance_type: InstanceType,
+        is_emulator: bool,
         project_id: Option<&str>,
     ) -> Self {
         let disable_builtin_metrics = std::env::var("SPANNER_DISABLE_BUILTIN_METRICS")
-            .map(|s| s.eq_ignore_ascii_case("true"))
+            .map(|s| s.eq_ignore_ascii_case("true") || s == "1")
             .unwrap_or(false);
-        if disable_builtin_metrics || instance_type == InstanceType::Omni {
+        if disable_builtin_metrics || instance_type == InstanceType::Omni || is_emulator {
             return Self::disabled();
         }
 
@@ -128,8 +144,10 @@ impl Observability {
 
         let exporter = GcpMonitoringExporter::new(monitoring_client, project_id);
 
-        // Set up PeriodicReader
-        let reader = PeriodicReader::builder(exporter).build();
+        // Set up PeriodicReader with a 60-second export interval.
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(DEFAULT_EXPORT_INTERVAL)
+            .build();
 
         let meter_provider = SdkMeterProvider::builder().with_reader(reader).build();
 
@@ -234,13 +252,7 @@ impl Observability {
 fn result_to_status_str<T>(result: &crate::Result<T>) -> &'static str {
     match result {
         Ok(_) => "OK",
-        Err(e) => {
-            if let Some(status) = e.status() {
-                status.code.name()
-            } else {
-                "UNKNOWN"
-            }
-        }
+        Err(e) => e.status().map_or("UNKNOWN", |status| status.code.name()),
     }
 }
 
@@ -257,24 +269,38 @@ pub(crate) fn parse_server_timing(header_val: &str) -> ServerTimings {
     let mut timings = ServerTimings::default();
     for part in header_val.split(',') {
         let mut subparts = part.split(';');
-        if let Some(name) = subparts.next().map(|s| s.trim()) {
-            for param in subparts {
-                let mut kv = param.split('=');
-                let dur_opt = match (kv.next(), kv.next()) {
-                    (Some(k), Some(v)) if k.trim() == "dur" => v.trim().parse::<f64>().ok(),
-                    _ => None,
-                };
-                if let Some(dur) = dur_opt {
-                    match name {
-                        "gfet4t7" => timings.gfe_latency = Some(dur),
-                        "afe" => timings.afe_latency = Some(dur),
-                        _ => {}
-                    }
-                }
+        let Some(name) = subparts.next().map(str::trim) else {
+            continue;
+        };
+        let is_gfe = name.eq_ignore_ascii_case("gfet4t7");
+        let is_afe = name.eq_ignore_ascii_case("afe");
+        if !is_gfe && !is_afe {
+            continue;
+        }
+        if let Some(duration) = subparts.find_map(parse_duration_param) {
+            if is_gfe {
+                timings.gfe_latency = Some(duration);
+            }
+            if is_afe {
+                timings.afe_latency = Some(duration);
             }
         }
     }
     timings
+}
+
+#[cfg(feature = "_experimental-builtin-metrics")]
+fn parse_duration_param(param: &str) -> Option<f64> {
+    let (key, value) = param.split_once('=')?;
+    if !key.trim().eq_ignore_ascii_case("dur") {
+        return None;
+    }
+    value
+        .trim()
+        .trim_matches('"')
+        .parse::<f64>()
+        .ok()
+        .filter(|duration| *duration >= 0.0 && duration.is_finite())
 }
 
 #[cfg(not(feature = "_experimental-builtin-metrics"))]
@@ -291,6 +317,7 @@ impl Observability {
     pub(crate) async fn init(
         _config: &ClientConfig,
         _instance_type: InstanceType,
+        _is_emulator: bool,
         _project_id: Option<&str>,
     ) -> Self {
         Self
@@ -312,6 +339,7 @@ impl Observability {
 #[cfg(all(test, feature = "_experimental-builtin-metrics"))]
 mod tests {
     use super::*;
+    use opentelemetry_sdk::metrics::InMemoryMetricExporter;
 
     #[test]
     fn test_parse_server_timing() {
@@ -339,6 +367,209 @@ mod tests {
         assert_eq!(
             parse_server_timing("invalid_format"),
             ServerTimings::default()
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7;dur=\"12.5\",afe;dur=\"5.0\""),
+            ServerTimings {
+                gfe_latency: Some(12.5),
+                afe_latency: Some(5.0),
+            }
+        );
+        assert_eq!(
+            parse_server_timing("GFET4T7; dur=12.5, Afe; dur=5.0"),
+            ServerTimings {
+                gfe_latency: Some(12.5),
+                afe_latency: Some(5.0),
+            }
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7;dur=-5.0,afe;dur=NaN"),
+            ServerTimings::default()
+        );
+        assert_eq!(
+            parse_server_timing(",,,gfet4t7;dur=10.0,,,"),
+            ServerTimings {
+                gfe_latency: Some(10.0),
+                afe_latency: None,
+            }
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7;dur=inf,afe;dur=Infinity"),
+            ServerTimings::default()
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7;dur=foo;dur=12.5"),
+            ServerTimings {
+                gfe_latency: Some(12.5),
+                afe_latency: None,
+            }
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7; dur = 12.5 , afe; dur = \"5.0\" "),
+            ServerTimings {
+                gfe_latency: Some(12.5),
+                afe_latency: Some(5.0),
+            }
+        );
+        assert_eq!(
+            parse_server_timing("gfet4t7;dur=10.0, gfet4t7;dur=20.0"),
+            ServerTimings {
+                gfe_latency: Some(20.0),
+                afe_latency: None,
+            }
+        );
+        assert_eq!(
+            parse_server_timing("foo;dur=1.0,gfet4t7;dur=12.5,bar;dur=2.0,afe;dur=5.0"),
+            ServerTimings {
+                gfe_latency: Some(12.5),
+                afe_latency: Some(5.0),
+            }
+        );
+    }
+
+    #[test]
+    fn test_default_export_interval() {
+        assert_eq!(DEFAULT_EXPORT_INTERVAL, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_bucket_boundaries_len_and_values() {
+        assert_eq!(BUCKET_BOUNDARIES.len(), 50);
+        assert_eq!(BUCKET_BOUNDARIES[0], 0.0);
+        assert_eq!(
+            *BUCKET_BOUNDARIES
+                .last()
+                .expect("BUCKET_BOUNDARIES should not be empty"),
+            3200000.0
+        );
+    }
+
+    #[tokio::test]
+    async fn test_observability_disabled_paths() {
+        let o11y = Observability::disabled();
+        assert!(
+            o11y.metrics.is_none(),
+            "disabled observability should have no metrics"
+        );
+
+        let config = ClientConfig::default();
+        let o11y_emulator =
+            Observability::init(&config, InstanceType::Cloud, true, Some("my-project")).await;
+        assert!(
+            o11y_emulator.metrics.is_none(),
+            "emulator client should have disabled metrics"
+        );
+
+        let o11y_omni =
+            Observability::init(&config, InstanceType::Omni, false, Some("my-project")).await;
+        assert!(
+            o11y_omni.metrics.is_none(),
+            "omni client should have disabled metrics"
+        );
+    }
+
+    #[test]
+    fn test_spanner_metrics_initialization_and_recording() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(DEFAULT_EXPORT_INTERVAL)
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("cloud.google.com/rust");
+        let metrics = SpannerMetrics::new(meter);
+
+        let attributes = [
+            opentelemetry::KeyValue::new("method", "ExecuteSql"),
+            opentelemetry::KeyValue::new("status", "OK"),
+        ];
+
+        metrics.operation_latencies.record(12.5, &attributes);
+        metrics.attempt_latencies.record(10.0, &attributes);
+        metrics.gfe_latencies.record(1.5, &attributes);
+        metrics.afe_latencies.record(2.0, &attributes);
+        metrics.operation_count.add(1, &attributes);
+        metrics.attempt_count.add(1, &attributes);
+
+        provider.force_flush().expect("force_flush should succeed");
+
+        let finished_metrics = exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics should succeed");
+        assert!(
+            !finished_metrics.is_empty(),
+            "exported metrics should not be empty"
+        );
+
+        let mut metric_names = Vec::new();
+        for resource_metrics in &finished_metrics {
+            for scope_metrics in resource_metrics.scope_metrics() {
+                for m in scope_metrics.metrics() {
+                    metric_names.push(m.name().to_string());
+                }
+            }
+        }
+
+        assert!(
+            metric_names.contains(
+                &"spanner.googleapis.com/internal/client/operation_latencies".to_string()
+            )
+        );
+        assert!(
+            metric_names
+                .contains(&"spanner.googleapis.com/internal/client/attempt_latencies".to_string())
+        );
+        assert!(
+            metric_names
+                .contains(&"spanner.googleapis.com/internal/client/gfe_latencies".to_string())
+        );
+        assert!(
+            metric_names
+                .contains(&"spanner.googleapis.com/internal/client/afe_latencies".to_string())
+        );
+        assert!(
+            metric_names
+                .contains(&"spanner.googleapis.com/internal/client/operation_count".to_string())
+        );
+        assert!(
+            metric_names
+                .contains(&"spanner.googleapis.com/internal/client/attempt_count".to_string())
+        );
+    }
+
+    #[test]
+    fn test_observability_recording_methods() {
+        let exporter = InMemoryMetricExporter::default();
+        let reader = PeriodicReader::builder(exporter.clone())
+            .with_interval(DEFAULT_EXPORT_INTERVAL)
+            .build();
+        let provider = SdkMeterProvider::builder().with_reader(reader).build();
+        let meter = provider.meter("cloud.google.com/rust");
+        let metrics = SpannerMetrics::new(meter);
+
+        let o11y = Observability {
+            metrics: Some(metrics),
+            _meter_provider: Some(provider),
+        };
+
+        o11y.record_operation("test_op", Duration::from_millis(15), &Ok(()));
+        o11y.record_attempt(
+            "test_op",
+            Duration::from_millis(10),
+            &Ok(()),
+            Some(3.0),
+            Some(2.0),
+        );
+
+        if let Some(ref provider) = o11y._meter_provider {
+            provider.force_flush().expect("force_flush should succeed");
+        }
+
+        let finished = exporter
+            .get_finished_metrics()
+            .expect("get_finished_metrics should succeed");
+        assert!(
+            !finished.is_empty(),
+            "exported metrics should not be empty after recording methods"
         );
     }
 }


### PR DESCRIPTION
- Configure the built-in metrics reader to export once every 60s
- Set up bucket boundaries
- Disable built-in metrics when connected to the emulator
- Harden the parsing of server timings