### PR TITLE
feat(gax): support type-erased ResponseReceiver with from_stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3180,6 +3180,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -9332,6 +9333,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -46,6 +46,7 @@ serde.workspace       = true
 serde_json.workspace  = true
 thiserror.workspace   = true
 tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio-stream          = { workspace = true, features = ["sync"] }
 # Local crates
 google-cloud-rpc = { workspace = true }
 wkt.workspace    = true

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -63,7 +63,7 @@ impl<Req> RequestSender<Req> {
         (self.inner)(item).await
     }
 
-    #[doc(hidden)]
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     pub fn from_fn<F, Fut>(f: F) -> Self
     where
         F: Fn(Req) -> Fut + Send + Sync + 'static,
@@ -75,21 +75,53 @@ impl<Req> RequestSender<Req> {
     }
 }
 
+/// A type-erased stream of incoming responses from a gRPC stream.
+///
+/// This wraps an underlying `futures::Stream` in a boxed pinned trait object,
+/// enabling [`ResponseReceiver`] to perform asynchronous transformations (such
+/// as Protobuf deserialization) without exposing `futures::Stream` in the public API.
+type ResponseStream<Resp> = Pin<Box<dyn futures::Stream<Item = crate::Result<Resp>> + Send>>;
+
 /// A handle for receiving inbound response items from a gRPC stream.
-#[derive(Debug)]
 pub struct ResponseReceiver<Resp> {
-    rx: mpsc::Receiver<crate::Result<Resp>>,
+    inner: ResponseStream<Resp>,
+}
+
+impl<Resp> std::fmt::Debug for ResponseReceiver<Resp> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResponseReceiver").finish()
+    }
 }
 
 impl<Resp> ResponseReceiver<Resp> {
     /// Creates a new [`ResponseReceiver`].
-    pub fn new(rx: mpsc::Receiver<crate::Result<Resp>>) -> Self {
-        Self { rx }
+    pub fn new(rx: mpsc::Receiver<crate::Result<Resp>>) -> Self
+    where
+        Resp: Send + 'static,
+    {
+        Self::from_stream(tokio_stream::wrappers::ReceiverStream::new(rx))
     }
 
     /// Receives the next response item from the stream.
     pub async fn recv(&mut self) -> Option<crate::Result<Resp>> {
-        self.rx.recv().await
+        use futures::StreamExt as _;
+        self.inner.next().await
+    }
+
+    /// Creates a [`ResponseReceiver`] from an asynchronous stream.
+    ///
+    /// This constructor is `doc(hidden)` (except when `_internal-semver` is enabled)
+    /// so that generated client transports can construct [`ResponseReceiver`] instances
+    /// directly from gRPC response streams without exposing `futures::Stream` in the
+    /// public API documentation.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: futures::Stream<Item = crate::Result<Resp>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(stream),
+        }
     }
 }
 
