### PR TITLE
chore(deps): update `jsonwebtoken`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7364,9 +7364,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,7 +433,7 @@ http                  = { default-features = false, version = "1.1", features = 
 http-body             = { default-features = false, version = "1.1" }
 humantime             = { default-features = false, version = "2" }
 hyper                 = { default-features = false, version = "1.10" }
-jsonwebtoken          = { default-features = false, version = "10.2" }
+jsonwebtoken          = { default-features = false, version = "11" }
 markdown              = { default-features = false, version = "1.0" }
 opentelemetry         = { default-features = false, version = "0.32" }
 opentelemetry-proto   = { default-features = false, version = "0.32" }

--- a/src/auth/README.md
+++ b/src/auth/README.md
@@ -34,6 +34,7 @@ also describes the common terminology used with authentication, such as
   - Configure this crate with `default-features = false`, and
     `features = ["idtoken"]`
   - Select the desired backend for `jsonwebtoken`.
+  - You **MUST** use the same major version of `jsonwebtoken` as we do.
 
 [authentication methods at google]: https://cloud.google.com/docs/authentication
 [aws-lc-rs]: https://crates.io/crates/aws-lc-rs

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -42,6 +42,7 @@
 //!   - Configure this crate with `default-features = false`, and
 //!     `features = ["idtoken"]`
 //!   - Select the desired backend for `jsonwebtoken`.
+//!   - You **MUST** use the same major version of `jsonwebtoken` as we do.
 //!
 //! [aws-lc-rs]: https://crates.io/crates/aws-lc-rs
 //! [ring]: https://crates.io/crates/ring

--- a/tests/crypto-providers/idtoken-with-rust-crypto/Cargo.toml
+++ b/tests/crypto-providers/idtoken-with-rust-crypto/Cargo.toml
@@ -33,4 +33,4 @@ rust-version = "1.92.0"
 anyhow            = { default-features = false, version = "1", features = ["std"] }
 test-metadata     = { path = "../test-metadata" }
 google-cloud-auth = { default-features = false, path = "../../../src/auth", features = ["idtoken"] }
-jsonwebtoken      = { default-features = false, version = "10", features = ["rust_crypto"] }
+jsonwebtoken      = { default-features = false, version = "11", features = ["rust_crypto"] }


### PR DESCRIPTION
Update to the next major version (11). Also update the tests, to validate the crypto provider overrides we need to use the same major version on both.

Update the README and lib.rs to highlight this.