### PR TITLE
chore(spanner): implement mutation routing key extraction and golden tests

### DIFF
--- a/src/spanner/src/routing/key_extractor.rs
+++ b/src/spanner/src/routing/key_extractor.rs
@@ -14,17 +14,22 @@
 
 //! Routing key extraction for Spanner client requests.
 //!
-//! Provides helpers to extract and encode binary routing keys from [`KeySet`]s and [`ReadRequest`]s
-//! using cached [`KeyRecipe`]s stored in [`KeyRecipeCache`].
+//! Provides helpers to extract and encode binary routing keys from [`KeySet`]s, [`ReadRequest`]s,
+//! and [`Mutation`]s using cached [`KeyRecipe`]s stored in [`KeyRecipeCache`].
 
-// TODO(#6236): Remove dead_code allowance once key extractor is integrated into DatabaseClient / Read operations.
+// TODO(#6236): Remove dead_code allowance once key extractor is integrated into DatabaseClient / Read / Write operations.
 #![allow(dead_code)]
 
 use crate::Result;
 use crate::key::{Endpoint, KeySet};
-use crate::model::KeyRecipe;
+use crate::model::mutation::Operation as ProtoOperation;
+use crate::model::{KeyRecipe, KeySet as ProtoKeySet, Mutation as ProtoMutation};
+use crate::mutation::{InternalMutation, Mutation};
 use crate::read::ReadRequest;
-use crate::routing::key_recipe::encode_key_from_recipe_into;
+use crate::routing::key_recipe::{
+    encode_key_from_columns_and_values_into, encode_key_from_json_columns_and_values_into,
+    encode_key_from_json_recipe_into, encode_key_from_recipe_into,
+};
 use crate::routing::key_recipe_cache::KeyRecipeCache;
 
 /// Extracts and encodes a binary routing key (`Vec<u8>`) from a [`KeyRecipe`] and [`KeySet`].
@@ -91,6 +96,250 @@ pub(crate) fn extract_key_from_key_set_into(
     Ok(false)
 }
 