@@ -145,5 +177,104 @@ mod tests {
         let err = sender.send(-1).await.unwrap_err();
         assert!(err.is_serialization());
         assert_eq!(format!("{sender:?}"), "RequestSender");
+    }
+
+    #[tokio::test]
+    async fn test_response_receiver_from_stream() {
+        let stream = futures::stream::iter(vec![
+            Ok("first".to_string()),
+            Err(crate::error::Error::deser("bad data")),
+            Ok("second".to_string()),
+        ]);
+        let mut receiver = ResponseReceiver::from_stream(stream);
+
+        assert_eq!(receiver.recv().await.unwrap().unwrap(), "first");
+        assert!(
+            receiver
+                .recv()
+                .await
+                .unwrap()
+                .unwrap_err()
+                .is_deserialization()
+        );
+        assert_eq!(receiver.recv().await.unwrap().unwrap(), "second");
+        assert!(receiver.recv().await.is_none());
+        assert_eq!(format!("{receiver:?}"), "ResponseReceiver");
+    }
+
+    #[tokio::test]
+    async fn test_response_receiver_generator_mapping_pipeline() {
+        use futures::StreamExt as _;
+
+        #[derive(Debug, PartialEq)]
+        struct RawProto {
+            text: String,
+            valid: bool,
+        }
+
+        #[derive(Debug, PartialEq)]
+        struct DomainModel {
+            text: String,
+        }
+
+        fn from_proto(raw: RawProto) -> Result<DomainModel, &'static str> {
+            if raw.valid {
+                Ok(DomainModel { text: raw.text })
+            } else {
+                Err("invalid proto payload")
+            }
+        }
+
+        // Simulates a tonic gRPC response stream yielding Result<RawProto, StatusError>
+        let raw_stream = futures::stream::iter(vec![
+            Ok(RawProto {
+                text: "hello".to_string(),
+                valid: true,
+            }),
+            Err(crate::error::Error::service("transport unavailable")),
+            Ok(RawProto {
+                text: "corrupted".to_string(),
+                valid: false,
+            }),
+            Ok(RawProto {
+                text: "world".to_string(),
+                valid: true,
+            }),
+        ]);
+
+        // Exact mapping pattern used by the generated transport:
+        let response_stream = raw_stream
+            .map(|res| res.and_then(|raw| from_proto(raw).map_err(crate::error::Error::deser)));
+
+        let mut receiver = ResponseReceiver::from_stream(response_stream);
+
+        // 1. Success
+        let item1 = receiver.recv().await.unwrap().unwrap();
+        assert_eq!(
+            item1,
+            DomainModel {
+                text: "hello".to_string()
+            }
+        );
+
+        // 2. Stream transport error
+        let err2 = receiver.recv().await.unwrap().unwrap_err();
+        assert!(err2.is_service());
+
+        // 3. Deserialization error
+        let err3 = receiver.recv().await.unwrap().unwrap_err();
+        assert!(err3.is_deserialization());
+
+        // 4. Success after recoverable error
+        let item4 = receiver.recv().await.unwrap().unwrap();
+        assert_eq!(
+            item4,
+            DomainModel {
+                text: "world".to_string()
+            }
+        );
+
+        // 5. Stream finished
+        assert!(receiver.recv().await.is_none());
     }
 }

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -136,21 +136,22 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_request_sender_and_response_receiver() {
+    async fn test_request_sender_and_response_receiver() -> Result<(), Box<dyn std::error::Error>> {
         let (req_tx, mut req_rx) = mpsc::channel::<String>(16);
         let (resp_tx, resp_rx) = mpsc::channel::<crate::Result<String>>(16);
 
         let sender = RequestSender::new(req_tx);
         let mut receiver = ResponseReceiver::new(resp_rx);
 
-        sender.send("hello".to_string()).await.unwrap();
-        assert_eq!(req_rx.recv().await.unwrap(), "hello");
+        sender.send("hello".to_string()).await?;
+        assert_eq!(req_rx.recv().await.as_deref(), Some("hello"));
 
-        resp_tx.send(Ok("world".to_string())).await.unwrap();
-        assert_eq!(receiver.recv().await.unwrap().unwrap(), "world");
+        resp_tx.send(Ok("world".to_string())).await?;
+        assert_eq!(receiver.recv().await.transpose()?.as_deref(), Some("world"));
 
         drop(resp_tx);
         assert!(receiver.recv().await.is_none());
+        Ok(())
     }
 
     #[tokio::test]
@@ -161,16 +162,19 @@ mod tests {
         let sender = RequestSender::new(req_tx);
 
         drop(req_rx);
-        let err = sender.send("hello".to_string()).await.unwrap_err();
+        let err = sender
+            .send("hello".to_string())
+            .await
+            .expect_err("send should fail when receiver is dropped");
         assert!(err.is_io());
         assert_eq!(
-            err.source().unwrap().to_string(),
-            "cannot send request: stream is closed"
+            err.source().map(|e| e.to_string()).as_deref(),
+            Some("cannot send request: stream is closed")
         );
     }
 
     #[tokio::test]
-    async fn test_request_sender_from_fn() {
+    async fn test_request_sender_from_fn() -> Result<(), Box<dyn std::error::Error>> {
         let sender = RequestSender::from_fn(|item: i32| async move {
             if item < 0 {
                 Err(crate::error::Error::ser("negative number"))
@@ -179,14 +183,18 @@ mod tests {
             }
         });
 
-        assert!(sender.send(42).await.is_ok());
-        let err = sender.send(-1).await.unwrap_err();
+        sender.send(42).await?;
+        let err = sender
+            .send(-1)
+            .await
+            .expect_err("negative number should trigger serialization error");
         assert!(err.is_serialization());
         assert_eq!(format!("{sender:?}"), "RequestSender");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_response_receiver_from_stream() {
+    async fn test_response_receiver_from_stream() -> Result<(), Box<dyn std::error::Error>> {
         let stream = futures::stream::iter(vec![
             Ok("first".to_string()),
             Err(crate::error::Error::deser("bad data")),
@@ -194,22 +202,36 @@ mod tests {
         ]);
         let mut receiver = ResponseReceiver::from_stream(stream);
 
-        assert_eq!(receiver.recv().await.unwrap().unwrap(), "first");
-        assert!(
+        assert_eq!(
             receiver
                 .recv()
                 .await
-                .unwrap()
-                .unwrap_err()
-                .is_deserialization()
+                .expect("expected first response")?
+                .as_str(),
+            "first"
         );
-        assert_eq!(receiver.recv().await.unwrap().unwrap(), "second");
+        let err = receiver
+            .recv()
+            .await
+            .expect("expected error item")
+            .expect_err("item should be Err");
+        assert!(err.is_deserialization());
+        assert_eq!(
+            receiver
+                .recv()
+                .await
+                .expect("expected second response")?
+                .as_str(),
+            "second"
+        );
         assert!(receiver.recv().await.is_none());
         assert_eq!(format!("{receiver:?}"), "ResponseReceiver");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_response_receiver_generator_mapping_pipeline() {
+    async fn test_response_receiver_generator_mapping_pipeline(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         use futures::StreamExt as _;
 
         #[derive(Debug, PartialEq)]
@@ -259,7 +281,7 @@ mod tests {
         let mut receiver = ResponseReceiver::from_stream(response_stream);
 
         // 1. Success
-        let item1 = receiver.recv().await.unwrap().unwrap();
+        let item1 = receiver.recv().await.expect("expected item 1")?;
         assert_eq!(
             item1,
             DomainModel {
@@ -268,18 +290,26 @@ mod tests {
         );
 
         // 2. Stream transport error
-        let err2 = receiver.recv().await.unwrap().unwrap_err();
+        let err2 = receiver
+            .recv()
+            .await
+            .expect("expected item 2")
+            .expect_err("item 2 should be Err");
         assert_eq!(
             err2.status().map(|s| s.code),
             Some(crate::error::rpc::Code::Unavailable)
         );
 
         // 3. Deserialization error
-        let err3 = receiver.recv().await.unwrap().unwrap_err();
+        let err3 = receiver
+            .recv()
+            .await
+            .expect("expected item 3")
+            .expect_err("item 3 should be Err");
         assert!(err3.is_deserialization());
 
         // 4. Success after recoverable error
-        let item4 = receiver.recv().await.unwrap().unwrap();
+        let item4 = receiver.recv().await.expect("expected item 4")?;
         assert_eq!(
             item4,
             DomainModel {
@@ -289,5 +319,6 @@ mod tests {
 
         // 5. Stream finished
         assert!(receiver.recv().await.is_none());
+        Ok(())
     }
 }

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -63,6 +63,12 @@ impl<Req> RequestSender<Req> {
         (self.inner)(item).await
     }
 
+    /// Creates a [`RequestSender`] from an asynchronous send function.
+    ///
+    /// This constructor is `doc(hidden)` (except when `_internal-semver` is enabled)
+    /// so that generated client transports can construct [`RequestSender`] instances
+    /// that perform pre-send transformations without exposing the closure types or
+    /// wire models in the public API documentation.
     #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     pub fn from_fn<F, Fut>(f: F) -> Self
     where
@@ -225,13 +231,17 @@ mod tests {
             }
         }
 
+        let status = crate::error::rpc::Status::default()
+            .set_code(crate::error::rpc::Code::Unavailable)
+            .set_message("transport unavailable");
+
         // Simulates a tonic gRPC response stream yielding Result<RawProto, StatusError>
         let raw_stream = futures::stream::iter(vec![
             Ok(RawProto {
                 text: "hello".to_string(),
                 valid: true,
             }),
-            Err(crate::error::Error::service("transport unavailable")),
+            Err(crate::error::Error::service(status)),
             Ok(RawProto {
                 text: "corrupted".to_string(),
                 valid: false,
@@ -259,7 +269,10 @@ mod tests {
 
         // 2. Stream transport error
         let err2 = receiver.recv().await.unwrap().unwrap_err();
-        assert!(err2.is_service());
+        assert_eq!(
+            err2.status().map(|s| s.code),
+            Some(crate::error::rpc::Code::Unavailable)
+        );
 
         // 3. Deserialization error
         let err3 = receiver.recv().await.unwrap().unwrap_err();

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -230,8 +230,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_response_receiver_generator_mapping_pipeline(
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_response_receiver_generator_mapping_pipeline()
+    -> Result<(), Box<dyn std::error::Error>> {
         use futures::StreamExt as _;
 
         #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Add type erasure to ResponseReceiver using an internal futures::Stream and a from_stream constructor.

This allows ResponseReceiver instances to directly wrap incoming gRPC response streams and perform asynchronous transformations and deserialization on demand without requiring a background tokio task or intermediate response channel.

For example, generated bidirectional streaming methods construct a ResponseReceiver as follows:
```rust
let response_stream = response.into_inner().map(|res| {
    res.map_err(gaxi::grpc::from_status::to_gax_error)
        .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
});
let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(response_stream);
```

The existing new() constructor is retained for compatibility and constructing mock implementations in the future.

For #2318 