### PR TITLE
refactor(bigquery): rename query metadata and builder

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.37.1-0.20260814190025-b8ffbf6000fa
+version: v0.37.1-0.20260814193952-f51a5f9543f5
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.37.1-0.20260814004615-cecd47a9776c
+version: v0.37.1-0.20260814190025-b8ffbf6000fa
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 use crate::ClientBuilderResult as BuilderResult;
+use crate::builder::bigquery::QueryBuilder;
 use crate::client_builder::ClientBuilder;
 use crate::error::QueryError;
-use crate::query::{Query, Result as QueryResult, RunQuery};
+use crate::query::{Query, Result as QueryResult};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::JobReference;
 use std::sync::Arc;
@@ -115,11 +116,11 @@ impl BigQuery {
 
     /// Creates a request builder to configure and execute a SQL query.
     ///
-    /// This method returns a [`RunQuery`] builder. You can chain additional configuration methods
+    /// This method returns a [`QueryBuilder`]. You can chain additional configuration methods
     /// (such as setting the project ID, positional or named parameters, query location, and maximum result buffer sizes)
-    /// before calling [`RunQuery::send()`] or [`RunQuery::until_done()`].
+    /// before calling [`QueryBuilder::send()`] or [`QueryBuilder::until_done()`].
     ///
-    /// The [`RunQuery`] builder automatically decides whether to route your request via the fast path ([`jobs.query`][jobs_query])
+    /// The [`QueryBuilder`] automatically decides whether to route your request via the fast path ([`jobs.query`][jobs_query])
     /// or the background job creation path ([`jobs.insert`][jobs_insert]). If the query configuration uses only options supported
     /// by the fast path, the client library uses [`jobs.query`][jobs_query] for lower latency. If advanced options (such as destination
     /// tables or allowing large results) are configured, the client automatically falls back to creating an asynchronous job.
@@ -152,24 +153,14 @@ impl BigQuery {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn query<S: Into<String>>(&self, sql: S) -> RunQuery {
-        let builder = RunQuery::new(self.job_service.clone(), sql.into());
+    pub fn query<S: Into<String>>(&self, sql: S) -> QueryBuilder {
+        let builder = QueryBuilder::new(self.job_service.clone(), sql.into());
         self.project_id
             .as_deref()
             .into_iter()
             .fold(builder, |builder, project_id| {
                 builder.with_project_id(project_id)
             })
-    }
-    #[cfg(test)]
-    pub(crate) fn from_job_service(
-        job_service: Arc<JobService>,
-        project_id: Option<String>,
-    ) -> Self {
-        Self {
-            job_service,
-            project_id,
-        }
     }
 
     /// Binds an existing out-of-process query job reference to a high-level `Query` handle.
@@ -238,10 +229,21 @@ mod tests {
     use crate::error::QueryError;
     use crate::query::tests::{MockJobService, create_job_service};
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+    use google_cloud_bigquery_v2::client::JobService;
     use google_cloud_bigquery_v2::model::{
         Job, JobConfiguration, JobConfigurationQuery, JobReference,
     };
     use google_cloud_gax::response::Response;
+    use std::sync::Arc;
+
+    impl BigQuery {
+        fn from_job_service(job_service: Arc<JobService>, project_id: Option<String>) -> Self {
+            Self {
+                job_service,
+                project_id,
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_bigquery_builder() -> anyhow::Result<()> {

--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use crate::ClientBuilderResult as BuilderResult;
-use crate::builder::bigquery::QueryBuilder;
+use crate::builder::bigquery::Query;
 use crate::client_builder::ClientBuilder;
 use crate::error::QueryError;
-use crate::query::{Query, Result as QueryResult};
+use crate::query::{Query as QueryHandle, Result as QueryResult};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::JobReference;
 use std::sync::Arc;
@@ -116,11 +116,11 @@ impl BigQuery {
 
     /// Creates a request builder to configure and execute a SQL query.
     ///
-    /// This method returns a [`QueryBuilder`]. You can chain additional configuration methods
+    /// This method returns a [`Query`] builder. You can chain additional configuration methods
     /// (such as setting the project ID, positional or named parameters, query location, and maximum result buffer sizes)
-    /// before calling [`QueryBuilder::send()`] or [`QueryBuilder::until_done()`].
+    /// before calling [`Query::send()`] or [`Query::until_done()`].
     ///
-    /// The [`QueryBuilder`] automatically decides whether to route your request via the fast path ([`jobs.query`][jobs_query])
+    /// The [`Query`] builder automatically decides whether to route your request via the fast path ([`jobs.query`][jobs_query])
     /// or the background job creation path ([`jobs.insert`][jobs_insert]). If the query configuration uses only options supported
     /// by the fast path, the client library uses [`jobs.query`][jobs_query] for lower latency. If advanced options (such as destination
     /// tables or allowing large results) are configured, the client automatically falls back to creating an asynchronous job.
@@ -153,8 +153,8 @@ impl BigQuery {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn query<S: Into<String>>(&self, sql: S) -> QueryBuilder {
-        let builder = QueryBuilder::new(self.job_service.clone(), sql.into());
+    pub fn query<S: Into<String>>(&self, sql: S) -> Query {
+        let builder = Query::new(self.job_service.clone(), sql.into());
         self.project_id
             .as_deref()
             .into_iter()
@@ -163,9 +163,9 @@ impl BigQuery {
             })
     }
 
-    /// Binds an existing out-of-process query job reference to a high-level `Query` handle.
+    /// Binds an existing out-of-process query job reference to a high-level [`Query`](crate::Query) handle.
     ///
-    /// Fetches the job metadata via [`JobService::get_job`] and initializes a [`Query`] handle.
+    /// Fetches the job metadata via [`JobService::get_job`] and initializes a [`Query`](crate::Query) handle.
     /// If `job_ref.project_id` is empty, it defaults to the client's billing project ID.
     ///
     /// # Arguments
@@ -189,7 +189,7 @@ impl BigQuery {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn attach_job(&self, mut job_ref: JobReference) -> QueryResult<Query> {
+    pub async fn attach_job(&self, mut job_ref: JobReference) -> QueryResult<QueryHandle> {
         if job_ref.project_id.is_empty()
             && let Some(proj) = &self.project_id
         {
@@ -219,7 +219,7 @@ impl BigQuery {
             return Err(QueryError::UnsupportedJobType);
         }
 
-        Ok(Query::from_job(self.job_service.clone(), job, None))
+        Ok(QueryHandle::from_job(self.job_service.clone(), job, None))
     }
 }
 

--- a/src/bigquery/src/generated.rs
+++ b/src/bigquery/src/generated.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod query_creation_metadata;
+mod complete_query_metadata;
 mod query_metadata;
-mod run_query_request;
+mod query_request;
 
-pub use query_creation_metadata::QueryCreationMetadata;
+pub use complete_query_metadata::CompleteQueryMetadata;
 pub use query_metadata::QueryMetadata;
-pub use run_query_request::RunQueryRequest;
+pub use query_request::QueryBuilderRequest;

--- a/src/bigquery/src/generated.rs
+++ b/src/bigquery/src/generated.rs
@@ -18,4 +18,4 @@ mod query_request;
 
 pub use complete_query_metadata::CompleteQueryMetadata;
 pub use query_metadata::QueryMetadata;
-pub use query_request::QueryBuilderRequest;
+pub use query_request::QueryRequest;

--- a/src/bigquery/src/generated/builder.rs
+++ b/src/bigquery/src/generated/builder.rs
@@ -18,9 +18,9 @@
 #[allow(rustdoc::broken_intra_doc_links)]
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-impl QueryBuilder {
+impl Query {
 
-    /// Sets the value of [request.allow_large_results][crate::generated::QueryBuilderRequest::allow_large_results].
+    /// Sets the value of [request.allow_large_results][crate::builder::bigquery::QueryRequest::allow_large_results].
     pub fn set_allow_large_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -28,7 +28,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.allow_large_results][crate::generated::QueryBuilderRequest::allow_large_results].
+    /// Sets or clears the value of [request.allow_large_results][crate::builder::bigquery::QueryRequest::allow_large_results].
     pub fn set_or_clear_allow_large_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -36,7 +36,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.clustering][crate::generated::QueryBuilderRequest::clustering].
+    /// Sets the value of [request.clustering][crate::builder::bigquery::QueryRequest::clustering].
     pub fn set_clustering<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::Clustering>
     {
@@ -44,7 +44,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.clustering][crate::generated::QueryBuilderRequest::clustering].
+    /// Sets or clears the value of [request.clustering][crate::builder::bigquery::QueryRequest::clustering].
     pub fn set_or_clear_clustering<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::Clustering>
     {
@@ -52,7 +52,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.connection_properties][crate::generated::QueryBuilderRequest::connection_properties].
+    /// Sets the value of [request.connection_properties][crate::builder::bigquery::QueryRequest::connection_properties].
     pub fn set_connection_properties<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -63,7 +63,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.continuous][crate::generated::QueryBuilderRequest::continuous].
+    /// Sets the value of [request.continuous][crate::builder::bigquery::QueryRequest::continuous].
     pub fn set_continuous<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -71,7 +71,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.continuous][crate::generated::QueryBuilderRequest::continuous].
+    /// Sets or clears the value of [request.continuous][crate::builder::bigquery::QueryRequest::continuous].
     pub fn set_or_clear_continuous<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -79,13 +79,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.create_disposition][crate::generated::QueryBuilderRequest::create_disposition].
+    /// Sets the value of [request.create_disposition][crate::builder::bigquery::QueryRequest::create_disposition].
     pub fn set_create_disposition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.create_disposition = v.into();
         self
     }
 
-    /// Sets the value of [request.create_session][crate::generated::QueryBuilderRequest::create_session].
+    /// Sets the value of [request.create_session][crate::builder::bigquery::QueryRequest::create_session].
     pub fn set_create_session<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -93,7 +93,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.create_session][crate::generated::QueryBuilderRequest::create_session].
+    /// Sets or clears the value of [request.create_session][crate::builder::bigquery::QueryRequest::create_session].
     pub fn set_or_clear_create_session<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -101,7 +101,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.default_dataset][crate::generated::QueryBuilderRequest::default_dataset].
+    /// Sets the value of [request.default_dataset][crate::builder::bigquery::QueryRequest::default_dataset].
     pub fn set_default_dataset<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::DatasetReference>
     {
@@ -109,7 +109,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.default_dataset][crate::generated::QueryBuilderRequest::default_dataset].
+    /// Sets or clears the value of [request.default_dataset][crate::builder::bigquery::QueryRequest::default_dataset].
     pub fn set_or_clear_default_dataset<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::DatasetReference>
     {
@@ -117,7 +117,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.destination_encryption_configuration][crate::generated::QueryBuilderRequest::destination_encryption_configuration].
+    /// Sets the value of [request.destination_encryption_configuration][crate::builder::bigquery::QueryRequest::destination_encryption_configuration].
     pub fn set_destination_encryption_configuration<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::EncryptionConfiguration>
     {
@@ -125,7 +125,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.destination_encryption_configuration][crate::generated::QueryBuilderRequest::destination_encryption_configuration].
+    /// Sets or clears the value of [request.destination_encryption_configuration][crate::builder::bigquery::QueryRequest::destination_encryption_configuration].
     pub fn set_or_clear_destination_encryption_configuration<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::EncryptionConfiguration>
     {
@@ -133,7 +133,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.destination_table][crate::generated::QueryBuilderRequest::destination_table].
+    /// Sets the value of [request.destination_table][crate::builder::bigquery::QueryRequest::destination_table].
     pub fn set_destination_table<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::TableReference>
     {
@@ -141,7 +141,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.destination_table][crate::generated::QueryBuilderRequest::destination_table].
+    /// Sets or clears the value of [request.destination_table][crate::builder::bigquery::QueryRequest::destination_table].
     pub fn set_or_clear_destination_table<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::TableReference>
     {
@@ -149,13 +149,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.dry_run][crate::generated::QueryBuilderRequest::dry_run].
+    /// Sets the value of [request.dry_run][crate::builder::bigquery::QueryRequest::dry_run].
     pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.request.dry_run = v.into();
         self
     }
 
-    /// Sets the value of [request.external_table_definitions][crate::generated::QueryBuilderRequest::external_table_definitions].
+    /// Sets the value of [request.external_table_definitions][crate::builder::bigquery::QueryRequest::external_table_definitions].
     pub fn set_external_table_definitions<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -167,7 +167,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.flatten_results][crate::generated::QueryBuilderRequest::flatten_results].
+    /// Sets the value of [request.flatten_results][crate::builder::bigquery::QueryRequest::flatten_results].
     pub fn set_flatten_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -175,7 +175,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.flatten_results][crate::generated::QueryBuilderRequest::flatten_results].
+    /// Sets or clears the value of [request.flatten_results][crate::builder::bigquery::QueryRequest::flatten_results].
     pub fn set_or_clear_flatten_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -183,13 +183,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.job_creation_mode][crate::generated::QueryBuilderRequest::job_creation_mode].
+    /// Sets the value of [request.job_creation_mode][crate::builder::bigquery::QueryRequest::job_creation_mode].
     pub fn set_job_creation_mode<T: std::convert::Into<crate::model::query_request::JobCreationMode>>(mut self, v: T) -> Self {
         self.request.job_creation_mode = v.into();
         self
     }
 
-    /// Sets the value of [request.job_timeout_ms][crate::generated::QueryBuilderRequest::job_timeout_ms].
+    /// Sets the value of [request.job_timeout_ms][crate::builder::bigquery::QueryRequest::job_timeout_ms].
     pub fn set_job_timeout_ms<T>(mut self, v: T) -> Self
     where T: std::convert::Into<i64>
     {
@@ -197,7 +197,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.job_timeout_ms][crate::generated::QueryBuilderRequest::job_timeout_ms].
+    /// Sets or clears the value of [request.job_timeout_ms][crate::builder::bigquery::QueryRequest::job_timeout_ms].
     pub fn set_or_clear_job_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<i64>
     {
@@ -205,7 +205,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.labels][crate::generated::QueryBuilderRequest::labels].
+    /// Sets the value of [request.labels][crate::builder::bigquery::QueryRequest::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -217,13 +217,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.location][crate::generated::QueryBuilderRequest::location].
+    /// Sets the value of [request.location][crate::builder::bigquery::QueryRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.location = v.into();
         self
     }
 
-    /// Sets the value of [request.max_results][crate::generated::QueryBuilderRequest::max_results].
+    /// Sets the value of [request.max_results][crate::builder::bigquery::QueryRequest::max_results].
     pub fn set_max_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -231,7 +231,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.max_results][crate::generated::QueryBuilderRequest::max_results].
+    /// Sets or clears the value of [request.max_results][crate::builder::bigquery::QueryRequest::max_results].
     pub fn set_or_clear_max_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -239,7 +239,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.max_slots][crate::generated::QueryBuilderRequest::max_slots].
+    /// Sets the value of [request.max_slots][crate::builder::bigquery::QueryRequest::max_slots].
     pub fn set_max_slots<T>(mut self, v: T) -> Self
     where T: std::convert::Into<i32>
     {
@@ -247,7 +247,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.max_slots][crate::generated::QueryBuilderRequest::max_slots].
+    /// Sets or clears the value of [request.max_slots][crate::builder::bigquery::QueryRequest::max_slots].
     pub fn set_or_clear_max_slots<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<i32>
     {
@@ -255,7 +255,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.maximum_bytes_billed][crate::generated::QueryBuilderRequest::maximum_bytes_billed].
+    /// Sets the value of [request.maximum_bytes_billed][crate::builder::bigquery::QueryRequest::maximum_bytes_billed].
     pub fn set_maximum_bytes_billed<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::Int64Value>
     {
@@ -263,7 +263,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.maximum_bytes_billed][crate::generated::QueryBuilderRequest::maximum_bytes_billed].
+    /// Sets or clears the value of [request.maximum_bytes_billed][crate::builder::bigquery::QueryRequest::maximum_bytes_billed].
     pub fn set_or_clear_maximum_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::Int64Value>
     {
@@ -271,25 +271,25 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.parameter_mode][crate::generated::QueryBuilderRequest::parameter_mode].
+    /// Sets the value of [request.parameter_mode][crate::builder::bigquery::QueryRequest::parameter_mode].
     pub fn set_parameter_mode<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.parameter_mode = v.into();
         self
     }
 
