### PR TITLE
docs(bigquery): add core job lifecycle samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "futures",
  "google-cloud-bigquery",
  "google-cloud-bigquery-v2",
+ "google-cloud-gax",
  "google-cloud-test-utils",
  "google-cloud-wkt",
  "rand 0.10.2",

--- a/src/bigquery/examples/Cargo.toml
+++ b/src/bigquery/examples/Cargo.toml
@@ -30,6 +30,7 @@ google-cloud-bigquery      = { workspace = true, features = ["default"] }
 google-cloud-bigquery-v2   = { workspace = true, features = ["default"] }
 google-cloud-test-utils    = { workspace = true }
 google-cloud-wkt.workspace = true
+google-cloud-gax.workspace = true
 rand.workspace             = true
 tokio.workspace            = true
 tracing.workspace          = true

--- a/src/bigquery/examples/src/job.rs
+++ b/src/bigquery/examples/src/job.rs
@@ -12,5 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod job;
-pub mod query;
+mod cancel_job;
+mod create_job;
+mod get_job;
+mod list_jobs;
+
+use google_cloud_test_utils::runtime_config::project_id;
+
+pub async fn run_samples() -> anyhow::Result<()> {
+    let project_id = project_id()?;
+
+    let job_id = create_job::sample(&project_id).await?;
+    get_job::sample(&project_id, &job_id).await?;
+    list_jobs::sample(&project_id).await?;
+    cancel_job::sample(&project_id).await?;
+
+    Ok(())
+}

--- a/src/bigquery/examples/src/job/cancel_job.rs
+++ b/src/bigquery/examples/src/job/cancel_job.rs
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_cancel_job]
+use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let job_service = JobService::builder().build().await?;
+
+    // Start a long-running analytical query job
+    let job = Job::new().set_configuration(
+        JobConfiguration::new().set_query(
+            JobConfigurationQuery::new()
+                .set_query("SELECT * FROM UNNEST(GENERATE_ARRAY(1, 10000000));")
+                .set_use_legacy_sql(false),
+        ),
+    );
+
+    let inserted = job_service
+        .insert_job()
+        .set_project_id(project_id)
+        .set_job(job)
+        .send()
+        .await?;
+
+    let job_id = inserted.job_reference.unwrap().job_id;
+    println!("Created long-running job: {}", job_id);
+
+    // Call the job cancellation API abruptly to abort its execution
+    let cancelled = job_service
+        .cancel_job()
+        .set_project_id(project_id)
+        .set_job_id(&job_id)
+        .set_location("US")
+        .send()
+        .await;
+
+    if let Err(e) = cancelled {
+        if e.to_string().contains("Root element must be a message") {
+            // NOTE: A known issue in protobuf/gax serialization for empty POSTs.
+            println!("Successfully called cancel_job (caught expected empty body error).");
+        } else {
+            return Err(e.into());
+        }
+    } else {
+        println!("Successfully cancelled job.");
+    }
+
+    Ok(())
+}
+// [END bigquery_cancel_job]

--- a/src/bigquery/examples/src/job/cancel_job.rs
+++ b/src/bigquery/examples/src/job/cancel_job.rs
@@ -45,11 +45,9 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .set_job_id(&job_id)
         .set_location("US")
         .send()
-        .await;
+        .await?;
 
-    if cancelled.is_ok() {
-        println!("Successfully cancelled job.");
-    }
+    println!("Successfully cancelled job: {cancelled:?}");
 
     Ok(())
 }

--- a/src/bigquery/examples/src/job/cancel_job.rs
+++ b/src/bigquery/examples/src/job/cancel_job.rs
@@ -47,14 +47,7 @@ pub async fn sample(project_id: &str) -> anyhow::Result<()> {
         .send()
         .await;
 
-    if let Err(e) = cancelled {
-        if e.to_string().contains("Root element must be a message") {
-            // NOTE: A known issue in protobuf/gax serialization for empty POSTs.
-            println!("Successfully called cancel_job (caught expected empty body error).");
-        } else {
-            return Err(e.into());
-        }
-    } else {
+    if cancelled.is_ok() {
         println!("Successfully cancelled job.");
     }
 

--- a/src/bigquery/examples/src/job/create_job.rs
+++ b/src/bigquery/examples/src/job/create_job.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_create_job]
+use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery};
+
+pub async fn sample(project_id: &str) -> anyhow::Result<String> {
+    let job_service = JobService::builder().build().await?;
+    let job = Job::new().set_configuration(
+        JobConfiguration::new().set_query(
+            JobConfigurationQuery::new()
+                .set_query("SELECT 1")
+                .set_use_legacy_sql(false),
+        ),
+    );
+
+    let inserted = job_service
+        .insert_job()
+        .set_project_id(project_id)
+        .set_job(job)
+        .send()
+        .await?;
+
+    let job_ref = inserted.job_reference.unwrap();
+    println!("Created job: {}", job_ref.job_id);
+
+    // Wait for the job to complete
+    loop {
+        let current_job = job_service
+            .get_job()
+            .set_project_id(project_id)
+            .set_job_id(&job_ref.job_id)
+            .send()
+            .await?;
+        if current_job.status.unwrap().state == "DONE" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+
+    println!("Job completed successfully.");
+    Ok(job_ref.job_id)
+}
+// [END bigquery_create_job]

--- a/src/bigquery/examples/src/job/create_job.rs
+++ b/src/bigquery/examples/src/job/create_job.rs
@@ -26,31 +26,17 @@ pub async fn sample(project_id: &str) -> anyhow::Result<String> {
         ),
     );
 
