### PR TITLE
impl(showcase): regenerate showcase to use new streaming constructors

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.33.1-0.20260806185819-40c48dff907c
+version: v0.33.1-0.20260807212623-17f5a3d75671
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -2702,7 +2702,7 @@ pub mod echo {
     /// # async fn sample() -> google_cloud_showcase_v1beta1::Result<()> {
     ///
     /// let builder = prepare_request_builder();
-    /// let (sender, mut receiver) = builder.build().await;
+    /// let (sender, mut receiver) = builder.send().await?;
     /// # Ok(()) }
     ///
     /// fn prepare_request_builder() -> Chat {
@@ -2719,20 +2719,105 @@ pub mod echo {
             Self(RequestBuilder::new(stub))
         }
 
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::EchoRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
         /// Sets all the options, replacing any prior values.
         pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
             self.0.options = v.into();
             self
         }
 
-        /// Builds the stream.
-        pub async fn build(
+        /// Initiates the bidirectional stream.
+        pub async fn send(
             self,
-        ) -> (
+        ) -> Result<(
             google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
             google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-        ) {
-            (*self.0.stub).chat(self.0.options).await
+        )> {
+            (*self.0.stub).chat(self.0.request, self.0.options).await
+        }
+
+        /// Sets the value of [severity][crate::model::EchoRequest::severity].
+        pub fn set_severity<T: Into<crate::model::Severity>>(mut self, v: T) -> Self {
+            self.0.request.severity = v.into();
+            self
+        }
+
+        /// Sets the value of [header][crate::model::EchoRequest::header].
+        pub fn set_header<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.header = v.into();
+            self
+        }
+
+        /// Sets the value of [other_header][crate::model::EchoRequest::other_header].
+        pub fn set_other_header<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.other_header = v.into();
+            self
+        }
+
+        /// Sets the value of [request_id][crate::model::EchoRequest::request_id].
+        pub fn set_request_id<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.request_id = v.into();
+            self
+        }
+
+        /// Sets the value of [other_request_id][crate::model::EchoRequest::other_request_id].
+        pub fn set_other_request_id<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<std::string::String>,
+        {
+            self.0.request.other_request_id = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [other_request_id][crate::model::EchoRequest::other_request_id].
+        pub fn set_or_clear_other_request_id<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<std::string::String>,
+        {
+            self.0.request.other_request_id = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [response][crate::model::EchoRequest::response].
+        ///
+        /// Note that all the setters affecting `response` are
+        /// mutually exclusive.
+        pub fn set_response<T: Into<Option<crate::model::echo_request::Response>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.response = v.into();
+            self
+        }
+
+        /// Sets the value of [response][crate::model::EchoRequest::response]
+        /// to hold a `Content`.
+        ///
+        /// Note that all the setters affecting `response` are
+        /// mutually exclusive.
+        pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request = self.0.request.set_content(v);
+            self
+        }
+
+        /// Sets the value of [response][crate::model::EchoRequest::response]
+        /// to hold a `Error`.
+        ///
+        /// Note that all the setters affecting `response` are
+        /// mutually exclusive.
+        pub fn set_error<
+            T: std::convert::Into<std::boxed::Box<google_cloud_rpc::model::Status>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request = self.0.request.set_error(v);
+            self
         }
     }
 
@@ -6237,7 +6322,7 @@ pub mod messaging {
     /// # async fn sample() -> google_cloud_showcase_v1beta1::Result<()> {
     ///
     /// let builder = prepare_request_builder();
-    /// let (sender, mut receiver) = builder.build().await;
+    /// let (sender, mut receiver) = builder.send().await?;
     /// # Ok(()) }
     ///
     /// fn prepare_request_builder() -> Connect {
@@ -6256,20 +6341,66 @@ pub mod messaging {
             Self(RequestBuilder::new(stub))
         }
 
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::ConnectRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
         /// Sets all the options, replacing any prior values.
         pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
             self.0.options = v.into();
             self
         }
 