-    /// Sets the value of [request.priority][crate::generated::QueryBuilderRequest::priority].
+    /// Sets the value of [request.priority][crate::builder::bigquery::QueryRequest::priority].
     pub fn set_priority<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.priority = v.into();
         self
     }
 
-    /// Sets the value of [request.query][crate::generated::QueryBuilderRequest::query].
+    /// Sets the value of [request.query][crate::builder::bigquery::QueryRequest::query].
     pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.query = v.into();
         self
     }
 
-    /// Sets the value of [request.query_parameters][crate::generated::QueryBuilderRequest::query_parameters].
+    /// Sets the value of [request.query_parameters][crate::builder::bigquery::QueryRequest::query_parameters].
     pub fn set_query_parameters<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -300,7 +300,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.range_partitioning][crate::generated::QueryBuilderRequest::range_partitioning].
+    /// Sets the value of [request.range_partitioning][crate::builder::bigquery::QueryRequest::range_partitioning].
     pub fn set_range_partitioning<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::RangePartitioning>
     {
@@ -308,7 +308,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.range_partitioning][crate::generated::QueryBuilderRequest::range_partitioning].
+    /// Sets or clears the value of [request.range_partitioning][crate::builder::bigquery::QueryRequest::range_partitioning].
     pub fn set_or_clear_range_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::RangePartitioning>
     {
@@ -316,7 +316,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.reservation][crate::generated::QueryBuilderRequest::reservation].
+    /// Sets the value of [request.reservation][crate::builder::bigquery::QueryRequest::reservation].
     pub fn set_reservation<T>(mut self, v: T) -> Self
     where T: std::convert::Into<std::string::String>
     {
@@ -324,7 +324,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.reservation][crate::generated::QueryBuilderRequest::reservation].
+    /// Sets or clears the value of [request.reservation][crate::builder::bigquery::QueryRequest::reservation].
     pub fn set_or_clear_reservation<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<std::string::String>
     {
@@ -332,7 +332,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.schema_update_options][crate::generated::QueryBuilderRequest::schema_update_options].
+    /// Sets the value of [request.schema_update_options][crate::builder::bigquery::QueryRequest::schema_update_options].
     pub fn set_schema_update_options<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -343,7 +343,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.script_options][crate::generated::QueryBuilderRequest::script_options].
+    /// Sets the value of [request.script_options][crate::builder::bigquery::QueryRequest::script_options].
     pub fn set_script_options<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::ScriptOptions>
     {
@@ -351,7 +351,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.script_options][crate::generated::QueryBuilderRequest::script_options].
+    /// Sets or clears the value of [request.script_options][crate::builder::bigquery::QueryRequest::script_options].
     pub fn set_or_clear_script_options<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::ScriptOptions>
     {
@@ -359,7 +359,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.time_partitioning][crate::generated::QueryBuilderRequest::time_partitioning].
+    /// Sets the value of [request.time_partitioning][crate::builder::bigquery::QueryRequest::time_partitioning].
     pub fn set_time_partitioning<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::TimePartitioning>
     {
@@ -367,7 +367,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.time_partitioning][crate::generated::QueryBuilderRequest::time_partitioning].
+    /// Sets or clears the value of [request.time_partitioning][crate::builder::bigquery::QueryRequest::time_partitioning].
     pub fn set_or_clear_time_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::TimePartitioning>
     {
@@ -375,7 +375,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.timeout_ms][crate::generated::QueryBuilderRequest::timeout_ms].
+    /// Sets the value of [request.timeout_ms][crate::builder::bigquery::QueryRequest::timeout_ms].
     pub fn set_timeout_ms<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -383,7 +383,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.timeout_ms][crate::generated::QueryBuilderRequest::timeout_ms].
+    /// Sets or clears the value of [request.timeout_ms][crate::builder::bigquery::QueryRequest::timeout_ms].
     pub fn set_or_clear_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -391,7 +391,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.use_legacy_sql][crate::generated::QueryBuilderRequest::use_legacy_sql].
+    /// Sets the value of [request.use_legacy_sql][crate::builder::bigquery::QueryRequest::use_legacy_sql].
     pub fn set_use_legacy_sql<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -399,7 +399,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.use_legacy_sql][crate::generated::QueryBuilderRequest::use_legacy_sql].
+    /// Sets or clears the value of [request.use_legacy_sql][crate::builder::bigquery::QueryRequest::use_legacy_sql].
     pub fn set_or_clear_use_legacy_sql<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -407,7 +407,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.use_query_cache][crate::generated::QueryBuilderRequest::use_query_cache].
+    /// Sets the value of [request.use_query_cache][crate::builder::bigquery::QueryRequest::use_query_cache].
     pub fn set_use_query_cache<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -415,7 +415,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets or clears the value of [request.use_query_cache][crate::generated::QueryBuilderRequest::use_query_cache].
+    /// Sets or clears the value of [request.use_query_cache][crate::builder::bigquery::QueryRequest::use_query_cache].
     pub fn set_or_clear_use_query_cache<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -423,7 +423,7 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.user_defined_function_resources][crate::generated::QueryBuilderRequest::user_defined_function_resources].
+    /// Sets the value of [request.user_defined_function_resources][crate::builder::bigquery::QueryRequest::user_defined_function_resources].
     pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -434,13 +434,13 @@ impl QueryBuilder {
         self
     }
 
-    /// Sets the value of [request.write_disposition][crate::generated::QueryBuilderRequest::write_disposition].
+    /// Sets the value of [request.write_disposition][crate::builder::bigquery::QueryRequest::write_disposition].
     pub fn set_write_disposition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.write_disposition = v.into();
         self
     }
 
-    /// Sets the value of [request.write_incremental_results][crate::generated::QueryBuilderRequest::write_incremental_results].
+    /// Sets the value of [request.write_incremental_results][crate::builder::bigquery::QueryRequest::write_incremental_results].
     pub fn set_write_incremental_results<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.request.write_incremental_results = v.into();
         self

--- a/src/bigquery/src/generated/builder.rs
+++ b/src/bigquery/src/generated/builder.rs
@@ -18,9 +18,9 @@
 #[allow(rustdoc::broken_intra_doc_links)]
 #[allow(rustdoc::invalid_html_tags)]
 #[allow(rustdoc::redundant_explicit_links)]
-impl RunQuery {
+impl QueryBuilder {
 
-    /// Sets the value of [request.allow_large_results][crate::model::RunQueryRequest::allow_large_results].
+    /// Sets the value of [request.allow_large_results][crate::generated::QueryBuilderRequest::allow_large_results].
     pub fn set_allow_large_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -28,7 +28,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.allow_large_results][crate::model::RunQueryRequest::allow_large_results].
+    /// Sets or clears the value of [request.allow_large_results][crate::generated::QueryBuilderRequest::allow_large_results].
     pub fn set_or_clear_allow_large_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -36,7 +36,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.clustering][crate::model::RunQueryRequest::clustering].
+    /// Sets the value of [request.clustering][crate::generated::QueryBuilderRequest::clustering].
     pub fn set_clustering<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::Clustering>
     {
@@ -44,7 +44,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.clustering][crate::model::RunQueryRequest::clustering].
+    /// Sets or clears the value of [request.clustering][crate::generated::QueryBuilderRequest::clustering].
     pub fn set_or_clear_clustering<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::Clustering>
     {
@@ -52,7 +52,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.connection_properties][crate::model::RunQueryRequest::connection_properties].
+    /// Sets the value of [request.connection_properties][crate::generated::QueryBuilderRequest::connection_properties].
     pub fn set_connection_properties<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -63,7 +63,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.continuous][crate::model::RunQueryRequest::continuous].
+    /// Sets the value of [request.continuous][crate::generated::QueryBuilderRequest::continuous].
     pub fn set_continuous<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -71,7 +71,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.continuous][crate::model::RunQueryRequest::continuous].
+    /// Sets or clears the value of [request.continuous][crate::generated::QueryBuilderRequest::continuous].
     pub fn set_or_clear_continuous<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -79,13 +79,13 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.create_disposition][crate::model::RunQueryRequest::create_disposition].
+    /// Sets the value of [request.create_disposition][crate::generated::QueryBuilderRequest::create_disposition].
     pub fn set_create_disposition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.create_disposition = v.into();
         self
     }
 
-    /// Sets the value of [request.create_session][crate::model::RunQueryRequest::create_session].
+    /// Sets the value of [request.create_session][crate::generated::QueryBuilderRequest::create_session].
     pub fn set_create_session<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -93,7 +93,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.create_session][crate::model::RunQueryRequest::create_session].
+    /// Sets or clears the value of [request.create_session][crate::generated::QueryBuilderRequest::create_session].
     pub fn set_or_clear_create_session<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -101,7 +101,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.default_dataset][crate::model::RunQueryRequest::default_dataset].
+    /// Sets the value of [request.default_dataset][crate::generated::QueryBuilderRequest::default_dataset].
     pub fn set_default_dataset<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::DatasetReference>
     {
@@ -109,7 +109,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.default_dataset][crate::model::RunQueryRequest::default_dataset].
+    /// Sets or clears the value of [request.default_dataset][crate::generated::QueryBuilderRequest::default_dataset].
     pub fn set_or_clear_default_dataset<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::DatasetReference>
     {
@@ -117,7 +117,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.destination_encryption_configuration][crate::model::RunQueryRequest::destination_encryption_configuration].
+    /// Sets the value of [request.destination_encryption_configuration][crate::generated::QueryBuilderRequest::destination_encryption_configuration].
     pub fn set_destination_encryption_configuration<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::EncryptionConfiguration>
     {
@@ -125,7 +125,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.destination_encryption_configuration][crate::model::RunQueryRequest::destination_encryption_configuration].
+    /// Sets or clears the value of [request.destination_encryption_configuration][crate::generated::QueryBuilderRequest::destination_encryption_configuration].
     pub fn set_or_clear_destination_encryption_configuration<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::EncryptionConfiguration>
     {
@@ -133,7 +133,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.destination_table][crate::model::RunQueryRequest::destination_table].
+    /// Sets the value of [request.destination_table][crate::generated::QueryBuilderRequest::destination_table].
     pub fn set_destination_table<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::TableReference>
     {
@@ -141,7 +141,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.destination_table][crate::model::RunQueryRequest::destination_table].
+    /// Sets or clears the value of [request.destination_table][crate::generated::QueryBuilderRequest::destination_table].
     pub fn set_or_clear_destination_table<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::TableReference>
     {
@@ -149,13 +149,13 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.dry_run][crate::model::RunQueryRequest::dry_run].
+    /// Sets the value of [request.dry_run][crate::generated::QueryBuilderRequest::dry_run].
     pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.request.dry_run = v.into();
         self
     }
 
-    /// Sets the value of [request.external_table_definitions][crate::model::RunQueryRequest::external_table_definitions].
+    /// Sets the value of [request.external_table_definitions][crate::generated::QueryBuilderRequest::external_table_definitions].
     pub fn set_external_table_definitions<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -167,7 +167,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.flatten_results][crate::model::RunQueryRequest::flatten_results].
+    /// Sets the value of [request.flatten_results][crate::generated::QueryBuilderRequest::flatten_results].
     pub fn set_flatten_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -175,7 +175,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.flatten_results][crate::model::RunQueryRequest::flatten_results].
+    /// Sets or clears the value of [request.flatten_results][crate::generated::QueryBuilderRequest::flatten_results].
     pub fn set_or_clear_flatten_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -183,13 +183,13 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.job_creation_mode][crate::model::RunQueryRequest::job_creation_mode].
+    /// Sets the value of [request.job_creation_mode][crate::generated::QueryBuilderRequest::job_creation_mode].
     pub fn set_job_creation_mode<T: std::convert::Into<crate::model::query_request::JobCreationMode>>(mut self, v: T) -> Self {
         self.request.job_creation_mode = v.into();
         self
     }
 
-    /// Sets the value of [request.job_timeout_ms][crate::model::RunQueryRequest::job_timeout_ms].
+    /// Sets the value of [request.job_timeout_ms][crate::generated::QueryBuilderRequest::job_timeout_ms].
     pub fn set_job_timeout_ms<T>(mut self, v: T) -> Self
     where T: std::convert::Into<i64>
     {
@@ -197,7 +197,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.job_timeout_ms][crate::model::RunQueryRequest::job_timeout_ms].
+    /// Sets or clears the value of [request.job_timeout_ms][crate::generated::QueryBuilderRequest::job_timeout_ms].
     pub fn set_or_clear_job_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<i64>
     {
@@ -205,7 +205,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.labels][crate::model::RunQueryRequest::labels].
+    /// Sets the value of [request.labels][crate::generated::QueryBuilderRequest::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -217,13 +217,13 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.location][crate::model::RunQueryRequest::location].
+    /// Sets the value of [request.location][crate::generated::QueryBuilderRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.location = v.into();
         self
     }
 
-    /// Sets the value of [request.max_results][crate::model::RunQueryRequest::max_results].
+    /// Sets the value of [request.max_results][crate::generated::QueryBuilderRequest::max_results].
     pub fn set_max_results<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -231,7 +231,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.max_results][crate::model::RunQueryRequest::max_results].
+    /// Sets or clears the value of [request.max_results][crate::generated::QueryBuilderRequest::max_results].
     pub fn set_or_clear_max_results<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -239,7 +239,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.max_slots][crate::model::RunQueryRequest::max_slots].
+    /// Sets the value of [request.max_slots][crate::generated::QueryBuilderRequest::max_slots].
     pub fn set_max_slots<T>(mut self, v: T) -> Self
     where T: std::convert::Into<i32>
     {
@@ -247,7 +247,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.max_slots][crate::model::RunQueryRequest::max_slots].
+    /// Sets or clears the value of [request.max_slots][crate::generated::QueryBuilderRequest::max_slots].
     pub fn set_or_clear_max_slots<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<i32>
     {
@@ -255,7 +255,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.maximum_bytes_billed][crate::model::RunQueryRequest::maximum_bytes_billed].
+    /// Sets the value of [request.maximum_bytes_billed][crate::generated::QueryBuilderRequest::maximum_bytes_billed].
     pub fn set_maximum_bytes_billed<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::Int64Value>
     {
@@ -263,7 +263,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.maximum_bytes_billed][crate::model::RunQueryRequest::maximum_bytes_billed].
+    /// Sets or clears the value of [request.maximum_bytes_billed][crate::generated::QueryBuilderRequest::maximum_bytes_billed].
     pub fn set_or_clear_maximum_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::Int64Value>
     {
@@ -271,25 +271,25 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.parameter_mode][crate::model::RunQueryRequest::parameter_mode].
+    /// Sets the value of [request.parameter_mode][crate::generated::QueryBuilderRequest::parameter_mode].
     pub fn set_parameter_mode<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.parameter_mode = v.into();
         self
     }
 
-    /// Sets the value of [request.priority][crate::model::RunQueryRequest::priority].
+    /// Sets the value of [request.priority][crate::generated::QueryBuilderRequest::priority].
     pub fn set_priority<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.priority = v.into();
         self
     }
 
-    /// Sets the value of [request.query][crate::model::RunQueryRequest::query].
+    /// Sets the value of [request.query][crate::generated::QueryBuilderRequest::query].
     pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.query = v.into();
         self
     }
 
-    /// Sets the value of [request.query_parameters][crate::model::RunQueryRequest::query_parameters].
+    /// Sets the value of [request.query_parameters][crate::generated::QueryBuilderRequest::query_parameters].
     pub fn set_query_parameters<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -300,7 +300,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.range_partitioning][crate::model::RunQueryRequest::range_partitioning].
