### PR TITLE
impl(bigquery): add arrow writer builder

### DIFF
--- a/src/bigquery-write/src/arrow.rs
+++ b/src/bigquery-write/src/arrow.rs
@@ -13,5 +13,7 @@
 // limitations under the License.
 
 mod default;
+mod writer_builder;
 
 pub use default::DefaultWriter;
+pub use writer_builder::WriterBuilder;

--- a/src/bigquery-write/src/arrow/default.rs
+++ b/src/bigquery-write/src/arrow/default.rs
@@ -19,16 +19,17 @@ use crate::runner::Runner;
 use crate::transport::Transport;
 use std::sync::Arc;
 
-/// A writer for the default stream
+/// A writer for the [default stream]
+///
+/// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
 pub struct DefaultWriter {
     // TODO(#5744) - support multiplexed connections
     runner: Runner,
-    write_stream: String,
-    schema: ArrowSchema,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ArrowSchema,
 }
 
 impl DefaultWriter {
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
         let runner = Runner::new(inner);
         Self {

--- a/src/bigquery-write/src/arrow/default.rs
+++ b/src/bigquery-write/src/arrow/default.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 /// A writer for the [default stream]
 ///
 /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
+#[derive(Debug)]
 pub struct DefaultWriter {
     // TODO(#5744) - support multiplexed connections
     runner: Runner,

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::arrow::DefaultWriter;
+use crate::model::ArrowSchema;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A builder to create a stream writer
+#[derive(Clone, Debug)]
+pub struct WriterBuilder {
+    inner: Arc<Transport>,
+    schema: ArrowSchema,
+}
+
+impl WriterBuilder {
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn new(inner: Arc<Transport>, schema: ArrowSchema) -> Self {
+        Self { inner, schema }
+    }
+
+    // TODO(#6224) - add an example showing the format of `table`
+    /// Create a writer for the [default stream] for the given table.
+    ///
+    /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
+    pub fn default<T: Into<String>>(self, table: T) -> DefaultWriter {
+        let mut write_stream = table.into();
+        write_stream.push_str("/streams/_default");
+        DefaultWriter::new(self.inner, write_stream, self.schema)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::tests::test_transport;
+
+    #[tokio::test]
+    async fn default() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer = builder.default("projects/p/tables/t");
+        assert_eq!(writer.write_stream, "projects/p/tables/t/streams/_default");
+        assert_eq!(writer.schema, schema);
+        Ok(())
+    }
+}

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::Result;
 use crate::arrow::DefaultWriter;
 use crate::model::ArrowSchema;
 use crate::transport::Transport;
@@ -34,10 +35,11 @@ impl WriterBuilder {
     /// Create a writer for the [default stream] for the given table.
     ///
     /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
-    pub fn default<T: Into<String>>(self, table: T) -> DefaultWriter {
+    pub fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
+        // TODO(#6249) - validate table resource format
         let mut write_stream = table.into();
         write_stream.push_str("/streams/_default");
-        DefaultWriter::new(self.inner, write_stream, self.schema)
+        Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
     }
 }
 
@@ -51,7 +53,7 @@ mod tests {
         let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
         let schema = ArrowSchema::new().set_serialized_schema("test");
         let builder = WriterBuilder::new(transport, schema.clone());
-        let writer = builder.default("projects/p/tables/t");
+        let writer = builder.default("projects/p/tables/t")?;
         assert_eq!(writer.write_stream, "projects/p/tables/t/streams/_default");
         assert_eq!(writer.schema, schema);
         Ok(())

--- a/src/bigquery-write/src/runner.rs
+++ b/src/bigquery-write/src/runner.rs
@@ -45,6 +45,7 @@ pub(crate) struct WriteRequest {
 /// If the stream terminates for any reason, the background task exits. Any
 /// unsatisfied requests are dropped, which surfaces to the client as a
 /// `oneshot::error::RecvError` on their response channel.
+#[derive(Debug)]
 pub(crate) struct Runner {
     pub(crate) req_tx: mpsc::Sender<WriteRequest>,
     pub(crate) handle: JoinHandle<()>,


### PR DESCRIPTION
Adds a writer builder for arrow format. This thing is used to make a stream.

At the moment it can only attach to the default stream. Note that the default stream always exists, so we do not need to send an RPC to Get/Create it first. We can just plumb the resource name.

In the future, the API will look more like:

```rs
impl WriterBuilder {
  // stream-level options. We list one as an example.
  pub fn set_multiplexing(self, bool) -> Self;

  // Use the default stream for a table.
  pub fn default(self) -> DefaultWriter;

  // Create a stream of a given type for a table.
  //
  // Note that these send a `CreateWriteStream` RPC, so they are async and can fail.
  pub async fn pending(self, table: String) -> Result<PendingWriter>;
  pub async fn committed(self, table: String) -> Result<CommittedWriter>;
  pub async fn buffered(self, table: String) -> Result<BufferedWriter>;

  // Attach to an existing write stream, by name
  pub async fn attach<W: Writer>(self, write_stream: String) -> Result<W>;
}
```

Towards #5664