### PR TITLE
chore(spanner): attach Request ID headers to Spanner RPCs

### DIFF
--- a/src/spanner/src/batch_read_only_transaction.rs
+++ b/src/spanner/src/batch_read_only_transaction.rs
@@ -385,6 +385,7 @@ impl Partition {
         gax_options: GaxRequestOptions,
     ) -> crate::Result<ResultSet> {
         let channel_hint = client.spanner.next_channel_hint();
+        let gax_options = client.spanner.attach_request_id(gax_options, channel_hint);
         let stream = client
             .spanner
             .execute_streaming_sql(req.clone(), gax_options.clone(), channel_hint)
@@ -416,6 +417,7 @@ impl Partition {
         gax_options: GaxRequestOptions,
     ) -> crate::Result<ResultSet> {
         let channel_hint = client.spanner.next_channel_hint();
+        let gax_options = client.spanner.attach_request_id(gax_options, channel_hint);
         let stream = client
             .spanner
             .streaming_read(req.clone(), gax_options.clone(), channel_hint)

--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -19,6 +19,8 @@ use crate::model::{
     PartitionReadRequest, PartitionResponse, RollbackRequest, Session, Transaction,
 };
 use crate::omni::{InstanceType, is_plaintext_endpoint};
+use crate::request_id::RequestIdCreator;
+use crate::request_id_interceptor::{REQUEST_ID_HEADER, SpannerRequestIdInterceptor};
 use crate::server_streaming::builder;
 use gaxi::options::{ClientConfig, Credentials};
 use google_cloud_auth::credentials::anonymous;
@@ -34,7 +36,7 @@ use http::{
     header::{HeaderName, HeaderValue},
 };
 use std::sync::{
-    LazyLock,
+    Arc, LazyLock,
     atomic::{AtomicUsize, Ordering},
 };
 
@@ -54,6 +56,7 @@ pub struct Spanner {
     pub(crate) config: ClientConfig,
     pub(crate) is_emulator: bool,
     pub(crate) instance_type: InstanceType,
+    pub(crate) request_id_creator: Arc<RequestIdCreator>,
 }
 
 /// A factory for constructing `Spanner` clients.
@@ -109,6 +112,7 @@ impl google_cloud_gax::client_builder::internal::ClientFactory for Factory {
             config,
             is_emulator,
             instance_type,
+            request_id_creator: Arc::new(RequestIdCreator::new()),
         })
     }
 }
