### PR TITLE
impl(bigquery): add `attach_job` method to query client

### DIFF
--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -194,13 +194,15 @@ impl BigQuery {
     /// ```
     pub fn attach_job(&self, mut job_ref: JobReference) -> QueryResult<Query> {
         if job_ref.job_id.is_empty() {
-            return Err(QueryError::InvalidJobReference(
+            return Err(QueryError::InvalidArgument(
                 "job_id cannot be empty".to_string(),
             ));
         }
         if job_ref.project_id.is_empty() {
             let Some(proj) = &self.project_id else {
-                return Err(QueryError::MissingProjectId);
+                return Err(QueryError::InvalidArgument(
+                    "no project ID was provided".to_string(),
+                ));
             };
             job_ref.project_id = proj.clone();
         }
@@ -304,8 +306,16 @@ mod tests {
             .build()
             .await?;
         let job_ref = JobReference::new().set_job_id("job_789");
-        let err = client.attach_job(job_ref).unwrap_err();
-        assert!(matches!(err, crate::error::QueryError::MissingProjectId));
+        let err = client
+            .attach_job(job_ref)
+            .expect_err("should return an error when project_id is missing");
+        assert!(
+            matches!(
+                &err,
+                crate::error::QueryError::InvalidArgument(msg) if msg == "no project ID was provided"
+            ),
+            "expected InvalidArgument for missing project ID, got {err:?}"
+        );
         Ok(())
     }
 
@@ -317,11 +327,16 @@ mod tests {
             .build()
             .await?;
         let job_ref = JobReference::new();
-        let err = client.attach_job(job_ref).unwrap_err();
-        assert!(matches!(
-            err,
-            crate::error::QueryError::InvalidJobReference(_)
-        ));
+        let err = client
+            .attach_job(job_ref)
+            .expect_err("should return an error when job_id is empty");
+        assert!(
+            matches!(
+                &err,
+                crate::error::QueryError::InvalidArgument(msg) if msg == "job_id cannot be empty"
+            ),
+            "expected InvalidArgument for empty job ID, got {err:?}"
+        );
         Ok(())
     }
 }

--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -14,8 +14,10 @@
 
 use crate::ClientBuilderResult as BuilderResult;
 use crate::client_builder::ClientBuilder;
-use crate::query::RunQuery;
+use crate::error::QueryError;
+use crate::query::{Query, Result as QueryResult, RunQuery};
 use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::model::JobReference;
 use std::sync::Arc;
 
 /// A high-level BigQuery client for executing queries and managing jobs.
@@ -163,12 +165,62 @@ impl BigQuery {
                 builder.with_project_id(project_id)
             })
     }
+
+    /// Binds an existing out-of-process query job reference to a high-level `Query` handle.
+    ///
+    /// This method does not submit a new SQL query or perform network I/O.
+    /// If `job_ref.project_id` is empty, it defaults to the client's billing project ID.
+    ///
+    /// # Arguments
+    /// * `job_ref` - A [`JobReference`] identifying the job to attach to.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery::client::BigQuery;
+    /// # use google_cloud_bigquery_v2::model::JobReference;
+    /// # async fn sample(client: &BigQuery) -> anyhow::Result<()> {
+    /// let job_ref = JobReference::new()
+    ///     .set_project_id("my-project")
+    ///     .set_job_id("my_job_id")
+    ///     .set_location("us-central1");
+    /// let query = client.attach_job(job_ref)?;
+    /// let mut results = query.until_done().await?.read();
+    /// while let Some(row) = results.next().await {
+    ///     let row = row?;
+    ///     // process row
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn attach_job(&self, mut job_ref: JobReference) -> QueryResult<Query> {
+        if job_ref.job_id.is_empty() {
+            return Err(QueryError::InvalidJobReference(
+                "job_id cannot be empty".to_string(),
+            ));
+        }
+        if job_ref.project_id.is_empty() {
+            let Some(proj) = &self.project_id else {
+                return Err(QueryError::MissingProjectId);
+            };
+            job_ref.project_id = proj.clone();
+        }
+
+        Ok(Query {
+            job_service: self.job_service.clone(),
+            job_ref: Some(job_ref),
+            completed: false,
+            initial_job: None,
+            initial_response: None,
+            max_results: None,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::BigQuery;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_bigquery_v2::model::JobReference;
 
     #[tokio::test]
     async fn test_bigquery_builder() -> anyhow::Result<()> {
@@ -211,6 +263,65 @@ mod tests {
             .await?;
         let run_query = client.query("SELECT 1");
         assert!(run_query.project_id.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_attach_job() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let job_ref = JobReference::new()
+            .set_project_id("test-proj")
+            .set_job_id("job_123");
+        let query = client.attach_job(job_ref)?;
+        let job_ref = query.job_ref.as_ref().expect("job_ref should be set");
+        assert_eq!(job_ref.project_id, "test-proj");
+        assert_eq!(job_ref.job_id, "job_123");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_attach_job_inherits_project_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_project_id("client-proj")
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let job_ref = JobReference::new().set_job_id("job_456");
+        let query = client.attach_job(job_ref)?;
+        let job_ref = query.job_ref.as_ref().expect("job_ref should be set");
+        assert_eq!(job_ref.project_id, "client-proj");
+        assert_eq!(job_ref.job_id, "job_456");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_attach_job_missing_project_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let job_ref = JobReference::new().set_job_id("job_789");
+        let err = client.attach_job(job_ref).unwrap_err();
+        assert!(matches!(err, crate::error::QueryError::MissingProjectId));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_bigquery_attach_job_empty_job_id() -> anyhow::Result<()> {
+        let client = BigQuery::builder()
+            .with_project_id("client-proj")
+            .with_credentials(Anonymous::new().build())
+            .build()
+            .await?;
+        let job_ref = JobReference::new();
+        let err = client.attach_job(job_ref).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::QueryError::InvalidJobReference(_)
+        ));
         Ok(())
     }
 }

--- a/src/bigquery/src/error.rs
+++ b/src/bigquery/src/error.rs
@@ -33,6 +33,10 @@ pub enum QueryError {
     #[error("cannot perform this operation on a stateless query")]
     StatelessQuery,
 
+    /// An invalid job reference was provided.
+    #[error("invalid job reference: {0}")]
+    InvalidJobReference(String),
+
     /// The query job failed on the BigQuery service side.
     /// Includes the list of error protocols returned by the service.
     #[error("query job failed: {errors:?}")]
@@ -166,6 +170,15 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "cannot perform this operation on a stateless query"
+        );
+    }
+
+    #[test]
+    fn test_invalid_job_reference_display() {
+        let err = QueryError::InvalidJobReference("job_id must not be empty".to_string());
+        assert_eq!(
+            err.to_string(),
+            "invalid job reference: job_id must not be empty"
         );
     }
 

--- a/src/bigquery/src/error.rs
+++ b/src/bigquery/src/error.rs
@@ -21,9 +21,9 @@ use google_cloud_gax::error::Error;
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum QueryError {
-    /// The project ID was not provided or could not be determined.
-    #[error("no project ID was provided")]
-    MissingProjectId,
+    /// An invalid argument was provided (e.g. missing job ID or project ID).
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
 
     /// Only query jobs are supported by this client.
     #[error("only query jobs are supported")]
@@ -32,10 +32,6 @@ pub enum QueryError {
     /// The operation is not supported for stateless queries.
     #[error("cannot perform this operation on a stateless query")]
     StatelessQuery,
-
-    /// An invalid job reference was provided.
-    #[error("invalid job reference: {0}")]
-    InvalidJobReference(String),
 
     /// The query job failed on the BigQuery service side.
     /// Includes the list of error protocols returned by the service.
@@ -174,11 +170,11 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_job_reference_display() {
-        let err = QueryError::InvalidJobReference("job_id must not be empty".to_string());
+    fn test_invalid_argument_display() {
+        let err = QueryError::InvalidArgument("job_id must not be empty".to_string());
         assert_eq!(
             err.to_string(),
-            "invalid job reference: job_id must not be empty"
+            "invalid argument: job_id must not be empty"
         );
     }
 

--- a/src/bigquery/src/query/run_query.rs
+++ b/src/bigquery/src/query/run_query.rs
@@ -66,7 +66,9 @@ impl RunQuery {
     /// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
     /// [jobs.insert]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
     pub async fn run(self) -> Result<Query> {
-        let project_id = self.project_id.ok_or(QueryError::MissingProjectId)?;
+        let project_id = self
+            .project_id
+            .ok_or_else(|| QueryError::InvalidArgument("no project ID was provided".to_string()))?;
         let max_results = self.request.max_results;
 
         if self.request.force_job_path() {
@@ -179,7 +181,7 @@ mod tests {
         let job_service = create_job_service(MockJobService::new());
         let run_query = RunQuery::new(job_service, "SELECT 1".to_string());
         let res = run_query.run().await;
-        assert!(matches!(res, Err(QueryError::MissingProjectId)));
+        assert!(matches!(res, Err(QueryError::InvalidArgument(_))));
     }
 
     #[test]


### PR DESCRIPTION
Add `BigQuery::attach_job` to bind an existing out-of-process query job reference (`JobReference`) to a high-level `Query` handle without re-submitting SQL.