### PR TITLE
test(bigquery): add long-running heavy poller test

### DIFF
--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -195,6 +195,60 @@ pub async fn job_service_poller_error() -> Result<()> {
 
     Ok(())
 }
+
+pub async fn job_service_poller_heavy() -> Result<()> {
+    let project_id = project_id()?;
+    let client = JobService::builder().build().await?;
+    cleanup_stale_jobs(&client, &project_id).await?;
+
+    let job_id = random_job_id();
+    println!("CREATING JOB (HEAVY POLLER) ID: {job_id}");
+
+    let query = r#"
+        DECLARE DELAY_TIME DATETIME;
+        DECLARE WAIT STRING;
+        SET WAIT = 'TRUE';
+        SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 5 SECOND);
+
+        WHILE WAIT = 'TRUE' DO
+          IF (DELAY_TIME < CURRENT_DATETIME) THEN
+            SET WAIT = 'FALSE';
+          END IF;
+        END WHILE;
+    "#;
+
+    let job = client
+        .insert_job()
+        .set_project_id(&project_id)
+        .set_job(
+            Job::new()
+                .set_job_reference(JobReference::new().set_job_id(&job_id))
+                .set_configuration(
+                    JobConfiguration::new()
+                        .set_labels([(INSTANCE_LABEL, "true")])
+                        .set_query(
+                            JobConfigurationQuery::new()
+                                .set_query(query)
+                                .set_use_legacy_sql(false),
+                        ),
+                ),
+        )
+        .into_job_poller()
+        .until_done()
+        .await?;
+
+    assert!(job.job_reference.is_some(), "{job:?}");
+    let status = job.status.as_ref().expect("job should have status");
+    assert_eq!(status.state.as_str(), "DONE");
+    assert!(
+        status.error_result.is_none(),
+        "job completed with unexpected error_result: {:?}",
+        status.error_result
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use anyhow::Result;

--- a/tests/bigquery/src/job.rs
+++ b/tests/bigquery/src/job.rs
@@ -204,18 +204,7 @@ pub async fn job_service_poller_heavy() -> Result<()> {
     let job_id = random_job_id();
     println!("CREATING JOB (HEAVY POLLER) ID: {job_id}");
 
-    let query = r#"
-        DECLARE DELAY_TIME DATETIME;
-        DECLARE WAIT STRING;
-        SET WAIT = 'TRUE';
-        SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 5 SECOND);
-
-        WHILE WAIT = 'TRUE' DO
-          IF (DELAY_TIME < CURRENT_DATETIME) THEN
-            SET WAIT = 'FALSE';
-          END IF;
-        END WHILE;
-    "#;
+    let query = "SELECT count(*) FROM UNNEST(GENERATE_ARRAY(1, 1000000)), UNNEST(GENERATE_ARRAY(1, 100)) as foo";
 
     let job = client
         .insert_job()

--- a/tests/bigquery/src/lib.rs
+++ b/tests/bigquery/src/lib.rs
@@ -19,7 +19,9 @@ mod reads;
 mod writes;
 
 pub use dataset::dataset_admin;
-pub use job::{job_service, job_service_poller, job_service_poller_error};
+pub use job::{
+    job_service, job_service_poller, job_service_poller_error, job_service_poller_heavy,
+};
 pub use query::{
     query_client, query_client_datatypes, query_client_job, query_client_multi_page,
     query_client_nested_types, query_client_numeric_limits,

--- a/tests/bigquery/tests/driver.rs
+++ b/tests/bigquery/tests/driver.rs
@@ -98,6 +98,14 @@ mod bigquery {
     }
 
     #[tokio::test]
+    async fn run_job_service_poller_heavy() -> anyhow::Result<()> {
+        let _guard = enable_tracing();
+        integration_tests_bigquery::job_service_poller_heavy()
+            .await
+            .inspect_err(anydump)
+    }
+
+    #[tokio::test]
     async fn run_job_service_poller() -> anyhow::Result<()> {
         let _guard = enable_tracing();
         integration_tests_bigquery::job_service_poller()


### PR DESCRIPTION
Add an integration test that proves the `JobPoller` LRO backoff logic is invoked.

Typical testing queries (e.g., `SELECT 1`) execute so fast that the initial `insert_job` REST call fast-paths and returns `DONE` instantly. This suppresses the inner `.poll()` loop from back-off sleeping, leaving the LRO logic untested.

Follow-up to #6232