### PR TITLE
fix(gax): update grpc-rust to 7482441 and add metadata conversion helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
 ]
 
@@ -580,7 +580,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -594,12 +594,6 @@ dependencies = [
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -754,6 +748,16 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -960,7 +964,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.20",
+ "thiserror",
 ]
 
 [[package]]
@@ -980,7 +984,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry_sdk",
  "rand 0.10.2",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -1140,18 +1144,6 @@ dependencies = [
  "google-cloud-secretmanager-v1",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2150,7 +2142,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tokio",
  "url",
@@ -2334,7 +2326,7 @@ dependencies = [
  "rust_decimal",
  "serde_json",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tokio",
  "uuid",
@@ -2489,7 +2481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid",
@@ -2516,7 +2508,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3506,7 +3498,7 @@ dependencies = [
  "serde_json",
  "static_assertions",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
 ]
@@ -3553,10 +3545,10 @@ dependencies = [
  "serde_with",
  "serial_test",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
  "tower",
  "tracing",
@@ -4806,7 +4798,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5272,7 +5264,7 @@ dependencies = [
  "serde_with",
  "spanner-grpc-mock",
  "static_assertions",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "tokio",
  "tracing",
@@ -5403,7 +5395,7 @@ dependencies = [
  "storage-grpc-mock",
  "tempfile",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5935,7 +5927,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "time",
  "url",
 ]
@@ -6581,9 +6573,8 @@ dependencies = [
 
 [[package]]
 name = "grpc"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83c69c319fc2e7fa5cfbbc13cd9fa01105594efab8fcfd682abfd91c912f2aa"
+version = "0.10.0"
+source = "git+https://github.com/grpc/grpc-rust.git?rev=7482441302cf85d10270d5cd9a2ce5fb520410ab#7482441302cf85d10270d5cd9a2ce5fb520410ab"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6594,20 +6585,21 @@ dependencies = [
  "hyper",
  "itoa",
  "parking_lot",
+ "percent-encoding",
  "pin-project-lite",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
- "rustls-webpki 0.102.8",
+ "rustls-platform-verifier",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (git+https://github.com/grpc/grpc-rust.git?rev=7482441302cf85d10270d5cd9a2ce5fb520410ab)",
  "tower",
  "tower-service",
  "trait-variant",
@@ -6628,7 +6620,7 @@ dependencies = [
  "prost-build",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
  "tonic-prost-build",
 ]
@@ -6701,24 +6693,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.5",
- "ring",
- "thiserror 2.0.20",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -6726,22 +6717,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.5",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.20",
+ "system-configuration",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -7261,7 +7277,7 @@ dependencies = [
  "test-case",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7328,10 +7344,10 @@ dependencies = [
  "storage-grpc-mock",
  "storage-samples",
  "test-case",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "tracing-opentelemetry",
  "tracing-serde",
@@ -7436,7 +7452,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower",
  "tracing",
 ]
@@ -7483,6 +7499,9 @@ name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "itertools"
@@ -7554,22 +7573,6 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -7577,10 +7580,10 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.20",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -7596,15 +7599,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -7949,6 +7943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "num-bigint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8081,7 +8081,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.20",
+ "thiserror",
  "tracing",
 ]
 
@@ -8120,9 +8120,9 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-types",
 ]
 
@@ -8135,7 +8135,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
 ]
 
@@ -8158,7 +8158,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tokio-stream",
 ]
@@ -8355,6 +8355,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8499,7 +8510,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
 ]
 
@@ -8545,7 +8556,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.20",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -8568,7 +8579,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.20",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8829,7 +8840,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8983,7 +8994,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.14",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -9021,40 +9032,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.14",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.14",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -9066,16 +9056,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -9230,7 +9210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9504,7 +9484,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
 ]
 
@@ -9583,7 +9563,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tonic-prost",
 ]
 
@@ -9773,6 +9753,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9886,31 +9887,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.20",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -10154,6 +10135,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "git+https://github.com/grpc/grpc-rust.git?rev=7482441302cf85d10270d5cd9a2ce5fb520410ab#7482441302cf85d10270d5cd9a2ce5fb520410ab"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10173,7 +10174,7 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10200,7 +10201,7 @@ checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -10701,20 +10702,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -10728,40 +10720,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -10771,21 +10742,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10801,21 +10760,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10825,21 +10772,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,7 +429,7 @@ crates_io_api         = { default-features = false, version = "0.12" }
 clap                  = { default-features = false, version = "4" }
 crc32c                = { default-features = false, version = "0.6.8" }
 futures               = { default-features = false, version = "0.3" }
-grpc                  = { version = "0.9.0" }
+grpc                  = { git = "https://github.com/grpc/grpc-rust.git", rev = "7482441302cf85d10270d5cd9a2ce5fb520410ab" }
 h2                    = { default-features = false, version = "0.4.14" }
 hex                   = { default-features = false, version = "0.4.3" }
 http                  = { default-features = false, version = "1.1", features = ["std"] }

--- a/deny.toml
+++ b/deny.toml
@@ -151,4 +151,6 @@ unused                    = "allow"
 unknown-registry = "deny"
 unknown-git      = "deny"
 allow-registry   = ["https://github.com/rust-lang/crates.io-index"]
-allow-git        = []
+allow-git        = [
+  "https://github.com/grpc/grpc-rust.git", # TODO(#5991): Remove when switching to grpc-rust 0.10 
+]

--- a/deny.toml
+++ b/deny.toml
@@ -149,8 +149,8 @@ unused                    = "allow"
 # Only allow dependencies via crates.io
 [sources]
 unknown-registry = "deny"
-unknown-git      = "deny"
-allow-registry   = ["https://github.com/rust-lang/crates.io-index"]
-allow-git        = [
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
   "https://github.com/grpc/grpc-rust.git", # TODO(#5991): Remove when switching to grpc-rust 0.10 
 ]

--- a/src/gax-internal/src/grpc/grpc_rust.rs
+++ b/src/gax-internal/src/grpc/grpc_rust.rs
@@ -38,11 +38,12 @@ use grpc::credentials::rustls::client::{
     ClientTlsConfig, RustlsChannelCredendials as RustlsChannelCredentials,
 };
 use http::{HeaderMap, Uri};
+use metadata::from_header_map;
 use std::sync::Arc;
 use std::time::Duration;
-use tonic::metadata::MetadataMap;
 
 pub mod bidi;
+mod metadata;
 mod receive;
 mod send;
 mod unary;
@@ -186,9 +187,7 @@ impl GrpcRustClient {
             call_options.set_deadline(std::time::Instant::now() + timeout);
         }
 
-        let metadata = MetadataMap::from_headers(headers)
-            .try_into()
-            .map_err(Error::ser)?;
+        let metadata = from_header_map(&headers)?;
         let request_headers = RequestHeaders::new()
             .with_method_name(path.as_str())
             .with_metadata(metadata);
@@ -269,9 +268,7 @@ impl GrpcRustClient {
         Self::note_ignored_extensions(&extensions);
         let headers = grpc_helpers::make_headers(api_client_header, request_params, &options)?;
         let headers = grpc_helpers::add_auth_headers(headers, &self.inner.credentials).await?;
-        let metadata = MetadataMap::from_headers(headers)
-            .try_into()
-            .map_err(Error::ser)?;
+        let metadata = from_header_map(&headers)?;
         let request_headers = RequestHeaders::new()
             .with_method_name(path.as_str())
             .with_metadata(metadata);

--- a/src/gax-internal/src/grpc/grpc_rust/metadata.rs
+++ b/src/gax-internal/src/grpc/grpc_rust/metadata.rs
@@ -1,0 +1,135 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(#5991): Replace with `grpc-rust`'s built-in header conversion methods
+// when available in a future release.
+
+use google_cloud_gax::Result as GaxResult;
+use grpc::metadata::{
+    Ascii as GrpcAscii, AsciiMetadataValue as GrpcAsciiMetadataValue, Binary as GrpcBinary,
+    KeyAndValueRef as GrpcKeyAndValueRef, MetadataKey as GrpcMetadataKey,
+    MetadataMap as GrpcMetadataMap, MetadataValue as GrpcMetadataValue,
+};
+use http::HeaderMap;
+use tonic::metadata::{
+    MetadataKey as TonicMetadataKey, MetadataMap as TonicMetadataMap,
+    MetadataValue as TonicMetadataValue,
+};
+
+/// Converts a [`HeaderMap`] into a [`GrpcMetadataMap`].
+pub(super) fn from_header_map(headers: &HeaderMap) -> GaxResult<GrpcMetadataMap> {
+    let mut grpc_map = GrpcMetadataMap::new();
+    for (key, value) in headers {
+        if key.as_str().ends_with("-bin") {
+            if let Ok(k) = GrpcMetadataKey::<GrpcBinary>::from_bytes(key.as_str().as_bytes()) {
+                grpc_map.append_bin(k, GrpcMetadataValue::from_bytes(value.as_bytes()));
+            }
+        } else if let (Ok(k), Ok(val)) = (
+            GrpcMetadataKey::<GrpcAscii>::from_bytes(key.as_str().as_bytes()),
+            GrpcAsciiMetadataValue::try_from(value.as_bytes()),
+        ) {
+            grpc_map.append(k, val);
+        }
+    }
+    Ok(grpc_map)
+}
+
+/// Converts a [`GrpcMetadataMap`] into a [`TonicMetadataMap`].
+pub(super) fn to_tonic_map(metadata: &GrpcMetadataMap) -> TonicMetadataMap {
+    let mut tonic_map = TonicMetadataMap::new();
+    for item in metadata.iter() {
+        match item {
+            GrpcKeyAndValueRef::Ascii(key, val) => {
+                if let (Ok(name), Ok(val)) = (
+                    TonicMetadataKey::from_bytes(key.as_str().as_bytes()),
+                    TonicMetadataValue::try_from(val.to_str().as_bytes()),
+                ) {
+                    tonic_map.append(name, val);
+                }
+            }
+            GrpcKeyAndValueRef::Binary(key, val) => {
+                if let Ok(name) = TonicMetadataKey::from_bytes(key.as_str().as_bytes()) {
+                    let val = TonicMetadataValue::from_bytes(val.as_bytes());
+                    tonic_map.append_bin(name, val);
+                }
+            }
+        }
+    }
+    tonic_map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const ASCII_KEY: &str = "x-test-header";
+    const ASCII_VAL: &str = "test-value";
+    const BIN_KEY: &str = "x-test-header-bin";
+    const BIN_VAL: &[u8] = b"test-binary-data";
+
+    #[test]
+    fn test_from_header_map() {
+        // Arrange
+        let mut headers = HeaderMap::new();
+
+        headers.insert(
+            http::header::HeaderName::from_static(ASCII_KEY),
+            http::header::HeaderValue::from_static(ASCII_VAL),
+        );
+        headers.insert(
+            http::header::HeaderName::from_static(BIN_KEY),
+            http::header::HeaderValue::from_bytes(BIN_VAL).expect("valid header value"),
+        );
+
+        // Act
+        let grpc_map = from_header_map(&headers).expect("conversion succeeded");
+
+        // Assert
+        let ascii_val = grpc_map.get(ASCII_KEY).expect("ascii header present");
+        assert_eq!(ascii_val.to_str(), ASCII_VAL);
+
+        let bin_val = grpc_map.get_bin(BIN_KEY).expect("binary header present");
+        assert_eq!(bin_val.as_bytes(), BIN_VAL);
+    }
+
+    #[test]
+    fn test_to_tonic_map() {
+        // Arrange
+        let mut grpc_map = GrpcMetadataMap::new();
+
+        let ascii_key =
+            GrpcMetadataKey::<GrpcAscii>::from_bytes(ASCII_KEY.as_bytes()).expect("valid key");
+        let ascii_val = GrpcAsciiMetadataValue::try_from(ASCII_VAL).expect("valid ascii value");
+        grpc_map.append(ascii_key, ascii_val);
+
+        let bin_key =
+            GrpcMetadataKey::<GrpcBinary>::from_bytes(BIN_KEY.as_bytes()).expect("valid key");
+        let bin_val = GrpcMetadataValue::from_bytes(BIN_VAL);
+        grpc_map.append_bin(bin_key, bin_val);
+
+        // Act
+        let tonic_map = to_tonic_map(&grpc_map);
+
+        // Assert
+        let tonic_ascii = tonic_map.get(ASCII_KEY).expect("ascii header in tonic");
+        assert_eq!(tonic_ascii.to_str().expect("valid str"), ASCII_VAL);
+
+        let tonic_bin = tonic_map.get_bin(BIN_KEY).expect("binary header in tonic");
+        assert_eq!(
+            tonic_bin.to_bytes().expect("valid bytes"),
+            bytes::Bytes::from_static(BIN_VAL)
+        );
+    }
+}

--- a/src/gax-internal/src/grpc/grpc_rust/metadata.rs
+++ b/src/gax-internal/src/grpc/grpc_rust/metadata.rs
@@ -16,6 +16,7 @@
 // when available in a future release.
 
 use google_cloud_gax::Result as GaxResult;
+use google_cloud_gax::error::Error;
 use grpc::metadata::{
     Ascii as GrpcAscii, AsciiMetadataValue as GrpcAsciiMetadataValue, Binary as GrpcBinary,
     KeyAndValueRef as GrpcKeyAndValueRef, MetadataKey as GrpcMetadataKey,
@@ -32,13 +33,13 @@ pub(super) fn from_header_map(headers: &HeaderMap) -> GaxResult<GrpcMetadataMap>
     let mut grpc_map = GrpcMetadataMap::new();
     for (key, value) in headers {
         if key.as_str().ends_with("-bin") {
-            if let Ok(k) = GrpcMetadataKey::<GrpcBinary>::from_bytes(key.as_str().as_bytes()) {
-                grpc_map.append_bin(k, GrpcMetadataValue::from_bytes(value.as_bytes()));
-            }
-        } else if let (Ok(k), Ok(val)) = (
-            GrpcMetadataKey::<GrpcAscii>::from_bytes(key.as_str().as_bytes()),
-            GrpcAsciiMetadataValue::try_from(value.as_bytes()),
-        ) {
+            let k = GrpcMetadataKey::<GrpcBinary>::from_bytes(key.as_str().as_bytes())
+                .map_err(Error::ser)?;
+            grpc_map.append_bin(k, GrpcMetadataValue::from_bytes(value.as_bytes()));
+        } else {
+            let k = GrpcMetadataKey::<GrpcAscii>::from_bytes(key.as_str().as_bytes())
+                .map_err(Error::ser)?;
+            let val = GrpcAsciiMetadataValue::try_from(value.as_bytes()).map_err(Error::ser)?;
             grpc_map.append(k, val);
         }
     }
@@ -51,18 +52,17 @@ pub(super) fn to_tonic_map(metadata: &GrpcMetadataMap) -> TonicMetadataMap {
     for item in metadata.iter() {
         match item {
             GrpcKeyAndValueRef::Ascii(key, val) => {
-                if let (Ok(name), Ok(val)) = (
-                    TonicMetadataKey::from_bytes(key.as_str().as_bytes()),
-                    TonicMetadataValue::try_from(val.to_str().as_bytes()),
-                ) {
-                    tonic_map.append(name, val);
-                }
+                let name = TonicMetadataKey::from_bytes(key.as_str().as_bytes())
+                    .expect("grpc-rust guarantees valid metadata keys");
+                let val = TonicMetadataValue::try_from(val.to_str().as_bytes())
+                    .expect("grpc-rust guarantees valid ascii metadata values");
+                tonic_map.append(name, val);
             }
             GrpcKeyAndValueRef::Binary(key, val) => {
-                if let Ok(name) = TonicMetadataKey::from_bytes(key.as_str().as_bytes()) {
-                    let val = TonicMetadataValue::from_bytes(val.as_bytes());
-                    tonic_map.append_bin(name, val);
-                }
+                let name = TonicMetadataKey::from_bytes(key.as_str().as_bytes())
+                    .expect("grpc-rust guarantees valid metadata keys");
+                let val = TonicMetadataValue::from_bytes(val.as_bytes());
+                tonic_map.append_bin(name, val);
             }
         }
     }
@@ -131,5 +131,23 @@ mod tests {
             tonic_bin.to_bytes().expect("valid bytes"),
             bytes::Bytes::from_static(BIN_VAL)
         );
+    }
+
+    #[test]
+    fn test_from_header_map_invalid_ascii_value_returns_error() {
+        // Arrange
+        let mut headers = HeaderMap::new();
+        let invalid_val =
+            http::header::HeaderValue::from_bytes(&[0xFA]).expect("valid http header value");
+        headers.insert(
+            http::header::HeaderName::from_static("x-invalid-ascii"),
+            invalid_val,
+        );
+
+        // Act
+        let result = from_header_map(&headers);
+
+        // Assert
+        assert!(result.is_err());
     }
 }

--- a/src/gax-internal/src/grpc/grpc_rust/receive.rs
+++ b/src/gax-internal/src/grpc/grpc_rust/receive.rs
@@ -16,6 +16,7 @@
 //! `grpc-rust` [`RecvStream`](grpc::client::RecvStream) in a background task,
 //! as well as [`GrpcRustRecv`] to decode protobuf messages using Prost.
 
+use super::metadata::to_tonic_map;
 use bytes::Buf;
 use grpc::StatusCodeError;
 use grpc::client::{RecvStream, ResponseStreamItem};
@@ -168,7 +169,7 @@ async fn receive_responses<Response, R>(
         };
         let (response, is_terminal) = match recv.recv(&mut slot).await {
             ResponseStreamItem::Headers(headers) => (
-                Ok(Some(RecvItem::Headers(headers.metadata().clone().into()))),
+                Ok(Some(RecvItem::Headers(to_tonic_map(headers.metadata())))),
                 false,
             ),
             ResponseStreamItem::Message => match slot.take() {
@@ -198,7 +199,7 @@ async fn receive_responses<Response, R>(
 /// Converts gRPC response [`Trailers`] into a [`tonic::Status`], preserving status code, message, metadata, and `grpc-status-details-bin`.
 pub(super) fn trailers_to_tonic_status(trailers: Trailers) -> Option<tonic::Status> {
     let status = trailers.status().as_ref().err()?;
-    let metadata: tonic::metadata::MetadataMap = trailers.metadata().clone().into();
+    let metadata = to_tonic_map(trailers.metadata());
     let details = metadata
         .get_bin("grpc-status-details-bin")
         .and_then(|value| value.to_bytes().ok())

--- a/src/gax-internal/src/grpc/grpc_rust/unary.rs
+++ b/src/gax-internal/src/grpc/grpc_rust/unary.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::metadata::to_tonic_map;
 use super::receive::{GrpcRustRecv, trailers_to_tonic_status};
 use super::send::GrpcRustSend;
 use bytes::Buf;
@@ -95,14 +96,14 @@ where
     loop {
         match recv.recv(&mut slot).await {
             ResponseStreamItem::Headers(headers) => {
-                metadata = headers.metadata().clone().into();
+                metadata = to_tonic_map(headers.metadata());
             }
             ResponseStreamItem::Message => {
                 message = Some(slot.take()?);
             }
             ResponseStreamItem::Trailers(trailers) => {
                 // The trailer metadata will be merged with the header metadata.
-                let trailer_metadata: MetadataMap = trailers.metadata().clone().into();
+                let trailer_metadata = to_tonic_map(trailers.metadata());
                 // If the server returned an error status in trailers, return that error.
                 if let Some(status) = trailers_to_tonic_status(trailers) {
                     return Err(status);


### PR DESCRIPTION
For #5991.

`grpc-rust` is removing direct `From/Into` type conversions between `grpc::metadata::MetadataMap` and `tonic::metadata::MetadataMap`. This PR introduces explicit conversion helpers to perform the conversion until built-in conversions are provided in a future `grpc-rust` release.

This will becoming a breaking change when switching to `0.10`, so fixing now.
