### PR TITLE
feat(bigquery): support committed streams

### DIFF
--- a/src/bigquery-write/src/arrow.rs
+++ b/src/bigquery-write/src/arrow.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod committed;
 mod default;
 mod pending;
 mod writer_builder;
 
+pub use committed::CommittedWriter;
 pub use default::DefaultWriter;
 pub use pending::PendingWriter;
 pub use writer_builder::WriterBuilder;

--- a/src/bigquery-write/src/arrow/committed.rs
+++ b/src/bigquery-write/src/arrow/committed.rs
@@ -1,0 +1,156 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::builder::write::AppendWithOffset;
+use crate::generated::gapic_storage::client::BigQueryWrite;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse};
+use crate::runner::Runner;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A writer for the [committed stream].
+///
+/// [committed stream]: https://docs.cloud.google.com/bigquery/docs/write-api-grpc#committed_type
+#[derive(Debug)]
+pub struct CommittedWriter {
+    runner: Runner,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ArrowSchema,
+    client: BigQueryWrite,
+}
+
+impl CommittedWriter {
+    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        let runner = Runner::new(inner.clone());
+        let client = BigQueryWrite::from_stub::<Transport>(inner);
+        Self {
+            runner,
+            write_stream,
+            schema,
+            client,
+        }
+    }
+
+    /// Append rows to the stream.
+    pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
+        let req = AppendRowsRequest::new()
+            .set_write_stream(&self.write_stream)
+            .set_arrow_rows(
+                ArrowData::new()
+                    .set_writer_schema(self.schema.clone())
+                    .set_rows(rows),
+            );
+        AppendWithOffset::new(self.runner.req_tx.clone(), req)
+    }
+
+    /// Finalize the stream, preventing further writes.
+    pub async fn finalize(&self) -> Result<FinalizeWriteStreamResponse> {
+        self.client
+            .finalize_write_stream()
+            .set_name(&self.write_stream)
+            .send()
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tests::*;
+    use crate::transport::tests::*;
+    use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Response as TonicResponse;
+    use tokio::sync::mpsc;
+
+    use crate::error::AppendError;
+
+    #[tokio::test]
+    async fn request_fields() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let writer = CommittedWriter::new(transport, write_stream(), schema());
+
+        let b = writer.append(rows(1));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "1");
+
+        let b = writer.append(rows(2));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "2");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_success() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+
+        mock.expect_finalize_write_stream().return_once(|_| {
+            Ok(TonicResponse::new(
+                bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse::default(),
+            ))
+        });
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+
+        let writer = CommittedWriter::new(transport, write_stream(), schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let resp = writer.append(rows(1)).send().await?;
+        assert_eq!(resp.offset, Some(1));
+
+        response_tx.send(Ok(convert(&test_response(2)))).await?;
+        let resp = writer.append(rows(2)).send().await?;
+        assert_eq!(resp.offset, Some(2));
+
+        response_tx.send(Ok(convert(&test_response(3)))).await?;
+        let resp = writer.append(rows(3)).send().await?;
+        assert_eq!(resp.offset, Some(3));
+
+        drop(response_tx);
+        let err = writer.append(rows(4)).send().await.expect_err("channel");
+        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
+
+        // We can still finalize the stream even if row appends hit a closed bidirectional stream
+        writer.finalize().await?;
+
+        Ok(())
+    }
+
+    fn write_stream() -> String {
+        "projects/p/datasets/d/tables/t/streams/s".to_string()
+    }
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::new().set_serialized_schema("test")
+    }
+
+    fn rows(id: i64) -> ArrowRecordBatch {
+        ArrowRecordBatch::new().set_serialized_record_batch(id.to_string())
+    }
+}

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -122,7 +122,11 @@ mod tests {
         use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
         use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
         let mut mock = MockBigQueryWrite::new();
-        mock.expect_create_write_stream().return_once(|_| {
+        mock.expect_create_write_stream().return_once(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.parent, "projects/p/datasets/d/tables/t");
+            let ws = req.write_stream.expect("write_stream populated");
+            assert_eq!(Type::from(ws.r#type), Type::Pending);
             Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
                 name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
                 ..Default::default()
@@ -166,8 +170,7 @@ mod tests {
             let req = req.into_inner();
             assert_eq!(req.parent, "projects/p/datasets/d/tables/t");
             let ws = req.write_stream.expect("write_stream populated");
-            // 1 == COMMITTED
-            assert_eq!(ws.r#type, 1);
+            assert_eq!(Type::from(ws.r#type), Type::Committed);
             Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
                 name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
                 ..Default::default()

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -65,6 +65,29 @@ impl WriterBuilder {
             self.schema,
         ))
     }
+
+    /// Creates a committed writer for the given table.
+    pub async fn committed<T: Into<String>>(
+        self,
+        table: T,
+    ) -> Result<crate::arrow::CommittedWriter> {
+        let table = table.into();
+        validate_table(table.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let write_stream = client
+            .create_write_stream()
+            .set_parent(table)
+            .set_write_stream(WriteStream::new().set_type(Type::Committed))
+            .send()
+            .await?;
+
+        Ok(crate::arrow::CommittedWriter::new(
+            self.inner,
+            write_stream.name,
+            self.schema,
+        ))
+    }
 }
 
 fn validate_table(table: &str) -> Result<()> {
@@ -131,6 +154,51 @@ mod tests {
         let builder = WriterBuilder::new(transport, schema.clone());
         let err = builder
             .pending(table)
+            .await
+            .expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn committed_success() -> anyhow::Result<()> {
+        use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_create_write_stream().return_once(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.parent, "projects/p/datasets/d/tables/t");
+            let ws = req.write_stream.expect("write_stream populated");
+            // 1 == COMMITTED
+            assert_eq!(ws.r#type, 1);
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                ..Default::default()
+            }))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer = builder.committed("projects/p/datasets/d/tables/t").await?;
+        assert_eq!(
+            writer.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.schema, schema);
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[tokio::test]
+    async fn committed_bad_table_format(table: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder
+            .committed(table)
             .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::arrow::{DefaultWriter, PendingWriter};
+use crate::arrow::{CommittedWriter, DefaultWriter, PendingWriter};
 use crate::generated::gapic_storage::client::BigQueryWrite;
 use crate::model::write_stream::Type;
 use crate::model::{ArrowSchema, WriteStream};
@@ -67,10 +67,7 @@ impl WriterBuilder {
     }
 
     /// Creates a committed writer for the given table.
-    pub async fn committed<T: Into<String>>(
-        self,
-        table: T,
-    ) -> Result<crate::arrow::CommittedWriter> {
+    pub async fn committed<T: Into<String>>(self, table: T) -> Result<CommittedWriter> {
         let table = table.into();
         validate_table(table.as_str())?;
 
@@ -82,7 +79,7 @@ impl WriterBuilder {
             .send()
             .await?;
 
-        Ok(crate::arrow::CommittedWriter::new(
+        Ok(CommittedWriter::new(
             self.inner,
             write_stream.name,
             self.schema,

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -38,7 +38,8 @@ pub async fn run_writes() -> Result<()> {
         create_writes_table(&table_service, &project_id, &dataset_id, table_id).await?;
         let client = Write::builder().build().await?;
         arrow::basic(&client, &project_id, &dataset_id, table_id).await?;
-        arrow::pending(&client, &project_id, &dataset_id, table_id).await
+        arrow::pending(&client, &project_id, &dataset_id, table_id).await?;
+        arrow::committed(&client, &project_id, &dataset_id, table_id).await
     }
     .await;
 

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -183,3 +183,67 @@ fn serialize_batch(batch: &RecordBatch, schema_len: usize) -> Result<Vec<u8>> {
     // to strip it.
     Ok(buf[schema_len..].to_vec())
 }
+
+pub async fn committed(
+    client: &Write,
+    project_id: &str,
+    dataset_id: &str,
+    table_id: &str,
+) -> Result<()> {
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+    let schema = create_test_schema();
+
+    // Create a writer for a committed stream
+    let writer = client
+        .arrow(ArrowSchema::new().set_serialized_schema(serialize_schema(&schema)?))
+        .committed(table)
+        .await?;
+
+    // Write the batches
+    let batch1 = create_test_batch(
+        schema.clone(),
+        vec!["Gerald", "Hannah"],
+        vec![20, 22],
+        "committed",
+    )?;
+    let _ = writer.append(batch1).send().await?;
+
+    let batch2 = create_test_batch(schema.clone(), vec!["Ian"], vec![24], "committed")?;
+    let _ = writer.append(batch2).send().await?;
+
+    // Verify the writes are immediately available since it's a committed stream
+    let users = read_writes_table(project_id, dataset_id, table_id, "committed").await?;
+    assert_eq!(
+        users,
+        vec![
+            WriteUserRecord {
+                name: "Gerald".to_string(),
+                age: 20,
+                test: "committed".to_string()
+            },
+            WriteUserRecord {
+                name: "Hannah".to_string(),
+                age: 22,
+                test: "committed".to_string()
+            },
+            WriteUserRecord {
+                name: "Ian".to_string(),
+                age: 24,
+                test: "committed".to_string()
+            },
+        ]
+    );
+
+    // Finalize the stream
+    writer.finalize().await?;
+
+    // Verify that appending to a finalized stream fails
+    let batch3 = create_test_batch(schema.clone(), vec!["Jack"], vec![26], "committed")?;
+    let _err = writer
+        .append(batch3)
+        .send()
+        .await
+        .expect_err("Appending to a finalized stream should fail");
+
+    Ok(())
+}


### PR DESCRIPTION
Introduce the `CommittedWriter`, allowing applications to stream data that is immediately committed to the table.
The committed writer behaves identically to `PendingWriter` but drops the `commit()` action because data becomes available for reading immediately.

Fixes https://github.com/googleapis/google-cloud-rust/issues/6403