### PR TITLE
test(gax): add retry policy exhaustion integration test for GrpcRustClient

### DIFF
--- a/src/gax-internal/tests/grpc_rust_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_rust_retry_loop.rs
@@ -22,6 +22,7 @@ mod tests {
     use google_cloud_gax::backoff_policy::BackoffPolicy;
     use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
     use google_cloud_gax::options::RequestOptions;
+    use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
     use google_cloud_gax_internal::grpc::GrpcRustClient;
     use google_cloud_gax_internal::options::ClientConfig;
     use grpc_server::google::test::v1::EchoResponse;
@@ -86,6 +87,25 @@ mod tests {
 
         // Act
         let response = send_request(client, "retry_then_error").await;
+
+        // Assert
+        assert!(response.is_err(), "{response:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn retry_policy_exhausted() -> anyhow::Result<()> {
+        // Arrange
+        let (endpoint, _server) = start_fixed_responses((0..3).map(|_| transient())).await?;
+
+        let mut config = test_config();
+        config.retry_policy = Some(Arc::new(Aip194Strict.with_attempt_limit(3)));
+        config.backoff_policy = Some(Arc::new(test_backoff()));
+
+        let client = GrpcRustClient::new(config, &endpoint).await?;
+
+        // Act
+        let response = send_request(client, "retry_policy_exhausted").await;
 
         // Assert
         assert!(response.is_err(), "{response:?}");

--- a/src/gax-internal/tests/grpc_rust_retry_loop.rs
+++ b/src/gax-internal/tests/grpc_rust_retry_loop.rs
@@ -20,6 +20,7 @@
 mod tests {
     use google_cloud_auth::credentials::{Credentials, anonymous::Builder as Anonymous};
     use google_cloud_gax::backoff_policy::BackoffPolicy;
+    use google_cloud_gax::error::rpc::Code;
     use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
     use google_cloud_gax::options::RequestOptions;
     use google_cloud_gax::retry_policy::{Aip194Strict, RetryPolicyExt};
@@ -108,7 +109,10 @@ mod tests {
         let response = send_request(client, "retry_policy_exhausted").await;
 
         // Assert
-        assert!(response.is_err(), "{response:?}");
+        let err = response.expect_err("should fail");
+        let status = err.status().expect("expected status");
+        assert_eq!(status.code, Code::Unavailable);
+        assert_eq!(status.message, "try-again");
         Ok(())
     }
 


### PR DESCRIPTION
For #5991.

Mirrors test from `src/gax-internal/tests/grpc_retry_loop.rs`:
- `retry_policy_exhausted`