### PR TITLE
cleanup(storage): skip troublesome field

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.37.1-0.20260816153656-85d1716233af
+version: v0.37.1-0.20260816173129-01e160eba49a
 repo: googleapis/google-cloud-rust
 sources:
   conformance:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1191,7 +1191,7 @@ libraries:
     rust:
       documentation_overrides:
         - id: .google.cloud.orgpolicy.v1.Policy.ListPolicy
-          match: 'Ancestry subtrees must be in one of the following formats:'
+          match: "Ancestry subtrees must be in one of the following formats:"
           replace: " \nAncestry subtrees must be in one of the following formats:"
         - id: .google.cloud.orgpolicy.v1.Policy.ListPolicy
           match: The `supports_under` field of the associated `Constraint`  defines whether
@@ -1517,6 +1517,8 @@ libraries:
         - module_path: crate::generated::gapic_control::model
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf
           output: src/storage/src/generated/convert/control
+          skipped_ids:
+            - .google.storage.control.v2.ObjectFullContext.extended_data
           api_path: google/storage/control/v2
           template: convert-prost
         - module_path: google_cloud_iam_v1::model
@@ -1590,6 +1592,8 @@ libraries:
           include_grpc_only_methods: true
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf
           output: src/storage/src/generated/gapic_control
+          skipped_ids:
+            - .google.storage.control.v2.ObjectFullContext.extended_data
           routing_required: true
           service_config: google/storage/control/v2/storage_v2.yaml
           api_path: google/storage/control/v2

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: rust
-version: v0.37.1-0.20260814214806-54acc4445345
+version: v0.37.1-0.20260816153656-85d1716233af
 repo: googleapis/google-cloud-rust
 sources:
   conformance:
@@ -1191,7 +1191,7 @@ libraries:
     rust:
       documentation_overrides:
         - id: .google.cloud.orgpolicy.v1.Policy.ListPolicy
-          match: "Ancestry subtrees must be in one of the following formats:"
+          match: 'Ancestry subtrees must be in one of the following formats:'
           replace: " \nAncestry subtrees must be in one of the following formats:"
         - id: .google.cloud.orgpolicy.v1.Policy.ListPolicy
           match: The `supports_under` field of the associated `Constraint`  defines whether
@@ -1592,10 +1592,10 @@ libraries:
           include_grpc_only_methods: true
           name_overrides: .google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_buckets=CloudStorageBucketsOneOf,.google.storage.control.v2.IntelligenceConfig.Filter.cloud_storage_locations=CloudStorageLocationsOneOf
           output: src/storage/src/generated/gapic_control
-          skipped_ids:
-            - .google.storage.control.v2.ObjectFullContext.extended_data
           routing_required: true
           service_config: google/storage/control/v2/storage_v2.yaml
+          skipped_ids:
+            - .google.storage.control.v2.ObjectFullContext.extended_data
           api_path: google/storage/control/v2
           template: grpc-client
         - output: src/storage/src/generated/protos/control

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1829,7 +1829,7 @@ impl super::stub::Echo for Echo {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                &x_goog_request_params,
+                x_goog_request_params,
             )
             .await?;
 
