### PR TITLE
docs(spanner): add runner for samples + add missing sample

### DIFF
--- a/src/spanner/examples/README.md
+++ b/src/spanner/examples/README.md
@@ -2,3 +2,60 @@
 
 This directory contains a number of code examples used in the Spanner
 documentation.
+
+## Running the Sample Applications
+
+You can run individual samples from the command line using Cargo. We provide two
+binary applications corresponding to the GoogleSQL and PostgreSQL dialects:
+
+### GoogleSQL Dialect (`spanner_sample`)
+
+```bash
+cargo run -p spanner-samples --bin spanner_sample -- <command> <instance-id> <database-id>
+```
+
+#### Example Commands
+
+- `createdatabase`: Provision a GoogleSQL database and initial schema
+- `write`: Insert initial data into Singers and Albums
+- `insertusingdml` / `writeusingdml`: Insert rows into Singers table using DML
+- `query`: Query Albums table
+- `querywithparameter`: Query Singers table using a parameter
+- `read`: Read rows from Albums table
+- `addindex` / `createindex`: Create an index
+- `readindex`: Read rows using an index
+- `addcolumn` / `addmarketingbudget`: Add a MarketingBudget column
+- `update`: Update MarketingBudget values
+- `updateusingdml`: Update values using DML
+- `updateusingpartitioneddml`: Update values using Partitioned DML
+- `querynewcolumn` / `querymarketingbudget`: Query rows with the new column
+- `addstoringindex`: Create a storing index
+- `readstoringindex`: Read rows using a storing index
+- `readonlytransaction`: Execute a read-only transaction
+- `deleteusingpartitioneddml`: Delete rows using Partitioned DML
+
+### PostgreSQL Dialect (`pg_spanner_sample`)
+
+```bash
+cargo run -p spanner-samples --bin pg_spanner_sample -- <command> <instance-id> <database-id>
+```
+
+#### Example Commands
+
+- `createpgdatabase` / `createdatabase`: Provision a PostgreSQL-dialect database
+  and initial schema
+- `write`: Insert initial data into Singers and Albums
+- `writeusingdml` / `insertusingdml`: Insert rows into Singers table using DML
+- `querysingerstable` / `query`: Query Singers table
+- `querywithparameter`: Query Singers table using a parameter
+- `addindex` / `createindex`: Create an index
+- `readindex`: Read rows using an index
+- `addcolumn` / `addmarketingbudget`: Add a MarketingBudget column
+- `update`: Update MarketingBudget values
+- `updateusingdml`: Update values using DML
+- `updateusingpartitioneddml`: Update values using Partitioned DML
+- `querynewcolumn` / `querymarketingbudget`: Query rows with the new column
+- `addstoringindex`: Create a storing index
+- `readstoringindex`: Read rows using a storing index
+- `readonlytransaction`: Execute a read-only transaction
+- `deleteusingpartitioneddml`: Delete rows using Partitioned DML

