### PR TITLE
chore: update librarian circa 2026-08-14

### DIFF
--- a/.gcb/scripts/coverage.sh
+++ b/.gcb/scripts/coverage.sh
@@ -19,7 +19,7 @@ cargo version
 rustup show active-toolchain -v
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
-"$(dirname "$0")"/install-librarian.sh
+source "$(dirname "$0")"/install-librarian.sh
 
 echo "==== Install cargo-llvm-cov ===="
 cargo install cargo-llvm-cov --version 0.8.5 --locked

--- a/.gcb/scripts/coverage.sh
+++ b/.gcb/scripts/coverage.sh
@@ -19,11 +19,7 @@ cargo version
 rustup show active-toolchain -v
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
-echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
-sha256sum -c <(echo 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42 /tmp/protoc.zip)
-env -C /usr/local unzip -x /tmp/protoc.zip
-protoc --version
+"$(dirname "$0")"/install-librarian.sh
 
 echo "==== Install cargo-llvm-cov ===="
 cargo install cargo-llvm-cov --version 0.8.5 --locked

--- a/.gcb/scripts/install-librarian.sh
+++ b/.gcb/scripts/install-librarian.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euv
+
+echo "==== Install go compiler ===="
+curl -fsSL --retry 5 --retry-delay 15 https://go.dev/dl/go1.25.6.linux-amd64.tar.gz -o /tmp/go.tar.gz
+sha256sum -c <(echo f022b6aad78e362bcba9b0b94d09ad58c5a70c6ba3b7582905fababf5fe0181a /tmp/go.tar.gz)
+tar -C /usr/local -xzf /tmp/go.tar.gz
+export PATH=${PATH}:/usr/local/go/bin
+
+echo "Installing the tools to regenerate the code"
+# Normally we recommend `librarian config get version` but that requires
+# downloading two copies of librarian.
+version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
+# Make multiple download attempts to avoid download-induced flakes.
+go install github.com/googleapis/librarian/cmd/librarian@${version} ||
+(sleep 5 && go install github.com/googleapis/librarian/cmd/librarian@${version}) ||
+(sleep 10 && go install github.com/googleapis/librarian/cmd/librarian@${version})
+# Make multiple attempts as install the tools may require downloads
+go run github.com/googleapis/librarian/cmd/librarian@${version} install ||
+(sleep 5 && go run github.com/googleapis/librarian/cmd/librarian@${version} install) ||
+(sleep 10 && go run github.com/googleapis/librarian/cmd/librarian@${version} install)

--- a/.gcb/scripts/install-librarian.sh
+++ b/.gcb/scripts/install-librarian.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
 go install github.com/googleapis/librarian/cmd/librarian@${version} ||
 (sleep 5 && go install github.com/googleapis/librarian/cmd/librarian@${version}) ||
 (sleep 10 && go install github.com/googleapis/librarian/cmd/librarian@${version})
-# Make multiple attempts as install the tools may require downloads
+# Make multiple attempts as installing the tools may require downloads.
 go run github.com/googleapis/librarian/cmd/librarian@${version} install ||
 (sleep 5 && go run github.com/googleapis/librarian/cmd/librarian@${version} install) ||
 (sleep 10 && go run github.com/googleapis/librarian/cmd/librarian@${version} install)

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -15,17 +15,7 @@
 
 set -ev
 
-echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v33.2/protoc-33.2-linux-x86_64.zip
-sha256sum -c <(echo b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf /tmp/protoc.zip)
-env -C /usr/local unzip -x /tmp/protoc.zip
-protoc --version
-
-echo "==== Install go compiler ===="
-curl -fsSL --retry 5 --retry-delay 15 https://go.dev/dl/go1.25.6.linux-amd64.tar.gz -o /tmp/go.tar.gz
-sha256sum -c <(echo f022b6aad78e362bcba9b0b94d09ad58c5a70c6ba3b7582905fababf5fe0181a /tmp/go.tar.gz)
-tar -C /usr/local -xzf /tmp/go.tar.gz
-export PATH=${PATH}:/usr/local/go/bin
+"$(dirname "$0")"/install-librarian.sh
 
 echo "==== Install taplo ===="
 cargo install taplo-cli --locked
@@ -35,13 +25,6 @@ rustup component add rustfmt
 rustup show active-toolchain -v
 
 echo "Regenerate all the code"
-# Normally we recommend `librarian config get version` but that requires
-# downloading two copies of librarian.
-version=$(sed -n 's/^version: *//p' /workspace/librarian.yaml)
-# Make multiple download attempts to avoid download-induced flakes.
-go install github.com/googleapis/librarian/cmd/librarian@${version} ||
-(sleep 5 && go install github.com/googleapis/librarian/cmd/librarian@${version}) ||
-(sleep 10 && go install github.com/googleapis/librarian/cmd/librarian@${version})
 go run github.com/googleapis/librarian/cmd/librarian@${version} generate --all
 
 # If there is any difference between the generated code and the