@@ -5084,7 +5084,7 @@ impl super::stub::Messaging for Messaging {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                &x_goog_request_params,
+                x_goog_request_params,
             )
             .await?;
 

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1798,6 +1798,8 @@ impl super::stub::Echo for Echo {
         let req =
             req.ok_or_else(|| google_cloud_gax::error::Error::binding("a request is required"))?;
 
+        let x_goog_request_params = "";
+
         let first_req = req
             .to_proto()
             .map_err(google_cloud_gax::error::Error::ser)?;
@@ -1816,7 +1818,6 @@ impl super::stub::Echo for Echo {
             e
         };
         let path = http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Echo/Chat");
-        let x_goog_request_params = "";
 
         let result = self.grpc_inner
             .bidi_stream::<
@@ -1828,7 +1829,7 @@ impl super::stub::Echo for Echo {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                x_goog_request_params,
+                &x_goog_request_params,
             )
             .await?;
 
@@ -5051,6 +5052,8 @@ impl super::stub::Messaging for Messaging {
         let req =
             req.ok_or_else(|| google_cloud_gax::error::Error::binding("a request is required"))?;
 
+        let x_goog_request_params = "";
+
         let first_req = req
             .to_proto()
             .map_err(google_cloud_gax::error::Error::ser)?;
@@ -5070,7 +5073,6 @@ impl super::stub::Messaging for Messaging {
         };
         let path =
             http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Messaging/Connect");
-        let x_goog_request_params = "";
 
         let result = self.grpc_inner
             .bidi_stream::<
@@ -5082,7 +5084,7 @@ impl super::stub::Messaging for Messaging {
                 req_stream,
                 options.into(),
                 &crate::info::X_GOOG_API_CLIENT_HEADER,
-                x_goog_request_params,
+                &x_goog_request_params,
             )
             .await?;
 

--- a/src/pubsub/grpc-mock/README.md
+++ b/src/pubsub/grpc-mock/README.md
@@ -17,7 +17,7 @@ streams. It seemed easier to reason about the mock if it always used
 
 ## Usage
 
-Create a `mocks::MockPublisher` and call `start()` to launch a (local) server
+Create a `mocks::MockSubscriber` and call `start()` to launch a (local) server
 using the mock. Then connect your test to this mock server.
 
 The types have comments with trivial examples.

--- a/src/pubsub/grpc-mock/src/lib.rs
+++ b/src/pubsub/grpc-mock/src/lib.rs
@@ -16,6 +16,38 @@
 
 #![allow(missing_docs)]
 
+//! End-to-end mocks for the `google.pubsub.v1.Subscriber` gRPC service.
+//!
+//! Use this crate for end-to-end client library tests. Start a local server
+//! implementing the `google.pubsub.v1.Subscriber` API, with the implementation
+//! defined by a mock. Then test the client library against this mock.
+//!
+//! # Example
+//! ```no_rust
+//! use pubsub_grpc_mock::{start, MockSubscriber};
+//! use google_cloud_subscriber::client::Subscriber;
+//! use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
+//!
+//! # async fn test() -> anyhow::Result<()> {
+//! let mut mock = MockSubscriber::new();
+//! mock.expect_get_subscription()
+//!     .return_once(|_| Err(tonic::Status::invalid_argument("test message")));
+//! // Starts a service using `mock` and a random port.
+//! let (endpoint, server) = start("0.0.0.0:0", mock).await?;
+//! // Use the service in a test.
+//! let client = Subscriber::builder()
+//!     .with_endpoint(endpoint)
+//!     .with_credentials(Anonymous::default().build())
+//!     .build()
+//!     .await?;
+//! let err = client
+//!     .get_subscription()
+//!     .send()
+//!     .unwrap_err("mock returns an error");
+//! assert_eq!(err.status().is_some(), "{err:?}");
+//! # Ok(()) }
+//! ```
+
 mod mocks;
 use std::net::SocketAddr;
 use tokio::task::JoinHandle;

--- a/src/storage/src/generated/convert/control/convert.rs
+++ b/src/storage/src/generated/convert/control/convert.rs
@@ -2221,7 +2221,7 @@ impl gaxi::prost::ToProto<ObjectFullContext> for crate::generated::gapic_control
             value: self.value.to_proto()?,
             create_time: self.create_time.map(|v| v.to_proto()).transpose()?,
             update_time: self.update_time.map(|v| v.to_proto()).transpose()?,
-            extended_data: None,
+            ..Self::Output::default()
         })
     }
 }

--- a/src/storage/src/generated/gapic_control/model.rs
+++ b/src/storage/src/generated/gapic_control/model.rs
@@ -10502,9 +10502,6 @@ pub struct ObjectFullContext {
     /// The time at which the object context was updated.
     pub update_time: std::option::Option<wkt::Timestamp>,
 
-    /// The extended data of the object context.
-    pub extended_data: std::option::Option<wkt::Any>,
-
     pub(crate) _unknown_fields: serde_json::Map<std::string::String, serde_json::Value>,
 }
 
