### PR TITLE
test: deflake `go run ..librarian`

### DIFF
--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -121,8 +121,13 @@ steps:
         go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
       git ls-files -z -- '*.yaml' '*.yml' ':!:testdata/**' ':!:**/generated/**' ':!:librarian.yaml' | \
         xargs -0 yamlfmt
+      go run github.com/googleapis/librarian/cmd/librarian@latest config get version || \
+        go run github.com/googleapis/librarian/cmd/librarian@latest config get version || \
+        go run github.com/googleapis/librarian/cmd/librarian@latest config get version
       V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
+      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy || \
+      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy || \
+        go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
     waitFor: ['-']
     env:
       - GOTOOLCHAIN=auto

--- a/.gcb/format.yaml
+++ b/.gcb/format.yaml
@@ -121,13 +121,14 @@ steps:
         go install github.com/google/yamlfmt/cmd/yamlfmt@v0.21.0
       git ls-files -z -- '*.yaml' '*.yml' ':!:testdata/**' ':!:**/generated/**' ':!:librarian.yaml' | \
         xargs -0 yamlfmt
-      go run github.com/googleapis/librarian/cmd/librarian@latest config get version || \
-        go run github.com/googleapis/librarian/cmd/librarian@latest config get version || \
-        go run github.com/googleapis/librarian/cmd/librarian@latest config get version
-      V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy || \
-      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy || \
-        go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
+      # Normally we recommend `librarian config get version` but that requires
+      # downloading two copies of librarian.
+      V=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
+      # Make multiple attempts to install librarian to avoid download-induced flakes.
+      go install github.com/googleapis/librarian/cmd/librarian@${V} || \
+        (sleep 5 && go install github.com/googleapis/librarian/cmd/librarian@${V}) || \
+        (sleep 10 && go install github.com/googleapis/librarian/cmd/librarian@${V})
+      go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
     waitFor: ['-']
     env:
       - GOTOOLCHAIN=auto

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -36,6 +36,10 @@ rustup show active-toolchain -v
 
 echo "Regenerate all the code"
 version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
+# Make multiple download attempts to avoid flakes
+go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null ||
+  go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null ||
+  go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null
 go run github.com/googleapis/librarian/cmd/librarian@${version} generate --all
 
 # If there is any difference between the generated code and the

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -37,9 +37,9 @@ rustup show active-toolchain -v
 echo "Regenerate all the code"
 version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
 # Make multiple download attempts to avoid flakes
-go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null ||
-  go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null ||
-  go run github.com/googleapis/librarian/cmd/librarian@${version} >/dev/null
+go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null ||
+  go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null ||
+  go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null
 go run github.com/googleapis/librarian/cmd/librarian@${version} generate --all
 
 # If there is any difference between the generated code and the

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -35,11 +35,13 @@ rustup component add rustfmt
 rustup show active-toolchain -v
 
 echo "Regenerate all the code"
+# Normally we recommend `librarian config get version` but that requires
+# downloading two copies of librarian.
 version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
-# Make multiple download attempts to avoid flakes
-go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null ||
-  go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null ||
-  go run github.com/googleapis/librarian/cmd/librarian@${version} help >/dev/null
+# Make multiple download attempts to avoid download-induced flakes.
+go install github.com/googleapis/librarian/cmd/librarian@${version} ||
+(sleep 5 && go install github.com/googleapis/librarian/cmd/librarian@${version}) ||
+(sleep 10 && go install github.com/googleapis/librarian/cmd/librarian@${version})
 go run github.com/googleapis/librarian/cmd/librarian@${version} generate --all
 
 # If there is any difference between the generated code and the


### PR DESCRIPTION
Minimize flakes by making multiple attempts to download `librarian` and its dependencies.

Towards #6373 