### PR TITLE
impl(bigquery): add arrow API surface

### DIFF
--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -26,7 +26,6 @@ pub struct WriterBuilder {
 }
 
 impl WriterBuilder {
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn new(inner: Arc<Transport>, schema: ArrowSchema) -> Self {
         Self { inner, schema }
     }

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -29,7 +29,6 @@ pub struct WriterBuilder {
 }
 
 impl WriterBuilder {
-    #[cfg_attr(not(test), expect(dead_code))]
     pub(crate) fn new(inner: Arc<Transport>, schema: ArrowSchema) -> Self {
         Self { inner, schema }
     }

--- a/src/bigquery-write/src/client.rs
+++ b/src/bigquery-write/src/client.rs
@@ -52,8 +52,7 @@ impl Write {
     ///
     /// use google_cloud_bigquery_write::model::ArrowSchema;
     /// fn schema() -> ArrowSchema {
-    ///   // Define your table's schema...
-    /// # panic!()
+    ///   todo!("Define your table's schema...")
     /// }
     /// ```
     ///

--- a/src/bigquery-write/src/client.rs
+++ b/src/bigquery-write/src/client.rs
@@ -47,7 +47,7 @@ impl Write {
     /// # async fn sample(client: Write) -> anyhow::Result<()> {
     /// let writer = client
     ///   .arrow(schema())
-    ///   .default("projects/p/datasets/d/tables/t")?;
+    ///   .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
     /// # Ok(()) }
     ///
     /// use google_cloud_bigquery_write::model::ArrowSchema;

--- a/src/bigquery-write/src/client.rs
+++ b/src/bigquery-write/src/client.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use crate::ClientBuilderResult as BuilderResult;
+use crate::arrow::WriterBuilder as ArrowWriterBuilder;
 use crate::client_builder::ClientBuilder;
+use crate::model::ArrowSchema;
 use crate::transport::Transport;
 use std::sync::Arc;
 
@@ -36,19 +38,61 @@ impl Write {
             inner: Arc::new(transport),
         })
     }
+
+    /// Create a writer using [Arrow] as the data format.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery_write::client::Write;
+    /// # async fn sample(client: Write) -> anyhow::Result<()> {
+    /// let writer = client
+    ///   .arrow(schema())
+    ///   .default("projects/p/datasets/d/tables/t")?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery_write::model::ArrowSchema;
+    /// fn schema() -> ArrowSchema {
+    ///   // Define your table's schema...
+    /// # panic!()
+    /// }
+    /// ```
+    ///
+    /// [arrow]: https://arrow.apache.org/
+    pub fn arrow(&self, schema: ArrowSchema) -> ArrowWriterBuilder {
+        ArrowWriterBuilder::new(self.inner.clone(), schema)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::AppendError;
+    use crate::model::{ArrowRecordBatch, ArrowSchema};
+    use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Status as TonicStatus;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 
     #[tokio::test]
-    async fn test_client_builder() -> anyhow::Result<()> {
-        let _ = Write::builder()
+    async fn arrow() -> anyhow::Result<()> {
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Err(TonicStatus::failed_precondition("fail")));
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let client = Write::builder()
+            .with_endpoint(endpoint)
             .with_credentials(Anonymous::new().build())
             .build()
             .await?;
+        let writer = client
+            .arrow(ArrowSchema::new())
+            .default("projects/p/datasets/d/tables/t")?;
+        let err = writer
+            .append(ArrowRecordBatch::new())
+            .send()
+            .await
+            .expect_err("write should fail");
+        assert!(matches!(err, AppendError::Rpc { source: _ }));
+
         Ok(())
     }
 }


### PR DESCRIPTION
Adds a hook to the client to create an arrow writer. This finally rounds out the most basic of API surfaces and attaches it to the implementation.

The code is now usable. We can also start writing examples for these public APIs. (I'll track that work in #6224)

I have an integration test written, but I need to clean it up. I will send it in a follow up PR.

Towards #5664. (I need to clean up some of the modules)