@@ -10618,39 +10615,6 @@ impl ObjectFullContext {
         T: std::convert::Into<wkt::Timestamp>,
     {
         self.update_time = v.map(|x| x.into());
-        self
-    }
-
-    /// Sets the value of [extended_data][crate::model::ObjectFullContext::extended_data].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_storage::model::ObjectFullContext;
-    /// use wkt::Any;
-    /// let x = ObjectFullContext::new().set_extended_data(Any::default()/* use setters */);
-    /// ```
-    pub fn set_extended_data<T>(mut self, v: T) -> Self
-    where
-        T: std::convert::Into<wkt::Any>,
-    {
-        self.extended_data = std::option::Option::Some(v.into());
-        self
-    }
-
-    /// Sets or clears the value of [extended_data][crate::model::ObjectFullContext::extended_data].
-    ///
-    /// # Example
-    /// ```ignore,no_run
-    /// # use google_cloud_storage::model::ObjectFullContext;
-    /// use wkt::Any;
-    /// let x = ObjectFullContext::new().set_or_clear_extended_data(Some(Any::default()/* use setters */));
-    /// let x = ObjectFullContext::new().set_or_clear_extended_data(None::<Any>);
-    /// ```
-    pub fn set_or_clear_extended_data<T>(mut self, v: std::option::Option<T>) -> Self
-    where
-        T: std::convert::Into<wkt::Any>,
-    {
-        self.extended_data = v.map(|x| x.into());
         self
     }
 }

--- a/src/storage/src/generated/gapic_control/model/debug.rs
+++ b/src/storage/src/generated/gapic_control/model/debug.rs
@@ -1180,7 +1180,6 @@ impl std::fmt::Debug for super::ObjectFullContext {
         debug_struct.field("value", &self.value);
         debug_struct.field("create_time", &self.create_time);
         debug_struct.field("update_time", &self.update_time);
-        debug_struct.field("extended_data", &self.extended_data);
         if !self._unknown_fields.is_empty() {
             debug_struct.field("_unknown_fields", &self._unknown_fields);
         }

--- a/src/storage/src/generated/gapic_control/model/deserialize.rs
+++ b/src/storage/src/generated/gapic_control/model/deserialize.rs
@@ -9880,7 +9880,6 @@ impl<'de> serde::de::Deserialize<'de> for super::ObjectFullContext {
             __value,
             __create_time,
             __update_time,
-            __extended_data,
             Unknown(std::string::String),
         }
         impl<'de> serde::de::Deserialize<'de> for __FieldTag {
@@ -9908,8 +9907,6 @@ impl<'de> serde::de::Deserialize<'de> for super::ObjectFullContext {
                             "create_time" => Ok(__FieldTag::__create_time),
                             "updateTime" => Ok(__FieldTag::__update_time),
                             "update_time" => Ok(__FieldTag::__update_time),
-                            "extendedData" => Ok(__FieldTag::__extended_data),
-                            "extended_data" => Ok(__FieldTag::__extended_data),
                             _ => Ok(__FieldTag::Unknown(value.to_string())),
                         }
                     }
@@ -9980,15 +9977,6 @@ impl<'de> serde::de::Deserialize<'de> for super::ObjectFullContext {
                             }
                             result.update_time =
                                 map.next_value::<std::option::Option<wkt::Timestamp>>()?;
-                        }
-                        __FieldTag::__extended_data => {
-                            if !fields.insert(__FieldTag::__extended_data) {
-                                return std::result::Result::Err(A::Error::duplicate_field(
-                                    "multiple values for extended_data",
-                                ));
-                            }
-                            result.extended_data =
-                                map.next_value::<std::option::Option<wkt::Any>>()?;
                         }
                         __FieldTag::Unknown(key) => {
                             let value = map.next_value::<serde_json::Value>()?;

--- a/src/storage/src/generated/gapic_control/model/serialize.rs
+++ b/src/storage/src/generated/gapic_control/model/serialize.rs
@@ -3018,9 +3018,6 @@ impl serde::ser::Serialize for super::ObjectFullContext {
         if self.update_time.is_some() {
             state.serialize_entry("updateTime", &self.update_time)?;
         }
-        if self.extended_data.is_some() {
-            state.serialize_entry("extendedData", &self.extended_data)?;
-        }
         if !self._unknown_fields.is_empty() {
             for (key, value) in self._unknown_fields.iter() {
                 state.serialize_entry(key, &value)?;


### PR DESCRIPTION
Skipping the field is cleaner than skipping the Sidekick-codegen <-> Prost-codegen conversion. If nothing else, the application developer get a clear signal that they cannot set the field, as there is no field to set.

Fixes #6353 