### PR TITLE
feat(gax): wrap stream closed errors in BrokenPipe io error

### DIFF
--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -73,15 +73,12 @@ where
         Self::from_fn(move |item| {
             let req_tx = req_tx.clone();
             async move {
-                req_tx
-                    .send(item)
-                    .await
-                    .map_err(|_| {
-                        crate::error::Error::io(std::io::Error::new(
-                            std::io::ErrorKind::BrokenPipe,
-                            "cannot send request: stream is closed",
-                        ))
-                    })
+                req_tx.send(item).await.map_err(|_| {
+                    crate::error::Error::io(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "cannot send request: stream is closed",
+                    ))
+                })
             }
         })
     }

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -76,7 +76,12 @@ where
                 req_tx
                     .send(item)
                     .await
-                    .map_err(|_| crate::error::Error::io("cannot send request: stream is closed"))
+                    .map_err(|_| {
+                        crate::error::Error::io(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "cannot send request: stream is closed",
+                        ))
+                    })
             }
         })
     }
@@ -176,6 +181,11 @@ mod tests {
             .await
             .expect_err("send should fail when receiver is dropped");
         assert!(err.is_io());
+        let io_err = err
+            .source()
+            .and_then(|e| e.downcast_ref::<std::io::Error>())
+            .expect("source should be std::io::Error");
+        assert_eq!(io_err.kind(), std::io::ErrorKind::BrokenPipe);
         assert_eq!(
             err.source().map(|e| e.to_string()).as_deref(),
             Some("cannot send request: stream is closed")


### PR DESCRIPTION
Update RequestSender's From<mpsc::Sender<Req>> implementation to construct a std::io::Error with std::io::ErrorKind::BrokenPipe when sending over a closed channel fails.

This provides standard I/O broken pipe semantics to callers while preserving the error kind and message.