### PR TITLE
feat(bigquery): support committed streams

### DIFF
--- a/src/bigquery-write/src/arrow.rs
+++ b/src/bigquery-write/src/arrow.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod committed;
 mod default;
 mod pending;
 mod writer_builder;
 
+pub use committed::CommittedWriter;
 pub use default::DefaultWriter;
 pub use pending::PendingWriter;
 pub use writer_builder::WriterBuilder;

--- a/src/bigquery-write/src/arrow.rs
+++ b/src/bigquery-write/src/arrow.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 mod default;
+mod pending;
 mod writer_builder;
 
 pub use default::DefaultWriter;
+pub use pending::PendingWriter;
 pub use writer_builder::WriterBuilder;

--- a/src/bigquery-write/src/arrow/committed.rs
+++ b/src/bigquery-write/src/arrow/committed.rs
@@ -1,0 +1,112 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::builder::write::AppendWithOffset;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema};
+use crate::runner::Runner;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A writer for a committed stream.
+#[derive(Debug)]
+pub struct CommittedWriter {
+    runner: Runner,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ArrowSchema,
+}
+
+impl CommittedWriter {
+    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        let runner = Runner::new(inner);
+        Self {
+            runner,
+            write_stream,
+            schema,
+        }
+    }
+
+    /// Appends rows to the committed stream.
+    ///
+    /// For a committed stream, you MUST specify the offset using `.set_offset(x)`
+    /// on the returned builder to guarantee exactly-once semantics.
+    pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
+        let req = AppendRowsRequest::new()
+            .set_write_stream(&self.write_stream)
+            .set_arrow_rows(
+                ArrowData::new()
+                    .set_writer_schema(self.schema.clone())
+                    .set_rows(rows),
+            );
+        AppendWithOffset::new(self.runner.req_tx.clone(), req)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tests::*;
+    use crate::transport::tests::*;
+    use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Response as TonicResponse;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn request_fields() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let writer = CommittedWriter::new(transport, write_stream(), schema());
+
+        let b = writer.append(rows(1));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "1");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_success() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+
+        let writer = CommittedWriter::new(transport, write_stream(), schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let resp = writer.append(rows(1)).set_offset(0).send().await?;
+        assert_eq!(resp.offset, Some(1));
+
+        Ok(())
+    }
+
+    fn write_stream() -> String {
+        "projects/p/datasets/d/tables/t/streams/s".to_string()
+    }
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::new().set_serialized_schema("test")
+    }
+
+    fn rows(id: i64) -> ArrowRecordBatch {
+        ArrowRecordBatch::new().set_serialized_record_batch(id.to_string())
+    }
+}

