### PR TITLE
impl(bigquery): support default `project_id` on `ClientBuilder`

### DIFF
--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -28,6 +28,7 @@ use std::sync::Arc;
 ///
 /// Common configuration customizations include:
 ///
+/// - [`with_project_id()`][crate::builder::bigquery::ClientBuilder::with_project_id]: Sets the default Google Cloud project ID for the client.
 /// - [`with_endpoint()`][crate::builder::bigquery::ClientBuilder::with_endpoint]: Overrides the default API endpoint (`https://bigquery.googleapis.com`). Useful when testing against mock servers or running in restricted network environments (for example, with VPC Service Controls).
 /// - [`with_credentials()`][crate::builder::bigquery::ClientBuilder::with_credentials]: Overrides the default Application Default Credentials with explicit or custom authentication credentials.
 ///
@@ -154,11 +155,13 @@ impl BigQuery {
     /// # }
     /// ```
     pub fn query<S: Into<String>>(&self, sql: S) -> RunQuery {
-        let mut run_query = RunQuery::new(self.job_service.clone(), sql.into());
-        if let Some(project_id) = self.project_id.as_deref() {
-            run_query = run_query.with_project_id(project_id);
-        }
-        run_query
+        let builder = RunQuery::new(self.job_service.clone(), sql.into());
+        self.project_id
+            .as_deref()
+            .into_iter()
+            .fold(builder, |builder, project_id| {
+                builder.with_project_id(project_id)
+            })
     }
 }
 

--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -62,6 +62,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct BigQuery {
     job_service: Arc<JobService>,
+    project_id: Option<String>,
 }
 
 impl BigQuery {
@@ -105,7 +106,10 @@ impl BigQuery {
             job_service_builder.with_retry_throttler(builder.config.retry_throttler);
         let job_service = Arc::new(job_service_builder.build().await?);
 
-        Ok(BigQuery { job_service })
+        Ok(BigQuery {
+            job_service,
+            project_id: builder.project_id,
+        })
     }
 
     /// Creates a request builder to configure and execute a SQL query.
@@ -150,7 +154,11 @@ impl BigQuery {
     /// # }
     /// ```
     pub fn query<S: Into<String>>(&self, sql: S) -> RunQuery {
-        RunQuery::new(self.job_service.clone(), sql.into())
+        let mut run_query = RunQuery::new(self.job_service.clone(), sql.into());
+        if let Some(project_id) = self.project_id.as_deref() {
+            run_query = run_query.with_project_id(project_id);
+        }
+        run_query
     }
 }
 
@@ -161,10 +169,45 @@ mod tests {
 
     #[tokio::test]
     async fn test_bigquery_builder() -> anyhow::Result<()> {
-        let _client = BigQuery::builder()
+        let client = BigQuery::builder()
             .with_credentials(Anonymous::new().build())
             .build()
             .await?;
+        assert!(client.project_id.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_builder_with_project_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_project_id("test-proj")
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        assert_eq!(client.project_id.as_deref(), Some("test-proj"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_query_inherits_project_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_project_id("test-proj")
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let run_query = client.query("SELECT 1");
+        assert_eq!(run_query.project_id.as_deref(), Some("test-proj"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_query_without_project_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let run_query = client.query("SELECT 1");
+        assert!(run_query.project_id.is_none());
         Ok(())
     }
 }

--- a/src/bigquery/src/client_builder.rs
+++ b/src/bigquery/src/client_builder.rs
@@ -52,6 +52,17 @@ impl ClientBuilder {
     }
 
     /// Sets the default Google Cloud project ID for the client.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_bigquery::client::BigQuery;
+    /// # async fn sample() -> anyhow::Result<()> {
+    /// let client = BigQuery::builder()
+    ///     .with_project_id("my-project-id")
+    ///     .build()
+    ///     .await?;
+    /// # Ok(()) }
+    /// ```
     pub fn with_project_id<V: Into<String>>(mut self, project_id: V) -> Self {
         self.project_id = Some(project_id.into());
         self

--- a/src/bigquery/src/client_builder.rs
+++ b/src/bigquery/src/client_builder.rs
@@ -33,6 +33,7 @@ use google_cloud_gax::client_builder::Result;
 #[derive(Clone, Debug)]
 pub struct ClientBuilder {
     pub(crate) config: ClientConfig,
+    pub(crate) project_id: Option<String>,
 }
 
 impl Default for ClientBuilder {
@@ -46,7 +47,14 @@ impl ClientBuilder {
     pub fn new() -> Self {
         Self {
             config: ClientConfig::default(),
+            project_id: None,
         }
+    }
+
+    /// Sets the default Google Cloud project ID for the client.
+    pub fn with_project_id<V: Into<String>>(mut self, project_id: V) -> Self {
+        self.project_id = Some(project_id.into());
+        self
     }
 
     /// Sets the [BigQuery v2] API endpoint.
@@ -164,6 +172,7 @@ mod tests {
         assert!(builder.config.universe_domain.is_none(), "{builder:?}");
         assert!(builder.config.cred.is_none(), "{builder:?}");
         assert!(!builder.config.tracing);
+        assert!(builder.project_id.is_none(), "{builder:?}");
 
         Ok(())
     }
@@ -171,11 +180,13 @@ mod tests {
     #[tokio::test]
     async fn setters() -> anyhow::Result<()> {
         let builder = ClientBuilder::new()
+            .with_project_id("test-project")
             .with_endpoint("test-endpoint.com")
             .with_universe_domain("test-universe.com")
             .with_credentials(Anonymous::new().build())
             .with_tracing();
 
+        assert_eq!(builder.project_id, Some("test-project".to_string()));
         assert_eq!(
             builder.config.endpoint,
             Some("test-endpoint.com".to_string())


### PR DESCRIPTION
Add support for configuring a default GCP `project_id` on `ClientBuilder`, which is stored on the `BigQuery` client and automatically used as the billing project when running queries or attaching to jobs.

For https://github.com/googleapis/google-cloud-rust/issues/6198