### PR TITLE
fix(gax): pass client extensions to make_headers in grpc-rust client

### DIFF
--- a/src/gax-internal/src/grpc/grpc_rust.rs
+++ b/src/gax-internal/src/grpc/grpc_rust.rs
@@ -61,6 +61,7 @@ struct GrpcRustClientInner {
     endpoint: ResolvedGrpcEndpoint,
     invoker: Channel,
     transport_policies: TransportPolicies,
+    extensions: crate::options::Extensions,
 }
 
 /// A gRPC endpoint resolved from the client configuration.
@@ -101,7 +102,12 @@ impl GrpcRustClient {
         Response: prost::Message + Default,
     {
         Self::note_ignored_extensions(&extensions);
-        let headers = grpc_helpers::make_headers(api_client_header, request_params, &options)?;
+        let headers = grpc_helpers::make_headers(
+            &self.inner.extensions,
+            api_client_header,
+            request_params,
+            &options,
+        )?;
         self.retry_loop::<Request, Response>(path, request, options, headers)
             .await
     }
@@ -264,7 +270,12 @@ impl GrpcRustClient {
         Response: prost::Message + Default + Send + 'static,
     {
         Self::note_ignored_extensions(&extensions);
-        let headers = grpc_helpers::make_headers(api_client_header, request_params, &options)?;
+        let headers = grpc_helpers::make_headers(
+            &self.inner.extensions,
+            api_client_header,
+            request_params,
+            &options,
+        )?;
         let headers = grpc_helpers::add_auth_headers(headers, &self.inner.credentials).await?;
         let metadata = from_header_map(&headers)?;
         let request_headers = RequestHeaders::new()
@@ -342,6 +353,7 @@ impl GrpcRustClient {
                 endpoint,
                 invoker,
                 transport_policies: TransportPolicies::from_config(&config),
+                extensions: config.extensions,
             }),
         })
     }

--- a/src/gax-internal/tests/grpc_rust_simple_request.rs
+++ b/src/gax-internal/tests/grpc_rust_simple_request.rs
@@ -126,6 +126,37 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn custom_global_headers() -> anyhow::Result<()> {
+        // Arrange
+        const CUSTOM_HEADER: &str = "x-custom-global-header";
+        const CUSTOM_VALUE: &str = "global-value";
+
+        let (endpoint, _server) = start_echo_server().await?;
+
+        let mut global_headers = http::HeaderMap::new();
+        global_headers.insert(
+            http::header::HeaderName::from_static(CUSTOM_HEADER),
+            http::header::HeaderValue::from_static(CUSTOM_VALUE),
+        );
+
+        let mut config = test_config();
+        config.extensions.insert(global_headers);
+
+        let client = GrpcRustClient::new(config, &endpoint).await?;
+
+        // Act
+        let response = send_request(client, "test message", "").await?;
+
+        // Assert
+        assert_eq!(&response.message, "test message");
+        assert_eq!(
+            response.metadata.get(CUSTOM_HEADER).map(String::as_str),
+            Some(CUSTOM_VALUE)
+        );
+        Ok(())
+    }
+
     fn test_credentials() -> Credentials {
         Anonymous::new().build()
     }


### PR DESCRIPTION
For #5991 