### PR TITLE
impl(convert-prost): update oneof conversions

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.31.0
+version: v0.31.2-0.20260803194200-96709e948366
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/bigquery-write/src/generated/convert/storage/convert.rs
+++ b/src/bigquery-write/src/generated/convert/storage/convert.rs
@@ -301,8 +301,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::read_rows_re
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::read_rows_response::Rows, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::read_rows_response::Rows as T;
         match self {
-            Self::AvroRows(v) => Ok(T::from_avro_rows(v.cnv()?)),
-            Self::ArrowRecordBatch(v) => Ok(T::from_arrow_record_batch(v.cnv()?)),
+            Self::AvroRows(v) => Ok(T::AvroRows(std::boxed::Box::new(v.cnv()?))),
+            Self::ArrowRecordBatch(v) => Ok(T::ArrowRecordBatch(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -321,8 +321,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::read_rows_re
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::read_rows_response::Schema, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::read_rows_response::Schema as T;
         match self {
-            Self::AvroSchema(v) => Ok(T::from_avro_schema(v.cnv()?)),
-            Self::ArrowSchema(v) => Ok(T::from_arrow_schema(v.cnv()?)),
+            Self::AvroSchema(v) => Ok(T::AvroSchema(std::boxed::Box::new(v.cnv()?))),
+            Self::ArrowSchema(v) => Ok(T::ArrowSchema(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -476,8 +476,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::append_rows_
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::append_rows_request::Rows, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::append_rows_request::Rows as T;
         match self {
-            Self::ProtoRows(v) => Ok(T::from_proto_rows(v.cnv()?)),
-            Self::ArrowRows(v) => Ok(T::from_arrow_rows(v.cnv()?)),
+            Self::ProtoRows(v) => Ok(T::ProtoRows(std::boxed::Box::new(v.cnv()?))),
+            Self::ArrowRows(v) => Ok(T::ArrowRows(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -549,8 +549,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::append_rows_
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::append_rows_response::Response, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::append_rows_response::Response as T;
         match self {
-            Self::AppendResult(v) => Ok(T::from_append_result(v.cnv()?)),
-            Self::Error(v) => Ok(T::from_error(v.cnv()?)),
+            Self::AppendResult(v) => Ok(T::AppendResult(std::boxed::Box::new(v.cnv()?))),
+            Self::Error(v) => Ok(T::Error(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -822,8 +822,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::read_session
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::read_session::table_read_options::OutputFormatSerializationOptions, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::read_session::table_read_options::OutputFormatSerializationOptions as T;
         match self {
-            Self::ArrowSerializationOptions(v) => Ok(T::from_arrow_serialization_options(v.cnv()?)),
-            Self::AvroSerializationOptions(v) => Ok(T::from_avro_serialization_options(v.cnv()?)),
+            Self::ArrowSerializationOptions(v) => Ok(T::ArrowSerializationOptions(std::boxed::Box::new(v.cnv()?))),
+            Self::AvroSerializationOptions(v) => Ok(T::AvroSerializationOptions(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -872,8 +872,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_storage::model::read_session
     fn cnv(self) -> std::result::Result<crate::generated::gapic_storage::model::read_session::Schema, gaxi::prost::ConvertError> {
         use crate::generated::gapic_storage::model::read_session::Schema as T;
         match self {
-            Self::AvroSchema(v) => Ok(T::from_avro_schema(v.cnv()?)),
-            Self::ArrowSchema(v) => Ok(T::from_arrow_schema(v.cnv()?)),
+            Self::AvroSchema(v) => Ok(T::AvroSchema(std::boxed::Box::new(v.cnv()?))),
+            Self::ArrowSchema(v) => Ok(T::ArrowSchema(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }

--- a/src/firestore/src/generated/convert/firestore/convert.rs
+++ b/src/firestore/src/generated/convert/firestore/convert.rs
@@ -115,8 +115,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::precondition::Condit
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::precondition::ConditionType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::precondition::ConditionType as T;
         match self {
-            Self::Exists(v) => Ok(T::from_exists(v.cnv()?)),
-            Self::UpdateTime(v) => Ok(T::from_update_time(v.cnv()?)),
+            Self::Exists(v) => Ok(T::Exists(v.cnv()?)),
+            Self::UpdateTime(v) => Ok(T::UpdateTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -172,7 +172,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options:
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::transaction_options::read_only::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -216,8 +216,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::transaction_options:
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::transaction_options::Mode, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::transaction_options::Mode as T;
         match self {
-            Self::ReadOnly(v) => Ok(T::from_read_only(v.cnv()?)),
-            Self::ReadWrite(v) => Ok(T::from_read_write(v.cnv()?)),
+            Self::ReadOnly(v) => Ok(T::ReadOnly(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadWrite(v) => Ok(T::ReadWrite(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -298,21 +298,21 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::value::ValueType> fo
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::value::ValueType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::value::ValueType as T;
         match self {
-            Self::NullValue(v) => Ok(T::from_null_value(v)),
-            Self::BooleanValue(v) => Ok(T::from_boolean_value(v.cnv()?)),
-            Self::IntegerValue(v) => Ok(T::from_integer_value(v.cnv()?)),
-            Self::DoubleValue(v) => Ok(T::from_double_value(v.cnv()?)),
-            Self::TimestampValue(v) => Ok(T::from_timestamp_value(v.cnv()?)),
-            Self::StringValue(v) => Ok(T::from_string_value(v.cnv()?)),
-            Self::BytesValue(v) => Ok(T::from_bytes_value(v.cnv()?)),
-            Self::ReferenceValue(v) => Ok(T::from_reference_value(v.cnv()?)),
-            Self::GeoPointValue(v) => Ok(T::from_geo_point_value(v.cnv()?)),
-            Self::ArrayValue(v) => Ok(T::from_array_value(v.cnv()?)),
-            Self::MapValue(v) => Ok(T::from_map_value(v.cnv()?)),
-            Self::FieldReferenceValue(v) => Ok(T::from_field_reference_value(v.cnv()?)),
-            Self::VariableReferenceValue(v) => Ok(T::from_variable_reference_value(v.cnv()?)),
-            Self::FunctionValue(v) => Ok(T::from_function_value(v.cnv()?)),
-            Self::PipelineValue(v) => Ok(T::from_pipeline_value(v.cnv()?)),
+            Self::NullValue(v) => Ok(T::NullValue(v.into())),
+            Self::BooleanValue(v) => Ok(T::BooleanValue(v.cnv()?)),
+            Self::IntegerValue(v) => Ok(T::IntegerValue(v.cnv()?)),
+            Self::DoubleValue(v) => Ok(T::DoubleValue(v.cnv()?)),
+            Self::TimestampValue(v) => Ok(T::TimestampValue(std::boxed::Box::new(v.cnv()?))),
+            Self::StringValue(v) => Ok(T::StringValue(v.cnv()?)),
+            Self::BytesValue(v) => Ok(T::BytesValue(v.cnv()?)),
+            Self::ReferenceValue(v) => Ok(T::ReferenceValue(v.cnv()?)),
+            Self::GeoPointValue(v) => Ok(T::GeoPointValue(std::boxed::Box::new(v.cnv()?))),
+            Self::ArrayValue(v) => Ok(T::ArrayValue(std::boxed::Box::new(v.cnv()?))),
+            Self::MapValue(v) => Ok(T::MapValue(std::boxed::Box::new(v.cnv()?))),
+            Self::FieldReferenceValue(v) => Ok(T::FieldReferenceValue(v.cnv()?)),
+            Self::VariableReferenceValue(v) => Ok(T::VariableReferenceValue(v.cnv()?)),
+            Self::FunctionValue(v) => Ok(T::FunctionValue(std::boxed::Box::new(v.cnv()?))),
+            Self::PipelineValue(v) => Ok(T::PipelineValue(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -484,8 +484,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::get_document_request
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::get_document_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::get_document_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::Transaction(v) => Ok(T::Transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -526,8 +526,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::list_documents_reque
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::list_documents_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::list_documents_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::Transaction(v) => Ok(T::Transaction(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -673,9 +673,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::batch_get_documents_
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::batch_get_documents_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
-            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::Transaction(v) => Ok(T::Transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::NewTransaction(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -722,8 +722,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::batch_get_documents_
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::batch_get_documents_response::Result, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::batch_get_documents_response::Result as T;
         match self {
-            Self::Found(v) => Ok(T::from_found(v.cnv()?)),
-            Self::Missing(v) => Ok(T::from_missing(v.cnv()?)),
+            Self::Found(v) => Ok(T::Found(std::boxed::Box::new(v.cnv()?))),
+            Self::Missing(v) => Ok(T::Missing(v.cnv()?)),
         }
     }
 }
@@ -871,7 +871,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_request::Q
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_request::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
+            Self::StructuredQuery(v) => Ok(T::StructuredQuery(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -891,9 +891,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_request::C
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
-            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::Transaction(v) => Ok(T::Transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::NewTransaction(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -935,7 +935,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::run_query_response::
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_query_response::ContinuationSelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_query_response::ContinuationSelector as T;
         match self {
-            Self::Done(v) => Ok(T::from_done(v.cnv()?)),
+            Self::Done(v) => Ok(T::Done(v.cnv()?)),
         }
     }
 }
@@ -981,7 +981,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::run_aggregation_quer
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_aggregation_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_aggregation_query_request::QueryType as T;
         match self {
-            Self::StructuredAggregationQuery(v) => Ok(T::from_structured_aggregation_query(v.cnv()?)),
+            Self::StructuredAggregationQuery(v) => Ok(T::StructuredAggregationQuery(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1001,9 +1001,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::run_aggregation_quer
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::run_aggregation_query_request::ConsistencySelector as T;
         match self {
-            Self::Transaction(v) => Ok(T::from_transaction(v.cnv()?)),
-            Self::NewTransaction(v) => Ok(T::from_new_transaction(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::Transaction(v) => Ok(T::Transaction(v.cnv()?)),
+            Self::NewTransaction(v) => Ok(T::NewTransaction(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1069,7 +1069,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::partition_query_requ
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::partition_query_request::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::partition_query_request::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
+            Self::StructuredQuery(v) => Ok(T::StructuredQuery(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1087,7 +1087,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::partition_query_requ
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::partition_query_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::partition_query_request::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1223,8 +1223,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::listen_request::Targ
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::listen_request::TargetChange, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::listen_request::TargetChange as T;
         match self {
-            Self::AddTarget(v) => Ok(T::from_add_target(v.cnv()?)),
-            Self::RemoveTarget(v) => Ok(T::from_remove_target(v.cnv()?)),
+            Self::AddTarget(v) => Ok(T::AddTarget(std::boxed::Box::new(v.cnv()?))),
+            Self::RemoveTarget(v) => Ok(T::RemoveTarget(v.cnv()?)),
         }
     }
 }
@@ -1275,11 +1275,11 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::listen_response::Res
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::listen_response::ResponseType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::listen_response::ResponseType as T;
         match self {
-            Self::TargetChange(v) => Ok(T::from_target_change(v.cnv()?)),
-            Self::DocumentChange(v) => Ok(T::from_document_change(v.cnv()?)),
-            Self::DocumentDelete(v) => Ok(T::from_document_delete(v.cnv()?)),
-            Self::DocumentRemove(v) => Ok(T::from_document_remove(v.cnv()?)),
-            Self::Filter(v) => Ok(T::from_filter(v.cnv()?)),
+            Self::TargetChange(v) => Ok(T::TargetChange(std::boxed::Box::new(v.cnv()?))),
+            Self::DocumentChange(v) => Ok(T::DocumentChange(std::boxed::Box::new(v.cnv()?))),
+            Self::DocumentDelete(v) => Ok(T::DocumentDelete(std::boxed::Box::new(v.cnv()?))),
+            Self::DocumentRemove(v) => Ok(T::DocumentRemove(std::boxed::Box::new(v.cnv()?))),
+            Self::Filter(v) => Ok(T::Filter(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1337,7 +1337,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::target::query_target
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::query_target::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::query_target::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
+            Self::StructuredQuery(v) => Ok(T::StructuredQuery(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1376,8 +1376,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::target::TargetType> 
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::TargetType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::TargetType as T;
         match self {
-            Self::Query(v) => Ok(T::from_query(v.cnv()?)),
-            Self::Documents(v) => Ok(T::from_documents(v.cnv()?)),
+            Self::Query(v) => Ok(T::Query(std::boxed::Box::new(v.cnv()?))),
+            Self::Documents(v) => Ok(T::Documents(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1396,8 +1396,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::target::ResumeType> 
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::target::ResumeType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::target::ResumeType as T;
         match self {
-            Self::ResumeToken(v) => Ok(T::from_resume_token(v.cnv()?)),
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::ResumeToken(v) => Ok(T::ResumeToken(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1478,7 +1478,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::list_collection_ids_
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::list_collection_ids_request::ConsistencySelector as T;
         match self {
-            Self::ReadTime(v) => Ok(T::from_read_time(v.cnv()?)),
+            Self::ReadTime(v) => Ok(T::ReadTime(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1654,9 +1654,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::fi
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::filter::FilterType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_query::filter::FilterType as T;
         match self {
-            Self::CompositeFilter(v) => Ok(T::from_composite_filter(v.cnv()?)),
-            Self::FieldFilter(v) => Ok(T::from_field_filter(v.cnv()?)),
-            Self::UnaryFilter(v) => Ok(T::from_unary_filter(v.cnv()?)),
+            Self::CompositeFilter(v) => Ok(T::CompositeFilter(std::boxed::Box::new(v.cnv()?))),
+            Self::FieldFilter(v) => Ok(T::FieldFilter(std::boxed::Box::new(v.cnv()?))),
+            Self::UnaryFilter(v) => Ok(T::UnaryFilter(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1759,7 +1759,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_query::un
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_query::unary_filter::OperandType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_query::unary_filter::OperandType as T;
         match self {
-            Self::Field(v) => Ok(T::from_field(v.cnv()?)),
+            Self::Field(v) => Ok(T::Field(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1997,9 +1997,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregati
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_aggregation_query::aggregation::Operator as T;
         match self {
-            Self::Count(v) => Ok(T::from_count(v.cnv()?)),
-            Self::Sum(v) => Ok(T::from_sum(v.cnv()?)),
-            Self::Avg(v) => Ok(T::from_avg(v.cnv()?)),
+            Self::Count(v) => Ok(T::Count(std::boxed::Box::new(v.cnv()?))),
+            Self::Sum(v) => Ok(T::Sum(std::boxed::Box::new(v.cnv()?))),
+            Self::Avg(v) => Ok(T::Avg(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2037,7 +2037,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::structured_aggregati
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::structured_aggregation_query::QueryType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::structured_aggregation_query::QueryType as T;
         match self {
-            Self::StructuredQuery(v) => Ok(T::from_structured_query(v.cnv()?)),
+            Self::StructuredQuery(v) => Ok(T::StructuredQuery(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2189,9 +2189,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::write::Operation> fo
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::write::Operation, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::write::Operation as T;
         match self {
-            Self::Update(v) => Ok(T::from_update(v.cnv()?)),
-            Self::Delete(v) => Ok(T::from_delete(v.cnv()?)),
-            Self::Transform(v) => Ok(T::from_transform(v.cnv()?)),
+            Self::Update(v) => Ok(T::Update(std::boxed::Box::new(v.cnv()?))),
+            Self::Delete(v) => Ok(T::Delete(v.cnv()?)),
+            Self::Transform(v) => Ok(T::Transform(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2249,12 +2249,12 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::document_transform::
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::document_transform::field_transform::TransformType, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::document_transform::field_transform::TransformType as T;
         match self {
-            Self::SetToServerValue(v) => Ok(T::from_set_to_server_value(v)),
-            Self::Increment(v) => Ok(T::from_increment(v.cnv()?)),
-            Self::Maximum(v) => Ok(T::from_maximum(v.cnv()?)),
-            Self::Minimum(v) => Ok(T::from_minimum(v.cnv()?)),
-            Self::AppendMissingElements(v) => Ok(T::from_append_missing_elements(v.cnv()?)),
-            Self::RemoveAllFromArray(v) => Ok(T::from_remove_all_from_array(v.cnv()?)),
+            Self::SetToServerValue(v) => Ok(T::SetToServerValue(v.into())),
+            Self::Increment(v) => Ok(T::Increment(std::boxed::Box::new(v.cnv()?))),
+            Self::Maximum(v) => Ok(T::Maximum(std::boxed::Box::new(v.cnv()?))),
+            Self::Minimum(v) => Ok(T::Minimum(std::boxed::Box::new(v.cnv()?))),
+            Self::AppendMissingElements(v) => Ok(T::AppendMissingElements(std::boxed::Box::new(v.cnv()?))),
+            Self::RemoveAllFromArray(v) => Ok(T::RemoveAllFromArray(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }

--- a/src/spanner/src/generated/convert/spanner/convert.rs
+++ b/src/spanner/src/generated/convert/spanner/convert.rs
@@ -323,11 +323,11 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::change_str
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::change_stream_record::Record, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::change_stream_record::Record as T;
         match self {
-            Self::DataChangeRecord(v) => Ok(T::from_data_change_record(v.cnv()?)),
-            Self::HeartbeatRecord(v) => Ok(T::from_heartbeat_record(v.cnv()?)),
-            Self::PartitionStartRecord(v) => Ok(T::from_partition_start_record(v.cnv()?)),
-            Self::PartitionEndRecord(v) => Ok(T::from_partition_end_record(v.cnv()?)),
-            Self::PartitionEventRecord(v) => Ok(T::from_partition_event_record(v.cnv()?)),
+            Self::DataChangeRecord(v) => Ok(T::DataChangeRecord(std::boxed::Box::new(v.cnv()?))),
+            Self::HeartbeatRecord(v) => Ok(T::HeartbeatRecord(std::boxed::Box::new(v.cnv()?))),
+            Self::PartitionStartRecord(v) => Ok(T::PartitionStartRecord(std::boxed::Box::new(v.cnv()?))),
+            Self::PartitionEndRecord(v) => Ok(T::PartitionEndRecord(std::boxed::Box::new(v.cnv()?))),
+            Self::PartitionEventRecord(v) => Ok(T::PartitionEventRecord(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -381,7 +381,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::commit_res
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::commit_response::MultiplexedSessionRetry, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::commit_response::MultiplexedSessionRetry as T;
         match self {
-            Self::PrecommitToken(v) => Ok(T::from_precommit_token(v.cnv()?)),
+            Self::PrecommitToken(v) => Ok(T::PrecommitToken(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -430,8 +430,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::key_range:
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::key_range::StartKeyType, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::key_range::StartKeyType as T;
         match self {
-            Self::StartClosed(v) => Ok(T::from_start_closed(v.cnv()?)),
-            Self::StartOpen(v) => Ok(T::from_start_open(v.cnv()?)),
+            Self::StartClosed(v) => Ok(T::StartClosed(std::boxed::Box::new(v.cnv()?))),
+            Self::StartOpen(v) => Ok(T::StartOpen(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -450,8 +450,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::key_range:
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::key_range::EndKeyType, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::key_range::EndKeyType as T;
         match self {
-            Self::EndClosed(v) => Ok(T::from_end_closed(v.cnv()?)),
-            Self::EndOpen(v) => Ok(T::from_end_open(v.cnv()?)),
+            Self::EndClosed(v) => Ok(T::EndClosed(std::boxed::Box::new(v.cnv()?))),
+            Self::EndOpen(v) => Ok(T::EndOpen(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -626,9 +626,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::key_recipe
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::key_recipe::part::ValueType, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::key_recipe::part::ValueType as T;
         match self {
-            Self::Identifier(v) => Ok(T::from_identifier(v.cnv()?)),
-            Self::Value(v) => Ok(T::from_value(v.cnv()?)),
-            Self::Random(v) => Ok(T::from_random(v.cnv()?)),
+            Self::Identifier(v) => Ok(T::Identifier(v.cnv()?)),
+            Self::Value(v) => Ok(T::Value(std::boxed::Box::new(v.cnv()?))),
+            Self::Random(v) => Ok(T::Random(v.cnv()?)),
         }
     }
 }
@@ -680,9 +680,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::key_recipe
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::key_recipe::Target, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::key_recipe::Target as T;
         match self {
-            Self::TableName(v) => Ok(T::from_table_name(v.cnv()?)),
-            Self::IndexName(v) => Ok(T::from_index_name(v.cnv()?)),
-            Self::OperationUid(v) => Ok(T::from_operation_uid(v.cnv()?)),
+            Self::TableName(v) => Ok(T::TableName(v.cnv()?)),
+            Self::IndexName(v) => Ok(T::IndexName(v.cnv()?)),
+            Self::OperationUid(v) => Ok(T::OperationUid(v.cnv()?)),
         }
     }
 }
@@ -942,13 +942,13 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::mutation::
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::mutation::Operation, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::mutation::Operation as T;
         match self {
-            Self::Insert(v) => Ok(T::from_insert(v.cnv()?)),
-            Self::Update(v) => Ok(T::from_update(v.cnv()?)),
-            Self::InsertOrUpdate(v) => Ok(T::from_insert_or_update(v.cnv()?)),
-            Self::Replace(v) => Ok(T::from_replace(v.cnv()?)),
-            Self::Delete(v) => Ok(T::from_delete(v.cnv()?)),
-            Self::Send(v) => Ok(T::from_send(v.cnv()?)),
-            Self::Ack(v) => Ok(T::from_ack(v.cnv()?)),
+            Self::Insert(v) => Ok(T::Insert(std::boxed::Box::new(v.cnv()?))),
+            Self::Update(v) => Ok(T::Update(std::boxed::Box::new(v.cnv()?))),
+            Self::InsertOrUpdate(v) => Ok(T::InsertOrUpdate(std::boxed::Box::new(v.cnv()?))),
+            Self::Replace(v) => Ok(T::Replace(std::boxed::Box::new(v.cnv()?))),
+            Self::Delete(v) => Ok(T::Delete(std::boxed::Box::new(v.cnv()?))),
+            Self::Send(v) => Ok(T::Send(std::boxed::Box::new(v.cnv()?))),
+            Self::Ack(v) => Ok(T::Ack(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1233,8 +1233,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::result_set
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::result_set_stats::RowCount, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::result_set_stats::RowCount as T;
         match self {
-            Self::RowCountExact(v) => Ok(T::from_row_count_exact(v.cnv()?)),
-            Self::RowCountLowerBound(v) => Ok(T::from_row_count_lower_bound(v.cnv()?)),
+            Self::RowCountExact(v) => Ok(T::RowCountExact(v.cnv()?)),
+            Self::RowCountLowerBound(v) => Ok(T::RowCountLowerBound(v.cnv()?)),
         }
     }
 }
@@ -1587,8 +1587,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::directed_r
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::directed_read_options::Replicas, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::directed_read_options::Replicas as T;
         match self {
-            Self::IncludeReplicas(v) => Ok(T::from_include_replicas(v.cnv()?)),
-            Self::ExcludeReplicas(v) => Ok(T::from_exclude_replicas(v.cnv()?)),
+            Self::IncludeReplicas(v) => Ok(T::IncludeReplicas(std::boxed::Box::new(v.cnv()?))),
+            Self::ExcludeReplicas(v) => Ok(T::ExcludeReplicas(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2013,8 +2013,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::commit_req
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::commit_request::Transaction, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::commit_request::Transaction as T;
         match self {
-            Self::TransactionId(v) => Ok(T::from_transaction_id(v.cnv()?)),
-            Self::SingleUseTransaction(v) => Ok(T::from_single_use_transaction(v.cnv()?)),
+            Self::TransactionId(v) => Ok(T::TransactionId(v.cnv()?)),
+            Self::SingleUseTransaction(v) => Ok(T::SingleUseTransaction(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2233,11 +2233,11 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::transactio
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::transaction_options::read_only::TimestampBound, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::transaction_options::read_only::TimestampBound as T;
         match self {
-            Self::Strong(v) => Ok(T::from_strong(v.cnv()?)),
-            Self::MinReadTimestamp(v) => Ok(T::from_min_read_timestamp(v.cnv()?)),
-            Self::MaxStaleness(v) => Ok(T::from_max_staleness(v.cnv()?)),
-            Self::ReadTimestamp(v) => Ok(T::from_read_timestamp(v.cnv()?)),
-            Self::ExactStaleness(v) => Ok(T::from_exact_staleness(v.cnv()?)),
+            Self::Strong(v) => Ok(T::Strong(v.cnv()?)),
+            Self::MinReadTimestamp(v) => Ok(T::MinReadTimestamp(std::boxed::Box::new(v.cnv()?))),
+            Self::MaxStaleness(v) => Ok(T::MaxStaleness(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadTimestamp(v) => Ok(T::ReadTimestamp(std::boxed::Box::new(v.cnv()?))),
+            Self::ExactStaleness(v) => Ok(T::ExactStaleness(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2284,9 +2284,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::transactio
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::transaction_options::Mode, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::transaction_options::Mode as T;
         match self {
-            Self::ReadWrite(v) => Ok(T::from_read_write(v.cnv()?)),
-            Self::PartitionedDml(v) => Ok(T::from_partitioned_dml(v.cnv()?)),
-            Self::ReadOnly(v) => Ok(T::from_read_only(v.cnv()?)),
+            Self::ReadWrite(v) => Ok(T::ReadWrite(std::boxed::Box::new(v.cnv()?))),
+            Self::PartitionedDml(v) => Ok(T::PartitionedDml(std::boxed::Box::new(v.cnv()?))),
+            Self::ReadOnly(v) => Ok(T::ReadOnly(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2352,9 +2352,9 @@ impl gaxi::prost::FromProto<crate::generated::gapic_dataplane::model::transactio
     fn cnv(self) -> std::result::Result<crate::generated::gapic_dataplane::model::transaction_selector::Selector, gaxi::prost::ConvertError> {
         use crate::generated::gapic_dataplane::model::transaction_selector::Selector as T;
         match self {
-            Self::SingleUse(v) => Ok(T::from_single_use(v.cnv()?)),
-            Self::Id(v) => Ok(T::from_id(v.cnv()?)),
-            Self::Begin(v) => Ok(T::from_begin(v.cnv()?)),
+            Self::SingleUse(v) => Ok(T::SingleUse(std::boxed::Box::new(v.cnv()?))),
+            Self::Id(v) => Ok(T::Id(v.cnv()?)),
+            Self::Begin(v) => Ok(T::Begin(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }

--- a/src/storage/src/generated/convert/control/convert.rs
+++ b/src/storage/src/generated/convert/control/convert.rs
@@ -1171,8 +1171,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_config::filter::CloudStorageLocationsOneOf, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_config::filter::CloudStorageLocationsOneOf as T;
         match self {
-            Self::IncludedCloudStorageLocations(v) => Ok(T::from_included_cloud_storage_locations(v.cnv()?)),
-            Self::ExcludedCloudStorageLocations(v) => Ok(T::from_excluded_cloud_storage_locations(v.cnv()?)),
+            Self::IncludedCloudStorageLocations(v) => Ok(T::IncludedCloudStorageLocations(std::boxed::Box::new(v.cnv()?))),
+            Self::ExcludedCloudStorageLocations(v) => Ok(T::ExcludedCloudStorageLocations(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1191,8 +1191,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_config::filter::CloudStorageBucketsOneOf, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_config::filter::CloudStorageBucketsOneOf as T;
         match self {
-            Self::IncludedCloudStorageBuckets(v) => Ok(T::from_included_cloud_storage_buckets(v.cnv()?)),
-            Self::ExcludedCloudStorageBuckets(v) => Ok(T::from_excluded_cloud_storage_buckets(v.cnv()?)),
+            Self::IncludedCloudStorageBuckets(v) => Ok(T::IncludedCloudStorageBuckets(std::boxed::Box::new(v.cnv()?))),
+            Self::ExcludedCloudStorageBuckets(v) => Ok(T::ExcludedCloudStorageBuckets(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1475,8 +1475,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_finding::coldline_and_archival_storage_operations_spike::bucket_contribution::Details, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_finding::coldline_and_archival_storage_operations_spike::bucket_contribution::Details as T;
         match self {
-            Self::Contribution(v) => Ok(T::from_contribution(v.cnv()?)),
-            Self::Error(v) => Ok(T::from_error(v.cnv()?)),
+            Self::Contribution(v) => Ok(T::Contribution(std::boxed::Box::new(v.cnv()?))),
+            Self::Error(v) => Ok(T::Error(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1589,8 +1589,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_finding::cross_region_egress_spike::bucket_contribution::Details, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_finding::cross_region_egress_spike::bucket_contribution::Details as T;
         match self {
-            Self::Contribution(v) => Ok(T::from_contribution(v.cnv()?)),
-            Self::Error(v) => Ok(T::from_error(v.cnv()?)),
+            Self::Contribution(v) => Ok(T::Contribution(std::boxed::Box::new(v.cnv()?))),
+            Self::Error(v) => Ok(T::Error(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1703,8 +1703,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_finding::throttled_request_spike::bucket_contribution::Details, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_finding::throttled_request_spike::bucket_contribution::Details as T;
         match self {
-            Self::Contribution(v) => Ok(T::from_contribution(v.cnv()?)),
-            Self::Error(v) => Ok(T::from_error(v.cnv()?)),
+            Self::Contribution(v) => Ok(T::Contribution(std::boxed::Box::new(v.cnv()?))),
+            Self::Error(v) => Ok(T::Error(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1772,7 +1772,7 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_finding::storage_growth_above_trend::bucket_contribution::Details, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_finding::storage_growth_above_trend::bucket_contribution::Details as T;
         match self {
-            Self::Error(v) => Ok(T::from_error(v.cnv()?)),
+            Self::Error(v) => Ok(T::Error(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -1843,10 +1843,10 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::intelligence
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::intelligence_finding::IntelligenceFindingDetails, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::intelligence_finding::IntelligenceFindingDetails as T;
         match self {
-            Self::ColdlineAndArchivalStorageOperationsSpike(v) => Ok(T::from_coldline_and_archival_storage_operations_spike(v.cnv()?)),
-            Self::ThrottledRequestsSpike(v) => Ok(T::from_throttled_requests_spike(v.cnv()?)),
-            Self::CrossRegionEgressSpike(v) => Ok(T::from_cross_region_egress_spike(v.cnv()?)),
-            Self::StorageGrowthAboveTrend(v) => Ok(T::from_storage_growth_above_trend(v.cnv()?)),
+            Self::ColdlineAndArchivalStorageOperationsSpike(v) => Ok(T::ColdlineAndArchivalStorageOperationsSpike(std::boxed::Box::new(v.cnv()?))),
+            Self::ThrottledRequestsSpike(v) => Ok(T::ThrottledRequestsSpike(std::boxed::Box::new(v.cnv()?))),
+            Self::CrossRegionEgressSpike(v) => Ok(T::CrossRegionEgressSpike(std::boxed::Box::new(v.cnv()?))),
+            Self::StorageGrowthAboveTrend(v) => Ok(T::StorageGrowthAboveTrend(std::boxed::Box::new(v.cnv()?))),
         }
     }
 }
@@ -2123,8 +2123,8 @@ impl gaxi::prost::FromProto<crate::generated::gapic_control::model::finding_summ
     fn cnv(self) -> std::result::Result<crate::generated::gapic_control::model::finding_summary::summary_details::Magnitude, gaxi::prost::ConvertError> {
         use crate::generated::gapic_control::model::finding_summary::summary_details::Magnitude as T;
         match self {
-            Self::Count(v) => Ok(T::from_count(v.cnv()?)),
-            Self::Percentage(v) => Ok(T::from_percentage(v.cnv()?)),
+            Self::Count(v) => Ok(T::Count(v.cnv()?)),
+            Self::Percentage(v) => Ok(T::Percentage(v.cnv()?)),
         }
     }
 }

--- a/tests/protojson-conformance/src/generated/convert/convert.rs
+++ b/tests/protojson-conformance/src/generated/convert/convert.rs
@@ -88,10 +88,10 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::conformance_request:
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::conformance_request::Payload, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::conformance_request::Payload as T;
         match self {
-            Self::ProtobufPayload(v) => Ok(T::from_protobuf_payload(v.cnv()?)),
-            Self::JsonPayload(v) => Ok(T::from_json_payload(v.cnv()?)),
-            Self::JspbPayload(v) => Ok(T::from_jspb_payload(v.cnv()?)),
-            Self::TextPayload(v) => Ok(T::from_text_payload(v.cnv()?)),
+            Self::ProtobufPayload(v) => Ok(T::ProtobufPayload(v.cnv()?)),
+            Self::JsonPayload(v) => Ok(T::JsonPayload(v.cnv()?)),
+            Self::JspbPayload(v) => Ok(T::JspbPayload(v.cnv()?)),
+            Self::TextPayload(v) => Ok(T::TextPayload(v.cnv()?)),
         }
     }
 }
@@ -145,15 +145,15 @@ impl gaxi::prost::FromProto<crate::generated::gapic::model::conformance_response
     fn cnv(self) -> std::result::Result<crate::generated::gapic::model::conformance_response::Result, gaxi::prost::ConvertError> {
         use crate::generated::gapic::model::conformance_response::Result as T;
         match self {
-            Self::ParseError(v) => Ok(T::from_parse_error(v.cnv()?)),
-            Self::SerializeError(v) => Ok(T::from_serialize_error(v.cnv()?)),
-            Self::TimeoutError(v) => Ok(T::from_timeout_error(v.cnv()?)),
-            Self::RuntimeError(v) => Ok(T::from_runtime_error(v.cnv()?)),
-            Self::ProtobufPayload(v) => Ok(T::from_protobuf_payload(v.cnv()?)),
-            Self::JsonPayload(v) => Ok(T::from_json_payload(v.cnv()?)),
-            Self::Skipped(v) => Ok(T::from_skipped(v.cnv()?)),
-            Self::JspbPayload(v) => Ok(T::from_jspb_payload(v.cnv()?)),
-            Self::TextPayload(v) => Ok(T::from_text_payload(v.cnv()?)),
+            Self::ParseError(v) => Ok(T::ParseError(v.cnv()?)),
+            Self::SerializeError(v) => Ok(T::SerializeError(v.cnv()?)),
+            Self::TimeoutError(v) => Ok(T::TimeoutError(v.cnv()?)),
+            Self::RuntimeError(v) => Ok(T::RuntimeError(v.cnv()?)),
+            Self::ProtobufPayload(v) => Ok(T::ProtobufPayload(v.cnv()?)),
+            Self::JsonPayload(v) => Ok(T::JsonPayload(v.cnv()?)),
+            Self::Skipped(v) => Ok(T::Skipped(v.cnv()?)),
+            Self::JspbPayload(v) => Ok(T::JspbPayload(v.cnv()?)),
+            Self::TextPayload(v) => Ok(T::TextPayload(v.cnv()?)),
         }
     }
 }


### PR DESCRIPTION
Update the prost conversion template for oneof fields to construct the model enum variant directly rather than invoking a setter method, which we don't generate universally.

The generator was updated with this change upstream.