@@ -157,6 +161,7 @@ macro_rules! define_idempotent_rpc {
             o11y: &crate::observability::Observability,
         ) -> crate::Result<$response_type> {
             o11y.trace_operation($canonical_name, || async move {
+                let options = self.attach_request_id(options, channel_hint);
                 self.get_channel(channel_hint)
                     .inner
                     .$method()
@@ -329,6 +334,7 @@ impl Spanner {
             config: ClientConfig::default(),
             is_emulator: false,
             instance_type: InstanceType::Cloud,
+            request_id_creator: Arc::new(RequestIdCreator::new()),
         }
     }
 
@@ -347,6 +353,37 @@ impl Spanner {
 
     pub(crate) fn next_channel_hint(&self) -> usize {
         self.counter.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(crate) fn attach_request_id(
+        &self,
+        options: crate::RequestOptions,
+        channel_hint: usize,
+    ) -> crate::RequestOptions {
+        if options
+            .get_extension::<HeaderMap>()
+            .is_some_and(|headers| headers.contains_key(&REQUEST_ID_HEADER))
+        {
+            return options;
+        }
+
+        // Spanner Request ID channel IDs are 1-based (1..=N), where 0 is reserved for unknown.
+        // We wrap `channel_hint` by the channel pool size so the advertised channel ID always
+        // matches the actual channel index used by `get_channel`.
+        let channel_id = channel_hint
+            .checked_rem(self.channels.len())
+            .map_or(0, |rem| rem + 1);
+        let header_val_str = self.request_id_creator.next_id_prefix(channel_id);
+        let Ok(val) = HeaderValue::from_str(&header_val_str) else {
+            return options;
+        };
+
+        let mut headers = options
+            .get_extension::<HeaderMap>()
+            .cloned()
+            .unwrap_or_default();
+        headers.insert(REQUEST_ID_HEADER.clone(), val);
+        options.insert_extension(headers)
     }
 
     define_idempotent_rpc!(
@@ -415,7 +452,7 @@ impl Spanner {
             .expect("Streaming RPCs are not supported when using a stub client");
         builder::ExecuteStreamingSql::new(grpc.clone())
             .with_request(request)
-            .with_options(options)
+            .with_options(self.attach_request_id(options, channel_hint))
     }
 
     /// Reads rows from the database, returning a stream of results.
@@ -435,7 +472,7 @@ impl Spanner {
             .expect("Streaming RPCs are not supported when using a stub client");
         builder::StreamingRead::new(grpc.clone())
             .with_request(request)
-            .with_options(options)
+            .with_options(self.attach_request_id(options, channel_hint))
     }
 
     pub(crate) fn batch_write(
@@ -451,7 +488,7 @@ impl Spanner {
             .expect("Streaming RPCs are not supported when using a stub client");
         builder::BatchWrite::new(grpc.clone())
             .with_request(request)
-            .with_options(options)
+            .with_options(self.attach_request_id(options, channel_hint))
     }
 }
 
@@ -463,8 +500,11 @@ pub(crate) struct Channel {
 
 impl Channel {
     pub(crate) async fn create(config: &ClientConfig) -> crate::ClientBuilderResult<Self> {
-        let transport =
+        let mut transport =
             crate::generated::gapic_dataplane::transport::Spanner::new(config.clone()).await?;
+        transport
+            .inner
+            .set_attempt_interceptor(Arc::new(SpannerRequestIdInterceptor));
         let grpc_client = transport.inner.clone();
 
         let inner = if gaxi::options::tracing_enabled(config) {
@@ -1817,6 +1857,78 @@ mod tests {
         assert_eq!(
             super::parse_emulator_endpoint("http_localhost:9010"),
             "http://http_localhost:9010"
+        );
+    }
+
+    #[test]
+    fn attach_request_id_adds_header() {
+        let spanner = Spanner {
+            channels: vec![],
+            counter: std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+            config: ClientConfig::default(),
+            is_emulator: false,
+            instance_type: InstanceType::Cloud,
+            request_id_creator: Arc::new(RequestIdCreator::new()),
+        };
+        let options = crate::RequestOptions::default();
+        let options = spanner.attach_request_id(options, 0);
+        let headers = options
+            .get_extension::<HeaderMap>()
+            .expect("HeaderMap should be present");
+        let val = headers
+            .get(&REQUEST_ID_HEADER)
+            .expect("x-goog-spanner-request-id should be present")
+            .to_str()
+            .expect("should be valid ASCII");
+        assert!(
+            val.starts_with("1."),
+            "Request ID prefix should start with protocol version 1, got {val}"
+        );
+        assert!(
+            val.ends_with('.'),
+            "Request ID prefix should end with a dot ready for AttemptInterceptor, got {val}"
+        );
+    }
+
+    #[tokio_test_no_panics]
+    async fn attach_request_id_channel_id_in_range() {
+        let mock = MockSpanner::new();
+        let (address, _server) = start("0.0.0.0:0", mock)
+            .await
+            .expect("Failed to start mock server");
+
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("Failed to build client");
+
+        assert_eq!(
+            client.channels.len(),
+            4,
+            "default pool size should be 4 channels"
+        );
+
+        // Test with a channel_hint that is larger than the pool size (e.g., hint = 7).
+        // Without our fix, this would have advertised channel ID 8 (7 + 1) instead of
+        // wrapping around to range 1..=4.
+        let options = crate::RequestOptions::default();
+        let options = client.attach_request_id(options, 7);
+        let headers = options
+            .get_extension::<HeaderMap>()
+            .expect("HeaderMap should be present");
+        let val = headers
+            .get(&REQUEST_ID_HEADER)
+            .expect("x-goog-spanner-request-id should be present")
+            .to_str()
+            .expect("should be valid ASCII");
+
+        // With 4 channels and hint = 7: (7 % 4) + 1 = 3 + 1 = 4.
+        // So the prefix should contain ".4." for channel ID 4.
+        assert!(
+            val.contains(".4."),
+            "Request ID should contain channel ID 4 for hint 7 with pool size 4, got {val}"
         );
     }
 }

--- a/src/spanner/src/read_only_transaction.rs
+++ b/src/spanner/src/read_only_transaction.rs
@@ -1145,7 +1145,10 @@ impl ReadContext {
         seqno: Option<i64>,
     ) -> crate::Result<ResultSet> {
         let statement = statement.into();
-        let gax_options = statement.gax_options().clone();
+        let gax_options = self
+            .client
+            .spanner
+            .attach_request_id(statement.gax_options().clone(), self.channel_hint);
         let mut request = statement
             .into_request()
             .set_session(self.session_name.clone())
@@ -1167,7 +1170,10 @@ impl ReadContext {
         read: T,
     ) -> crate::Result<ResultSet> {
         let read = read.into();
-        let gax_options = read.gax_options.clone();
+        let gax_options = self
+            .client
+            .spanner
+            .attach_request_id(read.gax_options.clone(), self.channel_hint);
         let mut request = read
             .into_request()
             .set_session(self.session_name.clone())

--- a/src/spanner/src/request_id.rs
+++ b/src/spanner/src/request_id.rs
@@ -27,7 +27,6 @@ const VERSION: &str = "1";
 
 /// A 64-bit random value formatted as 16 lowercase hexadecimal characters (`"%016x"`),
 /// generated once per process lifetime.
-#[allow(dead_code)]
 pub(crate) static RAND_PROCESS_ID: LazyLock<String> =
     LazyLock::new(|| format!("{:016x}", rand::random::<u64>()));
 
@@ -38,15 +37,12 @@ static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 /// Each `RequestIdCreator` receives a unique `client_id` upon creation and pre-computes
 /// the static prefix `<VERSION>.<RAND_PROCESS_ID>.<client_id>.` to minimize string formatting
 /// overhead on RPC invocations.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct RequestIdCreator {
-    client_id: u64,
     client_prefix: String,
     next_request_id: AtomicU64,
 }
 
-#[allow(dead_code)]
 impl RequestIdCreator {
     /// Constructs a new `RequestIdCreator` with an atomically incremented client ID.
     ///
@@ -56,17 +52,19 @@ impl RequestIdCreator {
         let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
         let client_prefix = format!("{VERSION}.{}.{}.", *RAND_PROCESS_ID, client_id);
         Self {
-            client_id,
             client_prefix,
             next_request_id: AtomicU64::new(1),
         }
     }
+}
 
-    /// Returns the unique client ID assigned to this generator.
-    pub(crate) fn client_id(&self) -> u64 {
-        self.client_id
+impl Default for RequestIdCreator {
+    fn default() -> Self {
+        Self::new()
     }
+}
 
+impl RequestIdCreator {
     /// Returns a Request ID prefix string for a new RPC, excluding the attempt suffix:
     /// `"1.<RAND_PROCESS_ID>.<client_id>.<channel_id>.<request_id>."`
     ///
@@ -82,34 +80,27 @@ impl RequestIdCreator {
         let _ = write!(result, "{channel_id}.{request_id}.");
         result
     }
-
-    /// Returns a full Request ID string for an RPC attempt:
-    /// `"1.<RAND_PROCESS_ID>.<client_id>.<channel_id>.<request_id>.<attempt>"`
-    ///
-    /// # Arguments
-    /// * `channel_id` - The 1-based channel identifier (`1, 2, ...`), or `0` for an unknown channel.
-    /// * `attempt` - The 1-based attempt number (`1` for initial attempt, `2` for first retry).
-    pub(crate) fn next_id_with_attempt(&self, channel_id: usize, attempt: u32) -> String {
-        let request_id = self.next_request_id.fetch_add(1, Ordering::Relaxed);
-        let mut result = String::with_capacity(self.client_prefix.len() + 48);
-        result.push_str(&self.client_prefix);
-        let _ = write!(result, "{channel_id}.{request_id}.{attempt}");
-        result
-    }
-
-    /// Resets the internal request counter to `1`. Primarily intended for testing.
-    pub(crate) fn reset(&self) {
-        self.next_request_id.store(1, Ordering::Relaxed);
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::Spanner;
+    use gaxi::grpc::tonic::{Response, Status};
+    use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_test_macros::tokio_test_no_panics;
+    use spanner_grpc_mock::google::spanner::v1 as mock_v1;
+    use spanner_grpc_mock::{MockSpanner, start};
+    use std::sync::Mutex;
 
     #[test]
     fn traits() {
-        static_assertions::assert_impl_all!(RequestIdCreator: Send, Sync, std::fmt::Debug);
+        static_assertions::assert_impl_all!(
+            RequestIdCreator: Send,
+            Sync,
+            std::fmt::Debug,
+            Default
+        );
     }
 
     #[test]
@@ -127,50 +118,566 @@ mod tests {
     #[test]
     fn request_id_creator_sequence() {
         let creator = RequestIdCreator::new();
-        let client_id = creator.client_id();
 
         let base_id1 = creator.next_id_prefix(1);
-        let expected_prefix = format!("{VERSION}.{}.{}.", *RAND_PROCESS_ID, client_id);
-        assert_eq!(base_id1, format!("{expected_prefix}1.1."));
+        assert!(
+            base_id1.starts_with(&format!("{VERSION}.{}.", *RAND_PROCESS_ID)),
+            "prefix should start with VERSION and RAND_PROCESS_ID, got {base_id1}"
+        );
+        assert!(
+            base_id1.ends_with(".1.1."),
+            "first call on channel 1 should end with .1.1., got {base_id1}"
+        );
 
         let base_id2 = creator.next_id_prefix(1);
-        assert_eq!(base_id2, format!("{expected_prefix}1.2."));
+        assert!(
+            base_id2.ends_with(".1.2."),
+            "second call on channel 1 should end with .1.2., got {base_id2}"
+        );
 
         let base_id3 = creator.next_id_prefix(2);
-        assert_eq!(base_id3, format!("{expected_prefix}2.3."));
+        assert!(
+            base_id3.ends_with(".2.3."),
+            "third call on channel 2 should end with .2.3., got {base_id3}"
+        );
     }
 
     #[test]
     fn multiple_creators_unique_client_ids() {
         let creator1 = RequestIdCreator::new();
         let creator2 = RequestIdCreator::new();
-        assert!(creator2.client_id() > creator1.client_id());
+        assert_ne!(creator1.next_id_prefix(1), creator2.next_id_prefix(1));
     }
 
-    #[test]
-    fn next_id_with_attempt() {
-        let creator = RequestIdCreator::new();
-        let client_id = creator.client_id();
-        let expected_prefix = format!("{VERSION}.{}.{}.", *RAND_PROCESS_ID, client_id);
+    #[tokio_test_no_panics]
+    async fn request_id_header_sent_unary_rpc() {
+        let captured = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut mock = MockSpanner::new();
+        let mut seq = mockall::Sequence::new();
 
-        let id1 = creator.next_id_with_attempt(1, 1);
-        assert_eq!(id1, format!("{expected_prefix}1.1.1"));
+        // 1. Initial attempt of first RPC -> records header and returns UNAVAILABLE to force retry
+        let captured_clone = captured.clone();
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for unary RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Err(Status::unavailable("server is unavailable"))
+            });
 
-        let id2 = creator.next_id_with_attempt(5, 42);
-        assert_eq!(id2, format!("{expected_prefix}5.2.42"));
+        // 2. Retry attempt of first RPC -> records header and returns Ok(Session)
+        let captured_clone = captured.clone();
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for unary RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Ok(Response::new(mock_v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/s1".to_string(),
+                    ..Default::default()
+                }))
+            });
+
+        // 3. Second RPC -> records header and returns Ok(Session)
+        let captured_clone = captured.clone();
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for unary RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Ok(Response::new(mock_v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/s2".to_string(),
+                    ..Default::default()
+                }))
+            });
+
+        let (address, _server) = start("127.0.0.1:0", mock)
+            .await
+            .expect("Failed to start mock server");
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("Failed to build Spanner client");
+
+        let request = crate::model::CreateSessionRequest {
+            database: "projects/p/instances/i/databases/d".to_string(),
+            ..Default::default()
+        };
+
+        // Execute first RPC (attempt 1 -> UNAVAILABLE, attempt 2 -> success)
+        let _session1 = client
+            .create_session(
+                request.clone(),
+                crate::RequestOptions::default(),
+                0,
+                &crate::observability::Observability::disabled(),
+            )
+            .await
+            .expect("first create_session should succeed after retry");
+
+        // Execute second RPC (attempt 1 -> success)
+        let _session2 = client
+            .create_session(
+                request,
+                crate::RequestOptions::default(),
+                0,
+                &crate::observability::Observability::disabled(),
+            )
+            .await
+            .expect("second create_session should succeed");
+
+        let ids = captured.lock().unwrap();
+        assert_eq!(ids.len(), 3, "should have captured 3 RPC attempt headers");
+
+        let id_rpc1_attempt1 = &ids[0];
+        let id_rpc1_attempt2 = &ids[1];
+        let id_rpc2_attempt1 = &ids[2];
+
+        assert!(
+            id_rpc1_attempt1.starts_with("1."),
+            "Request ID should start with version 1, got {id_rpc1_attempt1}"
+        );
+
+        let prefix1_attempt1 = id_rpc1_attempt1.rsplit_once('.').unwrap().0;
+        let prefix1_attempt2 = id_rpc1_attempt2.rsplit_once('.').unwrap().0;
+        assert_eq!(
+            prefix1_attempt2, prefix1_attempt1,
+            "Retry attempt should have exactly the same values as initial attempt"
+        );
+        assert!(
+            id_rpc1_attempt1.ends_with(".1"),
+            "Initial attempt should end with .1, got {id_rpc1_attempt1}"
+        );
+        assert!(
+            id_rpc1_attempt2.ends_with(".2"),
+            "Retry attempt should end with .2, got {id_rpc1_attempt2}"
+        );
+
+        let req_num_1: u64 = id_rpc1_attempt1
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        let req_num_2: u64 = id_rpc2_attempt1
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        assert_eq!(
+            req_num_2,
+            req_num_1 + 1,
+            "Following request should use a Request ID that is 1 higher ({id_rpc2_attempt1} vs {id_rpc1_attempt1})"
+        );
+        assert!(
+            id_rpc2_attempt1.ends_with(".1"),
+            "Following request initial attempt should end with .1, got {id_rpc2_attempt1}"
+        );
     }
 
-    #[test]
-    fn reset() {
-        let creator = RequestIdCreator::new();
-        let client_id = creator.client_id();
-        let expected_prefix = format!("{VERSION}.{}.{}.", *RAND_PROCESS_ID, client_id);
+    #[tokio_test_no_panics]
+    async fn request_id_header_sent_streaming_rpc() {
+        use crate::result_set::tests::adapt;
 
-        let _ = creator.next_id_prefix(1);
-        let _ = creator.next_id_prefix(1);
-        creator.reset();
+        let captured = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut mock = MockSpanner::new();
+        let mut seq = mockall::Sequence::new();
 
-        let base_id_after_reset = creator.next_id_prefix(1);
-        assert_eq!(base_id_after_reset, format!("{expected_prefix}1.1."));
+        // 1. Initial attempt of first streaming SQL -> records header and returns stream with 1 row + UNAVAILABLE
+        let captured_clone = captured.clone();
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for streaming RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+
+                let prs1 = mock_v1::PartialResultSet {
+                    metadata: Some(mock_v1::ResultSetMetadata {
+                        row_type: Some(mock_v1::StructType {
+                            fields: vec![mock_v1::struct_type::Field {
+                                name: "col0".to_string(),
+                                ..Default::default()
+                            }],
+                        }),
+                        ..Default::default()
+                    }),
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("row1".to_string())),
+                    }],
+                    resume_token: b"token1".to_vec(),
+                    ..Default::default()
+                };
+                let stream = adapt([Ok(prs1), Err(Status::unavailable("server is unavailable"))]);
+                Ok(Response::from(stream))
+            });
+
+        // 2. Retry attempt of first streaming SQL -> records header and returns stream with row2 (last)
+        let captured_clone = captured.clone();
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for streaming RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+
+                let prs2 = mock_v1::PartialResultSet {
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("row2".to_string())),
+                    }],
+                    resume_token: b"token2".to_vec(),
+                    last: true,
+                    ..Default::default()
+                };
+                let stream = adapt([Ok(prs2)]);
+                Ok(Response::from(stream))
+            });
+
+        // 3. Second streaming query -> records header and returns stream with row3 (last)
+        let captured_clone = captured.clone();
+        mock.expect_execute_streaming_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for streaming RPC")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+
+                let prs3 = mock_v1::PartialResultSet {
+                    metadata: Some(mock_v1::ResultSetMetadata {
+                        row_type: Some(mock_v1::StructType {
+                            fields: vec![mock_v1::struct_type::Field {
+                                name: "col0".to_string(),
+                                ..Default::default()
+                            }],
+                        }),
+                        ..Default::default()
+                    }),
+                    values: vec![prost_types::Value {
+                        kind: Some(prost_types::value::Kind::StringValue("row3".to_string())),
+                    }],
+                    resume_token: b"token3".to_vec(),
+                    last: true,
+                    ..Default::default()
+                };
+                let stream = adapt([Ok(prs3)]);
+                Ok(Response::from(stream))
+            });
+
+        mock.expect_create_session().returning(|_| {
+            Ok(Response::new(mock_v1::Session {
+                name: "projects/p/instances/i/databases/d/sessions/s1".to_string(),
+                multiplexed: true,
+                ..Default::default()
+            }))
+        });
+
+        let (address, _server) = start("127.0.0.1:0", mock)
+            .await
+            .expect("Failed to start mock server");
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("Failed to build Spanner client");
+
+        let db_client = client
+            .database_client("projects/p/instances/i/databases/d")
+            .build()
+            .await
+            .unwrap();
+
+        // Execute first streaming query via single_use().execute_query (attempt 1 -> row1 + UNAVAILABLE, attempt 2 -> row2)
+        let mut rs1 = db_client
+            .single_use()
+            .build()
+            .execute_query("SELECT 1")
+            .await
+            .expect("first execute_query should succeed");
+        while let Some(row) = rs1.next().await {
+            row.expect("row should succeed after stream retry");
+        }
+
+        // Execute second streaming query via single_use().execute_query (attempt 1 -> row3)
+        let mut rs2 = db_client
+            .single_use()
+            .build()
+            .execute_query("SELECT 2")
+            .await
+            .expect("second execute_query should succeed");
+        while let Some(row) = rs2.next().await {
+            row.expect("row should succeed");
+        }
+
+        let ids = captured.lock().unwrap();
+        assert_eq!(ids.len(), 3, "should have captured 3 RPC attempt headers");
+
+        let id_rpc1_attempt1 = &ids[0];
+        let id_rpc1_attempt2 = &ids[1];
+        let id_rpc2_attempt1 = &ids[2];
+
+        assert!(
+            id_rpc1_attempt1.starts_with("1."),
+            "Request ID should start with version 1, got {id_rpc1_attempt1}"
+        );
+
+        let prefix1_attempt1 = id_rpc1_attempt1.rsplit_once('.').unwrap().0;
+        let prefix1_attempt2 = id_rpc1_attempt2.rsplit_once('.').unwrap().0;
+        assert_eq!(
+            prefix1_attempt2, prefix1_attempt1,
+            "Retry attempt should have exactly the same values as initial attempt"
+        );
+        assert!(
+            id_rpc1_attempt1.ends_with(".1"),
+            "Initial attempt should end with .1, got {id_rpc1_attempt1}"
+        );
+        assert!(
+            id_rpc1_attempt2.ends_with(".2"),
+            "Retry attempt should end with .2, got {id_rpc1_attempt2}"
+        );
+
+        let req_num_1: u64 = id_rpc1_attempt1
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        let req_num_2: u64 = id_rpc2_attempt1
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        assert_eq!(
+            req_num_2,
+            req_num_1 + 1,
+            "Following request should use a Request ID that is 1 higher ({id_rpc2_attempt1} vs {id_rpc1_attempt1})"
+        );
+        assert!(
+            id_rpc2_attempt1.ends_with(".1"),
+            "Following request initial attempt should end with .1, got {id_rpc2_attempt1}"
+        );
+    }
+
+    #[tokio_test_no_panics]
+    async fn request_id_header_sent_read_write_transaction_aborted_retry() {
+        use crate::transaction_retry_policy::tests::create_aborted_status;
+
+        let captured = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut mock = MockSpanner::new();
+        let mut seq = mockall::Sequence::new();
+
+        mock.expect_create_session()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| {
+                Ok(Response::new(mock_v1::Session {
+                    name: "projects/p/instances/i/databases/d/sessions/s1".to_string(),
+                    multiplexed: true,
+                    ..Default::default()
+                }))
+            });
+
+        // 1. First transaction attempt -> execute_sql fails with ABORTED
+        let captured_clone = captured.clone();
+        mock.expect_execute_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for execute_sql")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Err(create_aborted_status(std::time::Duration::from_nanos(1)))
+            });
+
+        // 2. Second transaction attempt (after ABORTED retry) -> execute_sql succeeds
+        let captured_clone = captured.clone();
+        mock.expect_execute_sql()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for execute_sql")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Ok(Response::new(mock_v1::ResultSet {
+                    metadata: Some(mock_v1::ResultSetMetadata {
+                        transaction: Some(mock_v1::Transaction {
+                            id: vec![8, 8, 8],
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    }),
+                    stats: Some(mock_v1::ResultSetStats {
+                        row_count: Some(mock_v1::result_set_stats::RowCount::RowCountExact(1)),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+            });
+
+        // 3. Second transaction attempt -> commit succeeds
+        let captured_clone = captured.clone();
+        mock.expect_commit()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(move |req| {
+                let request_id = req
+                    .metadata()
+                    .get("x-goog-spanner-request-id")
+                    .expect("x-goog-spanner-request-id should be sent for commit")
+                    .to_str()
+                    .expect("should be valid ASCII")
+                    .to_string();
+                captured_clone.lock().unwrap().push(request_id);
+                Ok(Response::new(mock_v1::CommitResponse::default()))
+            });
+
+        let (address, _server) = start("127.0.0.1:0", mock)
+            .await
+            .expect("Failed to start mock server");
+        let client = Spanner::builder()
+            .with_endpoint(address)
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await
+            .expect("Failed to build Spanner client");
+
+        let db_client = client
+            .database_client("projects/p/instances/i/databases/d")
+            .build()
+            .await
+            .unwrap();
+
+        let count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_clone = count.clone();
+
+        let runner = db_client
+            .read_write_transaction()
+            .build()
+            .await
+            .expect("runner build");
+
+        runner
+            .run(async |tx| {
+                count_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                tx.execute_update("UPDATE foo SET bar = 1").await?;
+                Ok(())
+            })
+            .await
+            .expect("transaction should succeed after aborted retry");
+
+        assert_eq!(
+            count.load(std::sync::atomic::Ordering::Relaxed),
+            2,
+            "transaction closure should have run twice"
+        );
+
+        let ids = captured.lock().unwrap();
+        assert_eq!(
+            ids.len(),
+            3,
+            "should have captured 3 RPC attempt headers (execute_sql attempt 1, execute_sql attempt 2, commit)"
+        );
+
+        let id_exec1 = &ids[0];
+        let id_exec2 = &ids[1];
+        let id_commit = &ids[2];
+
+        // 1. Verify that all 3 RPCs have attempt number .1 (retrying an aborted transaction does NOT bump the attempt number)
+        assert!(
+            id_exec1.ends_with(".1"),
+            "First transaction execute_sql should end with .1, got {id_exec1}"
+        );
+        assert!(
+            id_exec2.ends_with(".1"),
+            "Retried transaction execute_sql should end with .1, got {id_exec2}"
+        );
+        assert!(
+            id_commit.ends_with(".1"),
+            "Commit should end with .1, got {id_commit}"
+        );
+
+        // 2. Verify that RequestIds are monotonically increasing across the aborted transaction retry
+        let req_num_exec1: u64 = id_exec1
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        let req_num_exec2: u64 = id_exec2
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+        let req_num_commit: u64 = id_commit
+            .split('.')
+            .nth(4)
+            .expect("request_id field")
+            .parse()
+            .expect("numeric request_id");
+
+        assert_eq!(
+            req_num_exec2,
+            req_num_exec1 + 1,
+            "Retried transaction execute_sql should increment Request ID by 1 ({req_num_exec2} vs {req_num_exec1})"
+        );
+        assert_eq!(
+            req_num_commit,
+            req_num_exec2 + 1,
+            "Commit should increment Request ID by 1 ({req_num_commit} vs {req_num_exec2})"
+        );
     }
 }