-    let inserted = job_service
+    let job = job_service
         .insert_job()
         .set_project_id(project_id)
         .set_job(job)
-        .send()
+        .into_job_poller()
+        .until_done()
         .await?;
-
-    let job_ref = inserted.job_reference.unwrap();
-    println!("Created job: {}", job_ref.job_id);
-
-    // Wait for the job to complete
-    loop {
-        let current_job = job_service
-            .get_job()
-            .set_project_id(project_id)
-            .set_job_id(&job_ref.job_id)
-            .send()
-            .await?;
-        if current_job.status.unwrap().state == "DONE" {
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    }
+    let job_id = job.job_reference.unwrap().job_id;
+    println!("Job completed successfully: {}", job_id);
 
     println!("Job completed successfully.");
-    Ok(job_ref.job_id)
+    Ok(job_id)
 }
 // [END bigquery_create_job]

--- a/src/bigquery/examples/src/job/create_job.rs
+++ b/src/bigquery/examples/src/job/create_job.rs
@@ -14,17 +14,27 @@
 
 // [START bigquery_create_job]
 use google_cloud_bigquery_v2::client::JobService;
-use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery};
+use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery, JobReference};
 
 pub async fn sample(project_id: &str) -> anyhow::Result<String> {
     let job_service = JobService::builder().build().await?;
-    let job = Job::new().set_configuration(
-        JobConfiguration::new().set_query(
-            JobConfigurationQuery::new()
-                .set_query("SELECT 1")
-                .set_use_legacy_sql(false),
-        ),
-    );
+    let job = Job::new()
+        .set_job_reference(
+            JobReference::new()
+                .set_project_id(project_id)
+                .set_job_id(format!("my_job_prefix_{}", rand::random::<u64>()))
+                .set_location("US"),
+        )
+        .set_configuration(
+            JobConfiguration::new()
+                .set_labels([("example-label", "example-value")])
+                .set_query(
+                    JobConfigurationQuery::new()
+                        .set_query("SELECT 1")
+                        .set_use_legacy_sql(false)
+                        .set_maximum_bytes_billed(10000000_i64),
+                ),
+        );
 
     let job = job_service
         .insert_job()
@@ -36,7 +46,6 @@ pub async fn sample(project_id: &str) -> anyhow::Result<String> {
     let job_id = job.job_reference.unwrap().job_id;
     println!("Job completed successfully: {}", job_id);
 
-    println!("Job completed successfully.");
     Ok(job_id)
 }
 // [END bigquery_create_job]

--- a/src/bigquery/examples/src/job/get_job.rs
+++ b/src/bigquery/examples/src/job/get_job.rs
@@ -24,8 +24,10 @@ pub async fn sample(project_id: &str, job_id: &str) -> anyhow::Result<()> {
         .send()
         .await?;
 
-    let job_ref = job.job_reference.unwrap();
-    println!("Job ID: {}", job_ref.job_id);
+    if let Some(job_ref) = job.job_reference {
+        println!("Job ID: {}", job_ref.job_id);
+    }
+
     if let Some(status) = job.status {
         println!("State: {:?}", status.state);
     }

--- a/src/bigquery/examples/src/job/get_job.rs
+++ b/src/bigquery/examples/src/job/get_job.rs
@@ -1,0 +1,43 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_get_job]
+use google_cloud_bigquery_v2::client::JobService;
+
+pub async fn sample(project_id: &str, job_id: &str) -> anyhow::Result<()> {
+    let job_service = JobService::builder().build().await?;
+    let job = job_service
+        .get_job()
+        .set_project_id(project_id)
+        .set_job_id(job_id)
+        .send()
+        .await?;
+
+    let job_ref = job.job_reference.unwrap();
+    println!("Job ID: {}", job_ref.job_id);
+    if let Some(status) = job.status {
+        println!("State: {:?}", status.state);
+    }
+
+    if let Some(stats) = job.statistics {
+        println!("Creation Time: {:?}", stats.creation_time);
+        println!("End Time: {:?}", stats.end_time);
+        if let Some(q_stats) = stats.query {
+            println!("Total Bytes Processed: {:?}", q_stats.total_bytes_processed);
+        }
+    }
+
+    Ok(())
+}
+// [END bigquery_get_job]

--- a/src/bigquery/examples/src/job/list_jobs.rs
+++ b/src/bigquery/examples/src/job/list_jobs.rs
@@ -14,38 +14,27 @@
 
 // [START bigquery_list_jobs]
 use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_gax::paginator::ItemPaginator;
 
 pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let job_service = JobService::builder().build().await?;
 
-    let mut page_token = String::new();
     let mut listed_count = 0;
 
-    loop {
-        let mut req = job_service
-            .list_jobs()
-            .set_project_id(project_id)
-            .set_max_results(20);
-        if !page_token.is_empty() {
-            req = req.set_page_token(page_token);
-        }
-        let res = req.send().await?;
+    let mut list = job_service
+        .list_jobs()
+        .set_project_id(project_id)
+        .set_max_results(20)
+        .by_item();
 
-        for job in res.jobs {
-            if let Some(job_ref) = job.job_reference {
-                println!("Job ID: {}", job_ref.job_id);
-                listed_count += 1;
-            }
+    while let Some(job) = list.next().await.transpose()? {
+        if let Some(job_ref) = job.job_reference {
+            println!("Job ID: {}", job_ref.job_id);
+            listed_count += 1;
         }
 
-        // Let's break early to not overwhelm the test output
         if listed_count >= 20 {
             break;
-        }
-
-        match Some(res.next_page_token) {
-            Some(token) if !token.is_empty() => page_token = token,
-            _ => break,
         }
     }
 

--- a/src/bigquery/examples/src/job/list_jobs.rs
+++ b/src/bigquery/examples/src/job/list_jobs.rs
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigquery_list_jobs]
+use google_cloud_bigquery_v2::client::JobService;
+
+pub async fn sample(project_id: &str) -> anyhow::Result<()> {
+    let job_service = JobService::builder().build().await?;
+
+    let mut page_token = String::new();
+    let mut listed_count = 0;
+
+    loop {
+        let mut req = job_service
+            .list_jobs()
+            .set_project_id(project_id)
+            .set_max_results(20);
+        if !page_token.is_empty() {
+            req = req.set_page_token(page_token);
+        }
+        let res = req.send().await?;
+
+        for job in res.jobs {
+            if let Some(job_ref) = job.job_reference {
+                println!("Job ID: {}", job_ref.job_id);
+                listed_count += 1;
+            }
+        }
+
+        // Let's break early to not overwhelm the test output
+        if listed_count >= 20 {
+            break;
+        }
+
+        match Some(res.next_page_token) {
+            Some(token) if !token.is_empty() => page_token = token,
+            _ => break,
+        }
+    }
+
+    Ok(())
+}
+// [END bigquery_list_jobs]

--- a/src/bigquery/examples/src/job/list_jobs.rs
+++ b/src/bigquery/examples/src/job/list_jobs.rs
@@ -19,22 +19,15 @@ use google_cloud_gax::paginator::ItemPaginator;
 pub async fn sample(project_id: &str) -> anyhow::Result<()> {
     let job_service = JobService::builder().build().await?;
 
-    let mut listed_count = 0;
-
-    let mut list = job_service
+    let mut jobs = job_service
         .list_jobs()
         .set_project_id(project_id)
         .set_max_results(20)
         .by_item();
 
-    while let Some(job) = list.next().await.transpose()? {
+    while let Some(job) = jobs.next().await.transpose()? {
         if let Some(job_ref) = job.job_reference {
             println!("Job ID: {}", job_ref.job_id);
-            listed_count += 1;
-        }
-
-        if listed_count >= 20 {
-            break;
         }
     }
 

--- a/src/bigquery/examples/tests/integration.rs
+++ b/src/bigquery/examples/tests/integration.rs
@@ -14,7 +14,7 @@
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod tests {
-    use bigquery_samples::query;
+    use bigquery_samples::{job, query};
     use google_cloud_test_utils::errors::anydump;
 
     #[tokio::test]
@@ -27,5 +27,10 @@ mod tests {
         query::run_samples_with_resources()
             .await
             .inspect_err(anydump)
+    }
+
+    #[tokio::test]
+    async fn job_samples() -> anyhow::Result<()> {
+        job::run_samples().await.inspect_err(anydump)
     }
 }


### PR DESCRIPTION
Demonstrate how to manage the lifecycle of BigQuery Jobs. These samples poll `JobService` to track status and metadata.

Added:
- `bigquery_create_job`: Creates and executes a job.
- `bigquery_get_job`: Retrieves the execution status and metadata of a job by its ID.
- `bigquery_list_jobs`: Lists recently executed jobs in the project. 
- `bigquery_cancel_job`: Cancels an active analytical query job.

Fixes #5762, fixes #5761 