--- a/.gcb/scripts/regenerate.sh
+++ b/.gcb/scripts/regenerate.sh
@@ -15,7 +15,7 @@
 
 set -ev
 
-"$(dirname "$0")"/install-librarian.sh
+source "$(dirname "$0")"/install-librarian.sh
 
 echo "==== Install taplo ===="
 cargo install taplo-cli --locked

--- a/.gcb/scripts/test-ignored-samples.sh
+++ b/.gcb/scripts/test-ignored-samples.sh
@@ -16,7 +16,7 @@
 set -ev
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
-"$(dirname "$0")"/install-librarian.sh
+source "$(dirname "$0")"/install-librarian.sh
 
 rustup component add clippy
 cargo version

--- a/.gcb/scripts/test-ignored-samples.sh
+++ b/.gcb/scripts/test-ignored-samples.sh
@@ -16,11 +16,7 @@
 set -ev
 
 # We use `--all-features` which triggers the Tonic+Prost code generation.
-echo "==== Install protoc ===="
-curl -fsSL --retry 5 --retry-delay 15 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v31.0/protoc-31.0-linux-x86_64.zip
-sha256sum -c <(echo 24e2ed32060b7c990d5eb00d642fde04869d7f77c6d443f609353f097799dd42 /tmp/protoc.zip)
-env -C /usr/local unzip -x /tmp/protoc.zip
-protoc --version
+"$(dirname "$0")"/install-librarian.sh
 
 rustup component add clippy
 cargo version

--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -391,6 +391,5 @@ go run github.com/googleapis/librarian/cmd/librarian@main generate google-cloud-
 [add new dependency]: #add-new-dependency
 [generate new library]: #generate-new-library
 [librarian.yaml]: https://github.com/googleapis/google-cloud-rust/blob/main/librarian.yaml
-[protocol buffer compiler installation]: https://protobuf.dev/installation/
 [sdk.yaml]: https://github.com/googleapis/librarian/blob/main/internal/serviceconfig/sdk.yaml
 [set up development environment]: /doc/contributor/howto-guide-set-up-development-environment.md

--- a/doc/contributor/howto-guide-generated-code-maintenance.md
+++ b/doc/contributor/howto-guide-generated-code-maintenance.md
@@ -7,18 +7,15 @@ when the generator changes.
 
 ## Prerequisites
 
-The generator and its unit tests use `protoc`, the Protobuf compiler. Ensure you
-have `protoc >= v23.0` installed and it is found via your `$PATH`.
-
-```bash
-protoc --version
-```
-
-If not, follow the steps in [Protocol Buffer Compiler Installation] to download
-a suitable version.
-
 Make sure your workstation has up-to-date versions of Rust and Go. Follow the
 instructions in [Set Up Development Environment].
+
+To install the generator dependencies use `librarian install`:
+
+```bash
+V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+go run github.com/googleapis/librarian/cmd/librarian@${V} install
+```
 
 ## Generate new library
 
@@ -309,7 +306,7 @@ Then finish your PR in `google-cloud-rust`.
 
    ```bash
    V=$(GOPROXY=direct go list -m -f '{{.Version}}' github.com/googleapis/librarian@main)
-   sed -i.bak "s;^version: .*;version: ${V};" librarian.yaml && rm librarian.yaml.bak
+   go run github.com/googleapis/librarian/cmd/librarian@${V} config set version ${V}
    ```
 
 1. Update the generated code:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.37.1-0.20260814004615-cecd47a9776c
+version: v0.37.1-0.20260814174020-ac64c4c58615
 repo: googleapis/google-cloud-rust
 sources:
   conformance:
@@ -43,6 +43,12 @@ tools:
       version: 0.4.0
     - name: taplo-cli
       version: 0.10.0
+  protoc:
+    version: "33.2"
+    sha256_by_platform:
+      linux-x86_64: b24b53f87c151bfd48b112fe4c3a6e6574e5198874f38036aff41df3456b8caf
+      osx-aarch_64: 5be1427127788c9f7dd7d606c3e69843dd3587327dea993917ffcb77e7234b44
+      win64: 376770cd4073beb63db56fdd339260edb9957b3c4472e05a75f5f9ec8f98d8f5
 default:
   output: src/generated/
   rust:


### PR DESCRIPTION
This version of librarian can install `protoc` for us, and then uses that installed version. It gives us a central place to control what version we use.

The PR includes changes to the CI builds to use that version of `protoc`.