-        /// Builds the stream.
-        pub async fn build(
+        /// Initiates the bidirectional stream.
+        pub async fn send(
             self,
-        ) -> (
+        ) -> Result<(
             google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
             google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-        ) {
-            (*self.0.stub).connect(self.0.options).await
+        )> {
+            (*self.0.stub).connect(self.0.request, self.0.options).await
+        }
+
+        /// Sets the value of [request][crate::model::ConnectRequest::request].
+        ///
+        /// Note that all the setters affecting `request` are
+        /// mutually exclusive.
+        pub fn set_request<T: Into<Option<crate::model::connect_request::Request>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request.request = v.into();
+            self
+        }
+
+        /// Sets the value of [request][crate::model::ConnectRequest::request]
+        /// to hold a `Config`.
+        ///
+        /// Note that all the setters affecting `request` are
+        /// mutually exclusive.
+        pub fn set_config<
+            T: std::convert::Into<std::boxed::Box<crate::model::connect_request::ConnectConfig>>,
+        >(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request = self.0.request.set_config(v);
+            self
+        }
+
+        /// Sets the value of [request][crate::model::ConnectRequest::request]
+        /// to hold a `Blurb`.
+        ///
+        /// Note that all the setters affecting `request` are
+        /// mutually exclusive.
+        pub fn set_blurb<T: std::convert::Into<std::boxed::Box<crate::model::Blurb>>>(
+            mut self,
+            v: T,
+        ) -> Self {
+            self.0.request = self.0.request.set_blurb(v);
+            self
         }
     }
 

--- a/src/generated/showcase/src/stub.rs
+++ b/src/generated/showcase/src/stub.rs
@@ -299,12 +299,13 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
+        _req: crate::model::EchoRequest,
         _options: crate::RequestOptions,
     ) -> impl std::future::Future<
-        Output = (
+        Output = crate::Result<(
             google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
             google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-        ),
+        )>,
     > + Send {
         async {
             let _ = gaxi::unimplemented::unimplemented_stub::<()>().await;
@@ -794,12 +795,13 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
+        _req: crate::model::ConnectRequest,
         _options: crate::RequestOptions,
     ) -> impl std::future::Future<
-        Output = (
+        Output = crate::Result<(
             google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
             google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-        ),
+        )>,
     > + Send {
         async {
             let _ = gaxi::unimplemented::unimplemented_stub::<()>().await;

--- a/src/generated/showcase/src/stub/dynamic.rs
+++ b/src/generated/showcase/src/stub/dynamic.rs
@@ -333,11 +333,12 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
+        req: crate::model::EchoRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-    );
+    )>;
 
     async fn paged_expand(
         &self,
@@ -473,12 +474,13 @@ impl<T: super::Echo> Echo for T {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
+        req: crate::model::EchoRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-    ) {
-        T::chat(self, options).await
+    )> {
+        T::chat(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.
@@ -923,11 +925,12 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn connect(
         &self,
+        req: crate::model::ConnectRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-    );
+    )>;
 
     async fn list_locations(
         &self,
@@ -1105,12 +1108,13 @@ impl<T: super::Messaging> Messaging for T {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn connect(
         &self,
+        req: crate::model::ConnectRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> crate::Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-    ) {
-        T::connect(self, options).await
+    )> {
+        T::connect(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.

--- a/src/generated/showcase/src/tracing.rs
+++ b/src/generated/showcase/src/tracing.rs
@@ -419,12 +419,13 @@ where
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
+        req: crate::model::EchoRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-    ) {
-        self.inner.chat(options).await
+    )> {
+        self.inner.chat(req, options).await
     }
 
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]
@@ -1135,12 +1136,13 @@ where
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn connect(
         &self,
+        req: crate::model::ConnectRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-    ) {
-        self.inner.connect(options).await
+    )> {
+        self.inner.connect(req, options).await
     }
 
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1786,76 +1786,70 @@ impl super::stub::Echo for Echo {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn chat(
         &self,
+        req: crate::model::EchoRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::EchoRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
-    ) {
+    )> {
         use futures::stream::StreamExt as _;
         use gaxi::prost::{FromProto, ToProto};
 
-        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<crate::model::EchoRequest>(16);
-        let (resp_tx, resp_rx) =
-            tokio::sync::mpsc::channel::<crate::Result<crate::model::EchoResponse>>(16);
+        let first_req = req
+            .to_proto()
+            .map_err(google_cloud_gax::error::Error::ser)?;
 
-        let grpc_client = self.grpc_inner.clone();
-        tokio::spawn(async move {
-            let first_req = match req_rx.recv().await {
-                Some(req) => req,
-                None => return,
-            };
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel(16);
 
-            let req_stream = futures::stream::once(async move { first_req })
-                .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx))
-                .map(|v| v.to_proto().expect("request serialization failed"));
+        let req_stream = futures::stream::once(async move { first_req })
+            .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx));
 
-            let extensions = {
-                let mut e = gaxi::grpc::tonic::Extensions::new();
-                e.insert(gaxi::grpc::tonic::GrpcMethod::new(
-                    "google.showcase.v1beta1.Echo",
-                    "Chat",
-                ));
-                e
-            };
-            let path = http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Echo/Chat");
-            let x_goog_request_params = "";
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.showcase.v1beta1.Echo",
+                "Chat",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Echo/Chat");
+        let x_goog_request_params = "";
 
-            let result = grpc_client
-                .bidi_stream::<
-                    crate::prost::google::showcase::v1beta1::EchoRequest,
-                    crate::prost::google::showcase::v1beta1::EchoResponse,
-                >(
-                    extensions,
-                    path,
-                    req_stream,
-                    options,
-                    &crate::info::X_GOOG_API_CLIENT_HEADER,
-                    x_goog_request_params,
-                )
-                .await;
+        let result = self.grpc_inner
+            .bidi_stream::<
+                crate::prost::google::showcase::v1beta1::EchoRequest,
+                crate::prost::google::showcase::v1beta1::EchoResponse,
+            >(
+                extensions,
+                path,
+                req_stream,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                x_goog_request_params,
+            )
+            .await?;
 
-            match result {
-                Ok(response) => {
-                    let mut response_stream = response.into_inner();
-                    while let Some(res) = response_stream.next().await {
-                        let item = res
-                            .map_err(gaxi::grpc::from_status::to_gax_error)
-                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser));
-                        if resp_tx.send(item).await.is_err() {
-                            break;
-                        }
-                    }
+        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
+            move |item: crate::model::EchoRequest| {
+                let req_tx = req_tx.clone();
+                async move {
+                    let prost_item = item
+                        .to_proto()
+                        .map_err(google_cloud_gax::error::Error::ser)?;
+                    req_tx.send(prost_item).await.map_err(|_| {
+                        google_cloud_gax::error::Error::io("cannot send request: stream is closed")
+                    })
                 }
-                Err(err) => {
-                    let _ = resp_tx.send(Err(err)).await;
-                }
-            }
-        });
+            },
+        );
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
+            result.into_inner().map(|res| {
+                res.map_err(gaxi::grpc::from_status::to_gax_error)
+                    .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
+            }),
+        );
 
