### PR TITLE
ci: use larger VMs for some builds

### DIFF
--- a/.gcb/builds/resources/main.tf
+++ b/.gcb/builds/resources/main.tf
@@ -93,6 +93,16 @@ resource "google_cloudbuild_worker_pool" "pool" {
   }
 }
 
+resource "google_cloudbuild_worker_pool" "large-pool" {
+  name     = "rust-sdk-pool-large"
+  location = "us-central1"
+  worker_config {
+    disk_size_gb   = 256
+    machine_type   = "e2-standard-32"
+    no_external_ip = false
+  }
+}
+
 output "build-cache" {
   value = resource.google_storage_bucket.build-cache.id
 }

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -248,7 +248,7 @@ resource "google_cloudbuild_trigger" "pull-request" {
     _UNSTABLE_CFG_FLAGS = lookup(each.value, "flags", "")
     _SCRIPT             = lookup(each.value, "script", "")
     _RUST_VERSION       = lookup(each.value, "rust_version", null)
-    _POOL_ID = lookup(each.value, "pool", null)
+    _POOL_ID            = lookup(each.value, "pool", null)
   }
 }
 
@@ -283,7 +283,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
     _UNSTABLE_CFG_FLAGS = lookup(each.value, "flags", "")
     _SCRIPT             = lookup(each.value, "script", "")
     _RUST_VERSION       = lookup(each.value, "rust_version", null)
-    _POOL_ID = lookup(each.value, "pool", null)
+    _POOL_ID            = lookup(each.value, "pool", null)
   }
 }
 

--- a/.gcb/builds/triggers/main.tf
+++ b/.gcb/builds/triggers/main.tf
@@ -51,14 +51,17 @@ locals {
     compute-full = {
       config = "complex.yaml"
       script = "compute-full"
+      pool   = "rust-sdk-pool-large"
     }
     coverage = {
       config = "coverage.yaml"
       script = "coverage"
+      pool   = "rust-sdk-pool-large"
       flags  = local.unstable_flags
     }
     crypto-providers = {
       config = "cryptoproviders.yaml"
+      pool   = "rust-sdk-pool-large"
     }
     deny = {
       config = "complex.yaml"
@@ -67,6 +70,7 @@ locals {
     docs = {
       config = "complex.yaml"
       script = "docs"
+      pool   = "rust-sdk-pool-large"
     }
     docs-rs = {
       config = "complex.yaml"
@@ -75,10 +79,12 @@ locals {
     features = {
       config = "complex.yaml"
       script = "features"
+      pool   = "rust-sdk-pool-large"
     }
     features-gax-internal = {
       config = "complex.yaml"
       script = "features-gax-internal"
+      pool   = "rust-sdk-pool-large"
     }
     per-client-features = {
       config = "complex.yaml"
@@ -89,13 +95,16 @@ locals {
     }
     integration = {
       config = "integration.yaml"
+      pool   = "rust-sdk-pool-large"
     }
     integration-unstable = {
       config = "integration.yaml"
+      pool   = "rust-sdk-pool-large"
       flags  = local.unstable_flags
     }
     lint = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       script = "lint"
     }
     lint-unstable = {
@@ -105,10 +114,12 @@ locals {
     }
     minimal-versions = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       script = "minimal-versions"
     }
     minimal-versions-direct = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       script = "minimal-versions-direct"
     }
     protojson-conformance = {
@@ -121,6 +132,7 @@ locals {
     }
     semver-checks = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       script = "semver-checks"
     }
     showcase = {
@@ -129,21 +141,25 @@ locals {
     }
     test-current = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       flags  = local.unstable_flags
       script = "test"
     }
     test-tokio-unstable = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       flags  = local.tokio_unstable_flags
       script = "test"
     }
     test-msrv = {
       config = "msrv.yaml"
+      pool   = "rust-sdk-pool-large"
       flags  = local.unstable_flags
       script = "test"
     }
     test-unstable-cfg = {
       config = "complex.yaml"
+      pool   = "rust-sdk-pool-large"
       flags  = local.unstable_flags
       script = "test-unstable-cfg"
     }
@@ -232,6 +248,7 @@ resource "google_cloudbuild_trigger" "pull-request" {
     _UNSTABLE_CFG_FLAGS = lookup(each.value, "flags", "")
     _SCRIPT             = lookup(each.value, "script", "")
     _RUST_VERSION       = lookup(each.value, "rust_version", null)
+    _POOL_ID = lookup(each.value, "pool", null)
   }
 }
 
@@ -244,6 +261,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
       flags          = try(v.flags, "")
       rust_version   = try(v.rust_version, null)
       included_files = try(v.included_files, [])
+      pool           = try(v.pool, null)
     }
   }
   location       = var.region
@@ -265,6 +283,7 @@ resource "google_cloudbuild_trigger" "post-merge" {
     _UNSTABLE_CFG_FLAGS = lookup(each.value, "flags", "")
     _SCRIPT             = lookup(each.value, "script", "")
     _RUST_VERSION       = lookup(each.value, "rust_version", null)
+    _POOL_ID = lookup(each.value, "pool", null)
   }
 }
 


### PR DESCRIPTION
The builds were too slow on `e2-standard-8` (over 20m), using `e2-standard-32` gets the builds to under 15m. We may still want to move some builds to post-PR.