--- a/src/spanner/src/request_id_interceptor.rs
+++ b/src/spanner/src/request_id_interceptor.rs
@@ -19,7 +19,6 @@ use http::HeaderMap;
 use http::header::{HeaderName, HeaderValue};
 use std::io::Write as _;
 
-#[allow(dead_code)]
 pub(crate) static REQUEST_ID_HEADER: HeaderName =
     HeaderName::from_static("x-goog-spanner-request-id");
 
@@ -28,7 +27,6 @@ pub(crate) static REQUEST_ID_HEADER: HeaderName =
 ///
 /// This implementation uses stack-allocated formatting and ASCII byte slices to eliminate heap
 /// allocations on the hot path.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SpannerRequestIdInterceptor;
 
@@ -45,6 +43,17 @@ impl AttemptInterceptor for SpannerRequestIdInterceptor {
             return;
         };
         let base_prefix = &bytes[..=dot_index];
+        let existing_attempt = std::str::from_utf8(&bytes[dot_index + 1..])
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(0);
+        // We use `existing_attempt.max(attempt)` to handle both unary and streaming RPC retries:
+        // 1. For initial RPC calls or unary retries, `existing_attempt` is 0 (or smaller than `attempt`
+        //    passed by the gaxi retry loop), so we use the passed-in `attempt` number (1, 2, ...).
+        // 2. For streaming retries, `ResultSet` manually bumps the attempt number on the existing
+        //    Request ID header in `RequestOptions`. When `gaxi` calls this interceptor with `attempt = 1`
+        //    for the retried stream, taking the maximum preserves the higher attempt number set by `ResultSet`.
+        let effective_attempt = existing_attempt.max(attempt);
 
         // We use a fixed-size 128-byte stack-allocated array as a scratch buffer to format
         // the updated header value without heap allocation.