--- a/src/bigquery-write/src/arrow/pending.rs
+++ b/src/bigquery-write/src/arrow/pending.rs
@@ -28,16 +28,18 @@ use std::sync::Arc;
 #[derive(Debug)]
 pub struct PendingWriter {
     runner: Runner,
+    pub(crate) parent: String,
     pub(crate) write_stream: String,
     pub(crate) schema: ArrowSchema,
     inner: Arc<Transport>,
 }
 
 impl PendingWriter {
-    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+    pub(crate) fn new(inner: Arc<Transport>, parent: String, write_stream: String, schema: ArrowSchema) -> Self {
         let runner = Runner::new(inner.clone());
         Self {
             runner,
+            parent,
             write_stream,
             schema,
             inner,
@@ -69,19 +71,9 @@ impl PendingWriter {
     /// Commits the pending stream to the table.
     pub async fn commit(&self) -> Result<BatchCommitWriteStreamsResponse> {
         let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
-
-        // Extract the parent table path from the stream name:
-        // "projects/p/datasets/d/tables/t/streams/s" -> "projects/p/datasets/d/tables/t"
-        let parent = self
-            .write_stream
-            .split_once("/streams/")
-            .map(|(p, _)| p)
-            .unwrap_or(self.write_stream.as_str())
-            .to_string();
-
         client
             .batch_commit_write_streams()
-            .set_parent(parent)
+            .set_parent(self.parent.clone())
             .set_write_streams(vec![self.write_stream.clone()])
             .send()
             .await
@@ -100,7 +92,7 @@ mod tests {
     #[tokio::test]
     async fn request_fields() -> anyhow::Result<()> {
         let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
-        let writer = PendingWriter::new(transport, write_stream(), schema());
+        let writer = PendingWriter::new(transport, parent(), write_stream(), schema());
 
         let b = writer.append(rows(1));
         assert_eq!(b.req.write_stream, write_stream());
@@ -134,7 +126,7 @@ mod tests {
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
 
-        let writer = PendingWriter::new(transport, write_stream(), schema());
+        let writer = PendingWriter::new(transport, parent(), write_stream(), schema());
 
         response_tx.send(Ok(convert(&test_response(1)))).await?;
         let resp = writer.append(rows(1)).send().await?;
@@ -144,6 +136,10 @@ mod tests {
         writer.commit().await?;
 
         Ok(())
+    }
+
+    fn parent() -> String {
+        "projects/p/datasets/d/tables/t".to_string()
     }
 
     fn write_stream() -> String {

--- a/src/bigquery-write/src/arrow/pending.rs
+++ b/src/bigquery-write/src/arrow/pending.rs
@@ -74,9 +74,9 @@ impl PendingWriter {
         // "projects/p/datasets/d/tables/t/streams/s" -> "projects/p/datasets/d/tables/t"
         let parent = self
             .write_stream
-            .split("/streams/")
-            .next()
-            .unwrap_or(&self.write_stream)
+            .split_once("/streams/")
+            .map(|(p, _)| p)
+            .unwrap_or(self.write_stream.as_str())
             .to_string();
 
         client
@@ -120,12 +120,12 @@ mod tests {
         let mut mock = MockBigQueryWrite::new();
         mock.expect_append_rows()
             .return_once(|_| Ok(TonicResponse::from(response_rx)));
-            
+
         mock.expect_finalize_write_stream()
             .return_once(|_| Ok(TonicResponse::new(
                 bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse::default()
             )));
-            
+
         mock.expect_batch_commit_write_streams()
             .return_once(|_| Ok(TonicResponse::new(
                 bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::BatchCommitWriteStreamsResponse::default()

--- a/src/bigquery-write/src/arrow/pending.rs
+++ b/src/bigquery-write/src/arrow/pending.rs
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::builder::write::AppendWithOffset;
+use crate::generated::gapic_storage::client::BigQueryWrite;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{
+    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
+    FinalizeWriteStreamResponse,
+};
+use crate::runner::Runner;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A writer for a pending stream.
+#[derive(Debug)]
+pub struct PendingWriter {
+    runner: Runner,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ArrowSchema,
+    inner: Arc<Transport>,
+}
+
+impl PendingWriter {
+    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        let runner = Runner::new(inner.clone());
+        Self {
+            runner,
+            write_stream,
+            schema,
+            inner,
+        }
+    }
+
+    /// Appends rows to the pending stream.
+    pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
+        let req = AppendRowsRequest::new()
+            .set_write_stream(&self.write_stream)
+            .set_arrow_rows(
+                ArrowData::new()
+                    .set_writer_schema(self.schema.clone())
+                    .set_rows(rows),
+            );
+        AppendWithOffset::new(self.runner.req_tx.clone(), req)
+    }
+
+    /// Finalizes the pending stream, preventing further writes.
+    pub async fn finalize(&self) -> Result<FinalizeWriteStreamResponse> {
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        client
+            .finalize_write_stream()
+            .set_name(&self.write_stream)
+            .send()
+            .await
+    }
+
+    /// Commits the pending stream to the table.
+    pub async fn commit(&self) -> Result<BatchCommitWriteStreamsResponse> {
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+
+        // Extract the parent table path from the stream name:
+        // "projects/p/datasets/d/tables/t/streams/s" -> "projects/p/datasets/d/tables/t"
+        let parent = self
+            .write_stream
+            .split("/streams/")
+            .next()
+            .unwrap_or(&self.write_stream)
+            .to_string();
+
+        client
+            .batch_commit_write_streams()
+            .set_parent(parent)
+            .set_write_streams(vec![self.write_stream.clone()])
+            .send()
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tests::*;
+    use crate::transport::tests::*;
+    use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Response as TonicResponse;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn request_fields() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let writer = PendingWriter::new(transport, write_stream(), schema());
+
+        let b = writer.append(rows(1));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "1");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_success() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+            
+        mock.expect_finalize_write_stream()
+            .return_once(|_| Ok(TonicResponse::new(
+                bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse::default()
+            )));
+            
+        mock.expect_batch_commit_write_streams()
+            .return_once(|_| Ok(TonicResponse::new(
+                bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::BatchCommitWriteStreamsResponse::default()
+            )));
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+
+        let writer = PendingWriter::new(transport, write_stream(), schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let resp = writer.append(rows(1)).send().await?;
+        assert_eq!(resp.offset, Some(1));
+
+        writer.finalize().await?;
+        writer.commit().await?;
+
+        Ok(())
+    }
+
+    fn write_stream() -> String {
+        "projects/p/datasets/d/tables/t/streams/s".to_string()
+    }
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::new().set_serialized_schema("test")
+    }
+
+    fn rows(id: i64) -> ArrowRecordBatch {
+        ArrowRecordBatch::new().set_serialized_record_batch(id.to_string())
+    }
+}

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -45,8 +45,6 @@ impl WriterBuilder {
     }
 
     /// Creates a pending writer for the given table.
-    ///
-    /// The client library creates a `WriteStream` with type `PENDING` on behalf of the application.
     pub async fn pending<T: Into<String>>(self, table: T) -> Result<PendingWriter> {
         use crate::generated::gapic_storage::client::BigQueryWrite;
         use crate::model::WriteStream;
@@ -100,6 +98,39 @@ mod tests {
     use super::*;
     use crate::transport::tests::test_transport;
     use test_case::test_case;
+
+    #[tokio::test]
+    async fn pending_success() -> anyhow::Result<()> {
+        use bigquery_write_grpc_mock::{start, MockBigQueryWrite};
+        use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_create_write_stream().return_once(|_| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                MockWriteStream { name: "projects/p/datasets/d/tables/t/streams/s".to_string(), ..Default::default() },
+            ))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer = builder.pending("projects/p/datasets/d/tables/t").await?;
+        assert_eq!(writer.write_stream, "projects/p/datasets/d/tables/t/streams/s");
+        assert_eq!(writer.schema, schema);
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[tokio::test]
+    async fn pending_bad_table_format(table: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder.pending(table).await.expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
 
     #[tokio::test]
     async fn default() -> anyhow::Result<()> {

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::arrow::{DefaultWriter, PendingWriter};
+use crate::arrow::{CommittedWriter, DefaultWriter, PendingWriter};
 use crate::model::ArrowSchema;
 use crate::transport::Transport;
 use crate::{Error, Result};
@@ -64,6 +64,32 @@ impl WriterBuilder {
         Ok(PendingWriter::new(
             self.inner,
             table,
+            write_stream.name,
+            self.schema,
+        ))
+    }
+
+    /// Creates a committed writer for the given table.
+    ///
+    /// The client library creates a `WriteStream` with type `COMMITTED` on behalf of the application.
+    pub async fn committed<T: Into<String>>(self, table: T) -> Result<CommittedWriter> {
+        use crate::generated::gapic_storage::client::BigQueryWrite;
+        use crate::model::WriteStream;
+        use crate::model::write_stream::Type;
+
+        let table = table.into();
+        validate_table(table.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let write_stream = client
+            .create_write_stream()
+            .set_parent(table)
+            .set_write_stream(WriteStream::new().set_type(Type::Committed))
+            .send()
+            .await?;
+
+        Ok(CommittedWriter::new(
+            self.inner,
             write_stream.name,
             self.schema,
         ))
@@ -139,6 +165,40 @@ mod tests {
         assert!(err.is_binding(), "{err:?}");
         Ok(())
     }
+
+    #[tokio::test]
+    async fn committed_success() -> anyhow::Result<()> {
+        use bigquery_write_grpc_mock::{start, MockBigQueryWrite};
+        use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_create_write_stream().return_once(|_| {
+            Ok(gaxi::grpc::tonic::Response::new(
+                MockWriteStream { name: "projects/p/datasets/d/tables/t/streams/s".to_string(), ..Default::default() },
+            ))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer = builder.committed("projects/p/datasets/d/tables/t").await?;
+        assert_eq!(writer.write_stream, "projects/p/datasets/d/tables/t/streams/s");
+        assert_eq!(writer.schema, schema);
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[tokio::test]
+    async fn committed_bad_table_format(table: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder.committed(table).await.expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+
 
     #[tokio::test]
     async fn default() -> anyhow::Result<()> {

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::arrow::DefaultWriter;
+use crate::arrow::{DefaultWriter, PendingWriter};
 use crate::model::ArrowSchema;
 use crate::transport::Transport;
 use crate::{Error, Result};
@@ -42,6 +42,32 @@ impl WriterBuilder {
         let mut write_stream = table;
         write_stream.push_str("/streams/_default");
         Ok(DefaultWriter::new(self.inner, write_stream, self.schema))
+    }
+
+    /// Creates a pending writer for the given table.
+    ///
+    /// The client library creates a `WriteStream` with type `PENDING` on behalf of the application.
+    pub async fn pending<T: Into<String>>(self, table: T) -> Result<PendingWriter> {
+        use crate::generated::gapic_storage::client::BigQueryWrite;
+        use crate::model::WriteStream;
+        use crate::model::write_stream::Type;
+
+        let table = table.into();
+        validate_table(table.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let write_stream = client
+            .create_write_stream()
+            .set_parent(table)
+            .set_write_stream(WriteStream::new().set_type(Type::Pending))
+            .send()
+            .await?;
+
+        Ok(PendingWriter::new(
+            self.inner,
+            write_stream.name,
+            self.schema,
+        ))
     }
 }
 

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -56,13 +56,14 @@ impl WriterBuilder {
         let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
         let write_stream = client
             .create_write_stream()
-            .set_parent(table)
+            .set_parent(table.clone())
             .set_write_stream(WriteStream::new().set_type(Type::Pending))
             .send()
             .await?;
 
         Ok(PendingWriter::new(
             self.inner,
+            table,
             write_stream.name,
             self.schema,
         ))
@@ -101,20 +102,24 @@ mod tests {
 
     #[tokio::test]
     async fn pending_success() -> anyhow::Result<()> {
-        use bigquery_write_grpc_mock::{start, MockBigQueryWrite};
         use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
         let mut mock = MockBigQueryWrite::new();
         mock.expect_create_write_stream().return_once(|_| {
-            Ok(gaxi::grpc::tonic::Response::new(
-                MockWriteStream { name: "projects/p/datasets/d/tables/t/streams/s".to_string(), ..Default::default() },
-            ))
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                ..Default::default()
+            }))
         });
         let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
         let transport = Arc::new(test_transport(endpoint).await?);
         let schema = ArrowSchema::new().set_serialized_schema("test");
         let builder = WriterBuilder::new(transport, schema.clone());
         let writer = builder.pending("projects/p/datasets/d/tables/t").await?;
-        assert_eq!(writer.write_stream, "projects/p/datasets/d/tables/t/streams/s");
+        assert_eq!(
+            writer.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
         assert_eq!(writer.schema, schema);
         Ok(())
     }
@@ -127,7 +132,10 @@ mod tests {
         let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
         let schema = ArrowSchema::new().set_serialized_schema("test");
         let builder = WriterBuilder::new(transport, schema.clone());
-        let err = builder.pending(table).await.expect_err("should fail locally on bad format");
+        let err = builder
+            .pending(table)
+            .await
+            .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
         Ok(())
     }

--- a/tests/bigquery/src/query.rs
+++ b/tests/bigquery/src/query.rs
@@ -404,12 +404,12 @@ pub async fn query_client_nested_types() -> Result<()> {
     let bob = UserRecord {
         name: "Bob".to_string(),
         age: 28,
-            test: None,
+        test: None,
     };
     let charlie = UserRecord {
         name: "Charlie".to_string(),
         age: 31,
-            test: None,
+        test: None,
     };
     assert_eq!(data.users, [bob, charlie]);
 

--- a/tests/bigquery/src/query.rs
+++ b/tests/bigquery/src/query.rs
@@ -348,6 +348,7 @@ pub async fn query_client_job() -> Result<()> {
 pub(crate) struct UserRecord {
     pub(crate) name: String,
     pub(crate) age: i64,
+    pub(crate) test: Option<String>,
 }
 
 #[derive(FromSql, Debug, PartialEq)]
@@ -403,10 +404,12 @@ pub async fn query_client_nested_types() -> Result<()> {
     let bob = UserRecord {
         name: "Bob".to_string(),
         age: 28,
+            test: None,
     };
     let charlie = UserRecord {
         name: "Charlie".to_string(),
         age: 31,
+            test: None,
     };
     assert_eq!(data.users, [bob, charlie]);
 

--- a/tests/bigquery/src/table.rs
+++ b/tests/bigquery/src/table.rs
@@ -29,6 +29,7 @@ pub(crate) async fn create_table(
     let schema = TableSchema::new().set_fields([
         TableFieldSchema::new().set_name("name").set_type("STRING"),
         TableFieldSchema::new().set_name("age").set_type("INTEGER"),
+        TableFieldSchema::new().set_name("test").set_type("STRING"),
     ]);
     table_service
         .insert_table()
@@ -54,9 +55,14 @@ pub(crate) async fn read_table(
     project_id: &str,
     dataset_id: &str,
     table_id: &str,
+    test_filter: Option<&str>,
 ) -> Result<Vec<UserRecord>> {
     let client = BigQuery::builder().build().await?;
-    let query = format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}` ORDER BY name");
+    let mut query = format!("SELECT * FROM `{project_id}.{dataset_id}.{table_id}`");
+    if let Some(test_name) = test_filter {
+        query.push_str(&format!(" WHERE test = '{test_name}'"));
+    }
+    query.push_str(" ORDER BY name");
     let mut rows = client
         .query(query)
         .with_project_id(project_id)

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -34,7 +34,8 @@ pub async fn run_writes() -> Result<()> {
 
     let result = async {
         create_table(&table_service, &project_id, &dataset_id, table_id).await?;
-        arrow::basic(&project_id, &dataset_id, table_id).await
+        arrow::basic(&project_id, &dataset_id, table_id).await?;
+        arrow::pending(&project_id, &dataset_id, table_id).await
     }
     .await;
 

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -15,8 +15,8 @@
 mod arrow;
 
 use crate::dataset::{cleanup_stale_datasets, create_dataset, delete_dataset, random_dataset_id};
-use crate::query::UserRecord;
-use crate::table::{create_table, read_table};
+
+use crate::table::create_table;
 use anyhow::Result;
 use google_cloud_bigquery_v2::client::{DatasetService, TableService};
 use google_cloud_test_utils::runtime_config::project_id;

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -35,7 +35,8 @@ pub async fn run_writes() -> Result<()> {
     let result = async {
         create_table(&table_service, &project_id, &dataset_id, table_id).await?;
         arrow::basic(&project_id, &dataset_id, table_id).await?;
-        arrow::pending(&project_id, &dataset_id, table_id).await
+        arrow::pending(&project_id, &dataset_id, table_id).await?;
+        arrow::committed(&project_id, &dataset_id, table_id).await
     }
     .await;
 

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -43,7 +43,10 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     let name = StringArray::from(vec!["Alice", "Bob"]);
     let age = Int64Array::from(vec![25, 28]);
     let test_col = StringArray::from(vec!["basic", "basic"]);
-    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
+    let batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(name), Arc::new(age), Arc::new(test_col)],
+    )?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the batch
@@ -54,7 +57,10 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     let name = StringArray::from(vec!["Charlie"]);
     let age = Int64Array::from(vec![31]);
     let test_col = StringArray::from(vec!["basic"]);
-    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![Arc::new(name), Arc::new(age), Arc::new(test_col)],
+    )?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the second batch
@@ -108,7 +114,10 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     let name = StringArray::from(vec!["David", "Eve"]);
     let age = Int64Array::from(vec![42, 38]);
     let test_col = StringArray::from(vec!["pending", "pending"]);
-    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
+    let batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(name), Arc::new(age), Arc::new(test_col)],
+    )?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the batch with offset 0
@@ -119,7 +128,10 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     let name = StringArray::from(vec!["Frank"]);
     let age = Int64Array::from(vec![55]);
     let test_col = StringArray::from(vec!["pending"]);
-    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![Arc::new(name), Arc::new(age), Arc::new(test_col)],
+    )?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the second batch with offset 2

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use super::*;
+use crate::query::UserRecord;
 use ::arrow::array::{Int64Array, StringArray};
 use ::arrow::datatypes::{DataType, Field, Schema};
 use ::arrow::ipc::writer::StreamWriter;
@@ -28,6 +29,7 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     let arrow_schema = Arc::new(Schema::new(vec![
         Field::new("name", DataType::Utf8, false),
         Field::new("age", DataType::Int64, false),
+        Field::new("test", DataType::Utf8, false),
     ]));
     let schema_buf = serialize_schema(&arrow_schema)?;
     let schema_len = schema_buf.len();
@@ -40,7 +42,8 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     // Create a RecordBatch
     let name = StringArray::from(vec!["Alice", "Bob"]);
     let age = Int64Array::from(vec![25, 28]);
-    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age)])?;
+    let test_col = StringArray::from(vec!["basic", "basic"]);
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the batch
@@ -50,7 +53,8 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     // Create a second RecordBatch
     let name = StringArray::from(vec!["Charlie"]);
     let age = Int64Array::from(vec![31]);
-    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age)])?;
+    let test_col = StringArray::from(vec!["basic"]);
+    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the second batch
@@ -58,21 +62,24 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     let _ = writer.append(rows).send().await?;
 
     // Verify the writes
-    let users = read_table(project_id, dataset_id, table_id).await?;
+    let users = crate::table::read_table(project_id, dataset_id, table_id, Some("basic")).await?;
     assert_eq!(
         users,
         vec![
             UserRecord {
-                name: "Alice".to_string(),
+                name: "Alice".to_string(), // from `basic`
                 age: 25,
+                test: Some("basic".to_string()),
             },
             UserRecord {
-                name: "Bob".to_string(),
+                name: "Bob".to_string(), // from `basic`
                 age: 28,
+                test: Some("basic".to_string()),
             },
             UserRecord {
-                name: "Charlie".to_string(),
+                name: "Charlie".to_string(), // from `basic`
                 age: 31,
+                test: Some("basic".to_string()),
             },
         ]
     );
@@ -87,6 +94,7 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     let arrow_schema = Arc::new(Schema::new(vec![
         Field::new("name", DataType::Utf8, false),
         Field::new("age", DataType::Int64, false),
+        Field::new("test", DataType::Utf8, false),
     ]));
     let schema_buf = serialize_schema(&arrow_schema)?;
     let schema_len = schema_buf.len();
@@ -99,7 +107,8 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     // Create a RecordBatch
     let name = StringArray::from(vec!["David", "Eve"]);
     let age = Int64Array::from(vec![42, 38]);
-    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age)])?;
+    let test_col = StringArray::from(vec!["pending", "pending"]);
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the batch with offset 0
@@ -109,7 +118,8 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     // Create a second RecordBatch
     let name = StringArray::from(vec!["Frank"]);
     let age = Int64Array::from(vec![55]);
-    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age)])?;
+    let test_col = StringArray::from(vec!["pending"]);
+    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
     let batch_buf = serialize_batch(&batch, schema_len)?;
 
     // Write the second batch with offset 2
@@ -120,34 +130,25 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     writer.finalize().await?;
     writer.commit().await?;
 
-    // Verify the writes (contains the data from `.basic()` test + the pending data we just committed)
-    let users = read_table(project_id, dataset_id, table_id).await?;
+    // Verify the writes (ONLY pending)
+    let users = crate::table::read_table(project_id, dataset_id, table_id, Some("pending")).await?;
     assert_eq!(
         users,
         vec![
             UserRecord {
-                name: "Alice".to_string(), // from `basic`
-                age: 25,
-            },
-            UserRecord {
-                name: "Bob".to_string(), // from `basic`
-                age: 28,
-            },
-            UserRecord {
-                name: "Charlie".to_string(), // from `basic`
-                age: 31,
-            },
-            UserRecord {
                 name: "David".to_string(), // from `pending`
                 age: 42,
+                test: Some("pending".to_string()),
             },
             UserRecord {
                 name: "Eve".to_string(), // from `pending`
                 age: 38,
+                test: Some("pending".to_string()),
             },
             UserRecord {
                 name: "Frank".to_string(), // from `pending`
                 age: 55,
+                test: Some("pending".to_string()),
             },
         ]
     );

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -80,6 +80,81 @@ pub async fn basic(project_id: &str, dataset_id: &str, table_id: &str) -> Result
     Ok(())
 }
 
+pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+
+    // Create a Schema
+    let arrow_schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int64, false),
+    ]));
+    let schema_buf = serialize_schema(&arrow_schema)?;
+    let schema_len = schema_buf.len();
+
+    // Create a writer for a pending stream
+    let client = Write::builder().build().await?;
+    let schema = ArrowSchema::new().set_serialized_schema(schema_buf);
+    let writer = client.arrow(schema).pending(table).await?;
+
+    // Create a RecordBatch
+    let name = StringArray::from(vec!["David", "Eve"]);
+    let age = Int64Array::from(vec![42, 38]);
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age)])?;
+    let batch_buf = serialize_batch(&batch, schema_len)?;
+
+    // Write the batch with offset 0
+    let rows = ArrowRecordBatch::new().set_serialized_record_batch(batch_buf);
+    let _ = writer.append(rows).set_offset(0).send().await?;
+
+    // Create a second RecordBatch
+    let name = StringArray::from(vec!["Frank"]);
+    let age = Int64Array::from(vec![55]);
+    let batch = RecordBatch::try_new(arrow_schema, vec![Arc::new(name), Arc::new(age)])?;
+    let batch_buf = serialize_batch(&batch, schema_len)?;
+
+    // Write the second batch with offset 2
+    let rows = ArrowRecordBatch::new().set_serialized_record_batch(batch_buf);
+    let _ = writer.append(rows).set_offset(2).send().await?;
+
+    // Finalize the stream and commit
+    writer.finalize().await?;
+    writer.commit().await?;
+
+    // Verify the writes (contains the data from `.basic()` test + the pending data we just committed)
+    let users = read_table(project_id, dataset_id, table_id).await?;
+    assert_eq!(
+        users,
+        vec![
+            UserRecord {
+                name: "Alice".to_string(), // from `basic`
+                age: 25,
+            },
+            UserRecord {
+                name: "Bob".to_string(), // from `basic`
+                age: 28,
+            },
+            UserRecord {
+                name: "Charlie".to_string(), // from `basic`
+                age: 31,
+            },
+            UserRecord {
+                name: "David".to_string(), // from `pending`
+                age: 42,
+            },
+            UserRecord {
+                name: "Eve".to_string(), // from `pending`
+                age: 38,
+            },
+            UserRecord {
+                name: "Frank".to_string(), // from `pending`
+                age: 55,
+            },
+        ]
+    );
+
+    Ok(())
+}
+
 fn serialize_schema(schema: &Schema) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     let _ = StreamWriter::try_new(&mut buf, schema)?;

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -168,6 +168,42 @@ pub async fn pending(project_id: &str, dataset_id: &str, table_id: &str) -> Resu
     Ok(())
 }
 
+pub async fn committed(project_id: &str, dataset_id: &str, table_id: &str) -> Result<()> {
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+
+    let arrow_schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, false),
+        Field::new("age", DataType::Int64, false),
+        Field::new("test", DataType::Utf8, false),
+    ]));
+    let schema_buf = serialize_schema(&arrow_schema)?;
+    let schema_len = schema_buf.len();
+
+    let client = Write::builder().build().await?;
+    let schema = ArrowSchema::new().set_serialized_schema(schema_buf);
+    let writer = client.arrow(schema).committed(table).await?;
+
+    let name = StringArray::from(vec!["George", "Hannah"]);
+    let age = Int64Array::from(vec![22, 27]);
+    let test_col = StringArray::from(vec!["committed", "committed"]);
+    let batch = RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(name), Arc::new(age), Arc::new(test_col)])?;
+    let batch_buf = serialize_batch(&batch, schema_len)?;
+
+    let rows = ArrowRecordBatch::new().set_serialized_record_batch(batch_buf);
+    let _ = writer.append(rows).set_offset(0).send().await?;
+
+    let users = crate::table::read_table(project_id, dataset_id, table_id, Some("committed")).await?;
+    let mut found = 0;
+    for user in users {
+        if user.name == "George" || user.name == "Hannah" {
+            found += 1;
+        }
+    }
+    assert_eq!(found, 2, "Committed rows not found immediately!");
+
+    Ok(())
+}
+
 fn serialize_schema(schema: &Schema) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     let _ = StreamWriter::try_new(&mut buf, schema)?;


### PR DESCRIPTION
Introduce the `CommittedWriter`,  allowing applications to stream data that is immediately committed to the table.
The committed writer behaves identically to `PendingWriter` but drops the `commit()` action because data becomes available for reading immediately.

