### PR TITLE
docs(gax): fix `with_custom_header()` sample

### DIFF
--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -331,10 +331,14 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
     /// comma-separated [`HeaderValue`]:
     ///
     /// ```rust,ignore
+    /// # use google_cloud_gax::options::RequestOptionsBuilder;
+    /// use http::header::{HeaderName, HeaderValue};
+    /// fn sample<T: RequestOptionsBuilder>(builder: T) -> T {
     /// builder.with_custom_header(
     ///     HeaderName::from_static("cache-control"),
     ///     HeaderValue::from_static("no-cache, no-store"),
     /// )
+    /// }
     /// ```
     ///
     /// [`HeaderValue`]: http::header::HeaderValue

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -334,10 +334,10 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
     /// # use google_cloud_gax::options::RequestOptionsBuilder;
     /// use http::header::{HeaderName, HeaderValue};
     /// fn sample<T: RequestOptionsBuilder>(builder: T) -> T {
-    /// builder.with_custom_header(
-    ///     HeaderName::from_static("cache-control"),
-    ///     HeaderValue::from_static("no-cache, no-store"),
-    /// )
+    ///     builder.with_custom_header(
+    ///         HeaderName::from_static("cache-control"),
+    ///         HeaderValue::from_static("no-cache, no-store"),
+    ///     )
     /// }
     /// ```
     ///

--- a/src/gax/src/options.rs
+++ b/src/gax/src/options.rs
@@ -330,7 +330,7 @@ pub trait RequestOptionsBuilder: internal::RequestBuilder {
     /// are defined as comma-separated lists. Callers can supply repeated values natively as a single
     /// comma-separated [`HeaderValue`]:
     ///
-    /// ```rust,ignore
+    /// ```
     /// # use google_cloud_gax::options::RequestOptionsBuilder;
     /// use http::header::{HeaderName, HeaderValue};
     /// fn sample<T: RequestOptionsBuilder>(builder: T) -> T {


### PR DESCRIPTION
The sample was marked `ignore`. The generated uses `ignore` to speed up the PRs. One of the CI builds compiles post-merge.

Towards #6373 