### PR TITLE
docs(bigquery): remove RPC routing explanation

### DIFF
--- a/src/bigquery/src/client.rs
+++ b/src/bigquery/src/client.rs
@@ -116,17 +116,15 @@ impl BigQuery {
 
     /// Creates a request builder to configure and execute a SQL query.
     ///
-    /// This method returns a [`Query`] builder. You can chain additional configuration methods
-    /// (such as setting the project ID, positional or named parameters, query location, and maximum result buffer sizes)
-    /// before calling [`Query::send()`] or [`Query::until_done()`].
+    /// This method returns a [`Query`] builder used to set parameters, specify options,
+    /// and execute the query.
     ///
-    /// The [`Query`] builder automatically decides whether to route your request via the fast path ([`jobs.query`][jobs_query])
-    /// or the background job creation path ([`jobs.insert`][jobs_insert]). If the query configuration uses only options supported
-    /// by the fast path, the client library uses [`jobs.query`][jobs_query] for lower latency. If advanced options (such as destination
-    /// tables or allowing large results) are configured, the client automatically falls back to creating an asynchronous job.
+    /// If you configured a default project ID on the client via
+    /// [`ClientBuilder::with_project_id`][crate::client_builder::ClientBuilder::with_project_id],
+    /// the returned query builder inherits it automatically.
     ///
-    /// [jobs_query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
-    /// [jobs_insert]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
+    /// Call [`Query::send()`] to start query execution, or [`Query::until_done()`]
+    /// to start execution and wait for results.
     ///
     /// # Example
     ///

--- a/src/bigquery/src/query/builder.rs
+++ b/src/bigquery/src/query/builder.rs
@@ -27,19 +27,13 @@ use uuid::Uuid;
 pub(crate) const JOB_ID_PREFIX: &str = "job_";
 pub(crate) const QUERY_REQUEST_ID_PREFIX: &str = "req_";
 
-/// A builder for executing a SQL query.
+/// A builder for configuring and executing a SQL query.
 ///
 /// [`BigQuery::query()`](crate::client::BigQuery::query) returns a [`Query`](crate::builder::bigquery::Query) builder.
 ///
-/// # Automatic Path Routing
-///
-/// The implementation routes internally to [jobs.query] (fast path) or
-/// [jobs.insert] (job path) depending on configured fields. If the fast path is
-/// available, the client library takes it. If not, it falls back to creating a
-/// job, which is typically slower.
-///
-/// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
-/// [jobs.insert]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
+/// Use this builder to configure query parameters, dataset defaults, geographic location,
+/// result limits, and caching before executing the query with [`send()`](Query::send)
+/// or [`until_done()`](Query::until_done).
 ///
 /// # Example
 ///
@@ -113,20 +107,14 @@ impl Query {
 
     /// Executes the SQL query.
     ///
-    /// This returns a [`Query`](crate::Query) handle representing an
-    /// asynchronous background job executing on BigQuery, or an already
-    /// completed query if it ran fast enough using the fast query path
-    /// ([jobs.query]).
-    ///
-    /// You can call [`until_done()`](crate::Query::until_done) on the
-    /// returned handle to wait for the final results.
+    /// Returns a [`Query`](crate::Query) handle representing the query execution.
+    /// You can call [`until_done()`](crate::Query::until_done) on the returned handle
+    /// to wait for results, or inspect the initial [`metadata()`](crate::Query::metadata).
     ///
     /// You must configure a target project ID on either the
     /// [`BigQuery`][crate::client::BigQuery] client via
     /// [`ClientBuilder::with_project_id`][crate::client_builder::ClientBuilder::with_project_id]
     /// or on this builder via [`with_project_id()`](Query::with_project_id).
-    ///
-    /// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
     ///
     /// # Example
     ///
@@ -188,7 +176,7 @@ impl Query {
         }
     }
 
-    /// Sends the query execution request and polls until execution completes.
+    /// Sends the query execution request and waits until execution completes.
     ///
     /// This is a convenience method equivalent to calling
     /// [`.send().await?.until_done().await`](Query::send).

--- a/src/bigquery/src/query/iterator.rs
+++ b/src/bigquery/src/query/iterator.rs
@@ -25,9 +25,8 @@ pub type Result<T> = std::result::Result<T, RowError>;
 /// [`CompleteQuery::read()`](crate::CompleteQuery::read) returns a
 /// `RowIterator`.
 ///
-/// `RowIterator` yields rows from the in-memory buffer fetched during query
-/// completion, then requests subsequent pages from BigQuery using pagination
-/// tokens until consuming the entire result set.
+/// `RowIterator` yields rows from the query result set, automatically requesting
+/// subsequent pages from BigQuery as needed until the entire result set has been consumed.
 ///
 /// # Example
 ///

--- a/src/bigquery/src/query/query_handle.rs
+++ b/src/bigquery/src/query/query_handle.rs
@@ -31,15 +31,8 @@ use std::sync::Arc;
 /// [`Query::send()`](crate::builder::bigquery::Query::send) returns a [`Query`](crate::Query).
 ///
 /// To obtain the final result set, call [`until_done()`](Query::until_done),
-/// which checks the execution status and automatically polls the service if the
-/// job is still running in the background.
-///
-/// Depending on how the query was routed and executed, this handle may represent
-/// an asynchronous background job currently executing on BigQuery, or may
-/// contain an already completed query if it ran fast enough using the fast query
-/// path ([jobs.query]).
-///
-/// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
+/// which waits for the query execution to complete and returns a
+/// [`CompleteQuery`](crate::CompleteQuery).
 ///
 /// # Example
 ///
@@ -102,11 +95,7 @@ impl Query {
         }
     }
 
-    /// Returns the initial metadata from query creation.
-    ///
-    /// This provides access to the [`QueryMetadata`] returned by the
-    /// initial query execution request (either [`jobs.query`] or
-    /// [`jobs.insert`]).
+    /// Returns the initial metadata from query execution.
     ///
     /// Depending on how the query was executed, the metadata contains:
     /// - [`job_reference`][QueryMetadata::job_reference]: The reference to the BigQuery job, if one was created.
@@ -116,9 +105,6 @@ impl Query {
     ///
     /// To wait for the query to finish and retrieve full results and final
     /// metadata, call [`until_done`][Self::until_done].
-    ///
-    /// [`jobs.query`]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
-    /// [`jobs.insert`]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/insert
     pub fn metadata(&self) -> &QueryMetadata {
         &self.metadata
     }
@@ -176,16 +162,11 @@ impl Query {
         Some(req)
     }
 
-    /// Periodically polls the background job status until query execution
-    /// finishes.
+    /// Waits for query execution to complete.
     ///
-    /// If the query was executed via the fast query path ([jobs.query]) and
-    /// already completed during the initial request, this method immediately
-    /// returns a [`CompleteQuery`](crate::CompleteQuery) without making
-    /// additional network calls. Otherwise, it implements a polling loop
-    /// querying the job status until it succeeds or fails.
-    ///
-    /// [jobs.query]: https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query
+    /// If the query completed immediately, this method returns a
+    /// [`CompleteQuery`](crate::CompleteQuery) without making additional
+    /// network calls. Otherwise, it polls the service until the query finishes.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Don't explain how the sausage factory works. 

Towards #5844 