### PR TITLE
impl(bigquery): migrate stream to unbounded channels

### DIFF
--- a/src/bigquery-write/src/append_builder.rs
+++ b/src/bigquery-write/src/append_builder.rs
@@ -23,12 +23,12 @@ use tokio::sync::{mpsc, oneshot};
 /// A request builder for appending rows on the default stream.
 #[derive(Clone, Debug)]
 pub struct Append {
-    req_tx: mpsc::Sender<WriteRequest>,
+    req_tx: mpsc::UnboundedSender<WriteRequest>,
     pub(crate) req: AppendRowsRequest,
 }
 
 impl Append {
-    pub(crate) fn new(req_tx: mpsc::Sender<WriteRequest>, req: AppendRowsRequest) -> Self {
+    pub(crate) fn new(req_tx: mpsc::UnboundedSender<WriteRequest>, req: AppendRowsRequest) -> Self {
         Self { req_tx, req }
     }
 
@@ -37,7 +37,7 @@ impl Append {
         let (resp_tx, resp_rx) = oneshot::channel();
         let req = self.req.to_proto().map_err(Error::deser)?;
         let write = WriteRequest { req, resp_tx };
-        let _ = self.req_tx.send(write).await;
+        let _ = self.req_tx.send(write);
         let resp = resp_rx
             .await
             .map_err(|_| AppendError::UnexpectedEndOfStream)??;
@@ -57,7 +57,7 @@ mod tests {
 
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::channel(10);
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
@@ -87,7 +87,7 @@ mod tests {
 
     #[tokio::test]
     async fn stream_closed() -> anyhow::Result<()> {
-        let (req_tx, req_rx) = mpsc::channel(10);
+        let (req_tx, req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn rpc_error() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::channel(10);
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);
@@ -124,7 +124,7 @@ mod tests {
 
     #[tokio::test]
     async fn row_errors() -> anyhow::Result<()> {
-        let (req_tx, mut req_rx) = mpsc::channel(10);
+        let (req_tx, mut req_rx) = mpsc::unbounded_channel();
         let req = AppendRowsRequest::new().set_write_stream(write_stream());
 
         let builder = Append::new(req_tx, req);

--- a/src/bigquery-write/src/append_future.rs
+++ b/src/bigquery-write/src/append_future.rs
@@ -17,7 +17,7 @@ use crate::model::AppendResponse;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::task::JoinHandle;
+use tokio::sync::oneshot;
 
 /// A future that resolves to the result of an async append operation.
 ///
@@ -26,13 +26,13 @@ use tokio::task::JoinHandle;
 /// or an error if the write fails.
 #[derive(Debug)]
 pub struct AppendFuture {
-    handle: JoinHandle<AppendResult<AppendResponse>>,
+    rx: oneshot::Receiver<AppendResult<AppendResponse>>,
 }
 
 impl AppendFuture {
     #[allow(dead_code)]
-    pub(crate) fn new(handle: JoinHandle<AppendResult<AppendResponse>>) -> Self {
-        Self { handle }
+    pub(crate) fn new(rx: oneshot::Receiver<AppendResult<AppendResponse>>) -> Self {
+        Self { rx }
     }
 }
 
@@ -40,15 +40,10 @@ impl Future for AppendFuture {
     type Output = AppendResult<AppendResponse>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let result = std::task::ready!(Pin::new(&mut self.handle).poll(cx));
+        let result = std::task::ready!(Pin::new(&mut self.rx).poll(cx));
         match result {
             Ok(res) => Poll::Ready(res),
-            Err(e) => {
-                if e.is_panic() {
-                    std::panic::resume_unwind(e.into_panic());
-                }
-                Poll::Ready(Err(AppendError::UnexpectedEndOfStream))
-            }
+            Err(_) => Poll::Ready(Err(AppendError::UnexpectedEndOfStream)),
         }
     }
 }
@@ -60,26 +55,24 @@ mod tests {
 
     #[tokio::test]
     async fn happy_path() {
-        let handle = tokio::spawn(async {
-            Ok(AppendResponse {
-                offset: None,
-                updated_schema: Some(TableSchema::default()),
-            })
-        });
-        let future = AppendFuture::new(handle);
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Ok(AppendResponse {
+            offset: None,
+            updated_schema: Some(TableSchema::default()),
+        }));
+        let future = AppendFuture::new(rx);
         let resp = future.await.expect("should succeed");
         assert_eq!(resp.offset, None);
         assert_eq!(resp.updated_schema, Some(TableSchema::default()));
     }
 
     #[tokio::test]
-    async fn dropped_task() {
-        let handle =
-            tokio::spawn(async { std::future::pending::<AppendResult<AppendResponse>>().await });
-        // Abort the task immediately
-        handle.abort();
+    async fn dropped_sender() {
+        let (tx, rx) = oneshot::channel::<AppendResult<AppendResponse>>();
+        // Drop the sender immediately
+        drop(tx);
 
-        let future = AppendFuture::new(handle);
+        let future = AppendFuture::new(rx);
         let err = future
             .await
             .expect_err("should return unexpected end of stream");
@@ -87,21 +80,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_returns_error() {
-        let handle = tokio::spawn(async { Err(AppendError::UnexpectedEndOfStream) });
-        let future = AppendFuture::new(handle);
+    async fn channel_returns_error() {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(AppendError::UnexpectedEndOfStream));
+        let future = AppendFuture::new(rx);
         let err = future.await.expect_err("should return error from task");
         assert!(matches!(err, AppendError::UnexpectedEndOfStream));
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "test panic")]
-    async fn panic_propagation() {
-        let handle: JoinHandle<AppendResult<AppendResponse>> = tokio::spawn(async {
-            panic!("test panic");
-        });
-
-        let future = AppendFuture::new(handle);
-        let _ = future.await;
     }
 }

--- a/src/bigquery-write/src/runner.rs
+++ b/src/bigquery-write/src/runner.rs
@@ -47,7 +47,7 @@ pub(crate) struct WriteRequest {
 /// `oneshot::error::RecvError` on their response channel.
 #[derive(Debug)]
 pub(crate) struct Runner {
-    pub(crate) req_tx: mpsc::Sender<WriteRequest>,
+    pub(crate) req_tx: mpsc::UnboundedSender<WriteRequest>,
     #[allow(dead_code)]
     pub(crate) handle: JoinHandle<()>,
 }
@@ -55,7 +55,7 @@ pub(crate) struct Runner {
 impl Runner {
     pub(crate) fn new(inner: Arc<Transport>) -> Self {
         // TODO(#6122) - configure flow control settings
-        let (req_tx, req_rx) = mpsc::channel(100);
+        let (req_tx, req_rx) = mpsc::unbounded_channel();
         let handle = tokio::spawn(async move {
             run_stream_task(inner, req_rx).await;
         });
@@ -63,7 +63,7 @@ impl Runner {
     }
 }
 
-async fn run_stream_task(inner: Arc<Transport>, mut req_rx: mpsc::Receiver<WriteRequest>) {
+async fn run_stream_task(inner: Arc<Transport>, mut req_rx: mpsc::UnboundedReceiver<WriteRequest>) {
     // Wait for the first write before opening the stream. Tonic will not yield
     // us a stream until we have performed the first write.
     let Some(initial_req) = req_rx.recv().await else {
@@ -186,7 +186,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).await?;
+        req_tx.send(write1).unwrap();
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -194,7 +194,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).await?;
+        req_tx.send(write2).unwrap();
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -207,7 +207,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).await?;
+        req_tx.send(write3).unwrap();
 
         // resp 2
         response_tx.send(Ok(convert(&test_response(2)))).await?;
@@ -241,7 +241,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx,
         };
-        req_tx.send(write).await?;
+        req_tx.send(write).unwrap();
 
         let resp = resp_rx.await?;
         let Err(AppendError::Rpc { source: err }) = resp else {
@@ -276,7 +276,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).await?;
+        req_tx.send(write1).unwrap();
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -284,7 +284,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).await?;
+        req_tx.send(write2).unwrap();
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -292,7 +292,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).await?;
+        req_tx.send(write3).unwrap();
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -340,7 +340,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).await?;
+        req_tx.send(write1).unwrap();
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -348,7 +348,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).await?;
+        req_tx.send(write2).unwrap();
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -356,7 +356,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).await?;
+        req_tx.send(write3).unwrap();
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -401,7 +401,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).await?;
+        req_tx.send(write1).unwrap();
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -409,7 +409,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).await?;
+        req_tx.send(write2).unwrap();
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -417,7 +417,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).await?;
+        req_tx.send(write3).unwrap();
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;

--- a/src/bigquery-write/src/runner.rs
+++ b/src/bigquery-write/src/runner.rs
@@ -186,7 +186,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).unwrap();
+        req_tx.send(write1)?;
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -194,7 +194,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).unwrap();
+        req_tx.send(write2)?;
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -207,7 +207,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).unwrap();
+        req_tx.send(write3)?;
 
         // resp 2
         response_tx.send(Ok(convert(&test_response(2)))).await?;
