### PR TITLE
chore(gax-internal): add attempt start and complete lifecycle hooks to AttemptInterceptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -523,7 +523,7 @@ tokio-stream      = { default-features = false, version = "0.1.16" }
 # Local packages used as dependencies.
 google-cloud-auth        = { default-features = false, version = "1.15.0", path = "src/auth" }
 google-cloud-gax         = { default-features = false, version = "1.13.0", path = "src/gax" }
-gaxi                     = { default-features = false, version = "0.7.16", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                     = { default-features = false, version = "0.7.17", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 wkt                      = { default-features = false, version = "1.7.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-wkt         = { default-features = false, version = "1.7.0", path = "src/wkt", package = "google-cloud-wkt" }
 google-cloud-api         = { default-features = false, version = "1.7.0", path = "src/generated/api/types" }

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -904,7 +904,7 @@ libraries:
     copyright_year: "2025"
     output: src/gax
   - name: google-cloud-gax-internal
-    version: 0.7.16
+    version: 0.7.17
     copyright_year: "2025"
     output: src/gax-internal
     rust:

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.7.16"
+version     = "0.7.17"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/src/attempt_interceptor.rs
+++ b/src/gax-internal/src/attempt_interceptor.rs
@@ -14,37 +14,265 @@
 
 //! Types and traits for intercepting and modifying outgoing RPC attempts.
 
+use google_cloud_gax::error::Error;
+use google_cloud_gax::options::RequestOptions;
 use http::HeaderMap;
+use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Instant;
 
-/// A callback invoked on every RPC attempt, allowing modification of gRPC headers.
-/// The callback receives the header map and the current 1-based attempt number.
-pub trait AttemptInterceptor: std::fmt::Debug + Send + Sync {
+/// A callback invoked on outgoing RPC attempts, allowing modification of gRPC headers and tracking attempt lifecycle.
+///
+/// # Unary vs. Streaming RPC Lifecycles
+/// - [`intercept`](Self::intercept): Invoked for **all** outgoing RPCs (unary and streaming) before transmission,
+///   allowing headers (such as authentication or request IDs) to be modified.
+/// - [`on_attempt_start`](Self::on_attempt_start) and [`on_attempt_complete`](Self::on_attempt_complete): Lifecycle
+///   hooks invoked specifically for **unary RPC attempts** managed by the GAX retry loop, allowing attempt
+///   duration, response headers, and attempt outcomes to be measured.
+///
+/// Streaming RPCs have lifecycles that extend across stream consumption beyond the initial request dispatch;
+/// their requests invoke [`intercept`](Self::intercept) during stream establishment, while stream iteration
+/// and retries are managed by the higher-level streaming layer.
+pub trait AttemptInterceptor: Debug + Send + Sync {
     /// Intercepts and modifies the headers of an outgoing RPC attempt.
     ///
-    /// `headers` is the mutable map of headers to be sent with the request.
-    /// `attempt` is the 1-based attempt number for the current RPC.
-    fn intercept(&self, headers: &mut HeaderMap, attempt: u32);
+    /// This method is invoked for all outgoing RPCs (both unary and streaming).
+    ///
+    /// * `headers`: The mutable map of headers to be sent with the request.
+    /// * `attempt`: The 1-based attempt number for the current RPC.
+    fn intercept(&self, _headers: &mut HeaderMap, _attempt: u32) {}
+
+    /// Callback invoked before a unary RPC attempt is dispatched by the GAX retry loop.
+    ///
+    /// Allows header mutation and returns the start [`Instant`] of the attempt.
+    /// The default implementation delegates to [`self.intercept(headers, attempt)`](Self::intercept)
+    /// and returns [`Instant::now()`].
+    ///
+    /// * `method`: The gRPC method path (e.g. `"/google.spanner.v1.Spanner/ExecuteSql"`).
+    /// * `attempt`: The 1-based attempt number for the current RPC.
+    /// * `headers`: The mutable map of headers to be sent with the request.
+    /// * `options`: The request options associated with the RPC.
+    fn on_attempt_start(
+        &self,
+        _method: &str,
+        attempt: u32,
+        headers: &mut HeaderMap,
+        _options: &RequestOptions,
+    ) -> Instant {
+        self.intercept(headers, attempt);
+        Instant::now()
+    }
+
+    /// Callback invoked when a unary RPC attempt completes (either successfully or with an error).
+    ///
+    /// * `method`: The gRPC method path (e.g. `"/google.spanner.v1.Spanner/ExecuteSql"`).
+    /// * `attempt`: The 1-based attempt number for the RPC.
+    /// * `start_time`: The instant returned by [`on_attempt_start`](Self::on_attempt_start).
+    /// * `response_headers`: The response metadata headers returned by the server, if available.
+    /// * `error`: The error returned by this attempt, if the attempt failed.
+    /// * `options`: The request options associated with the RPC.
+    fn on_attempt_complete(
+        &self,
+        _method: &str,
+        _attempt: u32,
+        _start_time: Instant,
+        _response_headers: Option<&HeaderMap>,
+        _error: Option<&Error>,
+        _options: &RequestOptions,
+    ) {
+    }
 }
 
 impl AttemptInterceptor for Vec<Arc<dyn AttemptInterceptor>> {
+    /// Callback invoked before a unary RPC attempt is dispatched.
+    ///
+    /// # Note
+    /// Any custom `Instant` returned by individual interceptors in the `Vec` is discarded.
+    /// The composite implementation always returns a fresh `Instant::now()`.
+    fn on_attempt_start(
+        &self,
+        method: &str,
+        attempt: u32,
+        headers: &mut HeaderMap,
+        options: &RequestOptions,
+    ) -> Instant {
+        for interceptor in self {
+            interceptor.on_attempt_start(method, attempt, headers, options);
+        }
+        Instant::now()
+    }
+
     fn intercept(&self, headers: &mut HeaderMap, attempt: u32) {
         for interceptor in self {
             interceptor.intercept(headers, attempt);
         }
     }
-}
 
-impl<T: AttemptInterceptor> AttemptInterceptor for Option<T> {
-    fn intercept(&self, headers: &mut HeaderMap, attempt: u32) {
-        if let Some(interceptor) = self {
-            interceptor.intercept(headers, attempt);
+    fn on_attempt_complete(
+        &self,
+        method: &str,
+        attempt: u32,
+        start_time: Instant,
+        response_headers: Option<&HeaderMap>,
+        error: Option<&Error>,
+        options: &RequestOptions,
+    ) {
+        for interceptor in self {
+            interceptor.on_attempt_complete(
+                method,
+                attempt,
+                start_time,
+                response_headers,
+                error,
+                options,
+            );
         }
     }
 }
 
 impl<T: AttemptInterceptor + ?Sized> AttemptInterceptor for Arc<T> {
+    fn on_attempt_start(
+        &self,
+        method: &str,
+        attempt: u32,
+        headers: &mut HeaderMap,
+        options: &RequestOptions,
+    ) -> Instant {
+        (**self).on_attempt_start(method, attempt, headers, options)
+    }
+
     fn intercept(&self, headers: &mut HeaderMap, attempt: u32) {
-        self.as_ref().intercept(headers, attempt);
+        (**self).intercept(headers, attempt);
+    }
+
+    fn on_attempt_complete(
+        &self,
+        method: &str,
+        attempt: u32,
+        start_time: Instant,
+        response_headers: Option<&HeaderMap>,
+        error: Option<&Error>,
+        options: &RequestOptions,
+    ) {
+        (**self).on_attempt_complete(
+            method,
+            attempt,
+            start_time,
+            response_headers,
+            error,
+            options,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+    fn assert_debug<T: Debug>() {}
+    fn assert_attempt_interceptor<T: AttemptInterceptor>() {}
+
+    #[test]
+    fn traits() {
+        assert_send::<Arc<dyn AttemptInterceptor>>();
+        assert_sync::<Arc<dyn AttemptInterceptor>>();
+        assert_debug::<Arc<dyn AttemptInterceptor>>();
+        assert_attempt_interceptor::<Arc<dyn AttemptInterceptor>>();
+
+        assert_send::<Vec<Arc<dyn AttemptInterceptor>>>();
+        assert_sync::<Vec<Arc<dyn AttemptInterceptor>>>();
+        assert_debug::<Vec<Arc<dyn AttemptInterceptor>>>();
+        assert_attempt_interceptor::<Vec<Arc<dyn AttemptInterceptor>>>();
+    }
+
+    #[derive(Debug, Default)]
+    struct MockInterceptor {
+        intercept_count: AtomicU32,
+        complete_count: AtomicU32,
+    }
+
+    impl AttemptInterceptor for MockInterceptor {
+        fn intercept(&self, _headers: &mut HeaderMap, _attempt: u32) {
+            self.intercept_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn on_attempt_complete(
+            &self,
+            _method: &str,
+            _attempt: u32,
+            _start_time: Instant,
+            _response_headers: Option<&HeaderMap>,
+            _error: Option<&Error>,
+            _options: &RequestOptions,
+        ) {
+            self.complete_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct DefaultInterceptor;
+    impl AttemptInterceptor for DefaultInterceptor {}
+
+    #[test]
+    fn default_trait_implementations() {
+        let interceptor = DefaultInterceptor;
+        let mut headers = HeaderMap::new();
+        let options = RequestOptions::default();
+        interceptor.intercept(&mut headers, 1);
+        let start = interceptor.on_attempt_start("test_method", 1, &mut headers, &options);
+        interceptor.on_attempt_complete("test_method", 1, start, Some(&headers), None, &options);
+    }
+
+    #[test]
+    fn default_on_attempt_start_calls_intercept() {
+        let interceptor = MockInterceptor::default();
+        let mut headers = HeaderMap::new();
+        let options = RequestOptions::default();
+        let _start = interceptor.on_attempt_start("test_method", 1, &mut headers, &options);
+        assert_eq!(interceptor.intercept_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn vec_interceptor_forwards_to_all() {
+        let first = Arc::new(MockInterceptor::default());
+        let second = Arc::new(MockInterceptor::default());
+        let interceptors: Vec<Arc<dyn AttemptInterceptor>> = vec![first.clone(), second.clone()];
+        let mut headers = HeaderMap::new();
+        let options = RequestOptions::default();
+
+        let start = interceptors.on_attempt_start("test_method", 1, &mut headers, &options);
+        assert_eq!(first.intercept_count.load(Ordering::SeqCst), 1);
+        assert_eq!(second.intercept_count.load(Ordering::SeqCst), 1);
+
+        interceptors.on_attempt_complete("test_method", 1, start, Some(&headers), None, &options);
+        assert_eq!(first.complete_count.load(Ordering::SeqCst), 1);
+        assert_eq!(second.complete_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn arc_interceptor_forwards_all_methods() {
+        let mock = Arc::new(MockInterceptor::default());
+        let arc_interceptor: Arc<dyn AttemptInterceptor> = mock.clone();
+        let mut headers = HeaderMap::new();
+        let options = RequestOptions::default();
+
+        let start = arc_interceptor.on_attempt_start("test_method", 1, &mut headers, &options);
+        assert_eq!(mock.intercept_count.load(Ordering::SeqCst), 1);
+
+        arc_interceptor.intercept(&mut headers, 2);
+        assert_eq!(mock.intercept_count.load(Ordering::SeqCst), 2);
+
+        arc_interceptor.on_attempt_complete(
+            "test_method",
+            1,
+            start,
+            Some(&headers),
+            None,
+            &options,
+        );
+        assert_eq!(mock.complete_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -28,7 +28,9 @@ use crate::attempt_interceptor::AttemptInterceptor;
 use crate::observability::attributes::{self, keys::*, otel_status_codes};
 use crate::universe_domain::DEFAULT_UNIVERSE_DOMAIN;
 use ::tonic::client::Grpc;
+use ::tonic::metadata::MetadataMap;
 use ::tonic::transport::Channel;
+use ::tonic::{Request as TonicRequest, Response as TonicResponse};
 use from_status::to_gax_error;
 use futures::TryFutureExt;
 use google_cloud_auth::credentials::Credentials;
@@ -46,6 +48,7 @@ use http::HeaderMap;
 use opentelemetry_semantic_conventions::{attribute as otel_attr, trace as otel_trace};
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 use transport_policies::TransportPolicies;
 
 // A tonic::transport::Channel always has a Buffer layer.
@@ -193,7 +196,7 @@ impl Client {
         use ::tonic::IntoStreamingRequest;
         let headers = make_headers(api_client_header, request_params, &options)?;
         let mut headers = add_auth_headers(headers, &self.credentials).await?;
-        self.attempt_interceptor.intercept(&mut headers, 1);
+        self.intercept(&mut headers, 1);
         let metadata = tonic::MetadataMap::from_headers(headers);
         let request = ::tonic::Request::from_parts(metadata, extensions, request);
         let codec = tonic_prost::ProstCodec::<Request, Response>::default();
@@ -259,7 +262,7 @@ impl Client {
         use ::tonic::IntoRequest;
         let headers = make_headers(api_client_header, request_params, &options)?;
         let mut headers = add_auth_headers(headers, &self.credentials).await?;
-        self.attempt_interceptor.intercept(&mut headers, 1);
+        self.intercept(&mut headers, 1);
         let metadata = tonic::MetadataMap::from_headers(headers);
         let mut request = ::tonic::Request::from_parts(metadata, extensions, request);
         if let Some(timeout) = crate::options::resolve_effective_timeout(
@@ -394,40 +397,112 @@ impl Client {
         let mut headers = add_auth_headers(headers, &self.credentials).await?;
 
         crate::observability::propagation::inject_context(&span, &mut headers);
+        let attempt_number = prior_attempt_count as u32 + 1;
+        let start_time = self.on_attempt_start(path.path(), attempt_number, &mut headers, options);
+
+        let result = async {
+            let metadata = MetadataMap::from_headers(headers);
+            let mut request = TonicRequest::from_parts(metadata, extensions, request);
+
+            if let Some(timeout) = crate::options::resolve_effective_timeout(
+                options,
+                self.transport_policies.attempt_timeout(),
+                remaining_time,
+            ) {
+                request.set_timeout(timeout);
+            }
+            let codec = tonic_prost::ProstCodec::<Request, Response>::default();
+            let mut inner = self.inner.clone();
+            inner.ready().await.map_err(Error::io)?;
+
+            if let Some(recorder) = crate::observability::RequestRecorder::current() {
+                recorder.on_grpc_request(&path);
+            }
+
+            let pending = inner
+                .unary(request, path.clone(), codec)
+                .map_err(to_gax_error);
+
+            use crate::observability::{
+                WithTransportLogging, WithTransportMetric, WithTransportSpan,
+            };
+
+            let pending =
+                WithTransportMetric::new(self.metric.clone(), pending, prior_attempt_count as u32);
+            let pending = WithTransportLogging::new(pending);
+            let pending = WithTransportSpan::new(span, pending);
+
+            if let Some(recorder) = crate::observability::RequestRecorder::current() {
+                recorder.scope(pending).await
+            } else {
+                pending.await
+            }
+        }
+        .await;
+
+        self.on_attempt_complete(path.path(), attempt_number, start_time, result, options)
+    }
+
+    #[inline]
+    fn intercept(&self, headers: &mut HeaderMap, attempt: u32) {
+        if let Some(interceptor) = &self.attempt_interceptor {
+            interceptor.intercept(headers, attempt);
+        }
+    }
+
+    #[inline]
+    fn on_attempt_start(
+        &self,
+        method: &str,
+        attempt: u32,
+        headers: &mut HeaderMap,
+        options: &RequestOptions,
+    ) -> Option<Instant> {
         self.attempt_interceptor
-            .intercept(&mut headers, prior_attempt_count as u32 + 1);
+            .as_ref()
+            .map(|interceptor| interceptor.on_attempt_start(method, attempt, headers, options))
+    }
 
-        let metadata = tonic::MetadataMap::from_headers(headers);
-        let mut request = ::tonic::Request::from_parts(metadata, extensions, request);
+    #[inline]
+    fn on_attempt_complete<Response>(
+        &self,
+        method: &str,
+        attempt: u32,
+        start_time: Option<Instant>,
+        result: Result<TonicResponse<Response>>,
+        options: &RequestOptions,
+    ) -> Result<TonicResponse<Response>> {
+        let (Some(interceptor), Some(start_time)) = (&self.attempt_interceptor, start_time) else {
+            return result;
+        };
 
-        if let Some(timeout) = crate::options::resolve_effective_timeout(
-            options,
-            self.transport_policies.attempt_timeout(),
-            remaining_time,
-        ) {
-            request.set_timeout(timeout);
-        }
-        let codec = tonic_prost::ProstCodec::<Request, Response>::default();
-        let mut inner = self.inner.clone();
-        inner.ready().await.map_err(Error::io)?;
-
-        if let Some(recorder) = crate::observability::RequestRecorder::current() {
-            recorder.on_grpc_request(&path);
-        }
-
-        let pending = inner.unary(request, path, codec).map_err(to_gax_error);
-
-        use crate::observability::{WithTransportLogging, WithTransportMetric, WithTransportSpan};
-
-        let pending =
-            WithTransportMetric::new(self.metric.clone(), pending, prior_attempt_count as u32);
-        let pending = WithTransportLogging::new(pending);
-        let pending = WithTransportSpan::new(span, pending);
-
-        if let Some(recorder) = crate::observability::RequestRecorder::current() {
-            recorder.scope(pending).await
-        } else {
-            pending.await
+        match result {
+            Ok(response) => {
+                let (metadata, message, extensions) = response.into_parts();
+                let headers = metadata.into_headers();
+                interceptor.on_attempt_complete(
+                    method,
+                    attempt,
+                    start_time,
+                    Some(&headers),
+                    None,
+                    options,
+                );
+                let metadata = MetadataMap::from_headers(headers);
+                let response = TonicResponse::from_parts(metadata, message, extensions);
+                Ok(response)
+            }
+            Err(error) => {
+                interceptor.on_attempt_complete(
+                    method,
+                    attempt,
+                    start_time,
+                    error.http_headers(),
+                    Some(&error),
+                    options,
+                );
+                Err(error)
+            }
         }
     }
 

--- a/src/gax-internal/tests/grpc_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_retry_loop.rs
@@ -16,6 +16,8 @@
 mod tests {
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
     use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::error::Error;
+    use google_cloud_gax::error::rpc::Code;
     use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
@@ -26,6 +28,7 @@ mod tests {
     use grpc_server::{builder, google, start_fixed_responses};
     use http::HeaderMap;
     use std::sync::{Arc, Mutex};
+    use std::time::Instant;
 
     fn test_credentials() -> Credentials {
         Anonymous::new().build()
@@ -108,7 +111,7 @@ mod tests {
         }
         impl AttemptInterceptor for AttemptTracker {
             fn intercept(&self, _headers: &mut HeaderMap, attempt: u32) {
-                self.attempts.lock().unwrap().push(attempt);
+                self.attempts.lock().expect("lock failed").push(attempt);
             }
         }
 
@@ -125,8 +128,94 @@ mod tests {
         client.set_attempt_interceptor(tracker.clone());
         let _response = send_request(client, "interceptor_on_retry").await?;
 
-        let attempts = tracker.attempts.lock().unwrap().clone();
+        let attempts = tracker.attempts.lock().expect("lock failed").clone();
         assert_eq!(attempts, vec![1, 2, 3]);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn interceptor_on_attempt_complete() -> anyhow::Result<()> {
+        #[derive(Clone, Debug, Default)]
+        struct AttemptCompletionRecord {
+            method: String,
+            attempt: u32,
+            has_response_headers: bool,
+            has_error: bool,
+            status_code: Option<Code>,
+            measured_start_time: bool,
+        }
+
+        #[derive(Debug, Default)]
+        struct AttemptCompletionTracker {
+            completed_attempts: Mutex<Vec<AttemptCompletionRecord>>,
+        }
+        impl AttemptInterceptor for AttemptCompletionTracker {
+            fn intercept(&self, _headers: &mut HeaderMap, _attempt: u32) {}
+
+            fn on_attempt_complete(
+                &self,
+                method: &str,
+                attempt: u32,
+                start_time: Instant,
+                response_headers: Option<&HeaderMap>,
+                error: Option<&Error>,
+                _options: &RequestOptions,
+            ) {
+                self.completed_attempts.lock().expect("lock failed").push(
+                    AttemptCompletionRecord {
+                        method: method.to_string(),
+                        attempt,
+                        has_response_headers: response_headers.is_some(),
+                        has_error: error.is_some(),
+                        status_code: error.and_then(|e| e.status().map(|s| s.code)),
+                        measured_start_time: start_time.elapsed().as_nanos() > 0,
+                    },
+                );
+            }
+        }
+
+        let tracker = Arc::new(AttemptCompletionTracker::default());
+        let (endpoint, _server) =
+            start_fixed_responses(vec![transient(), transient(), success()]).await?;
+
+        let mut config = ClientConfig::default();
+        config.cred = Some(test_credentials());
+        config.endpoint = Some(endpoint);
+        config.backoff_policy = Some(Arc::new(test_backoff()));
+
+        let mut client = grpc::Client::new(config, "https://test-only.googleapis.com").await?;
+        client.set_attempt_interceptor(tracker.clone());
+        let _response = send_request(client, "interceptor_on_attempt_complete").await?;
+
+        let completed = tracker
+            .completed_attempts
+            .lock()
+            .expect("lock failed")
+            .clone();
+        assert_eq!(completed.len(), 3);
+
+        // Attempt 1: Transient unavailable error
+        assert_eq!(completed[0].method, "/google.test.v1.EchoService/Echo");
+        assert_eq!(completed[0].attempt, 1);
+        assert!(completed[0].has_error);
+        assert_eq!(completed[0].status_code, Some(Code::Unavailable));
+        assert!(completed[0].measured_start_time);
+
+        // Attempt 2: Transient unavailable error
+        assert_eq!(completed[1].method, "/google.test.v1.EchoService/Echo");
+        assert_eq!(completed[1].attempt, 2);
+        assert!(completed[1].has_error);
+        assert_eq!(completed[1].status_code, Some(Code::Unavailable));
+        assert!(completed[1].measured_start_time);
+
+        // Attempt 3: Success with response headers
+        assert_eq!(completed[2].method, "/google.test.v1.EchoService/Echo");
+        assert_eq!(completed[2].attempt, 3);
+        assert!(!completed[2].has_error);
+        assert_eq!(completed[2].status_code, None);
+        assert!(completed[2].has_response_headers);
+        assert!(completed[2].measured_start_time);
 
         Ok(())
     }

--- a/src/gax-internal/tests/grpc_simple_request.rs
+++ b/src/gax-internal/tests/grpc_simple_request.rs
@@ -17,6 +17,7 @@ mod tests {
     use google_cloud_auth::credentials::{
         Credentials, anonymous::Builder as Anonymous, testing::error_credentials,
     };
+    use google_cloud_gax::error::Error;
     use google_cloud_gax::error::rpc::Code;
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax::retry_policy::NeverRetry;
@@ -25,7 +26,8 @@ mod tests {
     use google_cloud_gax_internal::options::ClientConfig;
     use grpc_server::{builder, google, start_echo_server, start_echo_server_with_address};
     use http::{HeaderMap, HeaderName, HeaderValue};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Instant;
 
     fn test_credentials() -> Credentials {
         Anonymous::new().build()
@@ -227,6 +229,186 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interceptor_lifecycle_hooks() -> anyhow::Result<()> {
+        #[derive(Debug, Default)]
+        struct CompletionRecord {
+            method: String,
+            attempt: u32,
+            measured_start_time: bool,
+            has_response_headers: bool,
+            is_success: bool,
+        }
+
+        #[derive(Debug, Default)]
+        struct LifecycleTracker {
+            started: Mutex<Option<(String, u32)>>,
+            completed: Mutex<Option<CompletionRecord>>,
+        }
+
+        impl AttemptInterceptor for LifecycleTracker {
+            fn on_attempt_start(
+                &self,
+                method: &str,
+                attempt: u32,
+                headers: &mut HeaderMap,
+                _options: &RequestOptions,
+            ) -> Instant {
+                *self.started.lock().expect("lock failed") = Some((method.to_string(), attempt));
+                headers.insert(
+                    HeaderName::from_static("x-lifecycle-test"),
+                    HeaderValue::from_static("present"),
+                );
+                Instant::now()
+            }
+
+            fn on_attempt_complete(
+                &self,
+                method: &str,
+                attempt: u32,
+                start_time: Instant,
+                response_headers: Option<&HeaderMap>,
+                error: Option<&Error>,
+                _options: &RequestOptions,
+            ) {
+                *self.completed.lock().expect("lock failed") = Some(CompletionRecord {
+                    method: method.to_string(),
+                    attempt,
+                    measured_start_time: start_time.elapsed().as_nanos() > 0,
+                    has_response_headers: response_headers.is_some(),
+                    is_success: error.is_none(),
+                });
+            }
+        }
+
+        let tracker = Arc::new(LifecycleTracker::default());
+        let (endpoint, _server) = start_echo_server().await?;
+
+        let mut config = ClientConfig::default();
+        config.cred = Some(test_credentials());
+        config.endpoint = Some(endpoint);
+
+        let mut client = grpc::Client::new(config, "https://test-only.googleapis.com").await?;
+        client.set_attempt_interceptor(tracker.clone());
+
+        let response = send_request(client, "lifecycle test", "").await?;
+        assert_eq!(&response.message, "lifecycle test");
+        assert_eq!(
+            response
+                .metadata
+                .get("x-lifecycle-test")
+                .map(String::as_str),
+            Some("present")
+        );
+
+        let started = tracker.started.lock().expect("lock failed").take();
+        assert_eq!(
+            started,
+            Some(("/google.test.v1.EchoService/Echo".to_string(), 1))
+        );
+
+        let completed = tracker
+            .completed
+            .lock()
+            .expect("lock failed")
+            .take()
+            .expect("completed record present");
+        assert_eq!(completed.method, "/google.test.v1.EchoService/Echo");
+        assert_eq!(completed.attempt, 1);
+        assert!(completed.measured_start_time);
+        assert!(completed.has_response_headers);
+        assert!(completed.is_success);
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interceptor_lifecycle_hooks_on_error() -> anyhow::Result<()> {
+        #[derive(Debug, Default)]
+        struct CompletionRecord {
+            method: String,
+            attempt: u32,
+            measured_start_time: bool,
+            is_success: bool,
+            status_code: Option<Code>,
+        }
+
+        #[derive(Debug, Default)]
+        struct LifecycleTracker {
+            started: Mutex<Option<(String, u32)>>,
+            completed: Mutex<Option<CompletionRecord>>,
+        }
+
+        impl AttemptInterceptor for LifecycleTracker {
+            fn on_attempt_start(
+                &self,
+                method: &str,
+                attempt: u32,
+                headers: &mut HeaderMap,
+                _options: &RequestOptions,
+            ) -> Instant {
+                *self.started.lock().expect("lock failed") = Some((method.to_string(), attempt));
+                headers.insert(
+                    HeaderName::from_static("x-lifecycle-test"),
+                    HeaderValue::from_static("present"),
+                );
+                Instant::now()
+            }
+
+            fn on_attempt_complete(
+                &self,
+                method: &str,
+                attempt: u32,
+                start_time: Instant,
+                _response_headers: Option<&HeaderMap>,
+                error: Option<&Error>,
+                _options: &RequestOptions,
+            ) {
+                *self.completed.lock().expect("lock failed") = Some(CompletionRecord {
+                    method: method.to_string(),
+                    attempt,
+                    measured_start_time: start_time.elapsed().as_nanos() > 0,
+                    is_success: error.is_none(),
+                    status_code: error.and_then(|e| e.status().map(|s| s.code)),
+                });
+            }
+        }
+
+        let tracker = Arc::new(LifecycleTracker::default());
+        let (endpoint, _server) = start_echo_server().await?;
+
+        let mut config = ClientConfig::default();
+        config.cred = Some(test_credentials());
+        config.endpoint = Some(endpoint);
+
+        let mut client = grpc::Client::new(config, "https://test-only.googleapis.com").await?;
+        client.set_attempt_interceptor(tracker.clone());
+
+        // An empty message causes the Echo server to return InvalidArgument error
+        let response = send_request(client, "", "").await;
+        assert!(response.is_err());
+
+        let started = tracker.started.lock().expect("lock failed").take();
+        assert_eq!(
+            started,
+            Some(("/google.test.v1.EchoService/Echo".to_string(), 1))
+        );
+
+        let completed = tracker
+            .completed
+            .lock()
+            .expect("lock failed")
+            .take()
+            .expect("completed record present");
+        assert_eq!(completed.method, "/google.test.v1.EchoService/Echo");
+        assert_eq!(completed.attempt, 1);
+        assert!(completed.measured_start_time);
+        assert!(!completed.is_success);
+        assert_eq!(completed.status_code, Some(Code::InvalidArgument));
+
+        Ok(())
+    }
+
     async fn send_request(
         client: grpc::Client,
         msg: &str,
@@ -279,7 +461,10 @@ mod tests {
                 .map(String::as_str),
             Some("name=test-only")
         );
-        let got_user_agent = response.metadata.get("user-agent").unwrap();
+        let got_user_agent = response
+            .metadata
+            .get("user-agent")
+            .expect("user-agent header present");
         assert!(got_user_agent.contains("tonic/"), "{got_user_agent:?}");
         Ok(())
     }


### PR DESCRIPTION
Extend the internal AttemptInterceptor trait with on_attempt_start and on_attempt_complete callbacks to allow tracking per-attempt latency, metadata, and response headers across unary gRPC attempts.

Bump google-cloud-gax-internal version to 0.7.17.

Needed for https://github.com/googleapis/google-cloud-rust/pull/6311