### PR TITLE
cleanup(bigquery): use correct resource name in tests

### DIFF
--- a/src/bigquery-write/src/append_builder.rs
+++ b/src/bigquery-write/src/append_builder.rs
@@ -58,22 +58,19 @@ mod tests {
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::channel(10);
-        let req = AppendRowsRequest::new().set_write_stream("projects/p/tables/t/streams/_default");
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
         let handle = tokio::spawn(async move { builder.send().await });
 
         // Receive and verify the request
         let write = req_rx.recv().await.expect("should receive request");
-        assert_eq!(
-            write.req.write_stream,
-            "projects/p/tables/t/streams/_default"
-        );
+        assert_eq!(write.req.write_stream, write_stream());
 
         // Provide a successful response
         let resp = v1::AppendRowsResponse {
             response: Some(Response::AppendResult(AppendResult::default())),
-            write_stream: "projects/p/tables/t/streams/_default".to_string(),
+            write_stream: write_stream(),
             updated_schema: Some(v1::TableSchema::default()),
             ..Default::default()
         };
@@ -91,7 +88,7 @@ mod tests {
     #[tokio::test]
     async fn stream_closed() -> anyhow::Result<()> {
         let (req_tx, req_rx) = mpsc::channel(10);
-        let req = AppendRowsRequest::new().set_write_stream("projects/p/tables/t/streams/_default");
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
         let handle = tokio::spawn(async move { builder.send().await });
@@ -107,7 +104,7 @@ mod tests {
     #[tokio::test]
     async fn rpc_error() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::channel(10);
-        let req = AppendRowsRequest::new().set_write_stream("projects/p/tables/t/streams/_default");
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
         let handle = tokio::spawn(async move { builder.send().await });
@@ -128,7 +125,7 @@ mod tests {
     #[tokio::test]
     async fn row_errors() -> anyhow::Result<()> {
         let (req_tx, mut req_rx) = mpsc::channel(10);
-        let req = AppendRowsRequest::new().set_write_stream("projects/p/tables/t/streams/_default");
+        let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
         let handle = tokio::spawn(async move { builder.send().await });
@@ -142,7 +139,7 @@ mod tests {
         };
         let resp = v1::AppendRowsResponse {
             row_errors: vec![row_error],
-            write_stream: "projects/p/tables/t/streams/_default".to_string(),
+            write_stream: write_stream(),
             ..Default::default()
         };
         write
@@ -153,5 +150,9 @@ mod tests {
         let err = handle.await?.expect_err("should return an error");
         assert!(matches!(err, AppendError::RowErrors(_)));
         Ok(())
+    }
+
+    fn write_stream() -> String {
+        "projects/p/datasets/d/tables/t/streams/_default".to_string()
     }
 }

--- a/src/bigquery-write/src/arrow/default.rs
+++ b/src/bigquery-write/src/arrow/default.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     fn write_stream() -> String {
-        "projects/p/tables/t/streams/_default".to_string()
+        "projects/p/datasets/d/tables/t/streams/_default".to_string()
     }
 
     fn schema() -> ArrowSchema {


### PR DESCRIPTION
:monkey:

https://github.com/googleapis/google-cloud-rust/pull/6247#discussion_r3692934978

While not important for these tests, having a bad resource name can only confuse the reader.