+/// Extracts and encodes a binary routing key (`Vec<u8>`) from a [`KeyRecipe`] and [`Mutation`].
+///
+/// Supports `Insert`, `Update`, `InsertOrUpdate`, `Replace` (mapping recipe column identifiers
+/// to mutation column positions case-insensitively), and `Delete` (delegating to [`KeySet`] extraction).
+///
+/// Returns:
+/// - `Ok(Some(routing_key))` if a valid point key or start range key was found and encoded.
+/// - `Ok(None)` if the mutation does not contain a single partition key (e.g. empty mutation or `all: true`).
+/// - `Err(e)` if encoding failed (e.g. unsupported column type or missing key column).
+pub(crate) fn extract_key_from_mutation(
+    recipe: &KeyRecipe,
+    mutation: &Mutation,
+) -> Result<Option<Vec<u8>>> {
+    let mut buffer = Vec::with_capacity(recipe.part.len().saturating_mul(16));
+    if !extract_key_from_mutation_into(recipe, mutation, &mut buffer)? {
+        return Ok(None);
+    }
+    Ok(Some(buffer))
+}
+
+/// Extracts and encodes a binary routing key from a [`KeyRecipe`] and [`Mutation`] directly into an
+/// existing output buffer.
+pub(crate) fn extract_key_from_mutation_into(
+    recipe: &KeyRecipe,
+    mutation: &Mutation,
+    buffer: &mut Vec<u8>,
+) -> Result<bool> {
+    match &mutation.inner {
+        InternalMutation::Insert(write)
+        | InternalMutation::Update(write)
+        | InternalMutation::InsertOrUpdate(write)
+        | InternalMutation::Replace(write) => {
+            if write.columns.is_empty() || write.values.is_empty() {
+                return Ok(false);
+            }
+            encode_key_from_columns_and_values_into(recipe, &write.columns, &write.values, buffer)?;
+            Ok(true)
+        }
+        InternalMutation::Delete(delete) => {
+            extract_key_from_key_set_into(recipe, &delete.key_set, buffer)
+        }
+    }
+}
+
+/// Extracts and encodes a binary routing key (`Vec<u8>`) from a [`KeyRecipe`] and protobuf [`ProtoMutation`].
+pub(crate) fn extract_key_from_proto_mutation(
+    recipe: &KeyRecipe,
+    mutation: &ProtoMutation,
+) -> Result<Option<Vec<u8>>> {
+    let mut buffer = Vec::with_capacity(recipe.part.len().saturating_mul(16));
+    if !extract_key_from_proto_mutation_into(recipe, mutation, &mut buffer)? {
+        return Ok(None);
+    }
+    Ok(Some(buffer))
+}
+
+/// Extracts and encodes a binary routing key from a [`KeyRecipe`] and protobuf [`ProtoMutation`] directly
+/// into an existing output buffer.
+pub(crate) fn extract_key_from_proto_mutation_into(
+    recipe: &KeyRecipe,
+    mutation: &ProtoMutation,
+    buffer: &mut Vec<u8>,
+) -> Result<bool> {
+    match &mutation.operation {
+        Some(ProtoOperation::Insert(write))
+        | Some(ProtoOperation::Update(write))
+        | Some(ProtoOperation::InsertOrUpdate(write))
+        | Some(ProtoOperation::Replace(write)) => {
+            if write.columns.is_empty() || write.values.is_empty() {
+                return Ok(false);
+            }
+            let first_row = match write.values.first() {
+                Some(row) if !row.is_empty() => row,
+                _ => return Ok(false),
+            };
+            encode_key_from_json_columns_and_values_into(
+                recipe,
+                &write.columns,
+                first_row,
+                buffer,
+            )?;
+            Ok(true)
+        }
+        Some(ProtoOperation::Delete(delete)) => {
+            let Some(key_set) = &delete.key_set else {
+                return Ok(false);
+            };
+            extract_key_from_proto_key_set_into(recipe, key_set, buffer)
+        }
+        Some(ProtoOperation::Send(send)) => {
+            extract_key_from_proto_key_list_into(recipe, send.key.as_deref(), buffer)
+        }
+        Some(ProtoOperation::Ack(ack)) => {
+            extract_key_from_proto_key_list_into(recipe, ack.key.as_deref(), buffer)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Extracts a routing key from a protobuf key value list into `buffer` if non-empty.
+fn extract_key_from_proto_key_list_into(
+    recipe: &KeyRecipe,
+    key_list: Option<&[serde_json::Value]>,
+    buffer: &mut Vec<u8>,
+) -> Result<bool> {
+    let Some(key_list) = key_list else {
+        return Ok(false);
+    };
+    if key_list.is_empty() {
+        return Ok(false);
+    }
+    encode_key_from_json_recipe_into(recipe, key_list, buffer)?;
+    Ok(true)
+}
+
+/// Extracts a routing key from a protobuf [`ProtoKeySet`].
+fn extract_key_from_proto_key_set_into(
+    recipe: &KeyRecipe,
+    key_set: &ProtoKeySet,
+    buffer: &mut Vec<u8>,
+) -> Result<bool> {
+    if key_set.all {
+        return Ok(false);
+    }
+    if let Some(first_key) = key_set.keys.first()
+        && extract_key_from_proto_key_list_into(recipe, Some(first_key.as_slice()), buffer)?
+    {
+        return Ok(true);
+    }
+    if let Some(first_range) = key_set.ranges.first() {
+        if extract_key_from_proto_key_list_into(
+            recipe,
+            first_range.start_closed().map(|values| values.as_slice()),
+            buffer,
+        )? {
+            return Ok(true);
+        }
+        if extract_key_from_proto_key_list_into(
+            recipe,
+            first_range.start_open().map(|values| values.as_slice()),
+            buffer,
+        )? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Returns the target table name of a [`Mutation`].
+pub(crate) fn extract_mutation_table_name(mutation: &Mutation) -> &str {
+    match &mutation.inner {
+        InternalMutation::Insert(write)
+        | InternalMutation::Update(write)
+        | InternalMutation::InsertOrUpdate(write)
+        | InternalMutation::Replace(write) => &write.table,
+        InternalMutation::Delete(delete) => &delete.table,
+    }
+}
+
+/// Returns the target table or queue name of a protobuf [`ProtoMutation`].
+pub(crate) fn extract_proto_mutation_table_name(mutation: &ProtoMutation) -> Option<&str> {
+    match &mutation.operation {
+        Some(ProtoOperation::Insert(write))
+        | Some(ProtoOperation::Update(write))
+        | Some(ProtoOperation::InsertOrUpdate(write))
+        | Some(ProtoOperation::Replace(write)) => Some(&write.table),
+        Some(ProtoOperation::Delete(delete)) => Some(&delete.table),
+        Some(ProtoOperation::Send(send)) => Some(&send.queue),
+        Some(ProtoOperation::Ack(ack)) => Some(&ack.queue),
+        None => None,
+    }
+}
+
+/// Trait abstracting mutation types (high-level [`Mutation`] and protobuf [`ProtoMutation`])
+/// for routing key extraction and cache lookup.
+pub(crate) trait ExtractableMutation {
+    /// Returns the target table or queue name.
+    fn table_name(&self) -> Option<&str>;
+
+    /// Extracts and encodes the routing key using the provided [`KeyRecipe`].
+    fn extract_key(&self, recipe: &KeyRecipe) -> Result<Option<Vec<u8>>>;
+
+    /// Extracts and encodes the routing key into `buffer` using the provided [`KeyRecipe`].
+    fn extract_key_into(&self, recipe: &KeyRecipe, buffer: &mut Vec<u8>) -> Result<bool>;
+}
+
+impl ExtractableMutation for Mutation {
+    fn table_name(&self) -> Option<&str> {
+        Some(extract_mutation_table_name(self))
+    }
+
+    fn extract_key(&self, recipe: &KeyRecipe) -> Result<Option<Vec<u8>>> {
+        extract_key_from_mutation(recipe, self)
+    }
+
+    fn extract_key_into(&self, recipe: &KeyRecipe, buffer: &mut Vec<u8>) -> Result<bool> {
+        extract_key_from_mutation_into(recipe, self, buffer)
+    }
+}
+
+impl ExtractableMutation for ProtoMutation {
+    fn table_name(&self) -> Option<&str> {
+        extract_proto_mutation_table_name(self)
+    }
+
+    fn extract_key(&self, recipe: &KeyRecipe) -> Result<Option<Vec<u8>>> {
+        extract_key_from_proto_mutation(recipe, self)
+    }
+
+    fn extract_key_into(&self, recipe: &KeyRecipe, buffer: &mut Vec<u8>) -> Result<bool> {
+        extract_key_from_proto_mutation_into(recipe, self, buffer)
+    }
+}
+
+/// Resolves the table recipe from [`KeyRecipeCache`] and encodes the routing key for a mutation.
+pub(crate) fn extract_mutation_routing_key<M: ExtractableMutation>(
+    key_recipe_cache: &KeyRecipeCache,
+    mutation: &M,
+) -> Option<Vec<u8>> {
+    let table = mutation.table_name()?;
+    let recipe = key_recipe_cache.get_table_recipe(table)?;
+    mutation.extract_key(&recipe).ok().flatten()
+}
+
+/// Iterates through a slice of mutations and extracts the routing key from the first
+/// eligible mutation whose table recipe exists in [`KeyRecipeCache`].
+///
+/// ### Mutation Selection Heuristics:
+/// This method performs sequential extraction over candidate mutations. When routing complex
+/// multi-mutation commit requests in [`LocationRouter`], specialized selection heuristics
+/// (such as prioritizing non-insert mutations or selecting the largest insert mutation)
+/// may be evaluated prior to calling this extraction helper.
+pub(crate) fn extract_mutations_routing_key<M: ExtractableMutation>(
+    key_recipe_cache: &KeyRecipeCache,
+    mutations: &[M],
+) -> Option<Vec<u8>> {
+    for mutation in mutations {
+        if let Some(routing_key) = extract_mutation_routing_key(key_recipe_cache, mutation) {
+            return Some(routing_key);
+        }
+    }
+    None
+}
+
 /// Resolves the table or index [`KeyRecipe`] from [`KeyRecipeCache`] and encodes the routing key for a read operation.
 ///
 /// If `index` is `Some` and non-empty, the index recipe is looked up; otherwise the table recipe is used.
@@ -136,6 +385,10 @@ mod tests {
     use crate::model::TypeCode;
     use crate::model::key_recipe::Part;
     use crate::model::key_recipe::part::{NullOrder, Order};
+    use crate::model::mutation::{
+        Ack as ProtoAck, Delete as ProtoDelete, Send as ProtoSend, Write as ProtoWrite,
+    };
+    use crate::model::{KeyRange as ProtoKeyRange, KeySet as ProtoKeySet};
     use crate::routing::key_recipe::encode_key_from_recipe;
     use crate::value::ToValue;
 
@@ -479,5 +732,527 @@ mod tests {
         let expected_key = encode_key_from_recipe(&index_recipe, &["acc_888".to_value()])
             .expect("direct encoding should succeed");
         assert_eq!(routing_key, expected_key);
+    }
+
+    fn sample_table_recipe_with_identifiers(
+        table_name: &str,
+        parts: Vec<(Part, &str)>,
+    ) -> KeyRecipe {
+        let mut all_parts = vec![Part::new().set_tag(50020_u32), Part::new().set_tag(1_u32)];
+        for (part, identifier) in parts {
+            all_parts.push(part.set_identifier(identifier.to_string()));
+        }
+        KeyRecipe::new()
+            .set_table_name(table_name.to_string())
+            .set_part(all_parts)
+    }
+
+    #[test]
+    fn extract_key_from_mutation_insert_case_insensitive_and_reordered() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![
+                (int64_part(Order::Ascending), "user_id"),
+                (string_part(Order::Ascending), "user_name"),
+            ],
+        );
+        let mutation = Mutation::new_insert_builder("Users")
+            .set("ExtraCol")
+            .to("extra")
+            .set("USER_NAME")
+            .to("Alice")
+            .set("USER_ID")
+            .to(1001_i64)
+            .build();
+
+        let routing_key = extract_key_from_mutation(&recipe, &mutation)
+            .expect("extraction should succeed")
+            .expect("should return some routing key");
+
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(
+            &recipe,
+            &[1001_i64.to_value(), "Alice".to_value()],
+            &mut expected_key,
+        )
+        .expect("direct encoding should succeed");
+
+        assert_eq!(routing_key, expected_key);
+    }
+
+    #[test]
+    fn extract_key_from_mutation_update_and_replace() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "k")],
+        );
+
+        let update_mutation = Mutation::new_update_builder("Users")
+            .set("k")
+            .to(80_i64)
+            .set("v")
+            .to("val")
+            .build();
+        let update_key = extract_key_from_mutation(&recipe, &update_mutation)
+            .expect("update extraction should succeed")
+            .expect("should return routing key");
+
+        let replace_mutation = Mutation::new_replace_builder("Users")
+            .set("k")
+            .to(80_i64)
+            .build();
+        let replace_key = extract_key_from_mutation(&recipe, &replace_mutation)
+            .expect("replace extraction should succeed")
+            .expect("should return routing key");
+
+        let insert_or_update_mutation = Mutation::new_insert_or_update_builder("Users")
+            .set("k")
+            .to(80_i64)
+            .build();
+        let insert_or_update_key = extract_key_from_mutation(&recipe, &insert_or_update_mutation)
+            .expect("insert_or_update extraction should succeed")
+            .expect("should return routing key");
+
+        assert_eq!(update_key, replace_key);
+        assert_eq!(update_key, insert_or_update_key);
+    }
+
+    #[test]
+    fn extract_key_from_mutation_delete() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "k")],
+        );
+        let mutation = Mutation::delete("Users", KeySet::from(key![80_i64]));
+
+        let routing_key = extract_key_from_mutation(&recipe, &mutation)
+            .expect("delete extraction should succeed")
+            .expect("should return routing key");
+
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[80_i64.to_value()], &mut expected_key)
+            .expect("direct encoding should succeed");
+        assert_eq!(routing_key, expected_key);
+    }
+
+    #[test]
+    fn extract_key_from_mutation_missing_column_returns_error() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![
+                (int64_part(Order::Ascending), "user_id"),
+                (string_part(Order::Ascending), "user_name"),
+            ],
+        );
+        let mutation = Mutation::new_insert_builder("Users")
+            .set("user_id")
+            .to(1001_i64)
+            .build();
+
+        let result = extract_key_from_mutation(&recipe, &mutation);
+        assert!(result.is_err(), "missing key column should return Err");
+    }
+
+    #[test]
+    fn extract_mutations_routing_key_first_eligible_mutation() {
+        let cache = KeyRecipeCache::new();
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "user_id")],
+        );
+        cache.insert(recipe.clone());
+
+        // First mutation is for an uncached table, second is for cached "Users".
+        let mutation1 = Mutation::new_insert_builder("UncachedTable")
+            .set("id")
+            .to(1)
+            .build();
+        let mutation2 = Mutation::new_insert_builder("Users")
+            .set("user_id")
+            .to(2002_i64)
+            .build();
+
+        let routing_key = extract_mutations_routing_key(&cache, &[mutation1, mutation2])
+            .expect("should extract key from second eligible mutation");
+
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[2002_i64.to_value()], &mut expected_key)
+            .expect("direct encoding should succeed");
+        assert_eq!(routing_key, expected_key);
+    }
+
+    #[test]
+    fn extract_key_from_proto_mutation_write() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "SimpleMutations",
+            vec![(int64_part(Order::Ascending), "k")],
+        );
+
+        let mut write = ProtoWrite::new();
+        write.table = "SimpleMutations".to_string();
+        write.columns = vec!["k".to_string()];
+        let row = vec![serde_json::Value::String("80".to_string())];
+        write.values = vec![row];
+
+        let proto_mutation = ProtoMutation::new().set_insert(write);
+
+        let routing_key = extract_key_from_proto_mutation(&recipe, &proto_mutation)
+            .expect("proto extraction should succeed")
+            .expect("should return routing key");
+
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[80_i64.to_value()], &mut expected_key)
+            .expect("direct encoding should succeed");
+        assert_eq!(routing_key, expected_key);
+    }
+
+    #[test]
+    fn extract_mutations_routing_key_proto() {
+        let cache = KeyRecipeCache::new();
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "user_id")],
+        );
+        cache.insert(recipe.clone());
+
+        let mut write1 = ProtoWrite::new();
+        write1.table = "UncachedTable".to_string();
+        write1.columns = vec!["id".to_string()];
+        write1.values = vec![vec![serde_json::json!(1)]];
+
+        let mut write2 = ProtoWrite::new();
+        write2.table = "Users".to_string();
+        write2.columns = vec!["user_id".to_string()];
+        write2.values = vec![vec![serde_json::Value::String("2002".to_string())]];
+
+        let mutation1 = ProtoMutation::new().set_insert(write1);
+        let mutation2 = ProtoMutation::new().set_insert(write2);
+
+        let routing_key = extract_mutations_routing_key(&cache, &[mutation1, mutation2])
+            .expect("should extract key from second eligible proto mutation");
+
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[2002_i64.to_value()], &mut expected_key)
+            .expect("direct encoding should succeed");
+        assert_eq!(routing_key, expected_key);
+    }
+
+    #[test]
+    fn extract_mutation_table_name_all_operations() {
+        let insert_mutation = Mutation::new_insert_builder("Users")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_table_name(&insert_mutation), "Users");
+
+        let update_mutation = Mutation::new_update_builder("Orders")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_table_name(&update_mutation), "Orders");
+
+        let insert_or_update = Mutation::new_insert_or_update_builder("Items")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_table_name(&insert_or_update), "Items");
+
+        let replace_mutation = Mutation::new_replace_builder("Products")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_table_name(&replace_mutation), "Products");
+
+        let delete_mutation = Mutation::delete("Accounts", KeySet::all());
+        assert_eq!(extract_mutation_table_name(&delete_mutation), "Accounts");
+    }
+
+    #[test]
+    fn extract_proto_mutation_table_name_all_operations() {
+        let mut write = ProtoWrite::new();
+        write.table = "Users".to_string();
+        let insert_mutation = ProtoMutation::new().set_insert(write.clone());
+        assert_eq!(
+            extract_proto_mutation_table_name(&insert_mutation),
+            Some("Users")
+        );
+
+        let update_mutation = ProtoMutation::new().set_update(write.clone());
+        assert_eq!(
+            extract_proto_mutation_table_name(&update_mutation),
+            Some("Users")
+        );
+
+        let insert_or_update = ProtoMutation::new().set_insert_or_update(write.clone());
+        assert_eq!(
+            extract_proto_mutation_table_name(&insert_or_update),
+            Some("Users")
+        );
+
+        let replace_mutation = ProtoMutation::new().set_replace(write);
+        assert_eq!(
+            extract_proto_mutation_table_name(&replace_mutation),
+            Some("Users")
+        );
+
+        let mut delete = ProtoDelete::new();
+        delete.table = "Accounts".to_string();
+        let delete_mutation = ProtoMutation::new().set_delete(delete);
+        assert_eq!(
+            extract_proto_mutation_table_name(&delete_mutation),
+            Some("Accounts")
+        );
+
+        let mut send = ProtoSend::new();
+        send.queue = "MyQueue".to_string();
+        let send_mutation = ProtoMutation::new().set_send(send);
+        assert_eq!(
+            extract_proto_mutation_table_name(&send_mutation),
+            Some("MyQueue")
+        );
+
+        let mut ack = ProtoAck::new();
+        ack.queue = "MyAckQueue".to_string();
+        let ack_mutation = ProtoMutation::new().set_ack(ack);
+        assert_eq!(
+            extract_proto_mutation_table_name(&ack_mutation),
+            Some("MyAckQueue")
+        );
+
+        let empty_mutation = ProtoMutation::new();
+        assert_eq!(extract_proto_mutation_table_name(&empty_mutation), None);
+    }
+
+    #[test]
+    fn extract_key_from_mutation_delete_ranges_and_all() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "k")],
+        );
+
+        // Delete all returns Ok(None)
+        let delete_all = Mutation::delete("Users", KeySet::all());
+        assert_eq!(
+            extract_key_from_mutation(&recipe, &delete_all).expect("delete all should succeed"),
+            None
+        );
+
+        // Delete empty KeySet returns Ok(None)
+        let delete_empty = Mutation::delete("Users", KeySet::builder().build());
+        assert_eq!(
+            extract_key_from_mutation(&recipe, &delete_empty).expect("delete empty should succeed"),
+            None
+        );
+
+        // Delete closed_open range
+        let delete_closed_open = Mutation::delete(
+            "Users",
+            KeySet::builder()
+                .add_range(KeyRange::closed_open(key![100_i64], key![200_i64]))
+                .build(),
+        );
+        let key = extract_key_from_mutation(&recipe, &delete_closed_open)
+            .expect("delete closed_open should succeed")
+            .expect("should return key");
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[100_i64.to_value()], &mut expected_key)
+            .expect("direct encode should succeed");
+        assert_eq!(key, expected_key);
+
+        // Delete open_closed range
+        let delete_open_closed = Mutation::delete(
+            "Users",
+            KeySet::builder()
+                .add_range(KeyRange::open_closed(key![100_i64], key![200_i64]))
+                .build(),
+        );
+        let key = extract_key_from_mutation(&recipe, &delete_open_closed)
+            .expect("delete open_closed should succeed")
+            .expect("should return key");
+        assert_eq!(key, expected_key);
+
+        // High-level write mutation with empty columns/values returns Ok(None)
+        let empty_insert = Mutation::new_insert_builder("Users").build();
+        assert_eq!(
+            extract_key_from_mutation(&recipe, &empty_insert)
+                .expect("empty high-level write should succeed"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_key_from_proto_mutation_edge_cases() {
+        let recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(int64_part(Order::Ascending), "k")],
+        );
+
+        // Proto write with empty values returns Ok(None)
+        let mut write_empty_values = ProtoWrite::new();
+        write_empty_values.table = "Users".to_string();
+        write_empty_values.columns = vec!["k".to_string()];
+        write_empty_values.values = vec![];
+        let proto_empty = ProtoMutation::new().set_insert(write_empty_values);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_empty)
+                .expect("empty write values should succeed"),
+            None
+        );
+
+        // Proto write with empty first row returns Ok(None)
+        let mut write_empty_first_row = ProtoWrite::new();
+        write_empty_first_row.table = "Users".to_string();
+        write_empty_first_row.columns = vec!["k".to_string()];
+        write_empty_first_row.values = vec![vec![]];
+        let proto_empty_row = ProtoMutation::new().set_insert(write_empty_first_row);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_empty_row)
+                .expect("empty first row should succeed"),
+            None
+        );
+
+        // Proto delete with None key_set returns Ok(None)
+        let mut delete_no_keyset = ProtoDelete::new();
+        delete_no_keyset.table = "Users".to_string();
+        let proto_delete_no_keyset = ProtoMutation::new().set_delete(delete_no_keyset);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_delete_no_keyset)
+                .expect("delete without keyset should succeed"),
+            None
+        );
+
+        // Proto delete with all: true returns Ok(None)
+        let mut delete_all = ProtoDelete::new();
+        delete_all.table = "Users".to_string();
+        let mut keyset_all = ProtoKeySet::new();
+        keyset_all.all = true;
+        delete_all.key_set = Some(keyset_all);
+        let proto_delete_all = ProtoMutation::new().set_delete(delete_all);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_delete_all)
+                .expect("delete all should succeed"),
+            None
+        );
+
+        // Proto delete with ranges start_closed
+        let mut delete_range = ProtoDelete::new();
+        delete_range.table = "Users".to_string();
+        let mut keyset_range = ProtoKeySet::new();
+        let proto_range = ProtoKeyRange::new()
+            .set_start_closed(vec![serde_json::Value::String("50".to_string())]);
+        keyset_range.ranges = vec![proto_range];
+        delete_range.key_set = Some(keyset_range);
+        let proto_delete_range = ProtoMutation::new().set_delete(delete_range);
+        let key = extract_key_from_proto_mutation(&recipe, &proto_delete_range)
+            .expect("delete range start_closed should succeed")
+            .expect("should return key");
+        let mut expected_key = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[50_i64.to_value()], &mut expected_key)
+            .expect("direct encode should succeed");
+        assert_eq!(key, expected_key);
+
+        // Proto delete with ranges start_open
+        let mut delete_range_open = ProtoDelete::new();
+        delete_range_open.table = "Users".to_string();
+        let mut keyset_range_open = ProtoKeySet::new();
+        let proto_range_open =
+            ProtoKeyRange::new().set_start_open(vec![serde_json::Value::String("60".to_string())]);
+        keyset_range_open.ranges = vec![proto_range_open];
+        delete_range_open.key_set = Some(keyset_range_open);
+        let proto_delete_range_open = ProtoMutation::new().set_delete(delete_range_open);
+        let key = extract_key_from_proto_mutation(&recipe, &proto_delete_range_open)
+            .expect("delete range start_open should succeed")
+            .expect("should return key");
+        let mut expected_key_open = Vec::new();
+        encode_key_from_recipe_into(&recipe, &[60_i64.to_value()], &mut expected_key_open)
+            .expect("direct encode should succeed");
+        assert_eq!(key, expected_key_open);
+
+        // Proto Send with None key returns Ok(None)
+        let mut send_none = ProtoSend::new();
+        send_none.queue = "Queue".to_string();
+        let proto_send_none = ProtoMutation::new().set_send(send_none);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_send_none)
+                .expect("send without key should succeed"),
+            None
+        );
+
+        // Proto Send with empty key returns Ok(None)
+        let mut send_empty = ProtoSend::new();
+        send_empty.queue = "Queue".to_string();
+        send_empty.key = Some(vec![]);
+        let proto_send_empty = ProtoMutation::new().set_send(send_empty);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_send_empty)
+                .expect("send with empty key should succeed"),
+            None
+        );
+
+        // Proto Ack with None key returns Ok(None)
+        let mut ack_none = ProtoAck::new();
+        ack_none.queue = "Queue".to_string();
+        let proto_ack_none = ProtoMutation::new().set_ack(ack_none);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_ack_none)
+                .expect("ack without key should succeed"),
+            None
+        );
+
+        // Proto Ack with empty key returns Ok(None)
+        let mut ack_empty = ProtoAck::new();
+        ack_empty.queue = "Queue".to_string();
+        ack_empty.key = Some(vec![]);
+        let proto_ack_empty = ProtoMutation::new().set_ack(ack_empty);
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_ack_empty)
+                .expect("ack with empty key should succeed"),
+            None
+        );
+
+        // Proto mutation with operation == None returns Ok(None)
+        let proto_empty_op = ProtoMutation::new();
+        assert_eq!(
+            extract_key_from_proto_mutation(&recipe, &proto_empty_op)
+                .expect("empty operation should succeed"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_mutation_routing_key_edge_cases() {
+        let cache = KeyRecipeCache::new();
+
+        // Empty mutations slice returns None
+        let empty_mutations: Vec<Mutation> = Vec::new();
+        assert_eq!(
+            extract_mutations_routing_key(&cache, &empty_mutations),
+            None
+        );
+
+        // Mutation for uncached table returns None
+        let mutation = Mutation::new_insert_builder("Uncached")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_routing_key(&cache, &mutation), None);
+
+        // Mutation for cached table with encoding error returns None
+        let unsupported_recipe = sample_table_recipe_with_identifiers(
+            "Users",
+            vec![(
+                Part::new()
+                    .set_order(Order::Ascending)
+                    .set_null_order(NullOrder::NotNull)
+                    .set_type(Type::default().set_code(TypeCode::Array)),
+                "id",
+            )],
+        );
+        cache.insert(unsupported_recipe);
+        let user_mutation = Mutation::new_insert_builder("Users")
+            .set("id")
+            .to(1)
+            .build();
+        assert_eq!(extract_mutation_routing_key(&cache, &user_mutation), None);
     }
 }

