### PR TITLE
refactor(bigquery): reorg jobs integration tests

### DIFF
--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -14,7 +14,7 @@
 
 use super::{INSTANCE_LABEL, random_id_suffix};
 use anyhow::Result;
-use futures::stream::StreamExt;
+use futures::stream::{StreamExt, TryStreamExt};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery, JobReference};
 use google_cloud_gax::paginator::ItemPaginator;
@@ -52,14 +52,10 @@ pub async fn job_service() -> Result<()> {
         .set_project_id(&project_id)
         .by_item()
         .into_stream();
-    let items = list.collect::<Vec<_>>().await;
+    let items: Vec<_> = list.try_collect().await?;
     println!("LIST JOBS = {} entries", items.len());
 
-    assert!(
-        items
-            .iter()
-            .any(|v| v.as_ref().unwrap().id.contains(&job_id))
-    );
+    assert!(items.iter().any(|v| v.id.contains(&job_id)));
 
     Ok(())
 }

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -64,12 +64,12 @@ pub async fn job_service() -> Result<()> {
     Ok(())
 }
 
-pub fn random_job_id() -> String {
+fn random_job_id() -> String {
     let rand_suffix = random_id_suffix();
     format!("rust_bq_test_job_{rand_suffix}")
 }
 
-pub async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()> {
+async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
     let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{INSTANCE_LABEL, random_id_suffix};
+use anyhow::Result;
+use futures::stream::StreamExt;
+use google_cloud_bigquery_v2::client::JobService;
+use google_cloud_bigquery_v2::model::{Job, JobConfiguration, JobConfigurationQuery, JobReference};
+use google_cloud_gax::paginator::ItemPaginator;
+use google_cloud_test_utils::runtime_config::project_id;
+
+pub async fn job_service() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().with_tracing().build().await?;
+    cleanup_stale_jobs(&client, &project_id).await?;
+
+    let job_id = random_job_id();
+    println!("CREATING JOB WITH ID: {job_id}");
+
+    let query = "SELECT 1 as one";
+    let job = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(JobConfigurationQuery::new().set_query(query)),
+                ),
+        )
+        .send()
+        .await?;
+    println!("CREATE JOB = {job:?}");
+
+    assert!(job.job_reference.is_some(), "{job:?}");
+
+    let list = client
+        .list_jobs()
+        .set_project_id(&project_id)
+        .by_item()
+        .into_stream();
+    let items = list.collect::<Vec<_>>().await;
+    println!("LIST JOBS = {} entries", items.len());
+
+    assert!(
+        items
+            .iter()
+            .any(|v| v.as_ref().unwrap().id.contains(&job_id))
+    );
+
+    Ok(())
+}
+
+pub fn random_job_id() -> String {
+    let rand_suffix = random_id_suffix();
+    format!("rust_bq_test_job_{rand_suffix}")
+}
+
+pub async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()> {
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
+    let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
+    let stale_deadline = stale_deadline.as_millis() as u64;
+
+    let list = client
+        .list_jobs()
+        .set_project_id(project_id)
+        .set_max_creation_time(stale_deadline)
+        .by_item()
+        .into_stream();
+    let items = list.collect::<Vec<_>>().await;
+    println!("LIST JOBS = {} entries", items.len());
+
+    let pending_all_stale_jobs = items
+        .iter()
+        .filter_map(|v| match v {
+            Ok(v) => {
+                if let Some(job_reference) = &v.job_reference {
+                    return Some(
+                        client
+                            .get_job()
+                            .set_project_id(project_id)
+                            .set_job_id(&job_reference.job_id)
+                            .send(),
+                    );
+                }
+                None
+            }
+            Err(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    let pending_deletion = futures::future::join_all(pending_all_stale_jobs)
+        .await
+        .into_iter()
+        .filter_map(|r| match r {
+            Ok(r) => {
+                let job_reference = r.job_reference?;
+                if r.configuration
+                    .is_some_and(|c| c.labels.get(INSTANCE_LABEL).is_some_and(|v| v == "true"))
+                    && r.status.is_some_and(|s| s.state == "DONE")
+                {
+                    return Some(
+                        client
+                            .delete_job()
+                            .set_project_id(project_id)
+                            .set_job_id(&job_reference.job_id)
+                            .send(),
+                    );
+                }
+                None
+            }
+            Err(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    println!("found {} stale test jobs", pending_deletion.len());
+
+    futures::future::join_all(pending_deletion).await;
+    Ok(())
+}

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod job;
 mod writes;
 
 use anyhow::Result;
 use futures::stream::StreamExt;
 use google_cloud_bigquery::client::BigQuery;
 use google_cloud_bigquery::{FromRow, FromSql};
-use google_cloud_bigquery_v2::client::{DatasetService, JobService};
-use google_cloud_bigquery_v2::model::{
-    Dataset, DatasetReference, Job, JobConfiguration, JobConfigurationQuery, JobReference,
-};
+use google_cloud_bigquery_v2::client::DatasetService;
+use google_cloud_bigquery_v2::model::{Dataset, DatasetReference};
 use google_cloud_gax::{error::rpc::Code, paginator::ItemPaginator};
 use google_cloud_test_utils::runtime_config::project_id;
 use google_cloud_type::model::Decimal;
@@ -30,6 +29,7 @@ use rust_decimal::Decimal as RustDecimal;
 
 const INSTANCE_LABEL: &str = "rust-sdk-integration-test";
 
+pub use job::job_service;
 pub use writes::run_writes;
 
 pub async fn dataset_admin() -> Result<()> {
@@ -177,11 +177,6 @@ fn random_dataset_id() -> String {
     format!("rust_bq_test_dataset_{rand_suffix}")
 }
 
-fn random_job_id() -> String {
-    let rand_suffix = random_id_suffix();
-    format!("rust_bq_test_job_{rand_suffix}")
-}
-
 fn random_table_id() -> String {
     let rand_suffix = random_id_suffix();
     format!("rust_bq_test_table_{rand_suffix}")
@@ -198,50 +193,6 @@ fn random_id_suffix() -> String {
 fn extract_dataset_id(project_id: &str, id: &str) -> Option<String> {
     id.strip_prefix(format!("{project_id}:").as_str())
         .map(|v| v.to_string())
-}
-
-pub async fn job_service() -> Result<()> {
-    let project_id = project_id()?;
-    let client = JobService::builder().with_tracing().build().await?;
-    cleanup_stale_jobs(&client, &project_id).await?;
-
-    let job_id = random_job_id();
-    println!("CREATING JOB WITH ID: {job_id}");
-
-    let query = "SELECT 1 as one";
-    let job = client
-        .insert_job()
-        .set_project_id(&project_id)
-        .set_job(
-            Job::new()
-                .set_job_reference(JobReference::new().set_job_id(&job_id))
-                .set_configuration(
-                    JobConfiguration::new()
-                        .set_labels([(INSTANCE_LABEL, "true")])
-                        .set_query(JobConfigurationQuery::new().set_query(query)),
-                ),
-        )
-        .send()
-        .await?;
-    println!("CREATE JOB = {job:?}");
-
-    assert!(job.job_reference.is_some(), "{job:?}");
-
-    let list = client
-        .list_jobs()
-        .set_project_id(&project_id)
-        .by_item()
-        .into_stream();
-    let items = list.collect::<Vec<_>>().await;
-    println!("LIST JOBS = {} entries", items.len());
-
-    assert!(
-        items
-            .iter()
-            .any(|v| v.as_ref().unwrap().id.contains(&job_id))
-    );
-
-    Ok(())
 }
 
 pub async fn query_client() -> Result<()> {
@@ -643,69 +594,5 @@ pub async fn query_client_nested_types() -> Result<()> {
     assert_eq!(data.profile.birth_date.month, 5);
     assert_eq!(data.profile.birth_date.day, 28);
 
-    Ok(())
-}
-
-async fn cleanup_stale_jobs(client: &JobService, project_id: &str) -> Result<()> {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    let stale_deadline = SystemTime::now().duration_since(UNIX_EPOCH)?;
-    let stale_deadline = stale_deadline - Duration::from_secs(48 * 60 * 60);
-    let stale_deadline = stale_deadline.as_millis() as u64;
-
-    let list = client
-        .list_jobs()
-        .set_project_id(project_id)
-        .set_max_creation_time(stale_deadline)
-        .by_item()
-        .into_stream();
-    let items = list.collect::<Vec<_>>().await;
-    println!("LIST JOBS = {} entries", items.len());
-
-    let pending_all_stale_jobs = items
-        .iter()
-        .filter_map(|v| match v {
-            Ok(v) => {
-                if let Some(job_reference) = &v.job_reference {
-                    return Some(
-                        client
-                            .get_job()
-                            .set_project_id(project_id)
-                            .set_job_id(&job_reference.job_id)
-                            .send(),
-                    );
-                }
-                None
-            }
-            Err(_) => None,
-        })
-        .collect::<Vec<_>>();
-
-    let pending_deletion = futures::future::join_all(pending_all_stale_jobs)
-        .await
-        .into_iter()
-        .filter_map(|r| match r {
-            Ok(r) => {
-                let job_reference = r.job_reference?;
-                if r.configuration
-                    .is_some_and(|c| c.labels.get(INSTANCE_LABEL).is_some_and(|v| v == "true"))
-                    && r.status.is_some_and(|s| s.state == "DONE")
-                {
-                    return Some(
-                        client
-                            .delete_job()
-                            .set_project_id(project_id)
-                            .set_job_id(&job_reference.job_id)
-                            .send(),
-                    );
-                }
-                None
-            }
-            Err(_) => None,
-        })
-        .collect::<Vec<_>>();
-
-    println!("found {} stale test jobs", pending_deletion.len());
-
-    futures::future::join_all(pending_deletion).await;
     Ok(())
 }


### PR DESCRIPTION
Split out BQ jobs-related tests, helpers into their own module within `integration-tests-bigquery`.