-        (
-            google_cloud_gax::streaming::RequestSender::new(req_tx),
-            google_cloud_gax::streaming::ResponseReceiver::new(resp_rx),
-        )
+        Ok((request_sender, response_receiver))
     }
 
     async fn paged_expand(
@@ -5039,77 +5033,71 @@ impl super::stub::Messaging for Messaging {
     #[cfg(google_cloud_unstable_gapic_streaming)]
     async fn connect(
         &self,
+        req: crate::model::ConnectRequest,
         options: crate::RequestOptions,
-    ) -> (
+    ) -> Result<(
         google_cloud_gax::streaming::RequestSender<crate::model::ConnectRequest>,
         google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
-    ) {
+    )> {
         use futures::stream::StreamExt as _;
         use gaxi::prost::{FromProto, ToProto};
 
-        let (req_tx, mut req_rx) = tokio::sync::mpsc::channel::<crate::model::ConnectRequest>(16);
-        let (resp_tx, resp_rx) =
-            tokio::sync::mpsc::channel::<crate::Result<crate::model::StreamBlurbsResponse>>(16);
+        let first_req = req
+            .to_proto()
+            .map_err(google_cloud_gax::error::Error::ser)?;
 
-        let grpc_client = self.grpc_inner.clone();
-        tokio::spawn(async move {
-            let first_req = match req_rx.recv().await {
-                Some(req) => req,
-                None => return,
-            };
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel(16);
 
-            let req_stream = futures::stream::once(async move { first_req })
-                .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx))
-                .map(|v| v.to_proto().expect("request serialization failed"));
+        let req_stream = futures::stream::once(async move { first_req })
+            .chain(tokio_stream::wrappers::ReceiverStream::new(req_rx));
 
-            let extensions = {
-                let mut e = gaxi::grpc::tonic::Extensions::new();
-                e.insert(gaxi::grpc::tonic::GrpcMethod::new(
-                    "google.showcase.v1beta1.Messaging",
-                    "Connect",
-                ));
-                e
-            };
-            let path =
-                http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Messaging/Connect");
-            let x_goog_request_params = "";
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.showcase.v1beta1.Messaging",
+                "Connect",
+            ));
+            e
+        };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Messaging/Connect");
+        let x_goog_request_params = "";
 
