### PR TITLE
feat(gax): add BidiStreamOptions for bidirectional streaming

### DIFF
--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -179,6 +179,9 @@ impl RequestOptions {
 #[cfg(google_cloud_unstable_gapic_streaming)]
 pub const MAX_REQUEST_CHANNEL_CAPACITY: usize = usize::MAX >> 3;
 
+#[cfg(google_cloud_unstable_gapic_streaming)]
+const DEFAULT_REQUEST_CHANNEL_CAPACITY: usize = 16;
+
 /// Configuration options specific to bidirectional streaming RPCs.
 ///
 /// Wraps standard [`RequestOptions`] while adding settings unique to bidirectional
@@ -195,7 +198,7 @@ impl Default for BidiStreamOptions {
     fn default() -> Self {
         Self {
             request_options: RequestOptions::default(),
-            request_channel_capacity: 16,
+            request_channel_capacity: DEFAULT_REQUEST_CHANNEL_CAPACITY,
         }
     }
 }
@@ -206,7 +209,7 @@ impl From<RequestOptions> for BidiStreamOptions {
     fn from(request_options: RequestOptions) -> Self {
         Self {
             request_options,
-            request_channel_capacity: 16,
+            request_channel_capacity: DEFAULT_REQUEST_CHANNEL_CAPACITY,
         }
     }
 }

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -172,6 +172,92 @@ impl RequestOptions {
     }
 }
 
+/// The maximum allowed capacity for a bidirectional stream request channel.
+///
+/// This upper limit matches Tokio's internal `mpsc::channel` capacity limit
+/// (`usize::MAX >> 3`).
+#[cfg(google_cloud_unstable_gapic_streaming)]
+pub const MAX_REQUEST_CHANNEL_CAPACITY: usize = usize::MAX >> 3;
+
+/// Configuration options specific to bidirectional streaming RPCs.
+///
+/// Wraps standard [`RequestOptions`] while adding settings unique to bidirectional
+/// streaming RPCs, such as internal channel capacity for buffering requests.
+#[cfg(google_cloud_unstable_gapic_streaming)]
+#[derive(Clone, Debug)]
+pub struct BidiStreamOptions {
+    request_options: RequestOptions,
+    request_channel_capacity: usize,
+}
+
+#[cfg(google_cloud_unstable_gapic_streaming)]
+impl Default for BidiStreamOptions {
+    fn default() -> Self {
+        Self {
+            request_options: RequestOptions::default(),
+            request_channel_capacity: 16,
+        }
+    }
+}
+
+/// Converts [`RequestOptions`] into [`BidiStreamOptions`] using default request channel capacity (`16`).
+#[cfg(google_cloud_unstable_gapic_streaming)]
+impl From<RequestOptions> for BidiStreamOptions {
+    fn from(request_options: RequestOptions) -> Self {
+        Self {
+            request_options,
+            request_channel_capacity: 16,
+        }
+    }
+}
+
+/// Extracts the underlying [`RequestOptions`] from [`BidiStreamOptions`], discarding streaming-specific configuration.
+#[cfg(google_cloud_unstable_gapic_streaming)]
+impl From<BidiStreamOptions> for RequestOptions {
+    fn from(options: BidiStreamOptions) -> Self {
+        options.request_options
+    }
+}
+
+#[cfg(google_cloud_unstable_gapic_streaming)]
+impl BidiStreamOptions {
+    /// Sets the buffer capacity of the internal request channel.
+    ///
+    /// Valid values must be between `1` and [`MAX_REQUEST_CHANNEL_CAPACITY`]. The default
+    /// capacity is `16`.
+    ///
+    /// Values outside this range will result in an error when initiating the stream via `.send()`.
+    pub fn set_request_channel_capacity(&mut self, capacity: usize) {
+        self.request_channel_capacity = capacity;
+    }
+
+    /// Returns the configured request channel capacity.
+    ///
+    /// Defaults to `16`.
+    pub fn request_channel_capacity(&self) -> usize {
+        self.request_channel_capacity
+    }
+
+    /// Sets all request options, replacing any prior values.
+    pub fn set_request_options(&mut self, options: impl Into<RequestOptions>) {
+        self.request_options = options.into();
+    }
+
+    /// Returns a reference to standard per-request options.
+    pub fn request_options(&self) -> &RequestOptions {
+        &self.request_options
+    }
+
+    /// Returns a mutable reference to standard per-request options.
+    ///
+    /// Used by generated RPC builders to implement [`internal::RequestBuilder`]
+    /// so callers can chain `.with_*` option setters directly on the RPC builder.
+    #[doc(hidden)]
+    pub fn request_options_mut(&mut self) -> &mut RequestOptions {
+        &mut self.request_options
+    }
+}
+
 /// Implementations of this trait provide setters to configure request options.
 ///
 /// The Google Cloud Client Libraries for Rust provide a builder for each RPC.
@@ -533,5 +619,36 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[test]
+    fn test_bidi_stream_options() {
+        let default_opts = BidiStreamOptions::default();
+        assert_eq!(default_opts.request_channel_capacity(), 16);
+        assert!(default_opts.request_options().user_agent().is_none());
+
+        let mut req_opts = RequestOptions::default();
+        req_opts.set_user_agent("custom-agent");
+
+        let mut opts = BidiStreamOptions::default();
+        opts.set_request_options(req_opts);
+        opts.set_request_channel_capacity(32);
+        assert_eq!(opts.request_channel_capacity(), 32);
+        assert_eq!(
+            opts.request_options().user_agent().as_deref(),
+            Some("custom-agent")
+        );
+
+        opts.set_request_channel_capacity(128);
+        assert_eq!(opts.request_channel_capacity(), 128);
+        opts.request_options_mut().set_user_agent("modified-agent");
+        assert_eq!(
+            opts.request_options().user_agent().as_deref(),
+            Some("modified-agent")
+        );
+
+        let into_opts: RequestOptions = opts.into();
+        assert_eq!(into_opts.user_agent().as_deref(), Some("modified-agent"));
     }
 }


### PR DESCRIPTION
Add BidiStreamOptions to google_cloud_gax::options to support configuring bidirectional streaming RPC parameters such as request channel buffer capacity. This is the only special option we currently have and I do not have other per stream options that I anticipate we set, so I decided to not implement a trait similar to RequestBuilder.

BidiStreamOptions holds a base RequestOptions and request_channel_capacity defaulting to 16, bounded between 1 and MAX_REQUEST_CHANNEL_CAPACITY. 

We also provide From conversions between RequestOptions and BidiStreamOptions with user-focused documentation. This enables our users to pass either into the `with_options` configuration.

For #2318 