--- a/src/spanner/src/routing/key_recipe.rs
+++ b/src/spanner/src/routing/key_recipe.rs
@@ -51,21 +51,72 @@ pub(crate) fn encode_key_from_recipe(recipe: &KeyRecipe, values: &[Value]) -> Re
     Ok(buffer)
 }
 
-/// Encodes a Spanner routing key from a [`KeyRecipe`] and a slice of column [`Value`]s directly
-/// into an existing output buffer.
+/// Trait abstracting over typed [`Value`] and raw JSON [`serde_json::Value`] for recipe encoding.
+pub(crate) trait RecipeValue: Sized {
+    /// Resolves nested struct fields based on `struct_identifiers`.
+    fn resolve_field(&self, struct_identifiers: &[i32]) -> Result<&Self>;
+
+    /// Encodes this value according to the recipe part specification.
+    fn encode_into(&self, buffer: &mut Vec<u8>, part: &Part) -> Result<()>;
+}
+
+impl RecipeValue for Value {
+    fn resolve_field(&self, struct_identifiers: &[i32]) -> Result<&Self> {
+        resolve_struct_field(self, struct_identifiers)
+    }
+
+    fn encode_into(&self, buffer: &mut Vec<u8>, part: &Part) -> Result<()> {
+        encode_part(buffer, part, self)
+    }
+}
+
+impl RecipeValue for serde_json::Value {
+    fn resolve_field(&self, struct_identifiers: &[i32]) -> Result<&Self> {
+        resolve_struct_field_json(self, struct_identifiers)
+    }
+
+    fn encode_into(&self, buffer: &mut Vec<u8>, part: &Part) -> Result<()> {
+        encode_json_part(buffer, part, self)
+    }
+}
+
+enum PreambleResult {
+    Handled,
+    ValuePart,
+}
+
+/// Encodes composite tags, random sharding tags, or literal constant parts if present.
+fn encode_recipe_part_preamble(part: &Part, buffer: &mut Vec<u8>) -> Result<PreambleResult> {
+    if part.tag != 0 {
+        ssformat::append_composite_tag(buffer, part.tag)?;
+        return Ok(PreambleResult::Handled);
+    }
+    if part.random() == Some(&true) {
+        let decreasing = matches!(part.order, Order::Descending);
+        encode_random_part(buffer, part, decreasing)?;
+        return Ok(PreambleResult::Handled);
+    }
+    if let Some(constant_val) = part.value() {
+        let resolved_value = resolve_struct_field_json(constant_val, &part.struct_identifiers)?;
+        encode_json_part(buffer, part, resolved_value)?;
+        return Ok(PreambleResult::Handled);
+    }
+    Ok(PreambleResult::ValuePart)
+}
+
+/// Generic encoder from a positional slice of values into `buffer`.
 ///
