### PR TITLE
refactor(storage): remove redundant trait bounds

### DIFF
--- a/src/storage/src/storage/bidi/transport.rs
+++ b/src/storage/src/storage/bidi/transport.rs
@@ -38,7 +38,7 @@ impl ObjectDescriptorTransport {
     ) -> Result<(Self, Vec<ReadObjectResponse>)>
     where
         T: super::Client + Clone + Sync,
-        <T as super::Client>::Stream: super::TonicStreaming + Send + Sync,
+        <T as super::Client>::Stream: super::TonicStreaming,
     {
         use gaxi::prost::FromProto;
 

--- a/src/storage/src/storage/bidi_write/transport.rs
+++ b/src/storage/src/storage/bidi_write/transport.rs
@@ -48,7 +48,7 @@ impl AppendableObjectWriterTransport {
     ) -> Result<Self>
     where
         T: Client + Clone + Sync + Send + 'static,
-        <T as Client>::Stream: TonicStreaming + Send + Sync,
+        <T as Client>::Stream: TonicStreaming,
     {
         let (initial, connection) = connector.connect_open(req).await?;
         Self::start_worker(connector, initial, connection, 0)
@@ -60,7 +60,7 @@ impl AppendableObjectWriterTransport {
     ) -> Result<Self>
     where
         T: Client + Clone + Sync + Send + 'static,
-        <T as Client>::Stream: TonicStreaming + Send + Sync,
+        <T as Client>::Stream: TonicStreaming,
     {
         let generation = req.generation;
         let (initial, connection) = connector.connect_reopen(req).await?;
@@ -75,7 +75,7 @@ impl AppendableObjectWriterTransport {
     ) -> Result<Self>
     where
         T: Client + Clone + Sync + Send + 'static,
-        <T as Client>::Stream: TonicStreaming + Send + Sync,
+        <T as Client>::Stream: TonicStreaming,
     {
         let mut persisted_size = 0;
         let mut generation = generation;


### PR DESCRIPTION
On  bidi's ObjectDescriptionTransport:

- The Send bound on <T as Client>::Stream is redundant because the TonicStreaming trait supertrait bounds already include Send. 
- The Sync bound is unnecessary because the stream is not shared across threads.