### PR TITLE
test(bigquery): test basic arrow writes against prod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +70,180 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.23.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
+
+[[package]]
+name = "arrow-select"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +252,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -527,6 +724,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +817,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -897,6 +1120,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -6268,12 +6501,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -6738,10 +6983,12 @@ name = "integration-tests-bigquery"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "bytes",
  "futures",
  "google-cloud-bigquery",
  "google-cloud-bigquery-v2",
+ "google-cloud-bigquery-write",
  "google-cloud-gax",
  "google-cloud-test-utils",
  "google-cloud-type",
@@ -7146,6 +7393,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7348,6 +7652,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7361,6 +7675,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -9256,6 +9579,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -417,6 +417,7 @@ inherits    = "dev"
 incremental = false
 
 [workspace.dependencies]
+arrow                 = { default-features = false, version = "59.2" }
 async-trait           = { default-features = false, version = "0.1.85" }
 base64                = { default-features = false, version = "0.23", features = ["std"] }
 bytes                 = { default-features = false, version = "1.10", features = ["serde"] }
@@ -575,6 +576,7 @@ google-cloud-spanner                 = { default-features = false, path = "src/s
 google-cloud-bigquery                = { default-features = false, path = "src/bigquery" }
 google-cloud-bigquery-derive         = { default-features = false, path = "src/bigquery-derive" }
 google-cloud-bigquery-v2             = { default-features = false, path = "src/generated/cloud/bigquery/v2" }
+google-cloud-bigquery-write          = { default-features = false, path = "src/bigquery-write" }
 google-cloud-iam-credentials-v1      = { default-features = false, path = "src/generated/iam/credentials/v1" }
 google-cloud-language-v2             = { default-features = false, path = "src/generated/cloud/language/v2" }
 google-cloud-dns-v1                  = { default-features = false, path = "src/generated/cloud/dns/v1" }

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,7 @@ git-fetch-with-cli = false
 ignore             = [{ id = "RUSTSEC-2023-0071", reason = "Only used in tests and no new version available" }]
 
 [licenses]
-allow                = ["Apache-2.0", "BSD-3-Clause", "ISC", "MIT", "Unicode-3.0"]
+allow                = ["Apache-2.0", "BSD-3-Clause", "CC0-1.0", "ISC", "MIT", "Unicode-3.0"]
 confidence-threshold = 0.8
 
 [[licenses.exceptions]]

--- a/tests/bigquery/Cargo.toml
+++ b/tests/bigquery/Cargo.toml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [package]
-description       = "Integration tests for google-cloud-bigquery-v2."
+description       = "Integration tests for BigQuery"
 name              = "integration-tests-bigquery"
 publish           = false
 version           = "0.0.0"
@@ -27,15 +27,17 @@ run-integration-tests = []
 log-integration-tests = []
 
 [dependencies]
-anyhow.workspace         = true
-bytes.workspace          = true
-futures.workspace        = true
-google-cloud-bigquery    = { path = "../../src/bigquery" }
-google-cloud-bigquery-v2 = { workspace = true, features = ["default"] }
-google-cloud-gax         = { workspace = true, features = ["unstable-stream"] }
-google-cloud-test-utils  = { workspace = true }
-google-cloud-type        = { workspace = true }
-rand.workspace           = true
-rust_decimal             = { workspace = true }
-tokio.workspace          = true
-wkt.workspace            = true
+anyhow.workspace            = true
+arrow                       = { workspace = true, features = ["ipc"] }
+bytes.workspace             = true
+futures.workspace           = true
+google-cloud-bigquery       = { workspace = true, features = ["default"] }
+google-cloud-bigquery-v2    = { workspace = true, features = ["default"] }
+google-cloud-bigquery-write = { workspace = true, features = ["default"] }
+google-cloud-gax            = { workspace = true, features = ["unstable-stream"] }
+google-cloud-test-utils     = { workspace = true }
+google-cloud-type           = { workspace = true }
+rand.workspace              = true
+rust_decimal                = { workspace = true }
+tokio.workspace             = true
+wkt.workspace               = true

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod writes;
+
 use anyhow::Result;
 use futures::stream::StreamExt;
 use google_cloud_bigquery::client::BigQuery;
+use google_cloud_bigquery::{FromRow, FromSql};
 use google_cloud_bigquery_v2::client::{DatasetService, JobService};
 use google_cloud_bigquery_v2::model::{
     Dataset, DatasetReference, Job, JobConfiguration, JobConfigurationQuery, JobReference,
@@ -27,6 +30,8 @@ use rust_decimal::Decimal as RustDecimal;
 
 const INSTANCE_LABEL: &str = "rust-sdk-integration-test";
 
+pub use writes::run_writes;
+
 pub async fn dataset_admin() -> Result<()> {
     let project_id = project_id()?;
     let client = DatasetService::builder().with_tracing().build().await?;
@@ -34,20 +39,8 @@ pub async fn dataset_admin() -> Result<()> {
 
     let dataset_id = random_dataset_id();
 
-    println!("CREATING DATASET WITH ID: {dataset_id}");
-
-    let create = client
-        .insert_dataset()
-        .set_project_id(&project_id)
-        .set_dataset(
-            Dataset::new()
-                .set_dataset_reference(DatasetReference::new().set_dataset_id(&dataset_id))
-                .set_labels([(INSTANCE_LABEL, "true")]),
-        )
-        .send()
-        .await?;
+    let create = create_dataset(&client, &project_id, &dataset_id).await?;
     println!("CREATE DATASET = {create:?}");
-
     assert!(create.dataset_reference.is_some(), "{create:?}");
 
     let list = client
@@ -65,15 +58,39 @@ pub async fn dataset_admin() -> Result<()> {
             .any(|v| v.as_ref().unwrap().id.contains(&dataset_id))
     );
 
+    delete_dataset(&client, &project_id, &dataset_id).await?;
+    println!("DELETE DATASET");
+
+    Ok(())
+}
+
+async fn create_dataset(
+    client: &DatasetService,
+    project_id: &str,
+    dataset_id: &str,
+) -> Result<Dataset> {
+    println!("CREATING DATASET WITH ID: {dataset_id}");
+    let ds = client
+        .insert_dataset()
+        .set_project_id(project_id)
+        .set_dataset(
+            Dataset::new()
+                .set_dataset_reference(DatasetReference::new().set_dataset_id(dataset_id))
+                .set_labels([(INSTANCE_LABEL, "true")]),
+        )
+        .send()
+        .await?;
+    Ok(ds)
+}
+
+async fn delete_dataset(client: &DatasetService, project_id: &str, dataset_id: &str) -> Result<()> {
     client
         .delete_dataset()
-        .set_project_id(&project_id)
-        .set_dataset_id(&dataset_id)
+        .set_project_id(project_id)
+        .set_dataset_id(dataset_id)
         .set_delete_contents(true)
         .send()
         .await?;
-    println!("DELETE DATASET");
-
     Ok(())
 }
 
@@ -165,6 +182,11 @@ fn random_job_id() -> String {
     format!("rust_bq_test_job_{rand_suffix}")
 }
 
+fn random_table_id() -> String {
+    let rand_suffix = random_id_suffix();
+    format!("rust_bq_test_table_{rand_suffix}")
+}
+
 fn random_id_suffix() -> String {
     rand::rng()
         .sample_iter(&Alphanumeric)
@@ -250,7 +272,7 @@ pub async fn query_client() -> Result<()> {
     Ok(())
 }
 
-#[derive(google_cloud_bigquery::FromRow, Debug, PartialEq)]
+#[derive(FromRow, Debug, PartialEq)]
 struct UserData {
     name: String,
     age: i64,
@@ -547,20 +569,20 @@ pub async fn query_client_job() -> Result<()> {
     Ok(())
 }
 
-#[derive(google_cloud_bigquery::FromSql, Debug, PartialEq)]
+#[derive(FromRow, FromSql, Debug, PartialEq)]
 struct UserRecord {
     name: String,
     age: i64,
 }
 
-#[derive(google_cloud_bigquery::FromSql, Debug, PartialEq)]
+#[derive(FromSql, Debug, PartialEq)]
 struct UserProfile {
     name: String,
     age: i64,
     birth_date: google_cloud_type::model::Date,
 }
 
-#[derive(google_cloud_bigquery::FromRow, Debug, PartialEq)]
+#[derive(FromRow, Debug, PartialEq)]
 struct RowData {
     user: UserRecord,
     numbers: Vec<i64>,

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -1,0 +1,88 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod arrow;
+
+use super::*;
+use google_cloud_bigquery_v2::client::TableService;
+use google_cloud_bigquery_v2::model::{Table, TableFieldSchema, TableReference, TableSchema};
+
+pub async fn run_writes() -> Result<()> {
+    let project_id = project_id()?;
+    let dataset_service = DatasetService::builder().with_tracing().build().await?;
+    cleanup_stale_datasets(&dataset_service, &project_id).await?;
+
+    let dataset_id = random_dataset_id();
+    let _ = create_dataset(&dataset_service, &project_id, &dataset_id).await?;
+
+    let table_service = TableService::builder().with_tracing().build().await?;
+    let table_id = random_table_id();
+    let _ = create_table(&table_service, &project_id, &dataset_id, &table_id).await?;
+
+    let result = arrow::basic(&project_id, &dataset_id, &table_id).await;
+
+    let _ = delete_dataset(&dataset_service, &project_id, &dataset_id).await;
+    result
+}
+
+async fn create_table(
+    table_service: &TableService,
+    project_id: &str,
+    dataset_id: &str,
+    table_id: &str,
+) -> Result<()> {
+    println!("CREATING TABLE WITH ID: {table_id}");
+    let schema = TableSchema::new().set_fields([
+        TableFieldSchema::new().set_name("name").set_type("STRING"),
+        TableFieldSchema::new().set_name("age").set_type("INTEGER"),
+    ]);
+    table_service
+        .insert_table()
+        .set_project_id(project_id)
+        .set_dataset_id(dataset_id)
+        .set_table(
+            Table::new()
+                .set_table_reference(
+                    TableReference::new()
+                        .set_project_id(project_id)
+                        .set_dataset_id(dataset_id)
+                        .set_table_id(table_id),
+                )
+                .set_schema(schema),
+        )
+        .send()
+        .await?;
+
+    Ok(())
+}
+
+async fn read_table(project_id: &str, dataset_id: &str, table_id: &str) -> Result<Vec<UserRecord>> {
+    let client = BigQuery::builder().build().await?;
+    let query = format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}` ORDER BY name");
+    let mut rows = client
+        .query(query)
+        .with_project_id(project_id)
+        .set_labels(vec![(INSTANCE_LABEL, "true")])
+        .run()
+        .await?
+        .until_done()
+        .await?
+        .read();
+
+    let mut users = Vec::new();
+    while let Some(row) = rows.next().await {
+        users.push(row?.try_into()?);
+    }
+    Ok(users)
+}

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -28,9 +28,12 @@ pub async fn run_writes() -> Result<()> {
 
     let table_service = TableService::builder().with_tracing().build().await?;
     let table_id = random_table_id();
-    let _ = create_table(&table_service, &project_id, &dataset_id, &table_id).await?;
 
-    let result = arrow::basic(&project_id, &dataset_id, &table_id).await;
+    let result = async {
+        create_table(&table_service, &project_id, &dataset_id, &table_id).await?;
+        arrow::basic(&project_id, &dataset_id, &table_id).await
+    }
+    .await;
 
     let _ = delete_dataset(&dataset_service, &project_id, &dataset_id).await;
     result

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -90,5 +90,7 @@ fn serialize_batch(batch: &RecordBatch, schema_len: usize) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     let mut writer = StreamWriter::try_new(&mut buf, &batch.schema())?;
     writer.write(batch)?;
+    // Note that the schema is encoded in the front of the record batch. We need
+    // to strip it.
     Ok(buf[schema_len..].to_vec())
 }

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+use ::arrow::array::{Int64Array, StringArray};
+use ::arrow::datatypes::{DataType, Field, Schema};
+use ::arrow::ipc::writer::StreamWriter;
+use ::arrow::record_batch::RecordBatch;
+use google_cloud_bigquery_write::client::Write;
+use google_cloud_bigquery_write::model::{ArrowRecordBatch, ArrowSchema};
+use std::sync::Arc;
+
+pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+
+    // Create a Schema
+    let arrow_schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int64, false),
+    ]));
+    let schema_buf = serialize_schema(&arrow_schema)?;
+    let schema_len = schema_buf.len();
+
+    // Create a writer for the default stream
+    let client = Write::builder().build().await?;
+    let schema = ArrowSchema::new().set_serialized_schema(schema_buf);
+    let writer = client.arrow(schema).default(table)?;
+
+    // Create a RecordBatch
+    let name = StringArray::from(vec!["Alice", "Bob"]);
+    let age = Int64Array::from(vec![25, 28]);
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age)])?;
+    let batch_buf = serialize_batch(&batch, schema_len)?;
+
+    // Write the batch
+    let rows = ArrowRecordBatch::new().set_serialized_record_batch(batch_buf);
+    let _ = writer.append(rows).send().await?;
+
+    // Create a second RecordBatch
+    let name = StringArray::from(vec!["Charlie"]);
+    let age = Int64Array::from(vec![31]);
+    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age)])?;
+    let batch_buf = serialize_batch(&batch, schema_len)?;
+
+    // Write the second batch
+    let rows = ArrowRecordBatch::new().set_serialized_record_batch(batch_buf);
+    let _ = writer.append(rows).send().await?;
+
+    // Verify the writes
+    let users = read_table(project_id, dataset_id, &table_id).await?;
+    assert_eq!(
+        users,
+        vec![
+            UserRecord {
+                name: "Alice".to_string(),
+                age: 25,
+            },
+            UserRecord {
+                name: "Bob".to_string(),
+                age: 28,
+            },
+            UserRecord {
+                name: "Charlie".to_string(),
+                age: 31,
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+fn serialize_schema(schema: &Schema) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    let _ = StreamWriter::try_new(&mut buf, schema)?;
+    Ok(buf)
+}
+
+fn serialize_batch(batch: &RecordBatch, schema_len: usize) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut buf, &batch.schema())?;
+    writer.write(batch)?;
+    Ok(buf[schema_len..].to_vec())
+}

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -58,7 +58,7 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     let _ = writer.append(rows).send().await?;
 
     // Verify the writes
-    let users = read_table(project_id, dataset_id, &table_id).await?;
+    let users = read_table(project_id, dataset_id, table_id).await?;
     assert_eq!(
         users,
         vec![

--- a/tests/bigquery/tests/driver.rs
+++ b/tests/bigquery/tests/driver.rs
@@ -80,4 +80,12 @@ mod bigquery {
             .await
             .inspect_err(anydump)
     }
+
+    #[tokio::test]
+    async fn run_writes() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::run_writes()
+            .await
+            .inspect_err(anydump)
+    }
 }


### PR DESCRIPTION
Add an integration test using the write client to stream data to BQ in Arrow format over the default stream.

### Organization

After this PR, I will do a pass to tidy up the `lib.rs`. It is a bit too unruly for my taste.

### Arrow types

It is definitely verbose to construct the schema and record batches. I know that `serde_arrow` is a thing, but (1) it is unstable and (2) I am not sure it is efficient. I am having the robot look into whether it can simplify the example code with it.

Fixes #5665, fixes #5311 
 