### PR TITLE
impl(gax-internal): add bidi_streaming helper on Client

### DIFF
--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -215,6 +215,82 @@ impl Client {
         Ok(result)
     }
 
+    /// Opens a bidirectional stream with automatic model <-> proto conversion and channel management.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    pub fn bidi_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
+        &self,
+        extensions: tonic::Extensions,
+        path: http::uri::PathAndQuery,
+        options: RequestOptions,
+        api_client_header: &'static str,
+        request_params: &str,
+    ) -> (
+        google_cloud_gax::streaming::RequestSender<DomainReq>,
+        google_cloud_gax::streaming::ResponseReceiver<DomainResp>,
+    )
+    where
+        DomainReq: crate::prost::ToProto<ProstReq, Output = ProstReq> + Send + 'static,
+        DomainResp: Send + 'static,
+        ProstReq: prost::Message + Send + 'static,
+        ProstResp: prost::Message + Default + crate::prost::FromProto<DomainResp> + 'static,
+    {
+        use futures::FutureExt as _;
+        use futures::stream::StreamExt as _;
+
+        let (req_tx, req_rx) = tokio::sync::mpsc::channel(
+            options
+                .request_stream_channel_capacity()
+                .unwrap_or(google_cloud_gax::options::internal::DEFAULT_REQUEST_CHANNEL_CAPACITY),
+        );
+        let req_stream = tokio_stream::wrappers::ReceiverStream::new(req_rx);
+
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+
+        let client = self.clone();
+        let request_params = request_params.to_string();
+        tokio::spawn(async move {
+            let result = client
+                .bidi_stream::<ProstReq, ProstResp>(
+                    extensions,
+                    path,
+                    req_stream,
+                    options,
+                    api_client_header,
+                    &request_params,
+                )
+                .await;
+            let _ = resp_tx.send(result);
+        });
+
+        let request_sender =
+            google_cloud_gax::streaming::RequestSender::from_fn(move |item: DomainReq| {
+                let req_tx = req_tx.clone();
+                async move {
+                    let prost_item = item
+                        .to_proto()
+                        .map_err(google_cloud_gax::streaming::SendError::ser)?;
+                    req_tx
+                        .send(prost_item)
+                        .await
+                        .map_err(|_| google_cloud_gax::streaming::SendError::stream_closed())
+                }
+            });
+        let future = resp_rx.map(|res| match res {
+            Ok(Ok(response)) => Ok(response.into_inner().map(|res| {
+                res.map_err(from_status::to_gax_error)
+                    .and_then(|m| m.cnv().map_err(Error::deser))
+            })),
+            Ok(Err(err)) => Err(err),
+            Err(_) => Err(Error::io(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream initialization task cancelled",
+            ))),
+        });
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_future(future);
+
+        (request_sender, response_receiver)
+    }
+
     /// Opens a server stream.
     #[cfg(feature = "_internal-grpc-server-streaming")]
     pub async fn server_streaming<Request, Response>(

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -217,7 +217,7 @@ impl Client {
 
     /// Opens a bidirectional stream with automatic model <-> proto conversion and channel management.
     #[cfg(google_cloud_unstable_gapic_streaming)]
-    pub fn bidi_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
+    pub fn execute_bidi_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
         &self,
         extensions: tonic::Extensions,
         path: http::uri::PathAndQuery,

--- a/src/gax-internal/tests/grpc_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_streaming_request.rs
@@ -299,7 +299,7 @@ mod tests {
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
     #[tokio::test]
-    async fn bidi_streaming_helper_basic() -> anyhow::Result<()> {
+    async fn execute_bidi_streaming_basic() -> anyhow::Result<()> {
         let (endpoint, _server) = start_echo_server().await?;
         let client = builder(endpoint)
             .with_credentials(test_credentials())
@@ -321,7 +321,7 @@ mod tests {
         };
 
         let (sender, mut receiver) = client
-            .bidi_streaming::<DomainEchoRequest, DomainEchoResponse, EchoRequest, EchoResponse>(
+            .execute_bidi_streaming::<DomainEchoRequest, DomainEchoResponse, EchoRequest, EchoResponse>(
                 extensions,
                 http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Chat"),
                 request_options,

--- a/src/gax-internal/tests/grpc_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_streaming_request.rs
@@ -258,4 +258,108 @@ mod tests {
             )
             .await
     }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct DomainEchoRequest {
+        message: String,
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl google_cloud_gax_internal::prost::ToProto<EchoRequest> for DomainEchoRequest {
+        type Output = EchoRequest;
+        fn to_proto(
+            self,
+        ) -> std::result::Result<EchoRequest, google_cloud_gax_internal::prost::ConvertError>
+        {
+            Ok(EchoRequest {
+                message: self.message,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct DomainEchoResponse {
+        message: String,
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl google_cloud_gax_internal::prost::FromProto<DomainEchoResponse> for EchoResponse {
+        fn cnv(
+            self,
+        ) -> std::result::Result<DomainEchoResponse, google_cloud_gax_internal::prost::ConvertError>
+        {
+            Ok(DomainEchoResponse {
+                message: self.message,
+            })
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[tokio::test]
+    async fn bidi_streaming_helper_basic() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_echo_server().await?;
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .build()
+            .await?;
+
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Chat",
+            ));
+            e
+        };
+        let request_options = {
+            let mut o = RequestOptions::default();
+            o.set_retry_policy(NeverRetry);
+            o
+        };
+
+        let (sender, mut receiver) = client
+            .bidi_streaming::<DomainEchoRequest, DomainEchoResponse, EchoRequest, EchoResponse>(
+                extensions,
+                http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Chat"),
+                request_options,
+                "test-only-api-client/1.0",
+                "resource=test",
+            );
+
+        sender
+            .send(DomainEchoRequest {
+                message: "msg0".to_string(),
+            })
+            .await?;
+
+        let r = receiver.recv().await;
+        assert_eq!(
+            r.transpose()?,
+            Some(DomainEchoResponse {
+                message: "msg0".to_string()
+            })
+        );
+
+        sender
+            .send(DomainEchoRequest {
+                message: "msg1".to_string(),
+            })
+            .await?;
+        let r = receiver.recv().await;
+        assert_eq!(
+            r.transpose()?,
+            Some(DomainEchoResponse {
+                message: "msg1".to_string()
+            })
+        );
+
+        drop(sender);
+        let r = receiver.recv().await;
+        assert!(r.is_none());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Add the bidi_streaming helper method to gaxi::grpc::Client to encapsulate model-to-proto conversion, mpsc channel management, and response stream decoding for bidirectional streaming RPCs.

This probably should have been done previously. There will be additional tests and refactoring to enable it in a future CL. This CL takes the contents of the generated code directly to minimize code to review.