+    /// Sets the value of [request.range_partitioning][crate::generated::QueryBuilderRequest::range_partitioning].
     pub fn set_range_partitioning<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::RangePartitioning>
     {
@@ -308,7 +308,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.range_partitioning][crate::model::RunQueryRequest::range_partitioning].
+    /// Sets or clears the value of [request.range_partitioning][crate::generated::QueryBuilderRequest::range_partitioning].
     pub fn set_or_clear_range_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::RangePartitioning>
     {
@@ -316,7 +316,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.reservation][crate::model::RunQueryRequest::reservation].
+    /// Sets the value of [request.reservation][crate::generated::QueryBuilderRequest::reservation].
     pub fn set_reservation<T>(mut self, v: T) -> Self
     where T: std::convert::Into<std::string::String>
     {
@@ -324,7 +324,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.reservation][crate::model::RunQueryRequest::reservation].
+    /// Sets or clears the value of [request.reservation][crate::generated::QueryBuilderRequest::reservation].
     pub fn set_or_clear_reservation<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<std::string::String>
     {
@@ -332,7 +332,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.schema_update_options][crate::model::RunQueryRequest::schema_update_options].
+    /// Sets the value of [request.schema_update_options][crate::generated::QueryBuilderRequest::schema_update_options].
     pub fn set_schema_update_options<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -343,7 +343,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.script_options][crate::model::RunQueryRequest::script_options].
+    /// Sets the value of [request.script_options][crate::generated::QueryBuilderRequest::script_options].
     pub fn set_script_options<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::ScriptOptions>
     {
@@ -351,7 +351,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.script_options][crate::model::RunQueryRequest::script_options].
+    /// Sets or clears the value of [request.script_options][crate::generated::QueryBuilderRequest::script_options].
     pub fn set_or_clear_script_options<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::ScriptOptions>
     {
@@ -359,7 +359,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.time_partitioning][crate::model::RunQueryRequest::time_partitioning].
+    /// Sets the value of [request.time_partitioning][crate::generated::QueryBuilderRequest::time_partitioning].
     pub fn set_time_partitioning<T>(mut self, v: T) -> Self
     where T: std::convert::Into<crate::model::TimePartitioning>
     {
@@ -367,7 +367,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.time_partitioning][crate::model::RunQueryRequest::time_partitioning].
+    /// Sets or clears the value of [request.time_partitioning][crate::generated::QueryBuilderRequest::time_partitioning].
     pub fn set_or_clear_time_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<crate::model::TimePartitioning>
     {
@@ -375,7 +375,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.timeout_ms][crate::model::RunQueryRequest::timeout_ms].
+    /// Sets the value of [request.timeout_ms][crate::generated::QueryBuilderRequest::timeout_ms].
     pub fn set_timeout_ms<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -383,7 +383,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.timeout_ms][crate::model::RunQueryRequest::timeout_ms].
+    /// Sets or clears the value of [request.timeout_ms][crate::generated::QueryBuilderRequest::timeout_ms].
     pub fn set_or_clear_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::UInt32Value>
     {
@@ -391,7 +391,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.use_legacy_sql][crate::model::RunQueryRequest::use_legacy_sql].
+    /// Sets the value of [request.use_legacy_sql][crate::generated::QueryBuilderRequest::use_legacy_sql].
     pub fn set_use_legacy_sql<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -399,7 +399,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.use_legacy_sql][crate::model::RunQueryRequest::use_legacy_sql].
+    /// Sets or clears the value of [request.use_legacy_sql][crate::generated::QueryBuilderRequest::use_legacy_sql].
     pub fn set_or_clear_use_legacy_sql<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -407,7 +407,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.use_query_cache][crate::model::RunQueryRequest::use_query_cache].
+    /// Sets the value of [request.use_query_cache][crate::generated::QueryBuilderRequest::use_query_cache].
     pub fn set_use_query_cache<T>(mut self, v: T) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -415,7 +415,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets or clears the value of [request.use_query_cache][crate::model::RunQueryRequest::use_query_cache].
+    /// Sets or clears the value of [request.use_query_cache][crate::generated::QueryBuilderRequest::use_query_cache].
     pub fn set_or_clear_use_query_cache<T>(mut self, v: std::option::Option<T>) -> Self
     where T: std::convert::Into<wkt::BoolValue>
     {
@@ -423,7 +423,7 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.user_defined_function_resources][crate::model::RunQueryRequest::user_defined_function_resources].
+    /// Sets the value of [request.user_defined_function_resources][crate::generated::QueryBuilderRequest::user_defined_function_resources].
     pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -434,13 +434,13 @@ impl RunQuery {
         self
     }
 
-    /// Sets the value of [request.write_disposition][crate::model::RunQueryRequest::write_disposition].
+    /// Sets the value of [request.write_disposition][crate::generated::QueryBuilderRequest::write_disposition].
     pub fn set_write_disposition<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.request.write_disposition = v.into();
         self
     }
 
-    /// Sets the value of [request.write_incremental_results][crate::model::RunQueryRequest::write_incremental_results].
+    /// Sets the value of [request.write_incremental_results][crate::generated::QueryBuilderRequest::write_incremental_results].
     pub fn set_write_incremental_results<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.request.write_incremental_results = v.into();
         self

--- a/src/bigquery/src/generated/complete_query_metadata.rs
+++ b/src/bigquery/src/generated/complete_query_metadata.rs
@@ -22,12 +22,9 @@
 #[allow(missing_docs)]
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub struct QueryCreationMetadata {
+pub struct CompleteQueryMetadata {
     /// Whether the query result was fetched from the query cache.
     pub cache_hit: std::option::Option<wkt::BoolValue>,
-
-    /// Required. Describes the job configuration.
-    pub configuration: std::option::Option<crate::model::JobConfiguration>,
 
     /// Output only. Creation time of this query, in milliseconds since the epoch.
     /// This field will be present on all queries.
@@ -41,32 +38,36 @@ pub struct QueryCreationMetadata {
     /// field will be present whenever a query job is in the DONE state.
     pub end_time: std::option::Option<i64>,
 
-    /// Output only. The first errors or warnings encountered during the running of
-    /// the job. The final message includes the number of errors that caused the
+    /// Output only. The first errors or warnings encountered during the running
+    /// of the job. The final message includes the number of errors that caused the
     /// process to stop. Errors here do not necessarily mean that the job has
     /// completed or was unsuccessful. For more information about error messages,
     /// see [Error
     /// messages](https://cloud.google.com/bigquery/docs/error-messages).
     pub errors: std::vec::Vec<crate::model::ErrorProto>,
 
-    /// Output only. A hash of this resource.
+    /// A hash of this response.
     pub etag: std::string::String,
-
-    /// Output only. Opaque ID field of the job.
-    pub id: std::string::String,
 
     /// Whether the query has completed or not. If rows or totalRows are present,
     /// this will always be true. If this is false, totalRows will not be
     /// available.
     pub job_complete: std::option::Option<wkt::BoolValue>,
 
-    /// Output only. The reason why a Job was created.
+    /// Optional. The reason why a Job was created.
+    ///
+    /// Only relevant when a job_reference is present in the response.
+    /// If job_reference is not present it will always be unset.
     pub job_creation_reason: std::option::Option<crate::model::JobCreationReason>,
 
-    /// Optional. Reference describing the unique-per-user name of the job.
+    /// Reference to the BigQuery Job that was created to run the query. This field
+    /// will be present even if the original request timed out, in which case
+    /// GetQueryResults can be used to read the results once the query has
+    /// completed. Since this API only returns the first page of results,
+    /// subsequent pages can be fetched via the same mechanism (GetQueryResults).
     pub job_reference: std::option::Option<crate::model::JobReference>,
 
-    /// Output only. The type of the resource.
+    /// The resource type of the response.
     pub kind: std::string::String,
 
     /// Output only. The geographic location of the query.
@@ -79,18 +80,9 @@ pub struct QueryCreationMetadata {
     /// for DML statements INSERT, UPDATE or DELETE.
     pub num_dml_affected_rows: std::option::Option<wkt::Int64Value>,
 
-    /// A token used for paging results. A non-empty token indicates that
-    /// additional results are available. To see additional results,
-    /// query the
-    /// [`jobs.getQueryResults`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults)
-    /// method. For more information, see [Paging through table
-    /// data](https://cloud.google.com/bigquery/docs/paging-results).
+    /// A token used for paging results.  When this token is non-empty, it
+    /// indicates additional results are available.
     pub page_token: std::string::String,
-
-    /// Output only. [Full-projection-only] String representation of identity of
-    /// requesting party. Populated for both first- and third-party identities.
-    /// Only present for APIs that support third-party identities.
-    pub principal_subject: std::string::String,
 
     /// Auto-generated ID for the query.
     pub query_id: std::string::String,
@@ -98,9 +90,6 @@ pub struct QueryCreationMetadata {
     /// The schema of the results. Present only when the query completes
     /// successfully.
     pub schema: std::option::Option<crate::model::TableSchema>,
-
-    /// Output only. A URL that can be used to access the resource again.
-    pub self_link: std::string::String,
 
     /// Output only. Information of the session if this job is part of one.
     pub session_info: std::option::Option<crate::model::SessionInfo>,
@@ -110,45 +99,33 @@ pub struct QueryCreationMetadata {
     /// state to either RUNNING or DONE.
     pub start_time: std::option::Option<i64>,
 
-    /// Output only. Information about the job, including starting time and ending
-    /// time of the job.
-    pub statistics: std::option::Option<crate::model::JobStatistics>,
-
-    /// Output only. The status of this job. Examine this value when polling an
-    /// asynchronous job to see if the job is complete.
-    pub status: std::option::Option<crate::model::JobStatus>,
-
     /// Output only. If the project is configured to use on-demand pricing,
     /// then this field contains the total bytes billed for the job.
     /// If the project is configured to use flat-rate pricing, then you are
     /// not billed for bytes and this field is informational only.
     pub total_bytes_billed: std::option::Option<i64>,
 
-    /// The total number of bytes processed for this query. If this query was a dry
-    /// run, this is the number of bytes that would be processed if the query were
-    /// run.
+    /// The total number of bytes processed for this query.
     pub total_bytes_processed: std::option::Option<wkt::Int64Value>,
 
     /// The total number of rows in the complete query result set, which can be
-    /// more than the number of rows in this single page of results.
+    /// more than the number of rows in this single page of results. Present only
+    /// when the query completes successfully.
     pub total_rows: std::option::Option<wkt::UInt64Value>,
 
     /// Output only. Number of slot ms the user is actually billed for.
     pub total_slot_ms: std::option::Option<i64>,
 
-    /// Output only. Email address of the user who ran the job.
-    pub user_email: std::string::String,
-
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
-impl QueryCreationMetadata {
+impl CompleteQueryMetadata {
     /// Creates a new default instance.
     pub fn new() -> Self {
         std::default::Default::default()
     }
 
-    /// Sets the value of [cache_hit][crate::model::QueryCreationMetadata::cache_hit].
+    /// Sets the value of [cache_hit][crate::model::CompleteQueryMetadata::cache_hit].
     pub fn set_cache_hit<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -157,7 +134,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [cache_hit][crate::model::QueryCreationMetadata::cache_hit].
+    /// Sets or clears the value of [cache_hit][crate::model::CompleteQueryMetadata::cache_hit].
     pub fn set_or_clear_cache_hit<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -166,25 +143,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [configuration][crate::model::QueryCreationMetadata::configuration].
-    pub fn set_configuration<T>(mut self, v: T) -> Self
-    where
-        T: std::convert::Into<crate::model::JobConfiguration>,
-    {
-        self.configuration = std::option::Option::Some(v.into());
-        self
-    }
-
-    /// Sets or clears the value of [configuration][crate::model::QueryCreationMetadata::configuration].
-    pub fn set_or_clear_configuration<T>(mut self, v: std::option::Option<T>) -> Self
-    where
-        T: std::convert::Into<crate::model::JobConfiguration>,
-    {
-        self.configuration = v.map(|x| x.into());
-        self
-    }
-
-    /// Sets the value of [creation_time][crate::model::QueryCreationMetadata::creation_time].
+    /// Sets the value of [creation_time][crate::model::CompleteQueryMetadata::creation_time].
     pub fn set_creation_time<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -193,7 +152,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [creation_time][crate::model::QueryCreationMetadata::creation_time].
+    /// Sets or clears the value of [creation_time][crate::model::CompleteQueryMetadata::creation_time].
     pub fn set_or_clear_creation_time<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -202,7 +161,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [dml_stats][crate::model::QueryCreationMetadata::dml_stats].
+    /// Sets the value of [dml_stats][crate::model::CompleteQueryMetadata::dml_stats].
     pub fn set_dml_stats<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::DmlStats>,
@@ -211,7 +170,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [dml_stats][crate::model::QueryCreationMetadata::dml_stats].
+    /// Sets or clears the value of [dml_stats][crate::model::CompleteQueryMetadata::dml_stats].
     pub fn set_or_clear_dml_stats<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::DmlStats>,
@@ -220,7 +179,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [end_time][crate::model::QueryCreationMetadata::end_time].
+    /// Sets the value of [end_time][crate::model::CompleteQueryMetadata::end_time].
     pub fn set_end_time<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -229,7 +188,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [end_time][crate::model::QueryCreationMetadata::end_time].
+    /// Sets or clears the value of [end_time][crate::model::CompleteQueryMetadata::end_time].
     pub fn set_or_clear_end_time<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -238,7 +197,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [errors][crate::model::QueryCreationMetadata::errors].
+    /// Sets the value of [errors][crate::model::CompleteQueryMetadata::errors].
     pub fn set_errors<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -249,19 +208,13 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [etag][crate::model::QueryCreationMetadata::etag].
+    /// Sets the value of [etag][crate::model::CompleteQueryMetadata::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
         self
     }
 
-    /// Sets the value of [id][crate::model::QueryCreationMetadata::id].
-    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id = v.into();
-        self
-    }
-
-    /// Sets the value of [job_complete][crate::model::QueryCreationMetadata::job_complete].
+    /// Sets the value of [job_complete][crate::model::CompleteQueryMetadata::job_complete].
     pub fn set_job_complete<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -270,7 +223,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [job_complete][crate::model::QueryCreationMetadata::job_complete].
+    /// Sets or clears the value of [job_complete][crate::model::CompleteQueryMetadata::job_complete].
     pub fn set_or_clear_job_complete<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -279,7 +232,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [job_creation_reason][crate::model::QueryCreationMetadata::job_creation_reason].
+    /// Sets the value of [job_creation_reason][crate::model::CompleteQueryMetadata::job_creation_reason].
     pub fn set_job_creation_reason<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::JobCreationReason>,
@@ -288,7 +241,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [job_creation_reason][crate::model::QueryCreationMetadata::job_creation_reason].
+    /// Sets or clears the value of [job_creation_reason][crate::model::CompleteQueryMetadata::job_creation_reason].
     pub fn set_or_clear_job_creation_reason<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::JobCreationReason>,
@@ -297,7 +250,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [job_reference][crate::model::QueryCreationMetadata::job_reference].
+    /// Sets the value of [job_reference][crate::model::CompleteQueryMetadata::job_reference].
     pub fn set_job_reference<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::JobReference>,
@@ -306,7 +259,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [job_reference][crate::model::QueryCreationMetadata::job_reference].
+    /// Sets or clears the value of [job_reference][crate::model::CompleteQueryMetadata::job_reference].
     pub fn set_or_clear_job_reference<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::JobReference>,
@@ -315,19 +268,19 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [kind][crate::model::QueryCreationMetadata::kind].
+    /// Sets the value of [kind][crate::model::CompleteQueryMetadata::kind].
     pub fn set_kind<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.kind = v.into();
         self
     }
 
-    /// Sets the value of [location][crate::model::QueryCreationMetadata::location].
+    /// Sets the value of [location][crate::model::CompleteQueryMetadata::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of [num_dml_affected_rows][crate::model::QueryCreationMetadata::num_dml_affected_rows].
+    /// Sets the value of [num_dml_affected_rows][crate::model::CompleteQueryMetadata::num_dml_affected_rows].
     pub fn set_num_dml_affected_rows<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -336,7 +289,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [num_dml_affected_rows][crate::model::QueryCreationMetadata::num_dml_affected_rows].
+    /// Sets or clears the value of [num_dml_affected_rows][crate::model::CompleteQueryMetadata::num_dml_affected_rows].
     pub fn set_or_clear_num_dml_affected_rows<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -345,28 +298,19 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [page_token][crate::model::QueryCreationMetadata::page_token].
+    /// Sets the value of [page_token][crate::model::CompleteQueryMetadata::page_token].
     pub fn set_page_token<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.page_token = v.into();
         self
     }
 
-    /// Sets the value of [principal_subject][crate::model::QueryCreationMetadata::principal_subject].
-    pub fn set_principal_subject<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.principal_subject = v.into();
-        self
-    }
-
-    /// Sets the value of [query_id][crate::model::QueryCreationMetadata::query_id].
+    /// Sets the value of [query_id][crate::model::CompleteQueryMetadata::query_id].
     pub fn set_query_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.query_id = v.into();
         self
     }
 
-    /// Sets the value of [schema][crate::model::QueryCreationMetadata::schema].
+    /// Sets the value of [schema][crate::model::CompleteQueryMetadata::schema].
     pub fn set_schema<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::TableSchema>,
@@ -375,7 +319,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [schema][crate::model::QueryCreationMetadata::schema].
+    /// Sets or clears the value of [schema][crate::model::CompleteQueryMetadata::schema].
     pub fn set_or_clear_schema<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::TableSchema>,
@@ -384,13 +328,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [self_link][crate::model::QueryCreationMetadata::self_link].
-    pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.self_link = v.into();
-        self
-    }
-
-    /// Sets the value of [session_info][crate::model::QueryCreationMetadata::session_info].
+    /// Sets the value of [session_info][crate::model::CompleteQueryMetadata::session_info].
     pub fn set_session_info<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::SessionInfo>,
@@ -399,7 +337,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [session_info][crate::model::QueryCreationMetadata::session_info].
+    /// Sets or clears the value of [session_info][crate::model::CompleteQueryMetadata::session_info].
     pub fn set_or_clear_session_info<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::SessionInfo>,
@@ -408,7 +346,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [start_time][crate::model::QueryCreationMetadata::start_time].
+    /// Sets the value of [start_time][crate::model::CompleteQueryMetadata::start_time].
     pub fn set_start_time<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -417,7 +355,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [start_time][crate::model::QueryCreationMetadata::start_time].
+    /// Sets or clears the value of [start_time][crate::model::CompleteQueryMetadata::start_time].
     pub fn set_or_clear_start_time<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -426,43 +364,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [statistics][crate::model::QueryCreationMetadata::statistics].
-    pub fn set_statistics<T>(mut self, v: T) -> Self
-    where
-        T: std::convert::Into<crate::model::JobStatistics>,
-    {
-        self.statistics = std::option::Option::Some(v.into());
-        self
-    }
-
-    /// Sets or clears the value of [statistics][crate::model::QueryCreationMetadata::statistics].
-    pub fn set_or_clear_statistics<T>(mut self, v: std::option::Option<T>) -> Self
-    where
-        T: std::convert::Into<crate::model::JobStatistics>,
-    {
-        self.statistics = v.map(|x| x.into());
-        self
-    }
-
-    /// Sets the value of [status][crate::model::QueryCreationMetadata::status].
-    pub fn set_status<T>(mut self, v: T) -> Self
-    where
-        T: std::convert::Into<crate::model::JobStatus>,
-    {
-        self.status = std::option::Option::Some(v.into());
-        self
-    }
-
-    /// Sets or clears the value of [status][crate::model::QueryCreationMetadata::status].
-    pub fn set_or_clear_status<T>(mut self, v: std::option::Option<T>) -> Self
-    where
-        T: std::convert::Into<crate::model::JobStatus>,
-    {
-        self.status = v.map(|x| x.into());
-        self
-    }
-
-    /// Sets the value of [total_bytes_billed][crate::model::QueryCreationMetadata::total_bytes_billed].
+    /// Sets the value of [total_bytes_billed][crate::model::CompleteQueryMetadata::total_bytes_billed].
     pub fn set_total_bytes_billed<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -471,7 +373,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [total_bytes_billed][crate::model::QueryCreationMetadata::total_bytes_billed].
+    /// Sets or clears the value of [total_bytes_billed][crate::model::CompleteQueryMetadata::total_bytes_billed].
     pub fn set_or_clear_total_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -480,7 +382,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [total_bytes_processed][crate::model::QueryCreationMetadata::total_bytes_processed].
+    /// Sets the value of [total_bytes_processed][crate::model::CompleteQueryMetadata::total_bytes_processed].
     pub fn set_total_bytes_processed<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -489,7 +391,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [total_bytes_processed][crate::model::QueryCreationMetadata::total_bytes_processed].
+    /// Sets or clears the value of [total_bytes_processed][crate::model::CompleteQueryMetadata::total_bytes_processed].
     pub fn set_or_clear_total_bytes_processed<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -498,7 +400,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [total_rows][crate::model::QueryCreationMetadata::total_rows].
+    /// Sets the value of [total_rows][crate::model::CompleteQueryMetadata::total_rows].
     pub fn set_total_rows<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::UInt64Value>,
@@ -507,7 +409,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [total_rows][crate::model::QueryCreationMetadata::total_rows].
+    /// Sets or clears the value of [total_rows][crate::model::CompleteQueryMetadata::total_rows].
     pub fn set_or_clear_total_rows<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::UInt64Value>,
@@ -516,7 +418,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets the value of [total_slot_ms][crate::model::QueryCreationMetadata::total_slot_ms].
+    /// Sets the value of [total_slot_ms][crate::model::CompleteQueryMetadata::total_slot_ms].
     pub fn set_total_slot_ms<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -525,7 +427,7 @@ impl QueryCreationMetadata {
         self
     }
 
-    /// Sets or clears the value of [total_slot_ms][crate::model::QueryCreationMetadata::total_slot_ms].
+    /// Sets or clears the value of [total_slot_ms][crate::model::CompleteQueryMetadata::total_slot_ms].
     pub fn set_or_clear_total_slot_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -533,26 +435,19 @@ impl QueryCreationMetadata {
         self.total_slot_ms = v.map(|x| x.into());
         self
     }
-
-    /// Sets the value of [user_email][crate::model::QueryCreationMetadata::user_email].
-    pub fn set_user_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.user_email = v.into();
-        self
-    }
 }
