### PR TITLE
ci(tools): validate publishable crates for path-only workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "cargo_metadata",
  "serde",
  "serde_yaml",
+ "tempfile",
  "toml_edit",
 ]
 

--- a/tools/check-versions/Cargo.toml
+++ b/tools/check-versions/Cargo.toml
@@ -28,3 +28,6 @@ toml_edit                = { workspace = true, features = ["display", "parse"] }
 serde                    = { workspace = true, features = ["derive"] }
 serde_yaml.workspace     = true
 anyhow.workspace         = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/tools/check-versions/src/main.rs
+++ b/tools/check-versions/src/main.rs
@@ -112,6 +112,83 @@ fn check_version_mismatches(
     mismatches
 }
 
+/// Validates that publishable workspace crates specify explicit version requirements
+/// for all non-dev workspace dependencies.
+///
+/// Crates.io does not permit path-only dependencies on published crates:
+/// <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#local-paths-in-published-crates>
+fn check_path_only_workspace_dependencies(
+    ws_packages: &HashMap<&str, &cargo_metadata::Package>,
+    workspace_root: &Path,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for pkg in ws_packages.values() {
+        // Skip unpublishable packages (e.g. publish = false -> publish = Some([]))
+        let is_publishable = pkg.publish.as_ref().is_none_or(|p| !p.is_empty());
+        if !is_publishable {
+            continue;
+        }
+
+        let rel_manifest_path = pkg
+            .manifest_path
+            .as_std_path()
+            .strip_prefix(workspace_root)
+            .unwrap_or(pkg.manifest_path.as_std_path());
+
+        for dep in &pkg.dependencies {
+            // Ignore dev-dependencies as crates.io permits path-only dev-dependencies.
+            if dep.kind == cargo_metadata::DependencyKind::Development {
+                continue;
+            }
+
+            // Check if dependency refers to a local workspace package
+            let target_pkg_name = dep.name.as_str();
+            let is_workspace_dep = ws_packages.contains_key(target_pkg_name)
+                || dep
+                    .path
+                    .as_ref()
+                    .is_some_and(|p| p.starts_with(workspace_root));
+
+            if !is_workspace_dep {
+                continue;
+            }
+
+            let dep_alias = dep.rename.as_deref().unwrap_or(&dep.name);
+
+            // 1. Check if version requirement is missing (path-only / wildcard STAR)
+            if dep.req == cargo_metadata::semver::VersionReq::STAR {
+                errors.push(format!(
+                    "  - {}: publishable package '{}' depends on workspace package '{}' (as '{}') without a version requirement in Cargo.toml ({})",
+                    pkg.name,
+                    pkg.name,
+                    target_pkg_name,
+                    dep_alias,
+                    rel_manifest_path.display()
+                ));
+            }
+
+            // 2. Check if dependency targets an unpublishable workspace package (publish = false)
+            if let Some(target_pkg) = ws_packages.get(target_pkg_name) {
+                let target_is_publishable =
+                    target_pkg.publish.as_ref().is_none_or(|p| !p.is_empty());
+                if !target_is_publishable {
+                    errors.push(format!(
+                        "  - {}: publishable package '{}' depends on unpublishable workspace package '{}' (as '{}') in Cargo.toml ({})",
+                        pkg.name,
+                        pkg.name,
+                        target_pkg_name,
+                        dep_alias,
+                        rel_manifest_path.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    errors
+}
+
 fn main() -> anyhow::Result<()> {
     let metadata = cargo_metadata::MetadataCommand::new().exec()?;
     let workspace_root = metadata.workspace_root.as_std_path();
@@ -132,6 +209,9 @@ fn main() -> anyhow::Result<()> {
         ws_packages.insert(pkg.name.as_str(), pkg);
     }
 
+    let path_only_errors =
+        check_path_only_workspace_dependencies(&ws_packages, metadata.workspace_root.as_std_path());
+
     let mismatches = check_version_mismatches(
         &libraries,
         &root_deps,
@@ -139,15 +219,112 @@ fn main() -> anyhow::Result<()> {
         metadata.workspace_root.as_std_path(),
     );
 
+    let mut has_errors = false;
+
+    if !path_only_errors.is_empty() {
+        has_errors = true;
+        eprintln!("\nFound path-only workspace dependencies in publishable crates:");
+        for e in path_only_errors {
+            eprintln!("{e}");
+        }
+        eprintln!(
+            "\nAll workspace dependencies in publishable crates must specify a version requirement in Cargo.toml."
+        );
+        eprintln!(
+            "See: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#local-paths-in-published-crates"
+        );
+    }
+
     if !mismatches.is_empty() {
+        has_errors = true;
         eprintln!("\nFound version mismatches:");
         for m in mismatches {
             eprintln!("{m}");
         }
         eprintln!("\nUse librarian to change versions of a library.");
+    }
+
+    if has_errors {
         std::process::exit(1);
     }
 
-    println!("\nAll versions match perfectly!");
+    println!("\nAll versions and dependency requirements match perfectly!");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn unpack_txtar(txtar_content: &str, target_dir: &Path) {
+        let mut current_file: Option<PathBuf> = None;
+        let mut current_content = String::new();
+
+        for line in txtar_content.lines() {
+            if line.starts_with("-- ") && line.ends_with(" --") {
+                if let Some(path) = current_file.take() {
+                    let full_path = target_dir.join(path);
+                    fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+                    fs::write(full_path, &current_content).unwrap();
+                    current_content.clear();
+                }
+                let rel_path = line[3..line.len() - 3].trim();
+                current_file = Some(PathBuf::from(rel_path));
+            } else if current_file.is_some() {
+                current_content.push_str(line);
+                current_content.push('\n');
+            }
+        }
+        if let Some(path) = current_file {
+            let full_path = target_dir.join(path);
+            fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+            fs::write(full_path, &current_content).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_check_path_only_workspace_dependencies_with_txtar() {
+        let txtar_content = include_str!("../testdata/workspace.txtar");
+        let dir = tempfile::tempdir().unwrap();
+        unpack_txtar(txtar_content, dir.path());
+
+        // Verify parse_root_cargo_deps on testdata root Cargo.toml
+        let root_deps = parse_root_cargo_deps(&dir.path().join("Cargo.toml")).unwrap();
+        assert_eq!(
+            root_deps.get("ws-dep-versioned"),
+            Some(&"1.0.0".to_string())
+        );
+        assert_eq!(root_deps.get("serde"), Some(&"1.0".to_string()));
+        assert_eq!(root_deps.get("ws-dep-path-only"), None);
+        assert_eq!(
+            root_deps.get("unpublishable-pkg"),
+            Some(&"0.1.0".to_string())
+        );
+
+        // Run cargo_metadata on testdata workspace
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .current_dir(dir.path())
+            .exec()
+            .unwrap();
+
+        let mut ws_packages = HashMap::new();
+        for pkg in metadata.workspace_packages() {
+            ws_packages.insert(pkg.name.as_str(), pkg);
+        }
+
+        let errors = check_path_only_workspace_dependencies(&ws_packages, dir.path());
+
+        assert_eq!(errors.len(), 2);
+        assert!(errors.iter().any(|e| {
+            e.contains("publishable-pkg")
+                && e.contains("ws-dep-path-only")
+                && e.contains("without a version requirement")
+        }));
+        assert!(errors.iter().any(|e| {
+            e.contains("publishable-pkg")
+                && e.contains("unpublishable-pkg")
+                && e.contains("unpublishable workspace package")
+        }));
+    }
 }

--- a/tools/check-versions/src/main.rs
+++ b/tools/check-versions/src/main.rs
@@ -144,11 +144,10 @@ fn check_path_only_workspace_dependencies(
 
             // Check if dependency refers to a local workspace package
             let target_pkg_name = dep.name.as_str();
-            let is_workspace_dep = ws_packages.contains_key(target_pkg_name)
-                || dep
-                    .path
-                    .as_ref()
-                    .is_some_and(|p| p.starts_with(workspace_root));
+            let is_workspace_dep = dep
+                .path
+                .as_ref()
+                .is_some_and(|p| p.starts_with(workspace_root));
 
             if !is_workspace_dep {
                 continue;

--- a/tools/check-versions/testdata/workspace.txtar
+++ b/tools/check-versions/testdata/workspace.txtar
@@ -1,0 +1,83 @@
+-- Cargo.toml --
+[workspace]
+members = [
+    "publishable-pkg",
+    "ws-dep-versioned",
+    "ws-dep-path-only",
+    "dev-dep-path-only",
+    "unpublishable-pkg",
+]
+
+[workspace.dependencies]
+# ✅ Successful Case 1: Path dependency WITH version constraint
+ws-dep-versioned = { version = "1.0.0", path = "ws-dep-versioned" }
+
+# ✅ Successful Case 2: External non-path dependency WITH version constraint
+serde = { version = "1.0" }
+
+# ❌ Error Case 1: Path-only workspace dependency with NO version specified
+ws-dep-path-only = { path = "ws-dep-path-only" }
+
+# ❌ Error Case 2: Workspace dependency with a version specified, but the target package is publish = false
+unpublishable-pkg = { version = "0.1.0", path = "unpublishable-pkg" }
+
+# ✅ Allowed Case: Path-only workspace dependency used ONLY as a dev-dependency
+dev-dep-path-only = { path = "dev-dep-path-only" }
+
+-- publishable-pkg/Cargo.toml --
+[package]
+name = "publishable-pkg"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]
+# ✅ Successful Case 1: Workspace path dependency WITH version constraint
+ws-dep-versioned = { workspace = true }
+
+# ✅ Successful Case 2: External non-path dependency WITH version constraint
+serde = { workspace = true }
+
+# ❌ Error Case 1: Depending on a path-only workspace package without a version constraint
+ws-dep-path-only = { workspace = true }
+
+# ❌ Error Case 2: Depending on an unpublishable workspace package (publish = false)
+unpublishable-pkg = { workspace = true }
+
+[dev-dependencies]
+# ✅ Allowed Case: Dev-dependencies are permitted to be path-only
+dev-dep-path-only = { workspace = true }
+
+-- publishable-pkg/src/lib.rs --
+
+-- ws-dep-versioned/Cargo.toml --
+[package]
+name = "ws-dep-versioned"
+version = "1.0.0"
+edition = "2021"
+
+-- ws-dep-versioned/src/lib.rs --
+
+-- ws-dep-path-only/Cargo.toml --
+[package]
+name = "ws-dep-path-only"
+version = "1.0.0"
+edition = "2021"
+
+-- ws-dep-path-only/src/lib.rs --
+
+-- dev-dep-path-only/Cargo.toml --
+[package]
+name = "dev-dep-path-only"
+version = "1.0.0"
+edition = "2021"
+
+-- dev-dep-path-only/src/lib.rs --
+
+-- unpublishable-pkg/Cargo.toml --
+[package]
+name = "unpublishable-pkg"
+version = "0.1.0"
+publish = false
+edition = "2021"
+
+-- unpublishable-pkg/src/lib.rs --


### PR DESCRIPTION
Extends the `check-versions` tool to verify that publishable workspace crates declare explicit version requirements for all non-dev workspace dependencies. Path-only dependencies without a version constraint default to a wildcard requirement when packaged, causing `cargo publish` to fail on crates.io.

Also checks that publishable crates do not depend on unpublishable workspace members (`publish = false`), while permitting path-only dev-dependencies.

Fixes #6240