@@ -241,7 +241,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx,
         };
-        req_tx.send(write).unwrap();
+        req_tx.send(write)?;
 
         let resp = resp_rx.await?;
         let Err(AppendError::Rpc { source: err }) = resp else {
@@ -276,7 +276,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).unwrap();
+        req_tx.send(write1)?;
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -284,7 +284,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).unwrap();
+        req_tx.send(write2)?;
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -292,7 +292,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).unwrap();
+        req_tx.send(write3)?;
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -340,7 +340,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).unwrap();
+        req_tx.send(write1)?;
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -348,7 +348,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).unwrap();
+        req_tx.send(write2)?;
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -356,7 +356,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).unwrap();
+        req_tx.send(write3)?;
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;
@@ -401,7 +401,7 @@ pub(crate) mod tests {
             req: test_request(1),
             resp_tx: resp_tx1,
         };
-        req_tx.send(write1).unwrap();
+        req_tx.send(write1)?;
 
         // write 2
         let (resp_tx2, resp_rx2) = oneshot::channel();
@@ -409,7 +409,7 @@ pub(crate) mod tests {
             req: test_request(2),
             resp_tx: resp_tx2,
         };
-        req_tx.send(write2).unwrap();
+        req_tx.send(write2)?;
 
         // write 3
         let (resp_tx3, resp_rx3) = oneshot::channel();
@@ -417,7 +417,7 @@ pub(crate) mod tests {
             req: test_request(3),
             resp_tx: resp_tx3,
         };
-        req_tx.send(write3).unwrap();
+        req_tx.send(write3)?;
 
         // resp 1
         response_tx.send(Ok(convert(&test_response(1)))).await?;


### PR DESCRIPTION
Migrate the background stream runner from an `mpsc` bounded channel to an unbounded channel, so that we no longer need to wrap every client append in a `tokio::spawn` task.

For #6401