### PR TITLE
chore: remove dedicated CODEOWNERS review requirement for /Cargo.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 *           @googleapis/cloud-sdk-rust-team
+# Root /Cargo.lock changes do not require a review from a dedicated team
+/Cargo.lock
 /librarian.yaml @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-librarian-team
 /src/auth/  @googleapis/cloud-sdk-rust-team @googleapis/cloud-sdk-auth-team
 


### PR DESCRIPTION
Add an unowned entry for /Cargo.lock in CODEOWNERS so changes modifying dependencies across individual crates do not require a dedicated review from the cloud-sdk-rust-team for the root lockfile.