-/// This avoids new `Vec<u8>` heap allocations when callers reuse a scratch buffer across RPCs
-/// on the Spanner Omni hot path.
-///
-/// # Caller Fallback Contract
-/// If encoding returns an error (for example, due to an unsupported key column type like `NUMERIC`
-/// or `FLOAT32`), callers (`LocationRouter` / `DatabaseClient`) MUST catch the error and silently
-/// fall back to default routing (without tablet affinity) rather than failing the user's RPC.
-pub(crate) fn encode_key_from_recipe_into(
+/// Iterates sequentially through each part of the recipe:
+/// 1. Validates the recipe structure (non-empty and starting with a table or index tag).
+/// 2. Evaluates the preamble for each part (composite tags, random root tags, or constant literals).
+/// 3. For column value parts, draws the next value positionally from `values` and encodes it.
+/// 4. If any step fails, restores `buffer` to its initial length before returning the error.
+fn encode_key_from_slice_into<V: RecipeValue>(
     recipe: &KeyRecipe,
-    values: &[Value],
+    values: &[V],
     buffer: &mut Vec<u8>,
 ) -> Result<()> {
+    // 1. Validate recipe structure.
     if recipe.part.is_empty() {
         return Err(internal_error(
             "Invalid KeyRecipe: must have at least one part",
@@ -81,41 +132,19 @@ pub(crate) fn encode_key_from_recipe_into(
     let mut values_iter = values.iter();
 
     for part in &recipe.part {
-        if part.tag != 0 {
-            if let Err(e) = ssformat::append_composite_tag(buffer, part.tag) {
+        // 2. Handle composite tags, random sharding tags, or constant JSON literals.
+        match encode_recipe_part_preamble(part, buffer) {
+            Ok(PreambleResult::Handled) => continue,
+            Ok(PreambleResult::ValuePart) => {}
+            Err(error) => {
                 buffer.truncate(initial_len);
-                return Err(e);
+                return Err(error);
             }
-            continue;
         }
 
-        if part.random() == Some(&true) {
-            let decreasing = matches!(part.order, Order::Descending);
-            if let Err(e) = encode_random_part(buffer, part, decreasing) {
-                buffer.truncate(initial_len);
-                return Err(e);
-            }
-            continue;
-        }
-
-        if let Some(constant_val) = part.value() {
-            let resolved_value =
-                match resolve_struct_field_json(constant_val, &part.struct_identifiers) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        buffer.truncate(initial_len);
-                        return Err(e);
-                    }
-                };
-            if let Err(e) = encode_json_part(buffer, part, resolved_value) {
-                buffer.truncate(initial_len);
-                return Err(e);
-            }
-            continue;
-        }
-
+        // 3. Take the next value positionally for this column part.
         let value = match values_iter.next() {
-            Some(v) => v,
+            Some(value) => value,
             None => {
                 buffer.truncate(initial_len);
                 return Err(internal_error(
@@ -124,13 +153,30 @@ pub(crate) fn encode_key_from_recipe_into(
             }
         };
 
-        if let Err(e) = encode_part(buffer, part, value) {
+        // 4. Encode the value according to the part's type, sort order, and null ordering.
+        if let Err(error) = value.encode_into(buffer, part) {
             buffer.truncate(initial_len);
-            return Err(e);
+            return Err(error);
         }
     }
 
     Ok(())
+}
+
+/// Encodes a Spanner routing key from a [`KeyRecipe`] and key values directly into an existing output buffer.
+///
+/// This avoids new heap allocations when callers reuse a scratch buffer across RPCs on hot paths.
+///
+/// # Caller Fallback Contract
+/// If encoding returns an error (for example, due to an unsupported key column type like `NUMERIC`
+/// or `FLOAT32`), callers (`LocationRouter` / `DatabaseClient`) MUST catch the error and silently
+/// fall back to default routing (without tablet affinity) rather than failing the user's RPC.
+pub(crate) fn encode_key_from_recipe_into(
+    recipe: &KeyRecipe,
+    values: &[Value],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    encode_key_from_slice_into(recipe, values, buffer)
 }
 
 /// Encodes a Spanner routing key (`Vec<u8>`) from a SQL [`KeyRecipe`] and query parameters.
@@ -188,24 +234,150 @@ pub(crate) fn encode_key_from_query_params_into(
     let initial_len = buffer.len();
 
     for part in &recipe.part {
-        // In Spanner's KeyRecipe proto definition, `tag` is a u32:
-        // - Non-zero tag (> 0): composite tag identifying the table or index prefix namespace.
-        // - Zero tag (== 0): key column value to be extracted from query parameters and encoded.
-        if part.tag != 0 {
-            if let Err(e) = ssformat::append_composite_tag(buffer, part.tag) {
+        match encode_recipe_part_preamble(part, buffer) {
+            Ok(PreambleResult::Handled) => continue,
+            Ok(PreambleResult::ValuePart) => {}
+            Err(error) => {
                 buffer.truncate(initial_len);
-                return Err(e);
+                return Err(error);
             }
-            continue;
         }
 
-        if let Err(e) = encode_query_part(buffer, part, params) {
+        if let Err(error) = encode_query_part(buffer, part, params) {
             buffer.truncate(initial_len);
-            return Err(e);
+            return Err(error);
         }
     }
 
     Ok(())
+}
+
+/// Generic encoder matching key column identifiers against column names and encoding values into `buffer`.
+///
+/// Evaluates each part of the recipe in order:
+/// 1. Validates the recipe structure (non-empty and starting with a table or index tag).
+/// 2. Evaluates the preamble for each part (composite tags, random root tags, or constant literals).
+/// 3. Looks up the column name in `columns` case-insensitively using the recipe part's identifier.
+/// 4. Retrieves the corresponding value from `values` at the resolved column index.
+/// 5. Drills down into nested struct fields if `part.struct_identifiers` is present.
+/// 6. Encodes the resolved value into `buffer` (handling sort order and null ordering).
+/// 7. If any step fails, restores `buffer` to its initial length before returning the error.
+fn encode_key_from_column_values_into<V: RecipeValue>(
+    recipe: &KeyRecipe,
+    columns: &[impl AsRef<str>],
+    values: &[V],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    // 1. Validate recipe structure.
+    if recipe.part.is_empty() {
+        return Err(internal_error(
+            "Invalid KeyRecipe: must have at least one part",
+        ));
+    }
+    if recipe.part[0].tag == 0 {
+        return Err(internal_error(
+            "Invalid KeyRecipe: must start with a table or index tag",
+        ));
+    }
+
+    let initial_len = buffer.len();
+
+    for part in &recipe.part {
+        // 2. Handle composite tags, random sharding tags, or constant JSON literals.
+        match encode_recipe_part_preamble(part, buffer) {
+            Ok(PreambleResult::Handled) => continue,
+            Ok(PreambleResult::ValuePart) => {}
+            Err(error) => {
+                buffer.truncate(initial_len);
+                return Err(error);
+            }
+        }
+
+        // 3. Extract the column identifier specified by this key recipe part.
+        let identifier = match part.identifier() {
+            Some(id) => id,
+            None => {
+                buffer.truncate(initial_len);
+                return Err(internal_error(
+                    "Invalid KeyRecipe part: missing column identifier",
+                ));
+            }
+        };
+
+        // 4. Find the column position in the mutation columns (case-insensitive matching).
+        let column_index = match columns
+            .iter()
+            .position(|column| column.as_ref().eq_ignore_ascii_case(identifier))
+        {
+            Some(index) => index,
+            None => {
+                buffer.truncate(initial_len);
+                return Err(internal_error(format!(
+                    "Missing key column '{identifier}' in mutation columns"
+                )));
+            }
+        };
+
+        // 5. Retrieve the value corresponding to the matched column.
+        let column_value = match values.get(column_index) {
+            Some(value) => value,
+            None => {
+                buffer.truncate(initial_len);
+                return Err(internal_error(format!(
+                    "Missing value at column index {column_index} for key column '{identifier}'"
+                )));
+            }
+        };
+
+        // 6. Traverse into nested struct fields if struct_identifiers path is specified.
+        let resolved_value = match column_value.resolve_field(&part.struct_identifiers) {
+            Ok(value) => value,
+            Err(error) => {
+                buffer.truncate(initial_len);
+                return Err(error);
+            }
+        };
+
+        // 7. Encode the resolved value into the buffer according to type, order, and null ordering.
+        if let Err(error) = resolved_value.encode_into(buffer, part) {
+            buffer.truncate(initial_len);
+            return Err(error);
+        }
+    }
+
+    Ok(())
+}
+
+/// Encodes a Spanner routing key from a [`KeyRecipe`], a column name slice, and row [`Value`]s.
+///
+/// Matches key column identifiers against mutation columns case-insensitively and encodes
+/// the resulting primary key into `buffer`.
+pub(crate) fn encode_key_from_columns_and_values_into(
+    recipe: &KeyRecipe,
+    columns: &[impl AsRef<str>],
+    values: &[Value],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    encode_key_from_column_values_into(recipe, columns, values, buffer)
+}
+
+/// Encodes a Spanner routing key from a [`KeyRecipe`], a column name slice, and row [`serde_json::Value`]s.
+pub(crate) fn encode_key_from_json_columns_and_values_into(
+    recipe: &KeyRecipe,
+    columns: &[impl AsRef<str>],
+    values: &[serde_json::Value],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    encode_key_from_column_values_into(recipe, columns, values, buffer)
+}
+
+/// Encodes a Spanner routing key from a [`KeyRecipe`] and a slice of raw [`serde_json::Value`]s.
+pub(crate) fn encode_key_from_json_recipe_into(
+    recipe: &KeyRecipe,
+    values: &[serde_json::Value],
+    buffer: &mut Vec<u8>,
+) -> Result<()> {
+    encode_key_from_slice_into(recipe, values, buffer)
 }
 
 /// Evaluates a single query recipe part against query parameters and appends it to `buffer`.
@@ -214,24 +386,7 @@ fn encode_query_part(
     part: &Part,
     params: &BTreeMap<String, Value>,
 ) -> Result<()> {
-    let decreasing = matches!(part.order, Order::Descending);
-
-    // 1. Random partition root tag:
-    // In Spanner tables/queries with distributed random root sharding, the client router
-    // generates a pseudo-random positive 63-bit integer to pick a candidate root tablet.
-    if part.random() == Some(&true) {
-        return encode_random_part(buffer, part, decreasing);
-    }
-
-    // 2. Constant literal value:
-    // Some recipes embed hardcoded literal constants directly in the schema definition.
-    // Borrows directly from &serde_json::Value with zero allocations and full 64-bit integer precision.
-    if let Some(constant_val) = part.value() {
-        let resolved_value = resolve_struct_field_json(constant_val, &part.struct_identifiers)?;
-        return encode_json_part(buffer, part, resolved_value);
-    }
-
-    // 3. Resolve root parameter by identifier (case-insensitive lookup matching Spanner SQL semantics):
+    // 1. Resolve root parameter by identifier (case-insensitive lookup matching Spanner SQL semantics):
     let identifier = part
         .identifier()
         .ok_or_else(|| internal_error("Invalid KeyRecipe part: missing parameter identifier"))?;
@@ -242,10 +397,10 @@ fn encode_query_part(
         ))
     })?;
 
-    // 4. Drill down into nested struct fields if struct_identifiers is present:
+    // 2. Drill down into nested struct fields if struct_identifiers is present:
     let resolved_value = resolve_struct_field(param_value, &part.struct_identifiers)?;
 
-    // 5. Encode the resolved column value (handling sort order, null ordering, and type serialization):
+    // 3. Encode the resolved column value (handling sort order, null ordering, and type serialization):
     encode_part(buffer, part, resolved_value)
 }
 
@@ -308,14 +463,62 @@ fn encode_json_part(buffer: &mut Vec<u8>, part: &Part, value: &serde_json::Value
 
     match *type_code {
         TypeCode::Bool => encode_json_bool_part(buffer, value, decreasing),
-        TypeCode::Int64 => encode_json_int64_part(buffer, value, decreasing),
+        TypeCode::Int64 | TypeCode::Enum => encode_json_int64_part(buffer, value, decreasing),
         TypeCode::Float64 => encode_json_float64_part(buffer, value, decreasing),
         TypeCode::String => encode_json_string_part(buffer, value, decreasing),
         TypeCode::Bytes => encode_json_bytes_part(buffer, value, decreasing),
+        TypeCode::Date => encode_json_date_part(buffer, value, decreasing),
+        TypeCode::Timestamp => encode_json_timestamp_part(buffer, value, decreasing),
+        TypeCode::Uuid => encode_json_uuid_part(buffer, value, decreasing),
         ref other => Err(internal_error(format!(
             "Unsupported TypeCode {other:?} for key recipe encoding",
         ))),
     }
+}
+
+/// Helper to extract a string value from a [`serde_json::Value`] and parse it.
+fn encode_json_parsed_string<T>(
+    value: &serde_json::Value,
+    type_name: &str,
+    parse: impl FnOnce(&str) -> Result<T>,
+) -> Result<T> {
+    let string_value = value.as_str().ok_or_else(|| {
+        internal_error(format!(
+            "Type mismatch: expected String value for {type_name} column"
+        ))
+    })?;
+    parse(string_value)
+}
+
+/// Evaluates a date constant JSON value (`DATE`).
+fn encode_json_date_part(
+    buffer: &mut Vec<u8>,
+    value: &serde_json::Value,
+    decreasing: bool,
+) -> Result<()> {
+    let days_since_epoch = encode_json_parsed_string(value, "DATE", temporal::parse_date_days)?;
+    append_int64_ordered(buffer, days_since_epoch, decreasing)
+}
+
+/// Evaluates a timestamp constant JSON value (`TIMESTAMP`).
+fn encode_json_timestamp_part(
+    buffer: &mut Vec<u8>,
+    value: &serde_json::Value,
+    decreasing: bool,
+) -> Result<()> {
+    let timestamp_bytes =
+        encode_json_parsed_string(value, "TIMESTAMP", temporal::parse_timestamp_bytes)?;
+    append_bytes_ordered(buffer, &timestamp_bytes, decreasing)
+}
+
+/// Evaluates a UUID constant JSON value (`UUID`).
+fn encode_json_uuid_part(
+    buffer: &mut Vec<u8>,
+    value: &serde_json::Value,
+    decreasing: bool,
+) -> Result<()> {
+    let uuid_bytes = encode_json_parsed_string(value, "UUID", uuid::parse_uuid_bytes)?;
+    append_bytes_ordered(buffer, &uuid_bytes, decreasing)
 }
 
 /// Evaluates a boolean constant JSON value (`BOOL`).
@@ -566,9 +769,9 @@ fn encode_int64_part(buffer: &mut Vec<u8>, value: &Value, decreasing: bool) -> R
     let string_value = value.try_as_string().ok_or_else(|| {
         internal_error("Type mismatch: expected String value for INT64 or ENUM column")
     })?;
-    let integer_value = string_value.parse::<i64>().map_err(|e| {
+    let integer_value = string_value.parse::<i64>().map_err(|error| {
         internal_error(format!(
-            "Failed to parse Int64 from string '{string_value}': {e}"
+            "Failed to parse Int64 from string '{string_value}': {error}"
         ))
     })?;
     append_int64_ordered(buffer, integer_value, decreasing)
@@ -577,7 +780,7 @@ fn encode_int64_part(buffer: &mut Vec<u8>, value: &Value, decreasing: bool) -> R
 /// Evaluates a floating-point column value (`FLOAT64`).
 fn encode_float64_part(buffer: &mut Vec<u8>, value: &Value, decreasing: bool) -> Result<()> {
     if let Some(string_value) = value.try_as_string() {
-        let num = match string_value {
+        let number = match string_value {
             "NaN" => f64::NAN,
             "Infinity" => f64::INFINITY,
             "-Infinity" => f64::NEG_INFINITY,
@@ -587,12 +790,12 @@ fn encode_float64_part(buffer: &mut Vec<u8>, value: &Value, decreasing: bool) ->
                 )));
             }
         };
-        return append_double_ordered(buffer, num, decreasing);
+        return append_double_ordered(buffer, number, decreasing);
     }
-    let num = value.try_as_f64().ok_or_else(|| {
+    let number = value.try_as_f64().ok_or_else(|| {
         internal_error("Type mismatch: expected Number or special String value for FLOAT64 column")
     })?;
-    append_double_ordered(buffer, num, decreasing)
+    append_double_ordered(buffer, number, decreasing)
 }
 
 /// Evaluates a string column value (`STRING`).
@@ -609,12 +812,12 @@ fn encode_bytes_part(buffer: &mut Vec<u8>, value: &Value, decreasing: bool) -> R
         internal_error("Type mismatch: expected base64 String value for BYTES column")
     })?;
     let mut stack_buffer = [0u8; 512];
-    if let Ok(len) = BASE64_STANDARD.decode_slice(string_value, &mut stack_buffer) {
-        return append_bytes_ordered(buffer, &stack_buffer[..len], decreasing);
+    if let Ok(length) = BASE64_STANDARD.decode_slice(string_value, &mut stack_buffer) {
+        return append_bytes_ordered(buffer, &stack_buffer[..length], decreasing);
     }
-    let bytes_value = BASE64_STANDARD.decode(string_value).map_err(|e| {
+    let bytes_value = BASE64_STANDARD.decode(string_value).map_err(|error| {
         internal_error(format!(
-            "Failed to decode base64 Bytes from string '{string_value}': {e}"
+            "Failed to decode base64 Bytes from string '{string_value}': {error}"
         ))
     })?;
     append_bytes_ordered(buffer, &bytes_value, decreasing)
@@ -2304,5 +2507,397 @@ mod tests {
                 .contains("TypeCode::Unspecified is not permitted"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn json_encoders_all_types_valid_and_invalid() {
+        // Int64 from string and number
+        let int64_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Int64));
+        let mut buffer = Vec::new();
+        encode_json_part(&mut buffer, &int64_part, &serde_json::json!("12345"))
+            .expect("int64 from string should succeed");
+        encode_json_part(&mut buffer, &int64_part, &serde_json::json!(67890))
+            .expect("int64 from number should succeed");
+        let error = encode_json_part(&mut buffer, &int64_part, &serde_json::json!(true))
+            .expect_err("int64 from bool should fail");
+        assert!(error.to_string().contains("expected String or Integer"));
+
+        // Bool
+        let bool_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Bool));
+        buffer.clear();
+        encode_json_part(&mut buffer, &bool_part, &serde_json::json!(true))
+            .expect("bool true should succeed");
+        let error = encode_json_part(&mut buffer, &bool_part, &serde_json::json!("not_a_bool"))
+            .expect_err("bool from string should fail");
+        assert!(error.to_string().contains("expected Bool"));
+
+        // Date
+        let date_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Date));
+        buffer.clear();
+        encode_json_part(&mut buffer, &date_part, &serde_json::json!("2026-08-17"))
+            .expect("valid date string should succeed");
+        let error = encode_json_part(&mut buffer, &date_part, &serde_json::json!("invalid-date"))
+            .expect_err("invalid date string should fail");
+        assert!(error.to_string().contains("Failed to parse DATE"));
+        let error = encode_json_part(&mut buffer, &date_part, &serde_json::json!(123))
+            .expect_err("date from number should fail");
+        assert!(error.to_string().contains("expected String value for DATE"));
+
+        // Timestamp
+        let timestamp_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Timestamp));
+        buffer.clear();
+        encode_json_part(
+            &mut buffer,
+            &timestamp_part,
+            &serde_json::json!("2026-08-17T12:00:00Z"),
+        )
+        .expect("valid timestamp string should succeed");
+        let error = encode_json_part(
+            &mut buffer,
+            &timestamp_part,
+            &serde_json::json!("invalid-timestamp"),
+        )
+        .expect_err("invalid timestamp string should fail");
+        assert!(error.to_string().contains("Failed to parse TIMESTAMP"));
+        let error = encode_json_part(&mut buffer, &timestamp_part, &serde_json::json!(123))
+            .expect_err("timestamp from number should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("expected String value for TIMESTAMP")
+        );
+
+        // Uuid
+        let uuid_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Uuid));
+        buffer.clear();
+        encode_json_part(
+            &mut buffer,
+            &uuid_part,
+            &serde_json::json!("123e4567-e89b-12d3-a456-426614174000"),
+        )
+        .expect("valid uuid string should succeed");
+        let error = encode_json_part(&mut buffer, &uuid_part, &serde_json::json!("invalid-uuid"))
+            .expect_err("invalid uuid string should fail");
+        assert!(error.to_string().contains("Invalid UUID string"));
+        let error = encode_json_part(&mut buffer, &uuid_part, &serde_json::json!(123))
+            .expect_err("uuid from number should fail");
+        assert!(error.to_string().contains("expected String value for UUID"));
+
+        // Enum
+        let enum_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Enum));
+        buffer.clear();
+        encode_json_part(&mut buffer, &enum_part, &serde_json::json!("42"))
+            .expect("enum from string should succeed");
+        encode_json_part(&mut buffer, &enum_part, &serde_json::json!(42))
+            .expect("enum from number should succeed");
+        let error = encode_json_part(&mut buffer, &enum_part, &serde_json::json!("invalid_enum"))
+            .expect_err("invalid enum string should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to parse Int64 from string")
+        );
+        let error = encode_json_part(&mut buffer, &enum_part, &serde_json::json!(true))
+            .expect_err("enum from bool should fail");
+        assert!(error.to_string().contains("expected String or Integer"));
+
+        // Float64
+        let float64_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Float64));
+        buffer.clear();
+        encode_json_part(&mut buffer, &float64_part, &serde_json::json!(123.456))
+            .expect("float64 number should succeed");
+        encode_json_part(&mut buffer, &float64_part, &serde_json::json!("NaN"))
+            .expect("float64 NaN string should succeed");
+        encode_json_part(&mut buffer, &float64_part, &serde_json::json!("Infinity"))
+            .expect("float64 Infinity string should succeed");
+        encode_json_part(&mut buffer, &float64_part, &serde_json::json!("-Infinity"))
+            .expect("float64 -Infinity string should succeed");
+        let error = encode_json_part(&mut buffer, &float64_part, &serde_json::json!("invalid"))
+            .expect_err("invalid float string should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Type mismatch: invalid FLOAT64 string")
+        );
+        let error = encode_json_part(&mut buffer, &float64_part, &serde_json::json!(true))
+            .expect_err("float from bool should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("expected Number or special String")
+        );
+
+        // String
+        let string_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::String));
+        buffer.clear();
+        encode_json_part(&mut buffer, &string_part, &serde_json::json!("hello"))
+            .expect("string should succeed");
+        let error = encode_json_part(&mut buffer, &string_part, &serde_json::json!(123))
+            .expect_err("string from number should fail");
+        assert!(error.to_string().contains("expected String value"));
+
+        // Bytes
+        let bytes_part = Part::new()
+            .set_order(Order::Ascending)
+            .set_null_order(NullOrder::NotNull)
+            .set_type(Type::default().set_code(TypeCode::Bytes));
+        buffer.clear();
+        let short_b64 = BASE64_STANDARD.encode(b"short");
+        encode_json_part(&mut buffer, &bytes_part, &serde_json::json!(short_b64))
+            .expect("short base64 bytes should succeed");
+        let long_bytes = vec![0xABu8; 600];
+        let long_b64 = BASE64_STANDARD.encode(&long_bytes);
+        encode_json_part(&mut buffer, &bytes_part, &serde_json::json!(long_b64))
+            .expect("long base64 bytes should succeed");
+        let error = encode_json_part(
+            &mut buffer,
+            &bytes_part,
+            &serde_json::json!("%%%invalid%%%"),
+        )
+        .expect_err("invalid base64 bytes string should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Failed to decode base64 Bytes from string")
+        );
+        let error = encode_json_part(&mut buffer, &bytes_part, &serde_json::json!(123))
+            .expect_err("bytes from number should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("expected base64 String value for BYTES")
+        );
+    }
+
+    #[test]
+    fn resolve_struct_field_json_valid_and_errors() {
+        let nested_json =
+            serde_json::json!(["first_field", ["nested_subfield_0", "nested_subfield_1"]]);
+
+        // Empty struct identifiers returns original value
+        let resolved = resolve_struct_field_json(&nested_json, &[])
+            .expect("empty struct identifiers should succeed");
+        assert_eq!(resolved, &nested_json);
+
+        // Path [1, 1] resolves to "nested_subfield_1"
+        let resolved = resolve_struct_field_json(&nested_json, &[1, 1])
+            .expect("nested struct field resolution should succeed");
+        assert_eq!(resolved, &serde_json::json!("nested_subfield_1"));
+
+        // Negative index returns Err
+        let error = resolve_struct_field_json(&nested_json, &[-1])
+            .expect_err("negative struct index should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid negative struct index -1")
+        );
+
+        // Out of bounds index returns Err
+        let error = resolve_struct_field_json(&nested_json, &[5])
+            .expect_err("out of bounds struct index should fail");
+        assert!(error.to_string().contains("out of bounds"));
+
+        // Non-array JSON value returns Err
+        let scalar_json = serde_json::json!("not_an_array");
+        let error = resolve_struct_field_json(&scalar_json, &[0])
+            .expect_err("struct field on scalar should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Expected Struct array for struct")
+        );
+    }
+
+    #[test]
+    fn encode_key_from_slice_into_validation_and_errors() {
+        let mut buffer = Vec::new();
+
+        // Empty recipe
+        let empty_recipe = KeyRecipe::new();
+        let error = encode_key_from_slice_into::<Value>(&empty_recipe, &[], &mut buffer)
+            .expect_err("empty recipe should fail");
+        assert!(error.to_string().contains("must have at least one part"));
+
+        // Recipe starting with tag 0
+        let invalid_recipe = KeyRecipe::new().set_part(vec![
+            Part::new().set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let error = encode_key_from_slice_into::<Value>(&invalid_recipe, &[], &mut buffer)
+            .expect_err("recipe without leading tag should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("must start with a table or index tag")
+        );
+
+        // Not enough values
+        let recipe = sample_recipe(vec![
+            Part::new()
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let values: Vec<Value> = Vec::new();
+        let error = encode_key_from_slice_into(&recipe, &values, &mut buffer)
+            .expect_err("not enough values should fail");
+        assert!(error.to_string().contains("Not enough column values"));
+
+        // Encoding failure rolls back buffer
+        buffer.extend_from_slice(b"prefix");
+        let initial_len = buffer.len();
+        let unsupported_recipe = sample_recipe(vec![
+            Part::new()
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Array)),
+        ]);
+        let values = vec![Value::null()];
+        let _ = encode_key_from_slice_into(&unsupported_recipe, &values, &mut buffer);
+        assert_eq!(buffer.len(), initial_len);
+    }
+
+    #[test]
+    fn encode_key_from_column_values_into_validation_and_errors() {
+        let mut buffer = Vec::new();
+
+        // Empty recipe
+        let empty_recipe = KeyRecipe::new();
+        let error = encode_key_from_column_values_into::<Value>(
+            &empty_recipe,
+            &["id"],
+            &[1_i64.to_value()],
+            &mut buffer,
+        )
+        .expect_err("empty recipe should fail");
+        assert!(error.to_string().contains("must have at least one part"));
+
+        // Recipe starting with tag 0
+        let invalid_recipe = KeyRecipe::new().set_part(vec![
+            Part::new().set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let error = encode_key_from_column_values_into::<Value>(
+            &invalid_recipe,
+            &["id"],
+            &[1_i64.to_value()],
+            &mut buffer,
+        )
+        .expect_err("recipe without leading tag should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("must start with a table or index tag")
+        );
+
+        // Missing column identifier in recipe part
+        let no_id_recipe = sample_recipe(vec![
+            Part::new()
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let error = encode_key_from_column_values_into::<Value>(
+            &no_id_recipe,
+            &["id"],
+            &[1_i64.to_value()],
+            &mut buffer,
+        )
+        .expect_err("part missing identifier should fail");
+        assert!(error.to_string().contains("missing column identifier"));
+
+        // Missing column in mutation columns
+        let id_recipe = sample_recipe(vec![
+            Part::new()
+                .set_identifier("user_id")
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let error = encode_key_from_column_values_into::<Value>(
+            &id_recipe,
+            &["wrong_column"],
+            &[1_i64.to_value()],
+            &mut buffer,
+        )
+        .expect_err("missing column in mutation should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Missing key column 'user_id' in mutation columns")
+        );
+
+        // Missing value at column index
+        let error =
+            encode_key_from_column_values_into::<Value>(&id_recipe, &["user_id"], &[], &mut buffer)
+                .expect_err("missing value at column index should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Missing value at column index 0")
+        );
+
+        // Struct traversal error
+        let struct_part_recipe = sample_recipe(vec![
+            Part::new()
+                .set_identifier("user_data")
+                .set_struct_identifiers(vec![0])
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Int64)),
+        ]);
+        let error = encode_key_from_column_values_into::<Value>(
+            &struct_part_recipe,
+            &["user_data"],
+            &[1_i64.to_value()],
+            &mut buffer,
+        )
+        .expect_err("struct traversal on scalar value should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Expected Struct ListValue for struct parameter traversal")
+        );
+
+        // Encoding failure rolls back buffer
+        buffer.extend_from_slice(b"prefix");
+        let initial_len = buffer.len();
+        let unsupported_recipe = sample_recipe(vec![
+            Part::new()
+                .set_identifier("user_id")
+                .set_order(Order::Ascending)
+                .set_null_order(NullOrder::NotNull)
+                .set_type(Type::default().set_code(TypeCode::Array)),
+        ]);
+        let _ = encode_key_from_column_values_into::<Value>(
+            &unsupported_recipe,
+            &["user_id"],
+            &[Value::null()],
+            &mut buffer,
+        );
+        assert_eq!(buffer.len(), initial_len);
     }
 }

--- a/src/spanner/src/routing/key_recipe/golden_tests.rs
+++ b/src/spanner/src/routing/key_recipe/golden_tests.rs
@@ -12,9 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::key::{Key, KeySet};
 use crate::model::key_recipe::Part;
 use crate::model::key_recipe::part::{NullOrder, Order};
-use crate::model::{KeyRecipe, Type, TypeCode};
+use crate::model::mutation::{
+    Ack as ProtoAck, Delete as ProtoDelete, Operation as ProtoOperation, Send as ProtoSend,
+    Write as ProtoWrite,
+};
+use crate::model::{
+    KeyRange as ProtoKeyRange, KeyRecipe, KeySet as ProtoKeySet, Mutation as ProtoMutation, Type,
+    TypeCode,
+};
+use crate::mutation::{Mutation, WriteBuilder};
+use crate::routing::key_extractor::{extract_key_from_mutation, extract_key_from_proto_mutation};
 use crate::routing::key_recipe::{encode_key_from_query_params, encode_key_from_recipe};
 use crate::value::{ToValue, Value};
 use std::collections::{BTreeMap, HashMap};
@@ -88,6 +98,7 @@ struct ParsedTestCase {
 struct ParsedTest {
     values: Vec<Value>,
     query_params: Option<BTreeMap<String, Value>>,
+    mutation: Option<ProtoMutation>,
     start: Vec<u8>,
     approximate: bool,
 }
@@ -193,21 +204,199 @@ fn parse_part_block<'a, I: Iterator<Item = &'a str>>(lines: &mut Peekable<I>) ->
     part
 }
 
+/// Consumes lines belonging to a `mutation { ... }` block inside a test block.
+fn parse_mutation_block<'a, I: Iterator<Item = &'a str>>(
+    lines: &mut Peekable<I>,
+) -> Option<ProtoMutation> {
+    let mutation = ProtoMutation::default();
+    let mut current_table = String::new();
+    let mut current_columns = Vec::new();
+    let mut current_rows = Vec::new();
+    let mut current_row_values = Vec::new();
+    let mut current_queue = String::new();
+    let mut current_key_values = Vec::new();
+    let mut delete_keys = Vec::new();
+    let mut delete_ranges = Vec::new();
+    let mut current_range_start_closed = Vec::new();
+    let mut current_range_start_open = Vec::new();
+    let mut delete_all = false;
+    let mut op_type = "";
+    let mut in_values_item = false;
+    let mut in_range_start_closed = false;
+    let mut in_range_start_open = false;
+    let mut in_delete_keys = false;
+    let mut in_key_block = false;
+    let mut depth = 1;
+
+    for line in lines.by_ref() {
+        let trimmed = line.trim();
+        if trimmed.ends_with('{') {
+            depth += 1;
+            if trimmed.starts_with("insert {") {
+                op_type = "insert";
+            } else if trimmed.starts_with("update {") {
+                op_type = "update";
+            } else if trimmed.starts_with("insert_or_update {") {
+                op_type = "insert_or_update";
+            } else if trimmed.starts_with("replace {") {
+                op_type = "replace";
+            } else if trimmed.starts_with("delete {") {
+                op_type = "delete";
+            } else if trimmed.starts_with("send {") {
+                op_type = "send";
+            } else if trimmed.starts_with("ack {") {
+                op_type = "ack";
+            } else if trimmed.starts_with("key {") {
+                in_key_block = true;
+            } else if trimmed.starts_with("keys {") {
+                in_delete_keys = true;
+            } else if trimmed.starts_with("start_closed {") {
+                in_range_start_closed = true;
+            } else if trimmed.starts_with("start_open {") {
+                in_range_start_open = true;
+            } else if trimmed.starts_with("values {") && depth >= 4 {
+                in_values_item = true;
+            }
+        } else if trimmed == "}" {
+            if in_values_item {
+                in_values_item = false;
+                if !current_row_values.is_empty() {
+                    current_rows.push(std::mem::take(&mut current_row_values));
+                }
+            } else if in_delete_keys {
+                in_delete_keys = false;
+                if !current_key_values.is_empty() {
+                    delete_keys.push(std::mem::take(&mut current_key_values));
+                }
+            } else if in_key_block && depth == 3 {
+                in_key_block = false;
+            } else if in_range_start_closed || in_range_start_open {
+                in_range_start_closed = false;
+                in_range_start_open = false;
+            } else if depth == 3
+                && op_type == "delete"
+                && (!current_range_start_closed.is_empty() || !current_range_start_open.is_empty())
+            {
+                let mut range = ProtoKeyRange::new();
+                if !current_range_start_closed.is_empty() {
+                    range = range.set_start_closed(std::mem::take(&mut current_range_start_closed));
+                }
+                if !current_range_start_open.is_empty() {
+                    range = range.set_start_open(std::mem::take(&mut current_range_start_open));
+                }
+                delete_ranges.push(range);
+            }
+            depth -= 1;
+            if depth == 0 {
+                break;
+            }
+        } else if let Some(table_value) = extract_value(trimmed, "table:") {
+            current_table = table_value.to_string();
+        } else if let Some(queue_value) = extract_value(trimmed, "queue:") {
+            current_queue = queue_value.to_string();
+        } else if let Some(column_value) = extract_value(trimmed, "columns:") {
+            current_columns.push(column_value.to_string());
+        } else if trimmed == "all: true" {
+            delete_all = true;
+        } else if let Some(string_value) = extract_value(trimmed, "string_value:") {
+            let json_val = serde_json::Value::String(string_value.to_string());
+            if in_range_start_closed {
+                current_range_start_closed.push(json_val);
+            } else if in_range_start_open {
+                current_range_start_open.push(json_val);
+            } else if in_delete_keys || in_key_block {
+                current_key_values.push(json_val);
+            } else if in_values_item {
+                current_row_values.push(json_val);
+            }
+        } else if let Some(number_string) = extract_value(trimmed, "number_value:")
+            && let Ok(number) = number_string.parse::<f64>()
+        {
+            let json_val = serde_json::json!(number);
+            if in_range_start_closed {
+                current_range_start_closed.push(json_val);
+            } else if in_range_start_open {
+                current_range_start_open.push(json_val);
+            } else if in_delete_keys || in_key_block {
+                current_key_values.push(json_val);
+            } else if in_values_item {
+                current_row_values.push(json_val);
+            }
+        }
+    }
+
+    match op_type {
+        "insert" => {
+            let mut write = ProtoWrite::new();
+            write.table = current_table;
+            write.columns = current_columns;
+            write.values = current_rows;
+            Some(ProtoMutation::new().set_insert(write))
+        }
+        "update" => {
+            let mut write = ProtoWrite::new();
+            write.table = current_table;
+            write.columns = current_columns;
+            write.values = current_rows;
+            Some(ProtoMutation::new().set_update(write))
+        }
+        "insert_or_update" => {
+            let mut write = ProtoWrite::new();
+            write.table = current_table;
+            write.columns = current_columns;
+            write.values = current_rows;
+            Some(ProtoMutation::new().set_insert_or_update(write))
+        }
+        "replace" => {
+            let mut write = ProtoWrite::new();
+            write.table = current_table;
+            write.columns = current_columns;
+            write.values = current_rows;
+            Some(ProtoMutation::new().set_replace(write))
+        }
+        "delete" => {
+            let mut delete = ProtoDelete::new();
+            delete.table = current_table;
+            let mut key_set = ProtoKeySet::new();
+            key_set.all = delete_all;
+            key_set.keys = delete_keys;
+            key_set.ranges = delete_ranges;
+            delete.key_set = Some(key_set);
+            Some(ProtoMutation::new().set_delete(delete))
+        }
+        "send" => {
+            let mut send = ProtoSend::new();
+            send.queue = current_queue;
+            send.key = Some(current_key_values);
+            Some(ProtoMutation::new().set_send(send))
+        }
+        "ack" => {
+            let mut ack = ProtoAck::new();
+            ack.queue = current_queue;
+            ack.key = Some(current_key_values);
+            Some(ProtoMutation::new().set_ack(ack))
+        }
+        _ => Some(mutation),
+    }
+}
+
 /// Consumes lines belonging to a `test { ... }` block inside a test case and returns a [`ParsedTest`]
-/// if it represents a point key evaluation (`key { ... }`) or query parameter evaluation (`query_params { ... }`).
+/// if it represents a point key evaluation (`key { ... }`), query parameter evaluation (`query_params { ... }`),
+/// or mutation evaluation (`mutation { ... }`).
 fn parse_test_block<'a, I: Iterator<Item = &'a str>>(
     lines: &mut Peekable<I>,
 ) -> Option<ParsedTest> {
     let mut values = Vec::new();
     let mut query_params: Option<BTreeMap<String, Value>> = None;
+    let mut mutation: Option<ProtoMutation> = None;
     let mut current_field_key: Option<String> = None;
     let mut in_query_params = false;
     let mut start = None;
     let mut approximate = false;
-    let mut is_point_key_or_query = false;
+    let mut is_point_key_or_query_or_mutation = false;
     let mut depth = 1;
 
-    for line in lines.by_ref() {
+    while let Some(line) = lines.next() {
         let trimmed = line.trim();
         if trimmed.ends_with('{') {
             depth += 1;
@@ -219,14 +408,20 @@ fn parse_test_block<'a, I: Iterator<Item = &'a str>>(
         }
 
         if trimmed.starts_with("key {") {
-            is_point_key_or_query = true;
+            is_point_key_or_query_or_mutation = true;
             in_query_params = false;
         } else if trimmed.starts_with("query_params {") {
-            is_point_key_or_query = true;
+            is_point_key_or_query_or_mutation = true;
             in_query_params = true;
             query_params = Some(BTreeMap::new());
+        } else if trimmed.starts_with("mutation {") {
+            is_point_key_or_query_or_mutation = true;
+            in_query_params = false;
+            // parse_mutation_block consumes the entire mutation { ... } block including its closing brace.
+            depth -= 1;
+            mutation = parse_mutation_block(lines);
         } else if trimmed.starts_with("key_range {") || trimmed.starts_with("key_set {") {
-            is_point_key_or_query = false;
+            is_point_key_or_query_or_mutation = false;
         } else if in_query_params && let Some(key_str) = extract_value(trimmed, "key:") {
             current_field_key = Some(key_str.to_string());
         } else if in_query_params && let Some(val_str) = extract_value(trimmed, "string_value:") {
@@ -270,10 +465,11 @@ fn parse_test_block<'a, I: Iterator<Item = &'a str>>(
         }
     }
 
-    if let (true, Some(start_bytes)) = (is_point_key_or_query, start) {
+    if let (true, Some(start_bytes)) = (is_point_key_or_query_or_mutation, start) {
         Some(ParsedTest {
             values,
             query_params,
+            mutation,
             start: start_bytes,
             approximate,
         })
@@ -339,6 +535,63 @@ fn parse_golden_textproto(content: &str) -> Vec<ParsedTestCase> {
     cases
 }
 
+fn json_value_to_spanner_value(json: &serde_json::Value) -> Option<Value> {
+    match json {
+        serde_json::Value::Bool(boolean_value) => Some(boolean_value.to_value()),
+        serde_json::Value::Number(number) => number
+            .as_i64()
+            .map(|integer| integer.to_value())
+            .or_else(|| number.as_f64().map(|float_number| float_number.to_value())),
+        serde_json::Value::String(string_value) => {
+            if let Ok(integer) = string_value.parse::<i64>() {
+                Some(integer.to_value())
+            } else {
+                Some(string_value.as_str().to_value())
+            }
+        }
+        serde_json::Value::Null => Some(Value::null()),
+        _ => None,
+    }
+}
+
+fn populate_builder(mut builder: WriteBuilder, write: &ProtoWrite) -> Option<Mutation> {
+    let first_row = write.values.first()?;
+    for (column, value) in write.columns.iter().zip(first_row.iter()) {
+        builder = builder.set(column).to(json_value_to_spanner_value(value)?);
+    }
+    Some(builder.build())
+}
+
+fn proto_mutation_to_high_level_mutation(proto: &ProtoMutation) -> Option<Mutation> {
+    match &proto.operation {
+        Some(ProtoOperation::Insert(write)) => {
+            populate_builder(Mutation::new_insert_builder(&write.table), write)
+        }
+        Some(ProtoOperation::Update(write)) => {
+            populate_builder(Mutation::new_update_builder(&write.table), write)
+        }
+        Some(ProtoOperation::InsertOrUpdate(write)) => {
+            populate_builder(Mutation::new_insert_or_update_builder(&write.table), write)
+        }
+        Some(ProtoOperation::Replace(write)) => {
+            populate_builder(Mutation::new_replace_builder(&write.table), write)
+        }
+        Some(ProtoOperation::Delete(delete)) => {
+            let key_set = delete.key_set.as_ref()?;
+            let first_key = key_set.keys.first()?;
+            let mut spanner_keys = Vec::new();
+            for value in first_key {
+                spanner_keys.push(json_value_to_spanner_value(value)?);
+            }
+            Some(Mutation::delete(
+                &delete.table,
+                KeySet::from(Key::new(spanner_keys)),
+            ))
+        }
+        _ => None,
+    }
+}
+
 #[test]
 fn golden_conformance_supported_types() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -357,8 +610,8 @@ fn golden_conformance_supported_types() {
         "recipe_test.textproto must parse all 38 Spanner golden test cases"
     );
 
-    // Execute golden conformance tests for all supported key column data types and key structure test cases.
-    // Table mutations, key sets, query parameters, and struct resolution will be enabled in subsequent pull requests.
+    // Execute golden conformance tests for all supported key column data types, table mutations, and SQL query parameter cases.
+    // Full table key sets and composite struct resolution will be enabled in subsequent pull requests.
     let supported_test_prefixes = [
         "DataTypeTest_BOOL",
         "DataTypeTest_INT64",
@@ -375,6 +628,8 @@ fn golden_conformance_supported_types() {
         "Interleaved",
         "GeneratedKeyColumns",
         "QueryEncoding",
+        "SimpleMutations",
+        "QueueMutations",
     ];
 
     let mut tests_per_prefix: HashMap<&'static str, usize> =
@@ -405,6 +660,32 @@ fn golden_conformance_supported_types() {
                     Ok(bytes) => bytes,
                     Err(e) => panic!(
                         "Golden query test case {} index {} failed encoding: {}",
+                        case.name, index, e
+                    ),
+                }
+            } else if let Some(mutation) = &test.mutation {
+                // When convertible, verify that our high-level crate::mutation::Mutation
+                // extractor produces the exact same routing key as the proto extractor.
+                if let Some(high_level_mutation) = proto_mutation_to_high_level_mutation(mutation) {
+                    let high_level_key =
+                        extract_key_from_mutation(&case.recipe, &high_level_mutation)
+                            .expect("extract_key_from_mutation should succeed")
+                            .expect("extract_key_from_mutation should return routing key");
+                    assert_eq!(
+                        &high_level_key, &test.start,
+                        "Mismatch in high-level mutation golden test case {} at index {}: expected {:?}, got {:?}",
+                        case.name, index, test.start, high_level_key
+                    );
+                }
+
+                match extract_key_from_proto_mutation(&case.recipe, mutation) {
+                    Ok(Some(bytes)) => bytes,
+                    Ok(None) => panic!(
+                        "Golden mutation test case {} index {} returned None routing key",
+                        case.name, index
+                    ),
+                    Err(e) => panic!(
+                        "Golden mutation test case {} index {} failed encoding: {}",
                         case.name, index, e
                     ),
                 }
@@ -440,7 +721,7 @@ fn golden_conformance_supported_types() {
     }
 
     assert_eq!(
-        executed_tests, 87,
-        "Expected exactly 87 golden test vectors for supported types, executed {executed_tests}"
+        executed_tests, 95,
+        "Expected exactly 95 golden test vectors for supported types, executed {executed_tests}"
     );
 }


### PR DESCRIPTION
### Summary
This PR implements mutation routing key extraction for Spanner Omni location-aware routing and enables the mutation golden tests from `recipe_test.textproto`.

### Changes
1. **Mutation Routing Key Extraction**:
   - Implemented `extract_key_from_mutation`, `extract_key_from_mutation_into`, `extract_key_from_proto_mutation`, and `extract_key_from_proto_mutation_into`.
   - Supports table-based mutations (`Insert`, `Update`, `InsertOrUpdate`, `Replace`, `Delete`) and queue-based mutations (`Send`, `Ack`).
   - Implemented table name extraction (`extract_mutation_table_name`, `extract_proto_mutation_table_name`).
   - Implemented batch extraction (`extract_mutations_routing_key`) over cached recipes.

2. **Deduplication & Performance**:
   - Introduced `RecipeValue` trait to share column-matching and slice encoders across `crate::Value` and `serde_json::Value`.
   - Introduced `ExtractableMutation` trait allowing high-level `crate::Mutation` and generated protobuf `crate::model::Mutation` to route through identical monomorphized functions without heap allocations or clone overhead.
   - Unified query parameter preamble handling (`encode_recipe_part_preamble`).

3. **Golden Tests Conformance**:
   - Enabled `SimpleMutations` and `QueueMutations` test cases in `golden_tests.rs`.
   - Added test coverage verifying that both high-level `crate::Mutation` and low-level protobuf mutations produce identical, spec-compliant routing keys.