### PR TITLE
impl(bigquery): wire up QueryCreationMetadata

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -497,8 +497,7 @@ libraries:
             - .google.cloud.bigquery.v2.QueryRequest.kind
             - .google.cloud.bigquery.v2.JobConfiguration.kind
             - .google.cloud.bigquery.v2.JobConfiguration.job_type
-            - .google.cloud.bigquery.v2.GetQueryResultsResponse.rows
-            - .google.cloud.bigquery.v2.QueryResponse.rows
+            - rows
           api_path: google/cloud/bigquery/v2
           template: bigquery
   - name: google-cloud-bigquery-analyticshub-v1

--- a/src/bigquery/src/generated.rs
+++ b/src/bigquery/src/generated.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod query_creation_metadata;
 mod query_metadata;
 mod run_query_request;
 
+pub use query_creation_metadata::QueryCreationMetadata;
 pub use query_metadata::QueryMetadata;
 pub use run_query_request::RunQueryRequest;

--- a/src/bigquery/src/generated/query_creation_metadata.rs
+++ b/src/bigquery/src/generated/query_creation_metadata.rs
@@ -23,7 +23,6 @@
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
 pub struct QueryCreationMetadata {
-
     /// Whether the query result was fetched from the query cache.
     pub cache_hit: std::option::Option<wkt::BoolValue>,
 
@@ -96,11 +95,6 @@ pub struct QueryCreationMetadata {
     /// Auto-generated ID for the query.
     pub query_id: std::string::String,
 
-    /// An object with as many results as can be contained within the maximum
-    /// permitted reply size. To get any additional rows, you can call
-    /// GetQueryResults and specify the jobReference returned above.
-    pub rows: std::vec::Vec<wkt::Struct>,
-
     /// The schema of the results. Present only when the query completes
     /// successfully.
     pub schema: std::option::Option<crate::model::TableSchema>,
@@ -156,7 +150,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [cache_hit][crate::model::QueryCreationMetadata::cache_hit].
     pub fn set_cache_hit<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<wkt::BoolValue>
+    where
+        T: std::convert::Into<wkt::BoolValue>,
     {
         self.cache_hit = std::option::Option::Some(v.into());
         self
@@ -164,7 +159,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [cache_hit][crate::model::QueryCreationMetadata::cache_hit].
     pub fn set_or_clear_cache_hit<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<wkt::BoolValue>
+    where
+        T: std::convert::Into<wkt::BoolValue>,
     {
         self.cache_hit = v.map(|x| x.into());
         self
@@ -172,7 +168,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [configuration][crate::model::QueryCreationMetadata::configuration].
     pub fn set_configuration<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::JobConfiguration>
+    where
+        T: std::convert::Into<crate::model::JobConfiguration>,
     {
         self.configuration = std::option::Option::Some(v.into());
         self
@@ -180,7 +177,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [configuration][crate::model::QueryCreationMetadata::configuration].
     pub fn set_or_clear_configuration<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::JobConfiguration>
+    where
+        T: std::convert::Into<crate::model::JobConfiguration>,
     {
         self.configuration = v.map(|x| x.into());
         self
@@ -188,7 +186,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [creation_time][crate::model::QueryCreationMetadata::creation_time].
     pub fn set_creation_time<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.creation_time = std::option::Option::Some(v.into());
         self
@@ -196,7 +195,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [creation_time][crate::model::QueryCreationMetadata::creation_time].
     pub fn set_or_clear_creation_time<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.creation_time = v.map(|x| x.into());
         self
@@ -204,7 +204,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [dml_stats][crate::model::QueryCreationMetadata::dml_stats].
     pub fn set_dml_stats<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::DmlStats>
+    where
+        T: std::convert::Into<crate::model::DmlStats>,
     {
         self.dml_stats = std::option::Option::Some(v.into());
         self
@@ -212,7 +213,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [dml_stats][crate::model::QueryCreationMetadata::dml_stats].
     pub fn set_or_clear_dml_stats<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::DmlStats>
+    where
+        T: std::convert::Into<crate::model::DmlStats>,
     {
         self.dml_stats = v.map(|x| x.into());
         self
@@ -220,7 +222,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [end_time][crate::model::QueryCreationMetadata::end_time].
     pub fn set_end_time<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.end_time = std::option::Option::Some(v.into());
         self
@@ -228,7 +231,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [end_time][crate::model::QueryCreationMetadata::end_time].
     pub fn set_or_clear_end_time<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.end_time = v.map(|x| x.into());
         self
@@ -238,7 +242,7 @@ impl QueryCreationMetadata {
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<crate::model::ErrorProto>
+        V: std::convert::Into<crate::model::ErrorProto>,
     {
         use std::iter::Iterator;
         self.errors = v.into_iter().map(|i| i.into()).collect();
@@ -259,7 +263,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [job_complete][crate::model::QueryCreationMetadata::job_complete].
     pub fn set_job_complete<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<wkt::BoolValue>
+    where
+        T: std::convert::Into<wkt::BoolValue>,
     {
         self.job_complete = std::option::Option::Some(v.into());
         self
@@ -267,7 +272,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [job_complete][crate::model::QueryCreationMetadata::job_complete].
     pub fn set_or_clear_job_complete<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<wkt::BoolValue>
+    where
+        T: std::convert::Into<wkt::BoolValue>,
     {
         self.job_complete = v.map(|x| x.into());
         self
@@ -275,7 +281,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [job_creation_reason][crate::model::QueryCreationMetadata::job_creation_reason].
     pub fn set_job_creation_reason<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::JobCreationReason>
+    where
+        T: std::convert::Into<crate::model::JobCreationReason>,
     {
         self.job_creation_reason = std::option::Option::Some(v.into());
         self
@@ -283,7 +290,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [job_creation_reason][crate::model::QueryCreationMetadata::job_creation_reason].
     pub fn set_or_clear_job_creation_reason<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::JobCreationReason>
+    where
+        T: std::convert::Into<crate::model::JobCreationReason>,
     {
         self.job_creation_reason = v.map(|x| x.into());
         self
@@ -291,7 +299,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [job_reference][crate::model::QueryCreationMetadata::job_reference].
     pub fn set_job_reference<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::JobReference>
+    where
+        T: std::convert::Into<crate::model::JobReference>,
     {
         self.job_reference = std::option::Option::Some(v.into());
         self
@@ -299,7 +308,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [job_reference][crate::model::QueryCreationMetadata::job_reference].
     pub fn set_or_clear_job_reference<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::JobReference>
+    where
+        T: std::convert::Into<crate::model::JobReference>,
     {
         self.job_reference = v.map(|x| x.into());
         self
@@ -319,7 +329,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [num_dml_affected_rows][crate::model::QueryCreationMetadata::num_dml_affected_rows].
     pub fn set_num_dml_affected_rows<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<wkt::Int64Value>
+    where
+        T: std::convert::Into<wkt::Int64Value>,
     {
         self.num_dml_affected_rows = std::option::Option::Some(v.into());
         self
@@ -327,7 +338,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [num_dml_affected_rows][crate::model::QueryCreationMetadata::num_dml_affected_rows].
     pub fn set_or_clear_num_dml_affected_rows<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<wkt::Int64Value>
+    where
+        T: std::convert::Into<wkt::Int64Value>,
     {
         self.num_dml_affected_rows = v.map(|x| x.into());
         self
@@ -340,7 +352,10 @@ impl QueryCreationMetadata {
     }
 
     /// Sets the value of [principal_subject][crate::model::QueryCreationMetadata::principal_subject].
-    pub fn set_principal_subject<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+    pub fn set_principal_subject<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
         self.principal_subject = v.into();
         self
     }
@@ -351,20 +366,10 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [rows][crate::model::QueryCreationMetadata::rows].
-    pub fn set_rows<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<wkt::Struct>
-    {
-        use std::iter::Iterator;
-        self.rows = v.into_iter().map(|i| i.into()).collect();
-        self
-    }
-
     /// Sets the value of [schema][crate::model::QueryCreationMetadata::schema].
     pub fn set_schema<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::TableSchema>
+    where
+        T: std::convert::Into<crate::model::TableSchema>,
     {
         self.schema = std::option::Option::Some(v.into());
         self
@@ -372,7 +377,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [schema][crate::model::QueryCreationMetadata::schema].
     pub fn set_or_clear_schema<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::TableSchema>
+    where
+        T: std::convert::Into<crate::model::TableSchema>,
     {
         self.schema = v.map(|x| x.into());
         self
@@ -386,7 +392,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [session_info][crate::model::QueryCreationMetadata::session_info].
     pub fn set_session_info<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::SessionInfo>
+    where
+        T: std::convert::Into<crate::model::SessionInfo>,
     {
         self.session_info = std::option::Option::Some(v.into());
         self
@@ -394,7 +401,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [session_info][crate::model::QueryCreationMetadata::session_info].
     pub fn set_or_clear_session_info<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::SessionInfo>
+    where
+        T: std::convert::Into<crate::model::SessionInfo>,
     {
         self.session_info = v.map(|x| x.into());
         self
@@ -402,7 +410,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [start_time][crate::model::QueryCreationMetadata::start_time].
     pub fn set_start_time<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.start_time = std::option::Option::Some(v.into());
         self
@@ -410,7 +419,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [start_time][crate::model::QueryCreationMetadata::start_time].
     pub fn set_or_clear_start_time<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.start_time = v.map(|x| x.into());
         self
@@ -418,7 +428,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [statistics][crate::model::QueryCreationMetadata::statistics].
     pub fn set_statistics<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::JobStatistics>
+    where
+        T: std::convert::Into<crate::model::JobStatistics>,
     {
         self.statistics = std::option::Option::Some(v.into());
         self
@@ -426,7 +437,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [statistics][crate::model::QueryCreationMetadata::statistics].
     pub fn set_or_clear_statistics<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::JobStatistics>
+    where
+        T: std::convert::Into<crate::model::JobStatistics>,
     {
         self.statistics = v.map(|x| x.into());
         self
@@ -434,7 +446,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [status][crate::model::QueryCreationMetadata::status].
     pub fn set_status<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<crate::model::JobStatus>
+    where
+        T: std::convert::Into<crate::model::JobStatus>,
     {
         self.status = std::option::Option::Some(v.into());
         self
@@ -442,7 +455,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [status][crate::model::QueryCreationMetadata::status].
     pub fn set_or_clear_status<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<crate::model::JobStatus>
+    where
+        T: std::convert::Into<crate::model::JobStatus>,
     {
         self.status = v.map(|x| x.into());
         self
@@ -450,7 +464,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [total_bytes_billed][crate::model::QueryCreationMetadata::total_bytes_billed].
     pub fn set_total_bytes_billed<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.total_bytes_billed = std::option::Option::Some(v.into());
         self
@@ -458,7 +473,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [total_bytes_billed][crate::model::QueryCreationMetadata::total_bytes_billed].
     pub fn set_or_clear_total_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.total_bytes_billed = v.map(|x| x.into());
         self
@@ -466,7 +482,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [total_bytes_processed][crate::model::QueryCreationMetadata::total_bytes_processed].
     pub fn set_total_bytes_processed<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<wkt::Int64Value>
+    where
+        T: std::convert::Into<wkt::Int64Value>,
     {
         self.total_bytes_processed = std::option::Option::Some(v.into());
         self
@@ -474,7 +491,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [total_bytes_processed][crate::model::QueryCreationMetadata::total_bytes_processed].
     pub fn set_or_clear_total_bytes_processed<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<wkt::Int64Value>
+    where
+        T: std::convert::Into<wkt::Int64Value>,
     {
         self.total_bytes_processed = v.map(|x| x.into());
         self
@@ -482,7 +500,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [total_rows][crate::model::QueryCreationMetadata::total_rows].
     pub fn set_total_rows<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<wkt::UInt64Value>
+    where
+        T: std::convert::Into<wkt::UInt64Value>,
     {
         self.total_rows = std::option::Option::Some(v.into());
         self
@@ -490,7 +509,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [total_rows][crate::model::QueryCreationMetadata::total_rows].
     pub fn set_or_clear_total_rows<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<wkt::UInt64Value>
+    where
+        T: std::convert::Into<wkt::UInt64Value>,
     {
         self.total_rows = v.map(|x| x.into());
         self
@@ -498,7 +518,8 @@ impl QueryCreationMetadata {
 
     /// Sets the value of [total_slot_ms][crate::model::QueryCreationMetadata::total_slot_ms].
     pub fn set_total_slot_ms<T>(mut self, v: T) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.total_slot_ms = std::option::Option::Some(v.into());
         self
@@ -506,7 +527,8 @@ impl QueryCreationMetadata {
 
     /// Sets or clears the value of [total_slot_ms][crate::model::QueryCreationMetadata::total_slot_ms].
     pub fn set_or_clear_total_slot_ms<T>(mut self, v: std::option::Option<T>) -> Self
-    where T: std::convert::Into<i64>
+    where
+        T: std::convert::Into<i64>,
     {
         self.total_slot_ms = v.map(|x| x.into());
         self
@@ -521,7 +543,7 @@ impl QueryCreationMetadata {
 
 impl std::convert::From<google_cloud_bigquery_v2::model::Job> for QueryCreationMetadata {
     fn from(resp: google_cloud_bigquery_v2::model::Job) -> Self {
-        Self{
+        Self {
             configuration: resp.configuration,
             etag: resp.etag,
             id: resp.id,
@@ -540,7 +562,7 @@ impl std::convert::From<google_cloud_bigquery_v2::model::Job> for QueryCreationM
 
 impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for QueryCreationMetadata {
     fn from(resp: google_cloud_bigquery_v2::model::QueryResponse) -> Self {
-        Self{
+        Self {
             cache_hit: resp.cache_hit,
             creation_time: resp.creation_time,
             dml_stats: resp.dml_stats,
@@ -554,7 +576,6 @@ impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for Quer
             num_dml_affected_rows: resp.num_dml_affected_rows,
             page_token: resp.page_token,
             query_id: resp.query_id,
-            rows: resp.rows,
             schema: resp.schema,
             session_info: resp.session_info,
             start_time: resp.start_time,
@@ -583,7 +604,6 @@ impl std::convert::From<QueryCreationMetadata> for crate::generated::QueryMetada
             num_dml_affected_rows: md.num_dml_affected_rows,
             page_token: md.page_token,
             query_id: md.query_id,
-            rows: md.rows,
             schema: md.schema,
             session_info: md.session_info,
             start_time: md.start_time,

--- a/src/bigquery/src/query/execution.rs
+++ b/src/bigquery/src/query/execution.rs
@@ -52,17 +52,11 @@ impl PostQueryExecutor {
             return Err(QueryError::JobFailed { errors: res.errors });
         }
 
-        let completed = res.job_complete.unwrap_or(false);
-        let job_ref = res.job_reference.clone();
-
-        Ok(Query {
-            job_service: self.job_service.clone(),
-            job_ref,
-            completed,
-            initial_response: Some(res),
-            initial_job: None,
+        Ok(Query::from_query_response(
+            self.job_service.clone(),
+            res,
             max_results,
-        })
+        ))
     }
 }
 
@@ -113,17 +107,11 @@ impl InsertJobExecutor {
             return Err(QueryError::JobFailed { errors });
         }
 
-        let completed = job_status.map(|s| s.state == "DONE").unwrap_or(false);
-        let job_ref = res.job_reference.clone();
-
-        Ok(Query {
-            job_service: self.job_service.clone(),
-            job_ref,
-            completed,
-            initial_job: Some(res),
-            initial_response: None,
-            max_results: self.max_results,
-        })
+        Ok(Query::from_job(
+            self.job_service.clone(),
+            res,
+            self.max_results,
+        ))
     }
 }
 
@@ -138,6 +126,7 @@ mod tests {
     use google_cloud_gax::error::Error as GaxError;
     use google_cloud_gax::error::rpc::{Code, Status};
     use google_cloud_gax::response::Response;
+    use serde_json::{Map, json};
     use test_case::test_case;
 
     type TestResult = anyhow::Result<()>;
@@ -149,7 +138,8 @@ mod tests {
             let job_ref = JobReference::new().set_job_id("my-job-123");
             let query_res = QueryResponse::new()
                 .set_job_complete(true)
-                .set_job_reference(job_ref.clone());
+                .set_job_reference(job_ref.clone())
+                .set_rows([Map::from_iter([("f".to_string(), json!([{"v": "Hello"}]))])]);
             Ok(Response::from(query_res))
         });
 
@@ -160,9 +150,13 @@ mod tests {
         let query = executor.execute().await?;
 
         assert!(query.completed, "{query:?}");
-        let job_ref = query.job_ref.clone().expect("should have job_ref");
+        let job_ref = query
+            .metadata
+            .job_reference
+            .clone()
+            .expect("should have job_ref");
         assert_eq!(job_ref.job_id, "my-job-123", "{job_ref:?}");
-        assert!(query.initial_response.is_some(), "{query:?}");
+        assert!(query.cached_rows.is_some(), "{query:?}");
 
         Ok(())
     }
@@ -310,7 +304,7 @@ mod tests {
         let query = executor.execute().await?;
 
         assert_eq!(query.completed, completed);
-        assert_eq!(query.job_ref, Some(job_ref));
+        assert_eq!(query.metadata.job_reference, Some(job_ref));
         Ok(())
     }
 }

--- a/src/bigquery/src/query/iterator.rs
+++ b/src/bigquery/src/query/iterator.rs
@@ -138,7 +138,7 @@ mod tests {
             .set_mode("NULLABLE")])
     }
 
-    pub(crate) fn create_test_row(val: &str) -> wkt::Struct {
+    fn create_test_row(val: &str) -> wkt::Struct {
         Map::from_iter([("f".to_string(), json!([{ "v": val }]))])
     }
 

--- a/src/bigquery/src/query/iterator.rs
+++ b/src/bigquery/src/query/iterator.rs
@@ -138,7 +138,7 @@ mod tests {
             .set_mode("NULLABLE")])
     }
 
-    fn create_test_row(val: &str) -> wkt::Struct {
+    pub(crate) fn create_test_row(val: &str) -> wkt::Struct {
         Map::from_iter([("f".to_string(), json!([{ "v": val }]))])
     }
 
@@ -164,7 +164,10 @@ mod tests {
         if let Some(token) = page_token {
             res = res.set_page_token(token);
         }
-        CompleteQuery::from_query_response(job_service, job_ref, res, None)
+        if let Some(job_ref) = job_ref {
+            res = res.set_job_reference(job_ref);
+        }
+        CompleteQuery::from_query_response(job_service, res, None)
     }
 
     #[tokio::test]
@@ -319,13 +322,9 @@ mod tests {
         let job_service = create_job_service(mock);
         let res = QueryResponse::new()
             .set_schema(create_test_schema())
+            .set_job_reference(create_test_job_ref())
             .set_page_token("token_1");
-        let q = CompleteQuery::from_query_response(
-            job_service,
-            Some(create_test_job_ref()),
-            res,
-            Some(25),
-        );
+        let q = CompleteQuery::from_query_response(job_service, res, Some(25));
         let mut iter = q.read();
 
         let row = iter.next().await.expect("should have row")?;

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use crate::error::QueryError;
+use crate::generated::QueryCreationMetadata;
 use crate::model::QueryMetadata;
 use crate::query::{QueryReference, Result, RowIterator, Schema};
 use google_cloud_bigquery_v2::client::JobService;
@@ -26,19 +27,63 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 /// A handle representing a running query.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Query {
     pub(crate) job_service: Arc<JobService>,
-    pub(crate) job_ref: Option<JobReference>,
     pub(crate) completed: bool,
-    // TODO(#5592): add QueryCreationMetadata to expose initial job and response data.
-    #[allow(dead_code)]
-    pub(crate) initial_job: Option<Job>,
-    pub(crate) initial_response: Option<QueryResponse>,
+    pub(crate) metadata: QueryCreationMetadata,
+    pub(crate) cached_rows: Option<VecDeque<wkt::Struct>>,
     pub(crate) max_results: Option<u32>,
 }
 
+impl std::fmt::Debug for Query {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Query")
+            .field("completed", &self.completed)
+            .field("job_reference", &self.metadata.job_reference)
+            .field("query_id", &self.metadata.query_id)
+            .field("max_results", &self.max_results)
+            .finish()
+    }
+}
+
 impl Query {
+    pub(crate) fn from_job(
+        job_service: Arc<JobService>,
+        initial_job: Job,
+        max_results: Option<u32>,
+    ) -> Self {
+        let completed = initial_job
+            .status
+            .as_ref()
+            .map(|s| s.state == "DONE")
+            .unwrap_or(false);
+        Self {
+            job_service,
+            completed,
+            cached_rows: None,
+            metadata: QueryCreationMetadata::from(initial_job),
+            max_results,
+        }
+    }
+
+    pub(crate) fn from_query_response(
+        job_service: Arc<JobService>,
+        mut query_response: QueryResponse,
+        max_results: Option<u32>,
+    ) -> Self {
+        let completed = query_response.job_complete.unwrap_or(false);
+        let cached_rows = VecDeque::from(std::mem::take(&mut query_response.rows));
+        let metadata = QueryCreationMetadata::from(query_response);
+        Self {
+            job_service,
+            completed,
+            cached_rows: Some(cached_rows),
+            metadata,
+            max_results,
+        }
+    }
+
     /// Returns the [`QueryReference`] for this query.
     ///
     /// The reference will be [`QueryReference::Job`] with a query [job reference],
@@ -47,13 +92,18 @@ impl Query {
     ///
     /// [job reference]: https://docs.cloud.google.com/bigquery/docs/reference/rest/v2/JobReference
     pub fn query_reference(&self) -> QueryReference {
-        let from_query_id = self
-            .initial_response
-            .as_ref()
-            .map(|res| res.query_id.clone())
-            .filter(|s| !s.is_empty())
-            .map(QueryReference::from_query_id);
-        let from_job_ref = self.job_ref.clone().map(QueryReference::from);
+        let from_query_id = if !self.metadata.query_id.is_empty() {
+            Some(QueryReference::from_query_id(
+                self.metadata.query_id.clone(),
+            ))
+        } else {
+            None
+        };
+        let from_job_ref = self
+            .metadata
+            .job_reference
+            .clone()
+            .map(QueryReference::from);
 
         from_job_ref
             .or(from_query_id)
@@ -65,23 +115,23 @@ impl Query {
     pub async fn until_done(self) -> Result<CompleteQuery> {
         let Query {
             job_service,
-            job_ref,
             completed,
-            initial_job: _,
-            initial_response,
+            metadata,
+            cached_rows,
             max_results,
         } = self;
 
-        if let (true, Some(initial_response)) = (completed, initial_response) {
-            return Ok(CompleteQuery::from_query_response(
+        if let (true, Some(cached_rows)) = (completed, cached_rows) {
+            return Ok(CompleteQuery::from_query_creation_metadata(
                 job_service,
-                job_ref,
-                initial_response,
+                metadata,
+                cached_rows,
                 max_results,
             ));
         }
 
-        let job_ref = job_ref
+        let job_ref = metadata
+            .job_reference
             .as_ref()
             .expect("query job should have job reference at this point");
         let backoff_policy = Arc::new(
@@ -151,14 +201,14 @@ impl CompleteQuery {
         }
     }
 
-    pub(crate) fn from_query_response(
+    pub(crate) fn from_query_creation_metadata(
         job_service: Arc<JobService>,
-        job_ref: Option<JobReference>,
-        mut res: QueryResponse,
+        metadata: QueryCreationMetadata,
+        cached_rows: VecDeque<wkt::Struct>,
         max_results: Option<u32>,
     ) -> Self {
-        let cached_rows = VecDeque::from(std::mem::take(&mut res.rows));
-        let metadata = QueryMetadata::from(res);
+        let job_ref = metadata.job_reference.clone();
+        let metadata = QueryMetadata::from(metadata);
         // DDL/DML queries have no schema.
         let schema = metadata.schema.clone().unwrap_or_default();
         let schema = Arc::new(Schema::new(schema));
@@ -267,6 +317,18 @@ mod tests {
 
     type TestResult = anyhow::Result<()>;
 
+    impl CompleteQuery {
+        pub(crate) fn from_query_response(
+            job_service: Arc<JobService>,
+            mut query_res: QueryResponse,
+            max_results: Option<u32>,
+        ) -> Self {
+            let cached_rows = std::mem::take(&mut query_res.rows).into();
+            let metadata = QueryCreationMetadata::from(query_res);
+            Self::from_query_creation_metadata(job_service, metadata, cached_rows, max_results)
+        }
+    }
+
     #[test_case(Some("query_123"), None, QueryReference::Stateless{ query_id: "query_123".to_string()}; "with query id")]
     #[test_case(Some(""), Some(JobReference::new()), QueryReference::Job(JobReference::new()); "empty query id")]
     #[test_case(None, Some(JobReference::new()), QueryReference::Job(JobReference::new()); "with job refearence")]
@@ -277,16 +339,15 @@ mod tests {
         expected: QueryReference,
     ) {
         let job_service = create_job_service(MockJobService::new());
-        let initial_response = query_id.map(|id| QueryResponse::new().set_query_id(id));
+        let res = QueryResponse::new();
+        let res = query_id
+            .into_iter()
+            .fold(res, |res, id| res.set_query_id(id));
+        let res = job_ref
+            .into_iter()
+            .fold(res, |res, j| res.set_job_reference(j));
 
-        let query = Query {
-            job_service,
-            job_ref,
-            completed: false,
-            initial_job: None,
-            initial_response,
-            max_results: None,
-        };
+        let query = Query::from_query_response(job_service, res, None);
 
         let result = query.query_reference();
         assert_eq!(result, expected);
@@ -306,14 +367,7 @@ mod tests {
             .set_rows([wkt::Struct::new()])
             .set_cache_hit(true);
 
-        let query = Query {
-            job_service,
-            job_ref: Some(job_ref),
-            completed: true,
-            initial_job: None,
-            initial_response: Some(query_res),
-            max_results: None,
-        };
+        let query = Query::from_query_response(job_service, query_res, None);
 
         let completed = query.until_done().await?;
         assert_eq!(completed.job_ref.as_ref().unwrap().job_id, "some_job_id");
@@ -339,14 +393,7 @@ mod tests {
             .set_job_reference(job_ref.clone())
             .set_schema(TableSchema::new());
 
-        let query = Query {
-            job_service,
-            job_ref: Some(job_ref),
-            completed: true,
-            initial_job: None,
-            initial_response: Some(query_res),
-            max_results: Some(42),
-        };
+        let query = Query::from_query_response(job_service, query_res, Some(42));
 
         let completed = query.until_done().await?;
         assert_eq!(completed.max_results, Some(42));
@@ -378,15 +425,9 @@ mod tests {
             .set_project_id("some_project")
             .set_job_id("some_job_id")
             .set_location("us-central1");
+        let job = Job::new().set_job_reference(job_ref);
 
-        let query = Query {
-            job_service,
-            job_ref: Some(job_ref),
-            completed: false,
-            initial_job: None,
-            initial_response: None,
-            max_results: None,
-        };
+        let query = Query::from_job(job_service, job, None);
 
         let completed = query.until_done().await?;
         assert_eq!(completed.job_ref.as_ref().unwrap().job_id, "some_job_id");
@@ -459,15 +500,9 @@ mod tests {
         let job_ref = JobReference::new()
             .set_project_id("some_project")
             .set_job_id("some_job_id");
+        let job = Job::new().set_job_reference(job_ref);
 
-        let query = Query {
-            job_service,
-            job_ref: Some(job_ref),
-            completed: false,
-            initial_job: None,
-            initial_response: None,
-            max_results: None,
-        };
+        let query = Query::from_job(job_service, job, None);
 
         let err = query.until_done().await.unwrap_err();
         let errors = match err {
@@ -500,15 +535,9 @@ mod tests {
         let job_ref = JobReference::new()
             .set_project_id("some_project")
             .set_job_id("some_job_id");
+        let job = Job::new().set_job_reference(job_ref);
 
-        let query = Query {
-            job_service,
-            job_ref: Some(job_ref),
-            completed: false,
-            initial_job: None,
-            initial_response: None,
-            max_results: None,
-        };
+        let query = Query::from_job(job_service, job, None);
 
         let err = query.until_done().await.unwrap_err();
         let source = match err {
@@ -536,12 +565,11 @@ mod tests {
         )]);
         let query_res = QueryResponse::new()
             .set_job_complete(true)
-            .set_job_reference(job_ref.clone())
+            .set_job_reference(job_ref)
             .set_schema(schema)
             .set_rows(vec![row]);
 
-        let complete_query =
-            CompleteQuery::from_query_response(job_service, Some(job_ref), query_res, None);
+        let complete_query = CompleteQuery::from_query_response(job_service, query_res, None);
 
         let mut iter = complete_query.read();
         let row = iter.next().await.expect("should return first row")?;
@@ -568,10 +596,11 @@ mod tests {
             .set_project_id("some_project")
             .set_job_id("some_job_id")
             .set_location("us-central1");
-        let query_res = QueryResponse::new().set_schema(TableSchema::new());
+        let query_res = QueryResponse::new()
+            .set_schema(TableSchema::new())
+            .set_job_reference(job_ref);
 
-        let complete_query =
-            CompleteQuery::from_query_response(job_service, Some(job_ref), query_res, None);
+        let complete_query = CompleteQuery::from_query_response(job_service, query_res, None);
         let job = complete_query.job_metadata().await?;
         assert_eq!(job.user_email, "test@example.com");
         Ok(())
@@ -581,7 +610,7 @@ mod tests {
     async fn test_complete_query_job_metadata_stateless() -> TestResult {
         let job_service = create_job_service(MockJobService::new());
         let query_res = QueryResponse::new().set_schema(TableSchema::new());
-        let complete_query = CompleteQuery::from_query_response(job_service, None, query_res, None);
+        let complete_query = CompleteQuery::from_query_response(job_service, query_res, None);
         let err = complete_query.job_metadata().await.unwrap_err();
         assert!(matches!(err, QueryError::StatelessQuery));
         Ok(())
@@ -602,10 +631,11 @@ mod tests {
         let job_ref = JobReference::new()
             .set_project_id("some_project")
             .set_job_id("some_job_id");
-        let query_res = QueryResponse::new().set_schema(TableSchema::new());
+        let query_res = QueryResponse::new()
+            .set_schema(TableSchema::new())
+            .set_job_reference(job_ref);
 
-        let complete_query =
-            CompleteQuery::from_query_response(job_service, Some(job_ref), query_res, None);
+        let complete_query = CompleteQuery::from_query_response(job_service, query_res, None);
         let err = complete_query.job_metadata().await.unwrap_err();
         let source = match err {
             QueryError::Rpc { source } => source,

--- a/src/bigquery/src/query/run_query.rs
+++ b/src/bigquery/src/query/run_query.rs
@@ -240,14 +240,16 @@ mod tests {
             let req_id = &req.query_request.as_ref().unwrap().request_id;
             assert!(req_id.starts_with(QUERY_REQUEST_ID_PREFIX), "{req_id:?}");
             assert!(req_id.len() <= BIGQUERY_REQ_ID_LIMIT, "{req_id:?}");
-            Ok(Response::from(QueryResponse::new()))
+            Ok(Response::from(
+                QueryResponse::new().set_query_id("some_query_id"),
+            ))
         });
         let job_service = create_job_service(mock);
         let run_query =
             RunQuery::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         let query = run_query.run().await?;
         assert!(!query.completed, "{query:?}");
-        assert!(query.initial_response.is_some(), "{query:?}");
+        assert_eq!(query.metadata.query_id, "some_query_id");
 
         Ok(())
     }


### PR DESCRIPTION
Wire up generated QueryCreationMetadata and use it internally. `Query::metadata()` to be added in a future PR, since we are probably gonna remove `query_reference`.

Towards #5844 