### PR TITLE
fix(gax-internal): serialize `NoBody` as empty JSON object

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -576,8 +576,19 @@ pub fn map_send_error(err: ::reqwest::Error) -> Error {
     }
 }
 
-#[derive(Default, serde::Serialize)]
+#[derive(Default)]
 pub struct NoBody;
+
+impl serde::Serialize for NoBody {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let map = serializer.serialize_map(Some(0))?;
+        map.end()
+    }
+}
 
 pub fn handle_empty<T: Default>(body: Option<T>, method: &Method) -> Option<T> {
     body.or_else(|| {
@@ -638,6 +649,13 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn nobody_serializes_to_empty_object() -> anyhow::Result<()> {
+        let serialized = serde_json::to_string(&super::NoBody)?;
+        assert_eq!(serialized, "{}");
+        Ok(())
+    }
+
     use super::*;
     use crate::options::ClientConfig;
     use crate::options::InstrumentationClientInfo;


### PR DESCRIPTION
Fix an edge case from #2823 where empty `POST`/`PUT` requests were failing with `Root element must be a message` on BigQuery's `cancel_job` https://github.com/googleapis/google-cloud-rust/pull/6340#discussion_r3764327581.

#2832 updated `gaxi::http::handle_empty` to return `Some(NoBody::default())` to make sure a payload was sent. However, since `NoBody` was defined as `pub struct NoBody;`, `serde_json` serializes it as "null". Our APIs expect an empty JSON object `{}` instead.

To fix this without breaking semver, we added a custom serialization to explicitly map `NoBody` to an empty size `0` struct, forcing the JSON payload out as `{}`. This resolves the empty JSON problem while maintaining backward compatibility.