### PR TITLE
feat(gax): support type-erased RequestSender with from_fn

### DIFF
--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -14,29 +14,64 @@
 
 //! Types for gRPC streaming requests and responses.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 
+/// A type-erased asynchronous function that sends a request item over a stream.
+///
+/// This closure takes an owned request item and returns a boxed, pinned future
+/// producing a [`crate::Result<()>`]. It allows [`RequestSender`] to perform
+/// pre-send transformations (such as converting high-level domain models to
+/// low-level Protobuf wire types) without exposing the underlying transport or
+/// wire types in the public API.
+type SenderFn<Req> =
+    dyn Fn(Req) -> Pin<Box<dyn Future<Output = crate::Result<()>> + Send>> + Send + Sync;
+
 /// A handle for sending outbound request items over a gRPC stream.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct RequestSender<Req> {
-    req_tx: mpsc::Sender<Req>,
+    inner: Arc<SenderFn<Req>>,
+}
+
+impl<Req> std::fmt::Debug for RequestSender<Req> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestSender").finish()
+    }
 }
 
 impl<Req> RequestSender<Req> {
     /// Creates a new [`RequestSender`].
-    pub fn new(req_tx: mpsc::Sender<Req>) -> Self {
-        Self { req_tx }
-    }
-
-    /// Sends a request item over the stream.
-    pub async fn send(&self, item: Req) -> Result<(), crate::error::Error>
+    pub fn new(req_tx: mpsc::Sender<Req>) -> Self
     where
         Req: Send + Sync + 'static,
     {
-        self.req_tx
-            .send(item)
-            .await
-            .map_err(crate::error::Error::io)
+        Self::from_fn(move |item| {
+            let req_tx = req_tx.clone();
+            async move {
+                req_tx
+                    .send(item)
+                    .await
+                    .map_err(|_| crate::error::Error::io("cannot send request: stream is closed"))
+            }
+        })
+    }
+
+    /// Sends a request item over the stream.
+    pub async fn send(&self, item: Req) -> Result<(), crate::error::Error> {
+        (self.inner)(item).await
+    }
+
+    #[doc(hidden)]
+    pub fn from_fn<F, Fut>(f: F) -> Self
+    where
+        F: Fn(Req) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = crate::Result<()>> + Send + 'static,
+    {
+        Self {
+            inner: Arc::new(move |item| Box::pin(f(item))),
+        }
     }
 }
 
@@ -90,6 +125,25 @@ mod tests {
         drop(req_rx);
         let err = sender.send("hello".to_string()).await.unwrap_err();
         assert!(err.is_io());
-        assert!(err.source().is_some());
+        assert_eq!(
+            err.source().unwrap().to_string(),
+            "cannot send request: stream is closed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_request_sender_from_fn() {
+        let sender = RequestSender::from_fn(|item: i32| async move {
+            if item < 0 {
+                Err(crate::error::Error::ser("negative number"))
+            } else {
+                Ok(())
+            }
+        });
+
+        assert!(sender.send(42).await.is_ok());
+        let err = sender.send(-1).await.unwrap_err();
+        assert!(err.is_serialization());
+        assert_eq!(format!("{sender:?}"), "RequestSender");
     }
 }


### PR DESCRIPTION
Add type erasure to RequestSender using an internal closure and a from_fn constructor.

This allows RequestSender instances to perform custom transformations such as synchronous request serialization and error mapping when sending items. These mapping should occur before putting the messages on the channel so that errors can be immediately returned to users.

For example, generated bidirectional streaming methods construct a RequestSender as follows:

```
let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
    move |item: crate::model::EchoRequest| {
        let req_tx = req_tx.clone();
        async move {
            let prost_item = item
                .to_proto()
                .map_err(google_cloud_gax::error::Error::ser)?;
            req_tx.send(prost_item).await.map_err(|_| {
                google_cloud_gax::error::Error::io("cannot send request: stream is closed")
            })
        }
    },
);
```

The existing new() constructor is retained so the generator can be updated independently. However we will likely keep this constructor for constructing mock implementations in the future.

For #2318 