--- a/src/spanner/examples/src/bin/pg_spanner_sample.rs
+++ b/src/spanner/examples/src/bin/pg_spanner_sample.rs
@@ -1,0 +1,107 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simple command-line application to execute PostgreSQL-dialect Spanner samples.
+//!
+//! # Usage
+//! ```bash
+//! cargo run -p spanner-samples --bin pg_spanner_sample -- <command> <instance-id> <database-id>
+//! ```
+
+use google_cloud_spanner::client::Spanner;
+use spanner_samples::{client, database, dml, mutation, query};
+
+fn print_usage_and_exit(program: &str) -> ! {
+    eprintln!("Usage: {program} <command> <instance-id> <database-id>");
+    eprintln!("Commands:");
+    eprintln!("  createpgdatabase | createdatabase");
+    eprintln!("  write");
+    eprintln!("  writeusingdml | insertusingdml");
+    eprintln!("  querysingerstable | query");
+    eprintln!("  querywithparameter");
+    eprintln!("  addindex | createindex");
+    eprintln!("  readindex");
+    eprintln!("  addmarketingbudget | addcolumn");
+    eprintln!("  update");
+    eprintln!("  updateusingdml");
+    eprintln!("  updateusingpartitioneddml");
+    eprintln!("  querymarketingbudget | querynewcolumn");
+    eprintln!("  addstoringindex");
+    eprintln!("  readstoringindex");
+    eprintln!("  readonlytransaction");
+    eprintln!("  deleteusingpartitioneddml");
+    std::process::exit(1);
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        print_usage_and_exit(&args[0]);
+    }
+
+    let command = &args[1];
+    let instance_id = &args[2];
+    let database_id = &args[3];
+
+    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
+        .or_else(|_| std::env::var("SPANNER_EMULATOR_HOST").map(|_| "test-project".to_string()))
+        .expect("GOOGLE_CLOUD_PROJECT environment variable must be set (or SPANNER_EMULATOR_HOST)");
+
+    let instance_name = format!("projects/{project_id}/instances/{instance_id}");
+    let database_name = format!("{instance_name}/databases/{database_id}");
+
+    if command == "createpgdatabase" || command == "createdatabase" {
+        let spanner = Spanner::builder().build().await?;
+        let admin_client = spanner.database_admin_builder().build().await?;
+        database::pg_create_database::sample(&admin_client, &instance_name, database_id).await?;
+        println!("Closed client");
+        return Ok(());
+    }
+
+    let (client, admin_client) = client::init_client::sample(&database_name).await?;
+
+    match command.as_str() {
+        "write" => mutation::insert_data::sample(&client).await?,
+        "writeusingdml" | "insertusingdml" => dml::pg_dml_insert::sample(&client).await?,
+        "querysingerstable" | "query" => query::pg_query_data::sample(&client).await?,
+        "querywithparameter" => query::pg_query_parameter::sample(&client).await?,
+        "addindex" | "createindex" => {
+            database::pg_create_index::sample(&admin_client, &database_name).await?
+        }
+        "readindex" => query::pg_read_data_with_index::sample(&client).await?,
+        "addmarketingbudget" | "addcolumn" => {
+            database::pg_add_column::sample(&admin_client, &database_name).await?
+        }
+        "update" => mutation::update_data::sample(&client).await?,
+        "updateusingdml" => dml::pg_dml_update::sample(&client).await?,
+        "updateusingpartitioneddml" => dml::pg_dml_partitioned_update::sample(&client).await?,
+        "querymarketingbudget" | "querynewcolumn" => {
+            query::pg_query_new_column::sample(&client).await?
+        }
+        "addstoringindex" => {
+            database::pg_create_storing_index::sample(&admin_client, &database_name).await?
+        }
+        "readstoringindex" => query::pg_read_data_with_storing_index::sample(&client).await?,
+        "readonlytransaction" => query::pg_read_only_transaction::sample(&client).await?,
+        "deleteusingpartitioneddml" => dml::pg_dml_partitioned_delete::sample(&client).await?,
+        _ => {
+            eprintln!("Unknown command: {command}");
+            print_usage_and_exit(&args[0]);
+        }
+    }
+
+    println!("Closed client");
+    Ok(())
+}

--- a/src/spanner/examples/src/bin/spanner_sample.rs
+++ b/src/spanner/examples/src/bin/spanner_sample.rs
@@ -1,0 +1,109 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Simple command-line application to execute GoogleSQL Spanner samples.
+//!
+//! # Usage
+//! ```bash
+//! cargo run -p spanner-samples --bin spanner_sample -- <command> <instance-id> <database-id>
+//! ```
+
+use google_cloud_spanner::client::Spanner;
+use spanner_samples::{client, database, dml, mutation, query, read};
+
+fn print_usage_and_exit(program: &str) -> ! {
+    eprintln!("Usage: {program} <command> <instance-id> <database-id>");
+    eprintln!("Commands:");
+    eprintln!("  createdatabase");
+    eprintln!("  write");
+    eprintln!("  insertusingdml | writeusingdml");
+    eprintln!("  query");
+    eprintln!("  querywithparameter");
+    eprintln!("  read");
+    eprintln!("  addindex | createindex");
+    eprintln!("  readindex");
+    eprintln!("  addcolumn | addmarketingbudget");
+    eprintln!("  update");
+    eprintln!("  updateusingdml");
+    eprintln!("  updateusingpartitioneddml");
+    eprintln!("  querynewcolumn | querymarketingbudget");
+    eprintln!("  addstoringindex");
+    eprintln!("  readstoringindex");
+    eprintln!("  readonlytransaction");
+    eprintln!("  deleteusingpartitioneddml");
+    std::process::exit(1);
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        print_usage_and_exit(&args[0]);
+    }
+
+    let command = &args[1];
+    let instance_id = &args[2];
+    let database_id = &args[3];
+
+    let project_id = std::env::var("GOOGLE_CLOUD_PROJECT")
+        .or_else(|_| std::env::var("SPANNER_EMULATOR_HOST").map(|_| "test-project".to_string()))
+        .expect("GOOGLE_CLOUD_PROJECT environment variable must be set (or SPANNER_EMULATOR_HOST)");
+
+    let instance_name = format!("projects/{project_id}/instances/{instance_id}");
+    let database_name = format!("{instance_name}/databases/{database_id}");
+
+    if command == "createdatabase" {
+        let spanner = Spanner::builder().build().await?;
+        let admin_client = spanner.database_admin_builder().build().await?;
+        database::create_database::sample(&admin_client, &instance_name, database_id).await?;
+        println!("Closed client");
+        return Ok(());
+    }
+
+    let (client, admin_client) = client::init_client::sample(&database_name).await?;
+
+    match command.as_str() {
+        "write" => mutation::insert_data::sample(&client).await?,
+        "insertusingdml" | "writeusingdml" => dml::dml_insert::sample(&client).await?,
+        "query" => query::query_data::sample(&client).await?,
+        "querywithparameter" => query::query_parameter::sample(&client).await?,
+        "read" => read::read_data::sample(&client).await?,
+        "addindex" | "createindex" => {
+            database::create_index::sample(&admin_client, &database_name).await?
+        }
+        "readindex" => query::read_data_with_index::sample(&client).await?,
+        "addcolumn" | "addmarketingbudget" => {
+            database::add_column::sample(&admin_client, &database_name).await?
+        }
+        "update" => mutation::update_data::sample(&client).await?,
+        "updateusingdml" => dml::dml_update::sample(&client).await?,
+        "updateusingpartitioneddml" => dml::dml_partitioned_update::sample(&client).await?,
+        "querynewcolumn" | "querymarketingbudget" => {
+            query::query_new_column::sample(&client).await?
+        }
+        "addstoringindex" => {
+            database::create_storing_index::sample(&admin_client, &database_name).await?
+        }
+        "readstoringindex" => query::read_data_with_storing_index::sample(&client).await?,
+        "readonlytransaction" => query::read_only_transaction::sample(&client).await?,
+        "deleteusingpartitioneddml" => dml::dml_partitioned_delete::sample(&client).await?,
+        _ => {
+            eprintln!("Unknown command: {command}");
+            print_usage_and_exit(&args[0]);
+        }
+    }
+
+    println!("Closed client");
+    Ok(())
+}

