### PR TITLE
test(samples): ignore flaky compute usage report test

### DIFF
--- a/guide/samples/tests/compute.rs
+++ b/guide/samples/tests/compute.rs
@@ -34,6 +34,7 @@ mod tests {
             .inspect_err(anydump)
     }
 
+    #[ignore = "TODO(#6297) - disabled because it was flaky"]
     #[tokio::test]
     async fn usage_report_samples() -> anyhow::Result<()> {
         let project_id = project_id()?;


### PR DESCRIPTION
Ignore `tests::usage_report_samples` in `guide/samples/tests/compute.rs` due to transient errors from Compute Engine when disabling usage export buckets.

For #6297