+
 mod debug {
 
-    impl std::fmt::Debug for super::QueryCreationMetadata {
+    impl std::fmt::Debug for super::CompleteQueryMetadata {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let mut debug_struct = f.debug_struct("QueryCreationMetadata");
+            let mut debug_struct = f.debug_struct("CompleteQueryMetadata");
             debug_struct.field("cache_hit", &self.cache_hit);
-            debug_struct.field("configuration", &self.configuration);
             debug_struct.field("creation_time", &self.creation_time);
             debug_struct.field("dml_stats", &self.dml_stats);
             debug_struct.field("end_time", &self.end_time);
             debug_struct.field("errors", &self.errors);
             debug_struct.field("etag", &self.etag);
-            debug_struct.field("id", &self.id);
             debug_struct.field("job_complete", &self.job_complete);
             debug_struct.field("job_creation_reason", &self.job_creation_reason);
             debug_struct.field("job_reference", &self.job_reference);
@@ -560,19 +455,14 @@ mod debug {
             debug_struct.field("location", &self.location);
             debug_struct.field("num_dml_affected_rows", &self.num_dml_affected_rows);
             debug_struct.field("page_token", &self.page_token);
-            debug_struct.field("principal_subject", &self.principal_subject);
             debug_struct.field("query_id", &self.query_id);
             debug_struct.field("schema", &self.schema);
-            debug_struct.field("self_link", &self.self_link);
             debug_struct.field("session_info", &self.session_info);
             debug_struct.field("start_time", &self.start_time);
-            debug_struct.field("statistics", &self.statistics);
-            debug_struct.field("status", &self.status);
             debug_struct.field("total_bytes_billed", &self.total_bytes_billed);
             debug_struct.field("total_bytes_processed", &self.total_bytes_processed);
             debug_struct.field("total_rows", &self.total_rows);
             debug_struct.field("total_slot_ms", &self.total_slot_ms);
-            debug_struct.field("user_email", &self.user_email);
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -581,26 +471,28 @@ mod debug {
     }
 }
 
-impl std::convert::From<google_cloud_bigquery_v2::model::Job> for QueryCreationMetadata {
-    fn from(resp: google_cloud_bigquery_v2::model::Job) -> Self {
+impl std::convert::From<google_cloud_bigquery_v2::model::GetQueryResultsResponse>
+    for CompleteQueryMetadata
+{
+    fn from(resp: google_cloud_bigquery_v2::model::GetQueryResultsResponse) -> Self {
         Self {
-            configuration: resp.configuration,
+            cache_hit: resp.cache_hit,
+            errors: resp.errors,
             etag: resp.etag,
-            id: resp.id,
-            job_creation_reason: resp.job_creation_reason,
+            job_complete: resp.job_complete,
             job_reference: resp.job_reference,
             kind: resp.kind,
-            principal_subject: resp.principal_subject,
-            self_link: resp.self_link,
-            statistics: resp.statistics,
-            status: resp.status,
-            user_email: resp.user_email,
+            num_dml_affected_rows: resp.num_dml_affected_rows,
+            page_token: resp.page_token,
+            schema: resp.schema,
+            total_bytes_processed: resp.total_bytes_processed,
+            total_rows: resp.total_rows,
             ..Default::default()
         }
     }
 }
 
-impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for QueryCreationMetadata {
+impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for CompleteQueryMetadata {
     fn from(resp: google_cloud_bigquery_v2::model::QueryResponse) -> Self {
         Self {
             cache_hit: resp.cache_hit,
@@ -623,34 +515,6 @@ impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for Quer
             total_bytes_processed: resp.total_bytes_processed,
             total_rows: resp.total_rows,
             total_slot_ms: resp.total_slot_ms,
-            ..Default::default()
-        }
-    }
-}
-
-impl std::convert::From<QueryCreationMetadata> for crate::generated::QueryMetadata {
-    fn from(md: QueryCreationMetadata) -> Self {
-        crate::generated::QueryMetadata {
-            cache_hit: md.cache_hit,
-            creation_time: md.creation_time,
-            dml_stats: md.dml_stats,
-            end_time: md.end_time,
-            errors: md.errors,
-            job_complete: md.job_complete,
-            job_creation_reason: md.job_creation_reason,
-            job_reference: md.job_reference,
-            kind: md.kind,
-            location: md.location,
-            num_dml_affected_rows: md.num_dml_affected_rows,
-            page_token: md.page_token,
-            query_id: md.query_id,
-            schema: md.schema,
-            session_info: md.session_info,
-            start_time: md.start_time,
-            total_bytes_billed: md.total_bytes_billed,
-            total_bytes_processed: md.total_bytes_processed,
-            total_rows: md.total_rows,
-            total_slot_ms: md.total_slot_ms,
             ..Default::default()
         }
     }

--- a/src/bigquery/src/generated/query_metadata.rs
+++ b/src/bigquery/src/generated/query_metadata.rs
@@ -26,6 +26,9 @@ pub struct QueryMetadata {
     /// Whether the query result was fetched from the query cache.
     pub cache_hit: std::option::Option<wkt::BoolValue>,
 
+    /// Required. Describes the job configuration.
+    pub configuration: std::option::Option<crate::model::JobConfiguration>,
+
     /// Output only. Creation time of this query, in milliseconds since the epoch.
     /// This field will be present on all queries.
     pub creation_time: std::option::Option<i64>,
@@ -38,36 +41,32 @@ pub struct QueryMetadata {
     /// field will be present whenever a query job is in the DONE state.
     pub end_time: std::option::Option<i64>,
 
-    /// Output only. The first errors or warnings encountered during the running
-    /// of the job. The final message includes the number of errors that caused the
+    /// Output only. The first errors or warnings encountered during the running of
+    /// the job. The final message includes the number of errors that caused the
     /// process to stop. Errors here do not necessarily mean that the job has
     /// completed or was unsuccessful. For more information about error messages,
     /// see [Error
     /// messages](https://cloud.google.com/bigquery/docs/error-messages).
     pub errors: std::vec::Vec<crate::model::ErrorProto>,
 
-    /// A hash of this response.
+    /// Output only. A hash of this resource.
     pub etag: std::string::String,
+
+    /// Output only. Opaque ID field of the job.
+    pub id: std::string::String,
 
     /// Whether the query has completed or not. If rows or totalRows are present,
     /// this will always be true. If this is false, totalRows will not be
     /// available.
     pub job_complete: std::option::Option<wkt::BoolValue>,
 
-    /// Optional. The reason why a Job was created.
-    ///
-    /// Only relevant when a job_reference is present in the response.
-    /// If job_reference is not present it will always be unset.
+    /// Output only. The reason why a Job was created.
     pub job_creation_reason: std::option::Option<crate::model::JobCreationReason>,
 
-    /// Reference to the BigQuery Job that was created to run the query. This field
-    /// will be present even if the original request timed out, in which case
-    /// GetQueryResults can be used to read the results once the query has
-    /// completed. Since this API only returns the first page of results,
-    /// subsequent pages can be fetched via the same mechanism (GetQueryResults).
+    /// Optional. Reference describing the unique-per-user name of the job.
     pub job_reference: std::option::Option<crate::model::JobReference>,
 
-    /// The resource type of the response.
+    /// Output only. The type of the resource.
     pub kind: std::string::String,
 
     /// Output only. The geographic location of the query.
@@ -80,9 +79,18 @@ pub struct QueryMetadata {
     /// for DML statements INSERT, UPDATE or DELETE.
     pub num_dml_affected_rows: std::option::Option<wkt::Int64Value>,
 
-    /// A token used for paging results.  When this token is non-empty, it
-    /// indicates additional results are available.
+    /// A token used for paging results. A non-empty token indicates that
+    /// additional results are available. To see additional results,
+    /// query the
+    /// [`jobs.getQueryResults`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults)
+    /// method. For more information, see [Paging through table
+    /// data](https://cloud.google.com/bigquery/docs/paging-results).
     pub page_token: std::string::String,
+
+    /// Output only. [Full-projection-only] String representation of identity of
+    /// requesting party. Populated for both first- and third-party identities.
+    /// Only present for APIs that support third-party identities.
+    pub principal_subject: std::string::String,
 
     /// Auto-generated ID for the query.
     pub query_id: std::string::String,
@@ -90,6 +98,9 @@ pub struct QueryMetadata {
     /// The schema of the results. Present only when the query completes
     /// successfully.
     pub schema: std::option::Option<crate::model::TableSchema>,
+
+    /// Output only. A URL that can be used to access the resource again.
+    pub self_link: std::string::String,
 
     /// Output only. Information of the session if this job is part of one.
     pub session_info: std::option::Option<crate::model::SessionInfo>,
@@ -99,22 +110,34 @@ pub struct QueryMetadata {
     /// state to either RUNNING or DONE.
     pub start_time: std::option::Option<i64>,
 
+    /// Output only. Information about the job, including starting time and ending
+    /// time of the job.
+    pub statistics: std::option::Option<crate::model::JobStatistics>,
+
+    /// Output only. The status of this job. Examine this value when polling an
+    /// asynchronous job to see if the job is complete.
+    pub status: std::option::Option<crate::model::JobStatus>,
+
     /// Output only. If the project is configured to use on-demand pricing,
     /// then this field contains the total bytes billed for the job.
     /// If the project is configured to use flat-rate pricing, then you are
     /// not billed for bytes and this field is informational only.
     pub total_bytes_billed: std::option::Option<i64>,
 
-    /// The total number of bytes processed for this query.
+    /// The total number of bytes processed for this query. If this query was a dry
+    /// run, this is the number of bytes that would be processed if the query were
+    /// run.
     pub total_bytes_processed: std::option::Option<wkt::Int64Value>,
 
     /// The total number of rows in the complete query result set, which can be
-    /// more than the number of rows in this single page of results. Present only
-    /// when the query completes successfully.
+    /// more than the number of rows in this single page of results.
     pub total_rows: std::option::Option<wkt::UInt64Value>,
 
     /// Output only. Number of slot ms the user is actually billed for.
     pub total_slot_ms: std::option::Option<i64>,
+
+    /// Output only. Email address of the user who ran the job.
+    pub user_email: std::string::String,
 
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
@@ -140,6 +163,24 @@ impl QueryMetadata {
         T: std::convert::Into<wkt::BoolValue>,
     {
         self.cache_hit = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [configuration][crate::model::QueryMetadata::configuration].
+    pub fn set_configuration<T>(mut self, v: T) -> Self
+    where
+        T: std::convert::Into<crate::model::JobConfiguration>,
+    {
+        self.configuration = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [configuration][crate::model::QueryMetadata::configuration].
+    pub fn set_or_clear_configuration<T>(mut self, v: std::option::Option<T>) -> Self
+    where
+        T: std::convert::Into<crate::model::JobConfiguration>,
+    {
+        self.configuration = v.map(|x| x.into());
         self
     }
 
@@ -211,6 +252,12 @@ impl QueryMetadata {
     /// Sets the value of [etag][crate::model::QueryMetadata::etag].
     pub fn set_etag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.etag = v.into();
+        self
+    }
+
+    /// Sets the value of [id][crate::model::QueryMetadata::id].
+    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.id = v.into();
         self
     }
 
@@ -304,6 +351,15 @@ impl QueryMetadata {
         self
     }
 
+    /// Sets the value of [principal_subject][crate::model::QueryMetadata::principal_subject].
+    pub fn set_principal_subject<T: std::convert::Into<std::string::String>>(
+        mut self,
+        v: T,
+    ) -> Self {
+        self.principal_subject = v.into();
+        self
+    }
+
     /// Sets the value of [query_id][crate::model::QueryMetadata::query_id].
     pub fn set_query_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.query_id = v.into();
@@ -325,6 +381,12 @@ impl QueryMetadata {
         T: std::convert::Into<crate::model::TableSchema>,
     {
         self.schema = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [self_link][crate::model::QueryMetadata::self_link].
+    pub fn set_self_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.self_link = v.into();
         self
     }
 
@@ -361,6 +423,42 @@ impl QueryMetadata {
         T: std::convert::Into<i64>,
     {
         self.start_time = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [statistics][crate::model::QueryMetadata::statistics].
+    pub fn set_statistics<T>(mut self, v: T) -> Self
+    where
+        T: std::convert::Into<crate::model::JobStatistics>,
+    {
+        self.statistics = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [statistics][crate::model::QueryMetadata::statistics].
+    pub fn set_or_clear_statistics<T>(mut self, v: std::option::Option<T>) -> Self
+    where
+        T: std::convert::Into<crate::model::JobStatistics>,
+    {
+        self.statistics = v.map(|x| x.into());
+        self
+    }
+
+    /// Sets the value of [status][crate::model::QueryMetadata::status].
+    pub fn set_status<T>(mut self, v: T) -> Self
+    where
+        T: std::convert::Into<crate::model::JobStatus>,
+    {
+        self.status = std::option::Option::Some(v.into());
+        self
+    }
+
+    /// Sets or clears the value of [status][crate::model::QueryMetadata::status].
+    pub fn set_or_clear_status<T>(mut self, v: std::option::Option<T>) -> Self
+    where
+        T: std::convert::Into<crate::model::JobStatus>,
+    {
+        self.status = v.map(|x| x.into());
         self
     }
 
@@ -435,18 +533,27 @@ impl QueryMetadata {
         self.total_slot_ms = v.map(|x| x.into());
         self
     }
+
+    /// Sets the value of [user_email][crate::model::QueryMetadata::user_email].
+    pub fn set_user_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
+        self.user_email = v.into();
+        self
+    }
 }
+
 mod debug {
 
     impl std::fmt::Debug for super::QueryMetadata {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             let mut debug_struct = f.debug_struct("QueryMetadata");
             debug_struct.field("cache_hit", &self.cache_hit);
+            debug_struct.field("configuration", &self.configuration);
             debug_struct.field("creation_time", &self.creation_time);
             debug_struct.field("dml_stats", &self.dml_stats);
             debug_struct.field("end_time", &self.end_time);
             debug_struct.field("errors", &self.errors);
             debug_struct.field("etag", &self.etag);
+            debug_struct.field("id", &self.id);
             debug_struct.field("job_complete", &self.job_complete);
             debug_struct.field("job_creation_reason", &self.job_creation_reason);
             debug_struct.field("job_reference", &self.job_reference);
@@ -454,14 +561,19 @@ mod debug {
             debug_struct.field("location", &self.location);
             debug_struct.field("num_dml_affected_rows", &self.num_dml_affected_rows);
             debug_struct.field("page_token", &self.page_token);
+            debug_struct.field("principal_subject", &self.principal_subject);
             debug_struct.field("query_id", &self.query_id);
             debug_struct.field("schema", &self.schema);
+            debug_struct.field("self_link", &self.self_link);
             debug_struct.field("session_info", &self.session_info);
             debug_struct.field("start_time", &self.start_time);
+            debug_struct.field("statistics", &self.statistics);
+            debug_struct.field("status", &self.status);
             debug_struct.field("total_bytes_billed", &self.total_bytes_billed);
             debug_struct.field("total_bytes_processed", &self.total_bytes_processed);
             debug_struct.field("total_rows", &self.total_rows);
             debug_struct.field("total_slot_ms", &self.total_slot_ms);
+            debug_struct.field("user_email", &self.user_email);
             if !self._unknown_fields.is_empty() {
                 debug_struct.field("_unknown_fields", &self._unknown_fields);
             }
@@ -470,22 +582,20 @@ mod debug {
     }
 }
 
-impl std::convert::From<google_cloud_bigquery_v2::model::GetQueryResultsResponse>
-    for QueryMetadata
-{
-    fn from(resp: google_cloud_bigquery_v2::model::GetQueryResultsResponse) -> Self {
+impl std::convert::From<google_cloud_bigquery_v2::model::Job> for QueryMetadata {
+    fn from(resp: google_cloud_bigquery_v2::model::Job) -> Self {
         Self {
-            cache_hit: resp.cache_hit,
-            errors: resp.errors,
+            configuration: resp.configuration,
             etag: resp.etag,
-            job_complete: resp.job_complete,
+            id: resp.id,
+            job_creation_reason: resp.job_creation_reason,
             job_reference: resp.job_reference,
             kind: resp.kind,
-            num_dml_affected_rows: resp.num_dml_affected_rows,
-            page_token: resp.page_token,
-            schema: resp.schema,
-            total_bytes_processed: resp.total_bytes_processed,
-            total_rows: resp.total_rows,
+            principal_subject: resp.principal_subject,
+            self_link: resp.self_link,
+            statistics: resp.statistics,
+            status: resp.status,
+            user_email: resp.user_email,
             ..Default::default()
         }
     }
@@ -514,6 +624,34 @@ impl std::convert::From<google_cloud_bigquery_v2::model::QueryResponse> for Quer
             total_bytes_processed: resp.total_bytes_processed,
             total_rows: resp.total_rows,
             total_slot_ms: resp.total_slot_ms,
+            ..Default::default()
+        }
+    }
+}
+
+impl std::convert::From<QueryMetadata> for crate::generated::CompleteQueryMetadata {
+    fn from(md: QueryMetadata) -> Self {
+        crate::generated::CompleteQueryMetadata {
+            cache_hit: md.cache_hit,
+            creation_time: md.creation_time,
+            dml_stats: md.dml_stats,
+            end_time: md.end_time,
+            errors: md.errors,
+            job_complete: md.job_complete,
+            job_creation_reason: md.job_creation_reason,
+            job_reference: md.job_reference,
+            kind: md.kind,
+            location: md.location,
+            num_dml_affected_rows: md.num_dml_affected_rows,
+            page_token: md.page_token,
+            query_id: md.query_id,
+            schema: md.schema,
+            session_info: md.session_info,
+            start_time: md.start_time,
+            total_bytes_billed: md.total_bytes_billed,
+            total_bytes_processed: md.total_bytes_processed,
+            total_rows: md.total_rows,
+            total_slot_ms: md.total_slot_ms,
             ..Default::default()
         }
     }

--- a/src/bigquery/src/generated/query_request.rs
+++ b/src/bigquery/src/generated/query_request.rs
@@ -22,7 +22,7 @@
 #[allow(missing_docs)]
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub struct RunQueryRequest {
+pub struct QueryBuilderRequest {
     /// Optional. If true and query uses legacy SQL dialect, allows the query
     /// to produce arbitrarily large result tables at a slight cost in performance.
     /// Requires destinationTable to be set.
@@ -250,13 +250,13 @@ pub struct RunQueryRequest {
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
-impl RunQueryRequest {
+impl QueryBuilderRequest {
     /// Creates a new default instance.
     pub fn new() -> Self {
         std::default::Default::default()
     }
 
-    /// Sets the value of [allow_large_results][crate::model::RunQueryRequest::allow_large_results].
+    /// Sets the value of [allow_large_results][crate::model::QueryBuilderRequest::allow_large_results].
     pub fn set_allow_large_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -265,7 +265,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [allow_large_results][crate::model::RunQueryRequest::allow_large_results].
+    /// Sets or clears the value of [allow_large_results][crate::model::QueryBuilderRequest::allow_large_results].
     pub fn set_or_clear_allow_large_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -274,7 +274,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [clustering][crate::model::RunQueryRequest::clustering].
+    /// Sets the value of [clustering][crate::model::QueryBuilderRequest::clustering].
     pub fn set_clustering<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::Clustering>,
@@ -283,7 +283,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [clustering][crate::model::RunQueryRequest::clustering].
+    /// Sets or clears the value of [clustering][crate::model::QueryBuilderRequest::clustering].
     pub fn set_or_clear_clustering<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::Clustering>,
@@ -292,7 +292,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [connection_properties][crate::model::RunQueryRequest::connection_properties].
+    /// Sets the value of [connection_properties][crate::model::QueryBuilderRequest::connection_properties].
     pub fn set_connection_properties<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -303,7 +303,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [continuous][crate::model::RunQueryRequest::continuous].
+    /// Sets the value of [continuous][crate::model::QueryBuilderRequest::continuous].
     pub fn set_continuous<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -312,7 +312,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [continuous][crate::model::RunQueryRequest::continuous].
+    /// Sets or clears the value of [continuous][crate::model::QueryBuilderRequest::continuous].
     pub fn set_or_clear_continuous<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -321,7 +321,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [create_disposition][crate::model::RunQueryRequest::create_disposition].
+    /// Sets the value of [create_disposition][crate::model::QueryBuilderRequest::create_disposition].
     pub fn set_create_disposition<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -330,7 +330,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [create_session][crate::model::RunQueryRequest::create_session].
+    /// Sets the value of [create_session][crate::model::QueryBuilderRequest::create_session].
     pub fn set_create_session<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -339,7 +339,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [create_session][crate::model::RunQueryRequest::create_session].
+    /// Sets or clears the value of [create_session][crate::model::QueryBuilderRequest::create_session].
     pub fn set_or_clear_create_session<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -348,7 +348,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [default_dataset][crate::model::RunQueryRequest::default_dataset].
+    /// Sets the value of [default_dataset][crate::model::QueryBuilderRequest::default_dataset].
     pub fn set_default_dataset<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::DatasetReference>,
@@ -357,7 +357,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [default_dataset][crate::model::RunQueryRequest::default_dataset].
+    /// Sets or clears the value of [default_dataset][crate::model::QueryBuilderRequest::default_dataset].
     pub fn set_or_clear_default_dataset<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::DatasetReference>,
@@ -366,7 +366,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [destination_encryption_configuration][crate::model::RunQueryRequest::destination_encryption_configuration].
+    /// Sets the value of [destination_encryption_configuration][crate::model::QueryBuilderRequest::destination_encryption_configuration].
     pub fn set_destination_encryption_configuration<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::EncryptionConfiguration>,
@@ -375,7 +375,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [destination_encryption_configuration][crate::model::RunQueryRequest::destination_encryption_configuration].
+    /// Sets or clears the value of [destination_encryption_configuration][crate::model::QueryBuilderRequest::destination_encryption_configuration].
     pub fn set_or_clear_destination_encryption_configuration<T>(
         mut self,
         v: std::option::Option<T>,
@@ -387,7 +387,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [destination_table][crate::model::RunQueryRequest::destination_table].
+    /// Sets the value of [destination_table][crate::model::QueryBuilderRequest::destination_table].
     pub fn set_destination_table<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::TableReference>,
@@ -396,7 +396,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [destination_table][crate::model::RunQueryRequest::destination_table].
+    /// Sets or clears the value of [destination_table][crate::model::QueryBuilderRequest::destination_table].
     pub fn set_or_clear_destination_table<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::TableReference>,
@@ -405,13 +405,13 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [dry_run][crate::model::RunQueryRequest::dry_run].
+    /// Sets the value of [dry_run][crate::model::QueryBuilderRequest::dry_run].
     pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.dry_run = v.into();
         self
     }
 
-    /// Sets the value of [external_table_definitions][crate::model::RunQueryRequest::external_table_definitions].
+    /// Sets the value of [external_table_definitions][crate::model::QueryBuilderRequest::external_table_definitions].
     pub fn set_external_table_definitions<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -424,7 +424,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [flatten_results][crate::model::RunQueryRequest::flatten_results].
+    /// Sets the value of [flatten_results][crate::model::QueryBuilderRequest::flatten_results].
     pub fn set_flatten_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -433,7 +433,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [flatten_results][crate::model::RunQueryRequest::flatten_results].
+    /// Sets or clears the value of [flatten_results][crate::model::QueryBuilderRequest::flatten_results].
     pub fn set_or_clear_flatten_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -442,7 +442,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [job_creation_mode][crate::model::RunQueryRequest::job_creation_mode].
+    /// Sets the value of [job_creation_mode][crate::model::QueryBuilderRequest::job_creation_mode].
     pub fn set_job_creation_mode<
         T: std::convert::Into<crate::model::query_request::JobCreationMode>,
     >(
@@ -453,7 +453,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [job_timeout_ms][crate::model::RunQueryRequest::job_timeout_ms].
+    /// Sets the value of [job_timeout_ms][crate::model::QueryBuilderRequest::job_timeout_ms].
     pub fn set_job_timeout_ms<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -462,7 +462,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [job_timeout_ms][crate::model::RunQueryRequest::job_timeout_ms].
+    /// Sets or clears the value of [job_timeout_ms][crate::model::QueryBuilderRequest::job_timeout_ms].
     pub fn set_or_clear_job_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -471,7 +471,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [labels][crate::model::RunQueryRequest::labels].
+    /// Sets the value of [labels][crate::model::QueryBuilderRequest::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -483,13 +483,13 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [location][crate::model::RunQueryRequest::location].
+    /// Sets the value of [location][crate::model::QueryBuilderRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of [max_results][crate::model::RunQueryRequest::max_results].
+    /// Sets the value of [max_results][crate::model::QueryBuilderRequest::max_results].
     pub fn set_max_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -498,7 +498,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [max_results][crate::model::RunQueryRequest::max_results].
+    /// Sets or clears the value of [max_results][crate::model::QueryBuilderRequest::max_results].
     pub fn set_or_clear_max_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -507,7 +507,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [max_slots][crate::model::RunQueryRequest::max_slots].
+    /// Sets the value of [max_slots][crate::model::QueryBuilderRequest::max_slots].
     pub fn set_max_slots<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i32>,
@@ -516,7 +516,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [max_slots][crate::model::RunQueryRequest::max_slots].
+    /// Sets or clears the value of [max_slots][crate::model::QueryBuilderRequest::max_slots].
     pub fn set_or_clear_max_slots<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i32>,
@@ -525,7 +525,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [maximum_bytes_billed][crate::model::RunQueryRequest::maximum_bytes_billed].
+    /// Sets the value of [maximum_bytes_billed][crate::model::QueryBuilderRequest::maximum_bytes_billed].
     pub fn set_maximum_bytes_billed<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -534,7 +534,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [maximum_bytes_billed][crate::model::RunQueryRequest::maximum_bytes_billed].
+    /// Sets or clears the value of [maximum_bytes_billed][crate::model::QueryBuilderRequest::maximum_bytes_billed].
     pub fn set_or_clear_maximum_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -543,25 +543,25 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [parameter_mode][crate::model::RunQueryRequest::parameter_mode].
+    /// Sets the value of [parameter_mode][crate::model::QueryBuilderRequest::parameter_mode].
     pub fn set_parameter_mode<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parameter_mode = v.into();
         self
     }
 
-    /// Sets the value of [priority][crate::model::RunQueryRequest::priority].
+    /// Sets the value of [priority][crate::model::QueryBuilderRequest::priority].
     pub fn set_priority<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.priority = v.into();
         self
     }
 
-    /// Sets the value of [query][crate::model::RunQueryRequest::query].
+    /// Sets the value of [query][crate::model::QueryBuilderRequest::query].
     pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.query = v.into();
         self
     }
 
-    /// Sets the value of [query_parameters][crate::model::RunQueryRequest::query_parameters].
+    /// Sets the value of [query_parameters][crate::model::QueryBuilderRequest::query_parameters].
     pub fn set_query_parameters<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -572,7 +572,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [range_partitioning][crate::model::RunQueryRequest::range_partitioning].
+    /// Sets the value of [range_partitioning][crate::model::QueryBuilderRequest::range_partitioning].
     pub fn set_range_partitioning<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::RangePartitioning>,
@@ -581,7 +581,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [range_partitioning][crate::model::RunQueryRequest::range_partitioning].
+    /// Sets or clears the value of [range_partitioning][crate::model::QueryBuilderRequest::range_partitioning].
     pub fn set_or_clear_range_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::RangePartitioning>,
@@ -590,7 +590,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [reservation][crate::model::RunQueryRequest::reservation].
+    /// Sets the value of [reservation][crate::model::QueryBuilderRequest::reservation].
     pub fn set_reservation<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<std::string::String>,
@@ -599,7 +599,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [reservation][crate::model::RunQueryRequest::reservation].
+    /// Sets or clears the value of [reservation][crate::model::QueryBuilderRequest::reservation].
     pub fn set_or_clear_reservation<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<std::string::String>,
@@ -608,7 +608,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [schema_update_options][crate::model::RunQueryRequest::schema_update_options].
+    /// Sets the value of [schema_update_options][crate::model::QueryBuilderRequest::schema_update_options].
     pub fn set_schema_update_options<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -619,7 +619,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [script_options][crate::model::RunQueryRequest::script_options].
+    /// Sets the value of [script_options][crate::model::QueryBuilderRequest::script_options].
     pub fn set_script_options<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::ScriptOptions>,
@@ -628,7 +628,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [script_options][crate::model::RunQueryRequest::script_options].
+    /// Sets or clears the value of [script_options][crate::model::QueryBuilderRequest::script_options].
     pub fn set_or_clear_script_options<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::ScriptOptions>,
@@ -637,7 +637,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [time_partitioning][crate::model::RunQueryRequest::time_partitioning].
+    /// Sets the value of [time_partitioning][crate::model::QueryBuilderRequest::time_partitioning].
     pub fn set_time_partitioning<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::TimePartitioning>,
@@ -646,7 +646,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [time_partitioning][crate::model::RunQueryRequest::time_partitioning].
+    /// Sets or clears the value of [time_partitioning][crate::model::QueryBuilderRequest::time_partitioning].
     pub fn set_or_clear_time_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::TimePartitioning>,
@@ -655,7 +655,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [timeout_ms][crate::model::RunQueryRequest::timeout_ms].
+    /// Sets the value of [timeout_ms][crate::model::QueryBuilderRequest::timeout_ms].
     pub fn set_timeout_ms<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -664,7 +664,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [timeout_ms][crate::model::RunQueryRequest::timeout_ms].
+    /// Sets or clears the value of [timeout_ms][crate::model::QueryBuilderRequest::timeout_ms].
     pub fn set_or_clear_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -673,7 +673,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [use_legacy_sql][crate::model::RunQueryRequest::use_legacy_sql].
+    /// Sets the value of [use_legacy_sql][crate::model::QueryBuilderRequest::use_legacy_sql].
     pub fn set_use_legacy_sql<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -682,7 +682,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [use_legacy_sql][crate::model::RunQueryRequest::use_legacy_sql].
+    /// Sets or clears the value of [use_legacy_sql][crate::model::QueryBuilderRequest::use_legacy_sql].
     pub fn set_or_clear_use_legacy_sql<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -691,7 +691,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [use_query_cache][crate::model::RunQueryRequest::use_query_cache].
+    /// Sets the value of [use_query_cache][crate::model::QueryBuilderRequest::use_query_cache].
     pub fn set_use_query_cache<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -700,7 +700,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets or clears the value of [use_query_cache][crate::model::RunQueryRequest::use_query_cache].
+    /// Sets or clears the value of [use_query_cache][crate::model::QueryBuilderRequest::use_query_cache].
     pub fn set_or_clear_use_query_cache<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -709,7 +709,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [user_defined_function_resources][crate::model::RunQueryRequest::user_defined_function_resources].
+    /// Sets the value of [user_defined_function_resources][crate::model::QueryBuilderRequest::user_defined_function_resources].
     pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -720,7 +720,7 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [write_disposition][crate::model::RunQueryRequest::write_disposition].
+    /// Sets the value of [write_disposition][crate::model::QueryBuilderRequest::write_disposition].
     pub fn set_write_disposition<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -729,17 +729,18 @@ impl RunQueryRequest {
         self
     }
 
-    /// Sets the value of [write_incremental_results][crate::model::RunQueryRequest::write_incremental_results].
+    /// Sets the value of [write_incremental_results][crate::model::QueryBuilderRequest::write_incremental_results].
     pub fn set_write_incremental_results<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.write_incremental_results = v.into();
         self
     }
 }
+
 mod debug {
 
-    impl std::fmt::Debug for super::RunQueryRequest {
+    impl std::fmt::Debug for super::QueryBuilderRequest {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let mut debug_struct = f.debug_struct("RunQueryRequest");
+            let mut debug_struct = f.debug_struct("QueryBuilderRequest");
             debug_struct.field("allow_large_results", &self.allow_large_results);
             debug_struct.field("clustering", &self.clustering);
             debug_struct.field("connection_properties", &self.connection_properties);
@@ -791,7 +792,7 @@ mod debug {
     }
 }
 
-impl RunQueryRequest {
+impl QueryBuilderRequest {
     #[allow(clippy::nonminimal_bool)]
     pub(crate) fn force_job_path(&self) -> bool {
         false
@@ -812,8 +813,8 @@ impl RunQueryRequest {
     }
 }
 
-impl std::convert::From<RunQueryRequest> for google_cloud_bigquery_v2::model::QueryRequest {
-    fn from(req: RunQueryRequest) -> Self {
+impl std::convert::From<QueryBuilderRequest> for google_cloud_bigquery_v2::model::QueryRequest {
+    fn from(req: QueryBuilderRequest) -> Self {
         let mut out = Self::default();
         out.connection_properties = req.connection_properties;
         out.create_session = req.create_session;
@@ -839,10 +840,10 @@ impl std::convert::From<RunQueryRequest> for google_cloud_bigquery_v2::model::Qu
     }
 }
 
-impl std::convert::From<RunQueryRequest>
+impl std::convert::From<QueryBuilderRequest>
     for google_cloud_bigquery_v2::model::JobConfigurationQuery
 {
-    fn from(req: RunQueryRequest) -> Self {
+    fn from(req: QueryBuilderRequest) -> Self {
         let mut out = Self::default();
         out.allow_large_results = req.allow_large_results;
         out.clustering = req.clustering;
@@ -873,9 +874,9 @@ impl std::convert::From<RunQueryRequest>
     }
 }
 
-impl std::convert::From<RunQueryRequest> for google_cloud_bigquery_v2::model::JobConfiguration {
+impl std::convert::From<QueryBuilderRequest> for google_cloud_bigquery_v2::model::JobConfiguration {
     #[allow(clippy::useless_conversion)]
-    fn from(req: RunQueryRequest) -> Self {
+    fn from(req: QueryBuilderRequest) -> Self {
         let mut query = google_cloud_bigquery_v2::model::JobConfigurationQuery::default();
         query.allow_large_results = req.allow_large_results;
         query.clustering = req.clustering;

--- a/src/bigquery/src/generated/query_request.rs
+++ b/src/bigquery/src/generated/query_request.rs
@@ -22,7 +22,7 @@
 #[allow(missing_docs)]
 #[derive(Clone, Default, PartialEq)]
 #[non_exhaustive]
-pub struct QueryBuilderRequest {
+pub struct QueryRequest {
     /// Optional. If true and query uses legacy SQL dialect, allows the query
     /// to produce arbitrarily large result tables at a slight cost in performance.
     /// Requires destinationTable to be set.
@@ -250,13 +250,13 @@ pub struct QueryBuilderRequest {
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
-impl QueryBuilderRequest {
+impl QueryRequest {
     /// Creates a new default instance.
     pub fn new() -> Self {
         std::default::Default::default()
     }
 
-    /// Sets the value of [allow_large_results][crate::model::QueryBuilderRequest::allow_large_results].
+    /// Sets the value of [allow_large_results][crate::model::QueryRequest::allow_large_results].
     pub fn set_allow_large_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -265,7 +265,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [allow_large_results][crate::model::QueryBuilderRequest::allow_large_results].
+    /// Sets or clears the value of [allow_large_results][crate::model::QueryRequest::allow_large_results].
     pub fn set_or_clear_allow_large_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -274,7 +274,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [clustering][crate::model::QueryBuilderRequest::clustering].
+    /// Sets the value of [clustering][crate::model::QueryRequest::clustering].
     pub fn set_clustering<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::Clustering>,
@@ -283,7 +283,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [clustering][crate::model::QueryBuilderRequest::clustering].
+    /// Sets or clears the value of [clustering][crate::model::QueryRequest::clustering].
     pub fn set_or_clear_clustering<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::Clustering>,
@@ -292,7 +292,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [connection_properties][crate::model::QueryBuilderRequest::connection_properties].
+    /// Sets the value of [connection_properties][crate::model::QueryRequest::connection_properties].
     pub fn set_connection_properties<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -303,7 +303,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [continuous][crate::model::QueryBuilderRequest::continuous].
+    /// Sets the value of [continuous][crate::model::QueryRequest::continuous].
     pub fn set_continuous<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -312,7 +312,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [continuous][crate::model::QueryBuilderRequest::continuous].
+    /// Sets or clears the value of [continuous][crate::model::QueryRequest::continuous].
     pub fn set_or_clear_continuous<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -321,7 +321,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [create_disposition][crate::model::QueryBuilderRequest::create_disposition].
+    /// Sets the value of [create_disposition][crate::model::QueryRequest::create_disposition].
     pub fn set_create_disposition<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -330,7 +330,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [create_session][crate::model::QueryBuilderRequest::create_session].
+    /// Sets the value of [create_session][crate::model::QueryRequest::create_session].
     pub fn set_create_session<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -339,7 +339,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [create_session][crate::model::QueryBuilderRequest::create_session].
+    /// Sets or clears the value of [create_session][crate::model::QueryRequest::create_session].
     pub fn set_or_clear_create_session<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -348,7 +348,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [default_dataset][crate::model::QueryBuilderRequest::default_dataset].
+    /// Sets the value of [default_dataset][crate::model::QueryRequest::default_dataset].
     pub fn set_default_dataset<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::DatasetReference>,
@@ -357,7 +357,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [default_dataset][crate::model::QueryBuilderRequest::default_dataset].
+    /// Sets or clears the value of [default_dataset][crate::model::QueryRequest::default_dataset].
     pub fn set_or_clear_default_dataset<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::DatasetReference>,
@@ -366,7 +366,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [destination_encryption_configuration][crate::model::QueryBuilderRequest::destination_encryption_configuration].
+    /// Sets the value of [destination_encryption_configuration][crate::model::QueryRequest::destination_encryption_configuration].
     pub fn set_destination_encryption_configuration<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::EncryptionConfiguration>,
@@ -375,7 +375,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [destination_encryption_configuration][crate::model::QueryBuilderRequest::destination_encryption_configuration].
+    /// Sets or clears the value of [destination_encryption_configuration][crate::model::QueryRequest::destination_encryption_configuration].
     pub fn set_or_clear_destination_encryption_configuration<T>(
         mut self,
         v: std::option::Option<T>,
@@ -387,7 +387,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [destination_table][crate::model::QueryBuilderRequest::destination_table].
+    /// Sets the value of [destination_table][crate::model::QueryRequest::destination_table].
     pub fn set_destination_table<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::TableReference>,
@@ -396,7 +396,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [destination_table][crate::model::QueryBuilderRequest::destination_table].
+    /// Sets or clears the value of [destination_table][crate::model::QueryRequest::destination_table].
     pub fn set_or_clear_destination_table<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::TableReference>,
@@ -405,13 +405,13 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [dry_run][crate::model::QueryBuilderRequest::dry_run].
+    /// Sets the value of [dry_run][crate::model::QueryRequest::dry_run].
     pub fn set_dry_run<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.dry_run = v.into();
         self
     }
 
-    /// Sets the value of [external_table_definitions][crate::model::QueryBuilderRequest::external_table_definitions].
+    /// Sets the value of [external_table_definitions][crate::model::QueryRequest::external_table_definitions].
     pub fn set_external_table_definitions<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -424,7 +424,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [flatten_results][crate::model::QueryBuilderRequest::flatten_results].
+    /// Sets the value of [flatten_results][crate::model::QueryRequest::flatten_results].
     pub fn set_flatten_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -433,7 +433,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [flatten_results][crate::model::QueryBuilderRequest::flatten_results].
+    /// Sets or clears the value of [flatten_results][crate::model::QueryRequest::flatten_results].
     pub fn set_or_clear_flatten_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -442,7 +442,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [job_creation_mode][crate::model::QueryBuilderRequest::job_creation_mode].
+    /// Sets the value of [job_creation_mode][crate::model::QueryRequest::job_creation_mode].
     pub fn set_job_creation_mode<
         T: std::convert::Into<crate::model::query_request::JobCreationMode>,
     >(
@@ -453,7 +453,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [job_timeout_ms][crate::model::QueryBuilderRequest::job_timeout_ms].
+    /// Sets the value of [job_timeout_ms][crate::model::QueryRequest::job_timeout_ms].
     pub fn set_job_timeout_ms<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i64>,
@@ -462,7 +462,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [job_timeout_ms][crate::model::QueryBuilderRequest::job_timeout_ms].
+    /// Sets or clears the value of [job_timeout_ms][crate::model::QueryRequest::job_timeout_ms].
     pub fn set_or_clear_job_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i64>,
@@ -471,7 +471,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [labels][crate::model::QueryBuilderRequest::labels].
+    /// Sets the value of [labels][crate::model::QueryRequest::labels].
     pub fn set_labels<T, K, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = (K, V)>,
@@ -483,13 +483,13 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [location][crate::model::QueryBuilderRequest::location].
+    /// Sets the value of [location][crate::model::QueryRequest::location].
     pub fn set_location<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.location = v.into();
         self
     }
 
-    /// Sets the value of [max_results][crate::model::QueryBuilderRequest::max_results].
+    /// Sets the value of [max_results][crate::model::QueryRequest::max_results].
     pub fn set_max_results<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -498,7 +498,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [max_results][crate::model::QueryBuilderRequest::max_results].
+    /// Sets or clears the value of [max_results][crate::model::QueryRequest::max_results].
     pub fn set_or_clear_max_results<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -507,7 +507,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [max_slots][crate::model::QueryBuilderRequest::max_slots].
+    /// Sets the value of [max_slots][crate::model::QueryRequest::max_slots].
     pub fn set_max_slots<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<i32>,
@@ -516,7 +516,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [max_slots][crate::model::QueryBuilderRequest::max_slots].
+    /// Sets or clears the value of [max_slots][crate::model::QueryRequest::max_slots].
     pub fn set_or_clear_max_slots<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<i32>,
@@ -525,7 +525,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [maximum_bytes_billed][crate::model::QueryBuilderRequest::maximum_bytes_billed].
+    /// Sets the value of [maximum_bytes_billed][crate::model::QueryRequest::maximum_bytes_billed].
     pub fn set_maximum_bytes_billed<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -534,7 +534,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [maximum_bytes_billed][crate::model::QueryBuilderRequest::maximum_bytes_billed].
+    /// Sets or clears the value of [maximum_bytes_billed][crate::model::QueryRequest::maximum_bytes_billed].
     pub fn set_or_clear_maximum_bytes_billed<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::Int64Value>,
@@ -543,25 +543,25 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [parameter_mode][crate::model::QueryBuilderRequest::parameter_mode].
+    /// Sets the value of [parameter_mode][crate::model::QueryRequest::parameter_mode].
     pub fn set_parameter_mode<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.parameter_mode = v.into();
         self
     }
 
-    /// Sets the value of [priority][crate::model::QueryBuilderRequest::priority].
+    /// Sets the value of [priority][crate::model::QueryRequest::priority].
     pub fn set_priority<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.priority = v.into();
         self
     }
 
-    /// Sets the value of [query][crate::model::QueryBuilderRequest::query].
+    /// Sets the value of [query][crate::model::QueryRequest::query].
     pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
         self.query = v.into();
         self
     }
 
-    /// Sets the value of [query_parameters][crate::model::QueryBuilderRequest::query_parameters].
+    /// Sets the value of [query_parameters][crate::model::QueryRequest::query_parameters].
     pub fn set_query_parameters<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -572,7 +572,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [range_partitioning][crate::model::QueryBuilderRequest::range_partitioning].
+    /// Sets the value of [range_partitioning][crate::model::QueryRequest::range_partitioning].
     pub fn set_range_partitioning<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::RangePartitioning>,
@@ -581,7 +581,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [range_partitioning][crate::model::QueryBuilderRequest::range_partitioning].
+    /// Sets or clears the value of [range_partitioning][crate::model::QueryRequest::range_partitioning].
     pub fn set_or_clear_range_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::RangePartitioning>,
@@ -590,7 +590,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [reservation][crate::model::QueryBuilderRequest::reservation].
+    /// Sets the value of [reservation][crate::model::QueryRequest::reservation].
     pub fn set_reservation<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<std::string::String>,
@@ -599,7 +599,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [reservation][crate::model::QueryBuilderRequest::reservation].
+    /// Sets or clears the value of [reservation][crate::model::QueryRequest::reservation].
     pub fn set_or_clear_reservation<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<std::string::String>,
@@ -608,7 +608,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [schema_update_options][crate::model::QueryBuilderRequest::schema_update_options].
+    /// Sets the value of [schema_update_options][crate::model::QueryRequest::schema_update_options].
     pub fn set_schema_update_options<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -619,7 +619,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [script_options][crate::model::QueryBuilderRequest::script_options].
+    /// Sets the value of [script_options][crate::model::QueryRequest::script_options].
     pub fn set_script_options<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::ScriptOptions>,
@@ -628,7 +628,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [script_options][crate::model::QueryBuilderRequest::script_options].
+    /// Sets or clears the value of [script_options][crate::model::QueryRequest::script_options].
     pub fn set_or_clear_script_options<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::ScriptOptions>,
@@ -637,7 +637,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [time_partitioning][crate::model::QueryBuilderRequest::time_partitioning].
+    /// Sets the value of [time_partitioning][crate::model::QueryRequest::time_partitioning].
     pub fn set_time_partitioning<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<crate::model::TimePartitioning>,
@@ -646,7 +646,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [time_partitioning][crate::model::QueryBuilderRequest::time_partitioning].
+    /// Sets or clears the value of [time_partitioning][crate::model::QueryRequest::time_partitioning].
     pub fn set_or_clear_time_partitioning<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<crate::model::TimePartitioning>,
@@ -655,7 +655,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [timeout_ms][crate::model::QueryBuilderRequest::timeout_ms].
+    /// Sets the value of [timeout_ms][crate::model::QueryRequest::timeout_ms].
     pub fn set_timeout_ms<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -664,7 +664,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [timeout_ms][crate::model::QueryBuilderRequest::timeout_ms].
+    /// Sets or clears the value of [timeout_ms][crate::model::QueryRequest::timeout_ms].
     pub fn set_or_clear_timeout_ms<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::UInt32Value>,
@@ -673,7 +673,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [use_legacy_sql][crate::model::QueryBuilderRequest::use_legacy_sql].
+    /// Sets the value of [use_legacy_sql][crate::model::QueryRequest::use_legacy_sql].
     pub fn set_use_legacy_sql<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -682,7 +682,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [use_legacy_sql][crate::model::QueryBuilderRequest::use_legacy_sql].
+    /// Sets or clears the value of [use_legacy_sql][crate::model::QueryRequest::use_legacy_sql].
     pub fn set_or_clear_use_legacy_sql<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -691,7 +691,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [use_query_cache][crate::model::QueryBuilderRequest::use_query_cache].
+    /// Sets the value of [use_query_cache][crate::model::QueryRequest::use_query_cache].
     pub fn set_use_query_cache<T>(mut self, v: T) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -700,7 +700,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets or clears the value of [use_query_cache][crate::model::QueryBuilderRequest::use_query_cache].
+    /// Sets or clears the value of [use_query_cache][crate::model::QueryRequest::use_query_cache].
     pub fn set_or_clear_use_query_cache<T>(mut self, v: std::option::Option<T>) -> Self
     where
         T: std::convert::Into<wkt::BoolValue>,
@@ -709,7 +709,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [user_defined_function_resources][crate::model::QueryBuilderRequest::user_defined_function_resources].
+    /// Sets the value of [user_defined_function_resources][crate::model::QueryRequest::user_defined_function_resources].
     pub fn set_user_defined_function_resources<T, V>(mut self, v: T) -> Self
     where
         T: std::iter::IntoIterator<Item = V>,
@@ -720,7 +720,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [write_disposition][crate::model::QueryBuilderRequest::write_disposition].
+    /// Sets the value of [write_disposition][crate::model::QueryRequest::write_disposition].
     pub fn set_write_disposition<T: std::convert::Into<std::string::String>>(
         mut self,
         v: T,
@@ -729,7 +729,7 @@ impl QueryBuilderRequest {
         self
     }
 
-    /// Sets the value of [write_incremental_results][crate::model::QueryBuilderRequest::write_incremental_results].
+    /// Sets the value of [write_incremental_results][crate::model::QueryRequest::write_incremental_results].
     pub fn set_write_incremental_results<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
         self.write_incremental_results = v.into();
         self
@@ -738,9 +738,9 @@ impl QueryBuilderRequest {
 
 mod debug {
 
-    impl std::fmt::Debug for super::QueryBuilderRequest {
+    impl std::fmt::Debug for super::QueryRequest {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let mut debug_struct = f.debug_struct("QueryBuilderRequest");
+            let mut debug_struct = f.debug_struct("QueryRequest");
             debug_struct.field("allow_large_results", &self.allow_large_results);
             debug_struct.field("clustering", &self.clustering);
             debug_struct.field("connection_properties", &self.connection_properties);
@@ -792,7 +792,7 @@ mod debug {
     }
 }
 
-impl QueryBuilderRequest {
+impl QueryRequest {
     #[allow(clippy::nonminimal_bool)]
     pub(crate) fn force_job_path(&self) -> bool {
         false
@@ -813,8 +813,8 @@ impl QueryBuilderRequest {
     }
 }
 
-impl std::convert::From<QueryBuilderRequest> for google_cloud_bigquery_v2::model::QueryRequest {
-    fn from(req: QueryBuilderRequest) -> Self {
+impl std::convert::From<QueryRequest> for google_cloud_bigquery_v2::model::QueryRequest {
+    fn from(req: QueryRequest) -> Self {
         let mut out = Self::default();
         out.connection_properties = req.connection_properties;
         out.create_session = req.create_session;
@@ -840,10 +840,8 @@ impl std::convert::From<QueryBuilderRequest> for google_cloud_bigquery_v2::model
     }
 }
 
-impl std::convert::From<QueryBuilderRequest>
-    for google_cloud_bigquery_v2::model::JobConfigurationQuery
-{
-    fn from(req: QueryBuilderRequest) -> Self {
+impl std::convert::From<QueryRequest> for google_cloud_bigquery_v2::model::JobConfigurationQuery {
+    fn from(req: QueryRequest) -> Self {
         let mut out = Self::default();
         out.allow_large_results = req.allow_large_results;
         out.clustering = req.clustering;
@@ -874,9 +872,9 @@ impl std::convert::From<QueryBuilderRequest>
     }
 }
 
-impl std::convert::From<QueryBuilderRequest> for google_cloud_bigquery_v2::model::JobConfiguration {
+impl std::convert::From<QueryRequest> for google_cloud_bigquery_v2::model::JobConfiguration {
     #[allow(clippy::useless_conversion)]
-    fn from(req: QueryBuilderRequest) -> Self {
+    fn from(req: QueryRequest) -> Self {
         let mut query = google_cloud_bigquery_v2::model::JobConfigurationQuery::default();
         query.allow_large_results = req.allow_large_results;
         query.clustering = req.clustering;

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -53,6 +53,7 @@ pub mod builder {
     pub mod bigquery {
         //! Builder for [BigQuery][crate::client::BigQuery].
         pub use crate::client_builder::ClientBuilder;
-        pub use crate::query::QueryBuilder;
+        pub use crate::generated::QueryRequest;
+        pub use crate::query::builder::Query;
     }
 }

--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -44,8 +44,7 @@ mod client_builder;
 
 pub mod model {
     //! Re-exports for the Google Cloud BigQuery v2 API types.
-    pub use crate::generated::{QueryCreationMetadata, QueryMetadata, RunQueryRequest};
-    pub use crate::query::{CompleteQuery, Query, RowIterator, RunQuery};
+    pub use crate::generated::{CompleteQueryMetadata, QueryMetadata};
     pub use google_cloud_bigquery_v2::model::*;
 }
 
@@ -54,7 +53,6 @@ pub mod builder {
     pub mod bigquery {
         //! Builder for [BigQuery][crate::client::BigQuery].
         pub use crate::client_builder::ClientBuilder;
-        pub use crate::generated::{QueryMetadata, RunQueryRequest};
-        pub use crate::query::RunQuery;
+        pub use crate::query::QueryBuilder;
     }
 }

--- a/src/bigquery/src/query.rs
+++ b/src/bigquery/src/query.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod builder;
+pub(crate) mod builder;
 pub(crate) mod execution;
 pub(crate) mod from_sql;
 mod iterator;
@@ -24,7 +24,6 @@ pub use iterator::RowIterator;
 pub use query_handle::{CompleteQuery, Query};
 pub(crate) use schema::Schema;
 
-pub use builder::QueryBuilder;
 pub use from_sql::FromSql;
 pub use row::Row;
 

--- a/src/bigquery/src/query.rs
+++ b/src/bigquery/src/query.rs
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod builder;
 pub(crate) mod execution;
 pub(crate) mod from_sql;
 mod iterator;
 mod query_handle;
 mod row;
-mod run_query;
 mod schema;
 
 pub use iterator::RowIterator;
 pub use query_handle::{CompleteQuery, Query};
 pub(crate) use schema::Schema;
 
+pub use builder::QueryBuilder;
 pub use from_sql::FromSql;
 pub use row::Row;
-pub use run_query::RunQuery;
 
 /// Result type for query execution.
 pub type Result<T> = std::result::Result<T, crate::error::QueryError>;

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::generated::QueryBuilderRequest;
+use crate::generated::QueryRequest;
 use crate::query::execution::{InsertJobExecutor, PostQueryExecutor};
-use crate::query::{CompleteQuery, Query, Result};
+use crate::query::{CompleteQuery, Query as QueryHandle, Result};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::query_request::JobCreationMode;
 use google_cloud_bigquery_v2::model::{
-    InsertJobRequest, Job, JobConfiguration, JobReference, PostQueryRequest, QueryRequest,
+    InsertJobRequest, Job, JobConfiguration, JobReference, PostQueryRequest,
+    QueryRequest as JobsQueryRequest,
 };
 use std::sync::Arc;
 use uuid::Uuid;
@@ -28,7 +29,7 @@ pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 
 /// A builder for executing a SQL query.
 ///
-/// [`BigQuery::query()`](crate::client::BigQuery::query) returns a `QueryBuilder`.
+/// [`BigQuery::query()`](crate::client::BigQuery::query) returns a [`Query`](crate::builder::bigquery::Query) builder.
 ///
 /// # Automatic Path Routing
 ///
@@ -61,18 +62,18 @@ pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 /// # }
 /// ```
 #[derive(Clone, Debug)]
-pub struct QueryBuilder {
+pub struct Query {
     pub(crate) job_service: Arc<JobService>,
-    pub(crate) request: QueryBuilderRequest,
+    pub(crate) request: QueryRequest,
     pub(crate) project_id: Option<String>,
 }
 
-impl QueryBuilder {
+impl Query {
     /// Creates a new `QueryBuilder` for the given SQL query.
     pub(crate) fn new(job_service: Arc<JobService>, sql: String) -> Self {
         Self {
             job_service,
-            request: QueryBuilderRequest::default()
+            request: QueryRequest::default()
                 .set_query(sql)
                 .set_use_legacy_sql(wkt::BoolValue::from(false))
                 .set_job_creation_mode(JobCreationMode::JobCreationOptional),
@@ -90,7 +91,7 @@ impl QueryBuilder {
     /// project ID for this specific query.
     ///
     /// You must specify a project ID either on the client or on the query
-    /// builder before calling [`send()`](QueryBuilder::send).
+    /// builder before calling [`send()`](Query::send).
     ///
     /// # Example
     ///
@@ -112,18 +113,18 @@ impl QueryBuilder {
 
     /// Executes the SQL query.
     ///
-    /// This returns a [`Query`](crate::query::Query) handle representing an
+    /// This returns a [`Query`](crate::Query) handle representing an
     /// asynchronous background job executing on BigQuery, or an already
     /// completed query if it ran fast enough using the fast query path
     /// ([jobs.query]).
     ///
-    /// You can call [`until_done()`](crate::query::Query::until_done) on the
+    /// You can call [`until_done()`](crate::Query::until_done) on the
     /// returned handle to wait for the final results.
     ///
     /// You must configure a target project ID on either the
     /// [`BigQuery`][crate::client::BigQuery] client via
     /// [`ClientBuilder::with_project_id`][crate::client_builder::ClientBuilder::with_project_id]
-    /// or on this builder via [`with_project_id()`](QueryBuilder::with_project_id).
+    /// or on this builder via [`with_project_id()`](Query::with_project_id).
     ///
     /// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
     ///
@@ -149,7 +150,7 @@ impl QueryBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn send(self) -> Result<Query> {
+    pub async fn send(self) -> Result<QueryHandle> {
         let project_id = self.project_id.unwrap_or_default();
         let max_results = self.request.max_results;
 
@@ -170,7 +171,7 @@ impl QueryBuilder {
         } else {
             let query_request_id = generate_prefixed_id(QUERY_REQUEST_ID_PREFIX);
             // Route to jobs.query
-            let query_request: QueryRequest = self.request.into();
+            let query_request: JobsQueryRequest = self.request.into();
             let query_request = query_request
                 .set_format_options(
                     google_cloud_bigquery_v2::model::DataFormatOptions::new()
@@ -190,7 +191,7 @@ impl QueryBuilder {
     /// Sends the query execution request and polls until execution completes.
     ///
     /// This is a convenience method equivalent to calling
-    /// [`.send().await?.until_done().await`](QueryBuilder::send).
+    /// [`.send().await?.until_done().await`](Query::send).
     ///
     /// # Example
     ///
@@ -254,7 +255,7 @@ mod tests {
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
     use google_cloud_bigquery_v2::model::query_request::JobCreationMode;
     use google_cloud_bigquery_v2::model::{
-        Job, JobConfiguration, JobReference, JobStatus, QueryRequest, QueryResponse,
+        Job, JobConfiguration, JobReference, JobStatus, QueryResponse,
     };
     use google_cloud_gax::response::Response;
 
@@ -267,7 +268,7 @@ mod tests {
     fn test_new() {
         let job_service = create_job_service(MockJobService::new());
         let sql = "SELECT 1".to_string();
-        let run_query = QueryBuilder::new(job_service, sql.clone());
+        let run_query = Query::new(job_service, sql.clone());
         assert_eq!(run_query.request.query, sql);
         assert_eq!(
             run_query.request.use_legacy_sql,
@@ -284,7 +285,7 @@ mod tests {
     fn test_with_project_id() {
         let job_service = create_job_service(MockJobService::new());
         let run_query =
-            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         assert_eq!(run_query.project_id.unwrap(), "my-project");
     }
 
@@ -384,7 +385,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
 
-        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
+        let run_query = Query::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_allow_large_results(true);
         let query = run_query.send().await?;
@@ -406,7 +407,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
         let run_query =
-            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         let query = run_query.send().await?;
         assert!(!query.completed, "{query:?}");
         assert_eq!(query.metadata.query_id, "some_query_id");
@@ -417,7 +418,7 @@ mod tests {
     #[test]
     fn test_force_job_path() {
         let job_service = create_job_service(MockJobService::new());
-        let mut run_query = QueryBuilder::new(job_service, "SELECT 1".to_string());
+        let mut run_query = Query::new(job_service, "SELECT 1".to_string());
         assert!(!run_query.request.force_job_path());
 
         // setting a jobs.insert exclusive field
@@ -427,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_request_conversions() {
-        let req = QueryBuilderRequest::default()
+        let req = QueryRequest::default()
             .set_query("SELECT 1".to_string())
             .set_dry_run(true)
             .set_use_legacy_sql(true);
@@ -457,7 +458,7 @@ mod tests {
             Ok(Response::from(QueryResponse::new()))
         });
         let job_service = create_job_service(mock);
-        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
+        let run_query = Query::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_max_results(100_u32);
         let query = run_query.send().await?;
@@ -480,7 +481,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
 
-        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
+        let run_query = Query::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_allow_large_results(true)
             .set_max_results(50_u32);
@@ -502,7 +503,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
         let run_query =
-            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            Query::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         let complete = run_query.until_done().await?;
         assert_eq!(complete.metadata().query_id, "some_query_id");
 

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -433,7 +433,7 @@ mod tests {
             .set_dry_run(true)
             .set_use_legacy_sql(true);
 
-        let query_request: QueryRequest = req.clone().into();
+        let query_request: JobsQueryRequest = req.clone().into();
         assert_eq!(query_request.query, "SELECT 1");
         assert!(query_request.dry_run);
         assert_eq!(

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::model::RunQueryRequest;
+use crate::generated::QueryBuilderRequest;
 use crate::query::execution::{InsertJobExecutor, PostQueryExecutor};
 use crate::query::{CompleteQuery, Query, Result};
 use google_cloud_bigquery_v2::client::JobService;
@@ -28,7 +28,7 @@ pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 
 /// A builder for executing a SQL query.
 ///
-/// [`BigQuery::query()`](crate::client::BigQuery::query) returns a `RunQuery`.
+/// [`BigQuery::query()`](crate::client::BigQuery::query) returns a `QueryBuilder`.
 ///
 /// # Automatic Path Routing
 ///
@@ -61,18 +61,18 @@ pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 /// # }
 /// ```
 #[derive(Clone, Debug)]
-pub struct RunQuery {
+pub struct QueryBuilder {
     pub(crate) job_service: Arc<JobService>,
-    pub(crate) request: RunQueryRequest,
+    pub(crate) request: QueryBuilderRequest,
     pub(crate) project_id: Option<String>,
 }
 
-impl RunQuery {
-    /// Creates a new `RunQuery` builder for the given SQL query.
+impl QueryBuilder {
+    /// Creates a new `QueryBuilder` for the given SQL query.
     pub(crate) fn new(job_service: Arc<JobService>, sql: String) -> Self {
         Self {
             job_service,
-            request: RunQueryRequest::default()
+            request: QueryBuilderRequest::default()
                 .set_query(sql)
                 .set_use_legacy_sql(wkt::BoolValue::from(false))
                 .set_job_creation_mode(JobCreationMode::JobCreationOptional),
@@ -90,7 +90,7 @@ impl RunQuery {
     /// project ID for this specific query.
     ///
     /// You must specify a project ID either on the client or on the query
-    /// builder before calling [`send()`](RunQuery::send).
+    /// builder before calling [`send()`](QueryBuilder::send).
     ///
     /// # Example
     ///
@@ -123,7 +123,7 @@ impl RunQuery {
     /// You must configure a target project ID on either the
     /// [`BigQuery`][crate::client::BigQuery] client via
     /// [`ClientBuilder::with_project_id`][crate::client_builder::ClientBuilder::with_project_id]
-    /// or on this builder via [`with_project_id()`](RunQuery::with_project_id).
+    /// or on this builder via [`with_project_id()`](QueryBuilder::with_project_id).
     ///
     /// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
     ///
@@ -190,7 +190,7 @@ impl RunQuery {
     /// Sends the query execution request and polls until execution completes.
     ///
     /// This is a convenience method equivalent to calling
-    /// [`.send().await?.until_done().await`](RunQuery::send).
+    /// [`.send().await?.until_done().await`](QueryBuilder::send).
     ///
     /// # Example
     ///
@@ -243,7 +243,7 @@ fn generate_prefixed_id(prefix: &str) -> String {
     format!("{prefix}{}", Uuid::new_v4().simple())
 }
 
-include!("../generated/run_query_builder.rs");
+include!("../generated/builder.rs");
 
 #[cfg(test)]
 mod tests {
@@ -267,7 +267,7 @@ mod tests {
     fn test_new() {
         let job_service = create_job_service(MockJobService::new());
         let sql = "SELECT 1".to_string();
-        let run_query = RunQuery::new(job_service, sql.clone());
+        let run_query = QueryBuilder::new(job_service, sql.clone());
         assert_eq!(run_query.request.query, sql);
         assert_eq!(
             run_query.request.use_legacy_sql,
@@ -284,7 +284,7 @@ mod tests {
     fn test_with_project_id() {
         let job_service = create_job_service(MockJobService::new());
         let run_query =
-            RunQuery::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         assert_eq!(run_query.project_id.unwrap(), "my-project");
     }
 
@@ -384,7 +384,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
 
-        let run_query = RunQuery::new(job_service, "SELECT 1".to_string())
+        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_allow_large_results(true);
         let query = run_query.send().await?;
@@ -406,7 +406,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
         let run_query =
-            RunQuery::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         let query = run_query.send().await?;
         assert!(!query.completed, "{query:?}");
         assert_eq!(query.metadata.query_id, "some_query_id");
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn test_force_job_path() {
         let job_service = create_job_service(MockJobService::new());
-        let mut run_query = RunQuery::new(job_service, "SELECT 1".to_string());
+        let mut run_query = QueryBuilder::new(job_service, "SELECT 1".to_string());
         assert!(!run_query.request.force_job_path());
 
         // setting a jobs.insert exclusive field
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_request_conversions() {
-        let req = RunQueryRequest::default()
+        let req = QueryBuilderRequest::default()
             .set_query("SELECT 1".to_string())
             .set_dry_run(true)
             .set_use_legacy_sql(true);
@@ -457,7 +457,7 @@ mod tests {
             Ok(Response::from(QueryResponse::new()))
         });
         let job_service = create_job_service(mock);
-        let run_query = RunQuery::new(job_service, "SELECT 1".to_string())
+        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_max_results(100_u32);
         let query = run_query.send().await?;
@@ -480,7 +480,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
 
-        let run_query = RunQuery::new(job_service, "SELECT 1".to_string())
+        let run_query = QueryBuilder::new(job_service, "SELECT 1".to_string())
             .with_project_id("my-project")
             .set_allow_large_results(true)
             .set_max_results(50_u32);
@@ -502,7 +502,7 @@ mod tests {
         });
         let job_service = create_job_service(mock);
         let run_query =
-            RunQuery::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
+            QueryBuilder::new(job_service, "SELECT 1".to_string()).with_project_id("my-project");
         let complete = run_query.until_done().await?;
         assert_eq!(complete.metadata().query_id, "some_query_id");
 

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 /// A handle representing a running or completed SQL query execution.
 ///
-/// [`QueryBuilder::send()`](crate::query::QueryBuilder::send) returns a `Query`.
+/// [`Query::send()`](crate::builder::bigquery::Query::send) returns a [`Query`](crate::Query).
 ///
 /// To obtain the final result set, call [`until_done()`](Query::until_done),
 /// which checks the execution status and automatically polls the service if the
@@ -127,7 +127,7 @@ impl Query {
     ///
     /// If the query was executed via the fast query path ([jobs.query]) and
     /// already completed during the initial request, this method immediately
-    /// returns a [`CompleteQuery`](crate::query::CompleteQuery) without making
+    /// returns a [`CompleteQuery`](crate::CompleteQuery) without making
     /// additional network calls. Otherwise, it implements a polling loop
     /// querying the job status until it succeeds or fails.
     ///

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use crate::error::QueryError;
-use crate::generated::QueryCreationMetadata;
-use crate::model::QueryMetadata;
+use crate::generated::{CompleteQueryMetadata, QueryMetadata};
 use crate::query::{Result, RowIterator, Schema};
 use google_cloud_bigquery_v2::client::JobService;
 use google_cloud_bigquery_v2::model::{
@@ -28,7 +27,7 @@ use std::sync::Arc;
 
 /// A handle representing a running or completed SQL query execution.
 ///
-/// [`RunQuery::send()`](crate::query::RunQuery::send) returns a `Query`.
+/// [`QueryBuilder::send()`](crate::query::QueryBuilder::send) returns a `Query`.
 ///
 /// To obtain the final result set, call [`until_done()`](Query::until_done),
 /// which checks the execution status and automatically polls the service if the
@@ -60,7 +59,7 @@ use std::sync::Arc;
 pub struct Query {
     pub(crate) job_service: Arc<JobService>,
     pub(crate) completed: bool,
-    pub(crate) metadata: QueryCreationMetadata,
+    pub(crate) metadata: QueryMetadata,
     pub(crate) cached_rows: Option<VecDeque<wkt::Struct>>,
     pub(crate) max_results: Option<u32>,
 }
@@ -80,7 +79,7 @@ impl Query {
             job_service,
             completed,
             cached_rows: None,
-            metadata: QueryCreationMetadata::from(initial_job),
+            metadata: QueryMetadata::from(initial_job),
             max_results,
         }
     }
@@ -92,7 +91,7 @@ impl Query {
     ) -> Self {
         let completed = query_response.job_complete.unwrap_or(false);
         let cached_rows = VecDeque::from(std::mem::take(&mut query_response.rows));
-        let metadata = QueryCreationMetadata::from(query_response);
+        let metadata = QueryMetadata::from(query_response);
         Self {
             job_service,
             completed,
@@ -104,22 +103,22 @@ impl Query {
 
     /// Returns the initial metadata from query creation.
     ///
-    /// This provides access to the [`QueryCreationMetadata`] returned by the
+    /// This provides access to the [`QueryMetadata`] returned by the
     /// initial query execution request (either [`jobs.query`] or
     /// [`jobs.insert`]).
     ///
     /// Depending on how the query was executed, the metadata contains:
-    /// - [`job_reference`][QueryCreationMetadata::job_reference]: The reference to the BigQuery job, if one was created.
-    /// - [`query_id`][QueryCreationMetadata::query_id]: The unique ID of the query if executed statelessly.
-    /// - [`job_creation_reason`][QueryCreationMetadata::job_creation_reason]: Why a job was created or skipped.
-    /// - [`job_complete`][QueryCreationMetadata::job_complete]: Whether the query completed immediately without requiring polling.
+    /// - [`job_reference`][QueryMetadata::job_reference]: The reference to the BigQuery job, if one was created.
+    /// - [`query_id`][QueryMetadata::query_id]: The unique ID of the query if executed statelessly.
+    /// - [`job_creation_reason`][QueryMetadata::job_creation_reason]: Why a job was created or skipped.
+    /// - [`job_complete`][QueryMetadata::job_complete]: Whether the query completed immediately without requiring polling.
     ///
     /// To wait for the query to finish and retrieve full results and final
     /// metadata, call [`until_done`][Self::until_done].
     ///
     /// [`jobs.query`]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
     /// [`jobs.insert`]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
-    pub fn metadata(&self) -> &QueryCreationMetadata {
+    pub fn metadata(&self) -> &QueryMetadata {
         &self.metadata
     }
 
@@ -163,7 +162,7 @@ impl Query {
         } = self;
 
         if let (true, Some(cached_rows)) = (completed, cached_rows) {
-            return Ok(CompleteQuery::from_query_creation_metadata(
+            return Ok(CompleteQuery::from_query_metadata(
                 job_service,
                 metadata,
                 cached_rows,
@@ -221,7 +220,7 @@ pub struct CompleteQuery {
     pub(crate) cached_rows: VecDeque<wkt::Struct>,
     pub(crate) schema: Arc<Schema>,
     pub(crate) page_token: Option<String>,
-    pub(crate) metadata: QueryMetadata,
+    pub(crate) metadata: CompleteQueryMetadata,
     pub(crate) max_results: Option<u32>,
 }
 
@@ -233,7 +232,7 @@ impl CompleteQuery {
         max_results: Option<u32>,
     ) -> Self {
         let cached_rows = VecDeque::from(std::mem::take(&mut res.rows));
-        let metadata = QueryMetadata::from(res);
+        let metadata = CompleteQueryMetadata::from(res);
         // DDL/DML queries have no schema.
         let schema = metadata.schema.clone().unwrap_or_default();
         let schema = Arc::new(Schema::new(schema));
@@ -253,14 +252,14 @@ impl CompleteQuery {
         }
     }
 
-    pub(crate) fn from_query_creation_metadata(
+    pub(crate) fn from_query_metadata(
         job_service: Arc<JobService>,
-        metadata: QueryCreationMetadata,
+        metadata: QueryMetadata,
         cached_rows: VecDeque<wkt::Struct>,
         max_results: Option<u32>,
     ) -> Self {
         let job_ref = metadata.job_reference.clone();
-        let metadata = QueryMetadata::from(metadata);
+        let metadata = CompleteQueryMetadata::from(metadata);
         // DDL/DML queries have no schema.
         let schema = metadata.schema.clone().unwrap_or_default();
         let schema = Arc::new(Schema::new(schema));
@@ -306,7 +305,7 @@ impl CompleteQuery {
 
     /// Returns a reference to the cached summary metadata for this query.
     ///
-    /// The returned [`QueryMetadata`](crate::model::QueryMetadata) contains
+    /// The returned [`CompleteQueryMetadata`](crate::model::CompleteQueryMetadata) contains
     /// summary statistics such as total rows, schema details, cache hit
     /// indicators, and estimated bytes processed without making additional
     /// RPCs.
@@ -326,7 +325,7 @@ impl CompleteQuery {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn metadata(&self) -> &QueryMetadata {
+    pub fn metadata(&self) -> &CompleteQueryMetadata {
         &self.metadata
     }
 
@@ -440,8 +439,8 @@ mod tests {
             max_results: Option<u32>,
         ) -> Self {
             let cached_rows = std::mem::take(&mut query_res.rows).into();
-            let metadata = QueryCreationMetadata::from(query_res);
-            Self::from_query_creation_metadata(job_service, metadata, cached_rows, max_results)
+            let metadata = QueryMetadata::from(query_res);
+            Self::from_query_metadata(job_service, metadata, cached_rows, max_results)
         }
     }
 


### PR DESCRIPTION
Based on API reviews, we decided to simplify some names:

* QueryCreationMetadata -> QueryMetadata
* QueryMetadata -> CompleteQueryMetadata
* RunQuery -> Query
* RunQueryRequest -> QueryRequest

Towards #5844 