@@ -69,7 +78,7 @@ impl AttemptInterceptor for SpannerRequestIdInterceptor {
         // Additionally, `write!` updates the slice cursor (`tail`) in place to point to the unwritten
         // remainder, so `max_len - tail.len()` gives the exact total bytes written.
         let mut tail = &mut buffer[base_prefix.len()..];
-        if write!(tail, "{attempt}").is_err() {
+        if write!(tail, "{effective_attempt}").is_err() {
             return;
         }
         let total_len = max_len - tail.len();
@@ -89,6 +98,18 @@ impl AttemptInterceptor for SpannerRequestIdInterceptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn traits() {
+        static_assertions::assert_impl_all!(
+            SpannerRequestIdInterceptor: AttemptInterceptor,
+            Send,
+            Sync,
+            std::fmt::Debug,
+            Clone,
+            Default
+        );
+    }
 
     #[test]
     fn initial_attempt_append() {
@@ -120,6 +141,24 @@ mod tests {
 
         interceptor.intercept(&mut headers, 2);
 
+        let value = headers
+            .get(&REQUEST_ID_HEADER)
+            .expect("header should be present")
+            .to_str()
+            .expect("header should be valid ASCII");
+        assert_eq!(value, "1.a1b2c3d4e5f60718.1.1.42.2");
+    }
+
+    #[test]
+    fn existing_higher_attempt_preserved() {
+        let interceptor = SpannerRequestIdInterceptor;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            REQUEST_ID_HEADER.clone(),
+            HeaderValue::from_static("1.a1b2c3d4e5f60718.1.1.42.2"),
+        );
+
+        interceptor.intercept(&mut headers, 1);
         let value = headers
             .get(&REQUEST_ID_HEADER)
             .expect("header should be present")

--- a/src/spanner/src/result_set.rs
+++ b/src/spanner/src/result_set.rs
@@ -19,6 +19,7 @@ use crate::model::ResultSetStats;
 use crate::model::result_set_stats::RowCount;
 use crate::precommit::PrecommitTokenTracker;
 use crate::read_only_transaction::{ReadContextTransactionSelector, TransactionState};
+use crate::request_id_interceptor::REQUEST_ID_HEADER;
 use crate::result_set_metadata::ResultSetMetadata;
 use crate::retry_policy::SpannerRetryPolicy;
 use crate::row::Row;
@@ -28,9 +29,11 @@ use gaxi::prost::FromProto;
 use google_cloud_gax::backoff_policy::BackoffPolicy;
 use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
 use google_cloud_gax::options::RequestOptions as GaxRequestOptions;
+use google_cloud_gax::options::internal::RequestOptionsExt;
 use google_cloud_gax::retry_policy::RetryPolicyExt;
 use google_cloud_gax::retry_result::RetryResult;
 use google_cloud_gax::retry_state::RetryState;
+use http::{HeaderMap, HeaderValue};
 use std::collections::VecDeque;
 use std::mem::take;
 use std::sync::Arc;
@@ -645,6 +648,29 @@ impl ResultSet {
         // it is extracted without triggering the 'only-once' metadata validation error.
         if self.last_resume_token.is_empty() {
             self.local_metadata = None;
+        }
+
+        // When retrying a streaming SQL/read RPC after a transient failure, we manually increment
+        // the attempt number suffix on the existing `x-goog-spanner-request-id` header in `RequestOptions`.
+        // When `gaxi` invokes `SpannerRequestIdInterceptor` with attempt 1 for the retried stream,
+        // the interceptor takes the maximum (`existing_attempt.max(attempt)`), preserving our bumped attempt number.
+        if self.retry_count > 0 {
+            let mut headers = self
+                .gax_options
+                .get_extension::<HeaderMap>()
+                .cloned()
+                .unwrap_or_default();
+            if let Some(val) = headers.get(&REQUEST_ID_HEADER)
+                && let Ok(s) = val.to_str()
+                && let Some((base, _)) = s.rsplit_once('.')
+            {
+                let new_id = format!("{}.{}", base, self.retry_count + 1);
+                if let Ok(new_val) = HeaderValue::from_str(&new_id) {
+                    headers.insert(REQUEST_ID_HEADER.clone(), new_val);
+                    self.gax_options =
+                        std::mem::take(&mut self.gax_options).insert_extension(headers);
+                }
+            }
         }
 
         match &mut self.operation {


### PR DESCRIPTION
Automatically attach unique `x-goog-spanner-request-id` headers to Spanner queries and reads, tracking attempt numbers across unary and streaming RPC retries.