--- a/src/spanner/examples/src/query/mod.rs
+++ b/src/spanner/examples/src/query/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod pg_query_data;
 pub mod pg_query_new_column;
 pub mod pg_query_parameter;
 pub mod pg_read_data_with_index;

--- a/src/spanner/examples/src/query/pg_query_data.rs
+++ b/src/spanner/examples/src/query/pg_query_data.rs
@@ -1,0 +1,37 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START spanner_postgresql_query_data]
+use google_cloud_spanner::client::DatabaseClient;
+use google_cloud_spanner::statement::Statement;
+
+pub async fn sample(client: &DatabaseClient) -> anyhow::Result<()> {
+    let statement = Statement::builder(
+        r#"SELECT singerid AS "SingerId", firstname as "FirstName", lastname as "LastName"
+         FROM Singers"#,
+    )
+    .build();
+
+    let transaction = client.single_use().build();
+    let mut result_set = transaction.execute_query(statement).await?;
+
+    while let Some(row) = result_set.next().await.transpose()? {
+        let singer_id: i64 = row.get("SingerId");
+        let first_name: String = row.get("FirstName");
+        let last_name: String = row.get("LastName");
+        println!("{singer_id} {first_name} {last_name}");
+    }
+    Ok(())
+}
+// [END spanner_postgresql_query_data]

--- a/src/spanner/examples/tests/integration.rs
+++ b/src/spanner/examples/tests/integration.rs
@@ -150,17 +150,22 @@ mod tests {
                 .await
                 .inspect_err(anydump)?;
 
-            // 2. Test spanner_postgresql_query_with_parameter sample
+            // 2. Test spanner_postgresql_query_data sample
+            query::pg_query_data::sample(client)
+                .await
+                .inspect_err(anydump)?;
+
+            // 2b. Test spanner_postgresql_query_with_parameter sample
             query::pg_query_parameter::sample(client)
                 .await
                 .inspect_err(anydump)?;
 
-            // 2b. Test spanner_postgresql_create_index sample
+            // 2c. Test spanner_postgresql_create_index sample
             database::pg_create_index::sample(&ctx.admin_client, &ctx.database_name)
                 .await
                 .inspect_err(anydump)?;
 
-            // 2c. Test spanner_postgresql_read_data_with_index sample
+            // 2d. Test spanner_postgresql_read_data_with_index sample
             query::pg_read_data_with_index::sample(client)
                 .await
                 .inspect_err(anydump)?;


### PR DESCRIPTION
- Adds a simple application for running the samples. This is used by the Spanner Getting Started Guide
- Adds a missing sample for querying Spanner PostgreSQL databases