-            let result = grpc_client
-                .bidi_stream::<
-                    crate::prost::google::showcase::v1beta1::ConnectRequest,
-                    crate::prost::google::showcase::v1beta1::StreamBlurbsResponse,
-                >(
-                    extensions,
-                    path,
-                    req_stream,
-                    options,
-                    &crate::info::X_GOOG_API_CLIENT_HEADER,
-                    x_goog_request_params,
-                )
-                .await;
+        let result = self.grpc_inner
+            .bidi_stream::<
+                crate::prost::google::showcase::v1beta1::ConnectRequest,
+                crate::prost::google::showcase::v1beta1::StreamBlurbsResponse,
+            >(
+                extensions,
+                path,
+                req_stream,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                x_goog_request_params,
+            )
+            .await?;
 
-            match result {
-                Ok(response) => {
-                    let mut response_stream = response.into_inner();
-                    while let Some(res) = response_stream.next().await {
-                        let item = res
-                            .map_err(gaxi::grpc::from_status::to_gax_error)
-                            .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser));
-                        if resp_tx.send(item).await.is_err() {
-                            break;
-                        }
-                    }
+        let request_sender = google_cloud_gax::streaming::RequestSender::from_fn(
+            move |item: crate::model::ConnectRequest| {
+                let req_tx = req_tx.clone();
+                async move {
+                    let prost_item = item
+                        .to_proto()
+                        .map_err(google_cloud_gax::error::Error::ser)?;
+                    req_tx.send(prost_item).await.map_err(|_| {
+                        google_cloud_gax::error::Error::io("cannot send request: stream is closed")
+                    })
                 }
-                Err(err) => {
-                    let _ = resp_tx.send(Err(err)).await;
-                }
-            }
-        });
+            },
+        );
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
+            result.into_inner().map(|res| {
+                res.map_err(gaxi::grpc::from_status::to_gax_error)
+                    .and_then(|m| m.cnv().map_err(google_cloud_gax::error::Error::deser))
+            }),
+        );
 
-        (
-            google_cloud_gax::streaming::RequestSender::new(req_tx),
-            google_cloud_gax::streaming::ResponseReceiver::new(resp_rx),
-        )
+        Ok((request_sender, response_receiver))
     }
 
     async fn list_locations(

--- a/tests/showcase/src/echo.rs
+++ b/tests/showcase/src/echo.rs
@@ -200,9 +200,11 @@ async fn request_id_custom(client: &Echo) -> Result<()> {
 async fn chat(client: &Echo) -> Result<()> {
     use google_cloud_showcase_v1beta1::model::EchoRequest;
 
-    let (sender, mut receiver) = client.chat().build().await;
-    let req = EchoRequest::new().set_content("hello from bidi echo");
-    sender.send(req).await?;
+    let (sender, mut receiver) = client
+        .chat()
+        .set_content("hello from bidi echo")
+        .send()
+        .await?;
 
     let res = receiver
         .recv()
@@ -210,5 +212,13 @@ async fn chat(client: &Echo) -> Result<()> {
         .expect("expected response from bidi stream");
     let response = res?;
     assert_eq!(response.content, "hello from bidi echo");
+
+    let req2 = EchoRequest::new().set_content("second message");
+    sender.send(req2).await?;
+    let res2 = receiver
+        .recv()
+        .await
+        .expect("expected response for second message")?;
+    assert_eq!(res2.content, "second message");
     Ok(())
 }


### PR DESCRIPTION
The integration test also needs to be updated due to the eager initialization changes.

For #2318 