### PR TITLE
perf(bigquery): avoid allocating when converting booleans

### DIFF
--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -336,13 +336,19 @@ fn convert_basic_type(value: String, field_name: &str, field_type: &str) -> Resu
             }
         }
         "BOOLEAN" | "BOOL" => {
-            let b = value
-                .to_lowercase()
-                .parse::<bool>()
-                .map_err(|e| RowError::TypeConversion {
+            let b = if value.eq_ignore_ascii_case("true") {
+                true
+            } else if value.eq_ignore_ascii_case("false") {
+                false
+            } else {
+                return Err(RowError::TypeConversion {
                     column: field_name.to_string(),
-                    source: ConvertError::Convert(Box::new(e)),
-                })?;
+                    source: ConvertError::TypeMismatch {
+                        expected: "bool",
+                        got: Value::String(value),
+                    },
+                });
+            };
             Ok(Value::Bool(b))
         }
         _ => Err(RowError::InvalidRowFormat(format!(

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -343,10 +343,9 @@ fn convert_basic_type(value: String, field_name: &str, field_type: &str) -> Resu
             } else {
                 return Err(RowError::TypeConversion {
                     column: field_name.to_string(),
-                    source: ConvertError::TypeMismatch {
-                        expected: "bool",
-                        got: Value::String(value),
-                    },
+                    source: ConvertError::Convert(
+                        "provided string was not `true` or `false`".into(),
+                    ),
                 });
             };
             Ok(Value::Bool(b))


### PR DESCRIPTION
`convert_basic_type` called `String::to_lowercase()` before parsing every BOOLEAN/BOOL cell, allocating and copying a new string per value. Match the valid spellings with `eq_ignore_ascii_case` instead, which accepts exactly the same inputs without allocating.

Malformed values now report `ConvertError::TypeMismatch` (the variant used elsewhere in the crate for this kind of failure) rather than wrapping a `ParseBoolError`, which also names the offending value in the message.