### PR TITLE
impl(gax): refactor SendError to use BoxError

### DIFF
--- a/src/gax-internal/src/grpc/streaming.rs
+++ b/src/gax-internal/src/grpc/streaming.rs
@@ -51,11 +51,13 @@ where
     RequestSender::from_fn(move |item: DomainReq| {
         let req_tx = req_tx.clone();
         async move {
-            let prost_item = item.to_proto().map_err(SendError::ser)?;
+            let prost_item = item
+                .to_proto()
+                .map_err(|e| SendError::Serialization(Box::new(e)))?;
             req_tx
                 .send(prost_item)
                 .await
-                .map_err(|_| SendError::stream_closed())
+                .map_err(|_| SendError::StreamClosed)
         }
     })
 }

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -98,6 +98,25 @@ pub enum SendError {
     Serialization(#[source] BoxError),
 }
 
+impl SendError {
+    /// Converts this `SendError` into a [`crate::error::Error`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use google_cloud_gax::streaming::SendError;
+    /// let err = SendError::StreamClosed;
+    /// let gax_err = err.into_error();
+    /// assert!(gax_err.is_io());
+    /// ```
+    pub fn into_error(self) -> crate::error::Error {
+        match self {
+            Self::StreamClosed => crate::error::Error::io(self),
+            Self::Serialization(e) => crate::error::Error::ser(e),
+        }
+    }
+}
+
 /// A type-erased asynchronous function that sends a request item over a stream.
 ///
 /// This closure takes an owned request item and returns a boxed, pinned future
@@ -433,6 +452,7 @@ mod tests {
             err.to_string(),
             "cannot send request: stream is closed; inspect ResponseReceiver for details"
         );
+        assert!(err.into_error().is_io());
     }
 
     #[tokio::test]
@@ -458,6 +478,7 @@ mod tests {
             "cannot serialize the request: negative number"
         );
         assert_eq!(format!("{sender:?}"), "RequestSender");
+        assert!(err.into_error().is_serialization());
     }
 
     #[tokio::test]

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -61,6 +61,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// An error returned when sending a request over a stream fails.
 ///
@@ -93,25 +94,8 @@ pub enum SendError {
     StreamClosed,
 
     /// Serialization / proto conversion of the request failed.
-    #[error(transparent)]
-    Serialization(#[from] crate::error::Error),
-}
-
-impl SendError {
-    /// Not part of the public API, subject to change without notice.
-    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
-    pub fn stream_closed() -> Self {
-        Self::StreamClosed
-    }
-
-    /// Not part of the public API, subject to change without notice.
-    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
-    pub fn ser<T>(source: T) -> Self
-    where
-        T: Into<Box<dyn std::error::Error + Send + Sync>>,
-    {
-        Self::Serialization(crate::error::Error::ser(source))
-    }
+    #[error("cannot serialize the request")]
+    Serialization(#[source] BoxError),
 }
 
 /// A type-erased asynchronous function that sends a request item over a stream.
@@ -221,12 +205,7 @@ where
     fn from(req_tx: mpsc::Sender<Req>) -> RequestSender<Req> {
         Self::from_fn(move |item| {
             let req_tx = req_tx.clone();
-            async move {
-                req_tx
-                    .send(item)
-                    .await
-                    .map_err(|_| SendError::stream_closed())
-            }
+            async move { req_tx.send(item).await.map_err(|_| SendError::StreamClosed) }
         })
     }
 }
@@ -454,16 +433,15 @@ mod tests {
             err.to_string(),
             "cannot send request: stream is closed; inspect ResponseReceiver for details"
         );
-
-        let constructed = SendError::stream_closed();
-        assert!(matches!(constructed, SendError::StreamClosed));
     }
 
     #[tokio::test]
     async fn request_sender_send_error_serialization() {
         let sender = RequestSender::from_fn(|item: i32| async move {
             if item < 0 {
-                Err(SendError::ser("negative number"))
+                Err(SendError::Serialization(Box::new(std::io::Error::other(
+                    "negative number",
+                ))))
             } else {
                 Ok(())
             }
@@ -475,14 +453,8 @@ mod tests {
             .await
             .expect_err("negative number should trigger serialization error");
         assert!(matches!(err, SendError::Serialization(_)));
-        assert_eq!(
-            err.to_string(),
-            "cannot serialize the request negative number"
-        );
+        assert_eq!(err.to_string(), "cannot serialize the request");
         assert_eq!(format!("{sender:?}"), "RequestSender");
-
-        let ser_err = SendError::ser("test ser");
-        assert!(matches!(ser_err, SendError::Serialization(_)));
     }
 
     #[tokio::test]

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -94,7 +94,7 @@ pub enum SendError {
     StreamClosed,
 
     /// Serialization / proto conversion of the request failed.
-    #[error("cannot serialize the request")]
+    #[error("cannot serialize the request: {0}")]
     Serialization(#[source] BoxError),
 }
 
@@ -453,7 +453,10 @@ mod tests {
             .await
             .expect_err("negative number should trigger serialization error");
         assert!(matches!(err, SendError::Serialization(_)));
-        assert_eq!(err.to_string(), "cannot serialize the request");
+        assert_eq!(
+            err.to_string(),
+            "cannot serialize the request: negative number"
+        );
         assert_eq!(format!("{sender:?}"), "RequestSender");
     }
 

--- a/src/gax/src/streaming.rs
+++ b/src/gax/src/streaming.rs
@@ -98,25 +98,6 @@ pub enum SendError {
     Serialization(#[source] BoxError),
 }
 
-impl SendError {
-    /// Converts this `SendError` into a [`crate::error::Error`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use google_cloud_gax::streaming::SendError;
-    /// let err = SendError::StreamClosed;
-    /// let gax_err = err.into_error();
-    /// assert!(gax_err.is_io());
-    /// ```
-    pub fn into_error(self) -> crate::error::Error {
-        match self {
-            Self::StreamClosed => crate::error::Error::io(self),
-            Self::Serialization(e) => crate::error::Error::ser(e),
-        }
-    }
-}
-
 /// A type-erased asynchronous function that sends a request item over a stream.
 ///
 /// This closure takes an owned request item and returns a boxed, pinned future
@@ -452,7 +433,6 @@ mod tests {
             err.to_string(),
             "cannot send request: stream is closed; inspect ResponseReceiver for details"
         );
-        assert!(err.into_error().is_io());
     }
 
     #[tokio::test]
@@ -478,7 +458,6 @@ mod tests {
             "cannot serialize the request: negative number"
         );
         assert_eq!(format!("{sender:?}"), "RequestSender");
-        assert!(err.into_error().is_serialization());
     }
 
     #[tokio::test]

--- a/tests/showcase/src/streaming.rs
+++ b/tests/showcase/src/streaming.rs
@@ -139,7 +139,6 @@ async fn chat_server_error(client: &Echo) -> Result<()> {
     assert!(matches!(
         err,
         google_cloud_gax::streaming::SendError::StreamClosed
-            | google_cloud_gax::streaming::SendError::Serialization(_)
     ));
 
     Ok(())


### PR DESCRIPTION
Refactor SendError in google-cloud-gax to capture BoxError directly in the Serialization variant instead of wrapping crate::error::Error.

Remove temporary stream_closed and ser constructors now that construction is handled directly via SendError::StreamClosed and SendError::Serialization. These were intended to make refactoring the error type easier, but I have decided to keep an enum instead of doing an opaque struct with an internal SendErrorKind.