### PR TITLE
feat(bigquery): support buffered streams

### DIFF
--- a/src/bigquery-write/src/arrow.rs
+++ b/src/bigquery-write/src/arrow.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod buffered;
 mod committed;
 mod default;
 mod pending;
 mod writer_builder;
 
+pub use buffered::BufferedWriter;
 pub use committed::CommittedWriter;
 pub use default::DefaultWriter;
 pub use pending::PendingWriter;

--- a/src/bigquery-write/src/arrow/buffered.rs
+++ b/src/bigquery-write/src/arrow/buffered.rs
@@ -24,7 +24,9 @@ use crate::runner::Runner;
 use crate::transport::Transport;
 use std::sync::Arc;
 
-/// A writer for a buffered stream.
+/// A writer for the [buffered stream].
+///
+/// [buffered stream]: https://docs.cloud.google.com/bigquery/docs/write-api-grpc#buffered_type
 #[derive(Debug)]
 pub struct BufferedWriter {
     runner: Runner,

--- a/src/bigquery-write/src/arrow/buffered.rs
+++ b/src/bigquery-write/src/arrow/buffered.rs
@@ -1,0 +1,210 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Result;
+use crate::builder::write::AppendWithOffset;
+use crate::generated::gapic_storage::client::BigQueryWrite;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{
+    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse,
+    FlushRowsResponse,
+};
+use crate::runner::Runner;
+use crate::transport::Transport;
+use std::sync::Arc;
+
+/// A writer for a buffered stream.
+#[derive(Debug)]
+pub struct BufferedWriter {
+    runner: Runner,
+    pub(crate) write_stream: String,
+    pub(crate) schema: ArrowSchema,
+    client: BigQueryWrite,
+}
+
+impl BufferedWriter {
+    pub(crate) fn new(inner: Arc<Transport>, write_stream: String, schema: ArrowSchema) -> Self {
+        let runner = Runner::new(inner.clone());
+        let client = BigQueryWrite::from_stub::<Transport>(inner);
+        Self {
+            runner,
+            write_stream,
+            schema,
+            client,
+        }
+    }
+
+    /// Append rows to the buffered stream.
+    pub fn append(&self, rows: ArrowRecordBatch) -> AppendWithOffset {
+        let req = AppendRowsRequest::new()
+            .set_write_stream(&self.write_stream)
+            .set_arrow_rows(
+                ArrowData::new()
+                    .set_writer_schema(self.schema.clone())
+                    .set_rows(rows),
+            );
+        AppendWithOffset::new(self.runner.req_tx.clone(), req)
+    }
+
+    /// Flush the buffered stream, making rows up to the specified offset available for reading.
+    pub async fn flush(&self, offset: i64) -> Result<FlushRowsResponse> {
+        self.client
+            .flush_rows()
+            .set_write_stream(&self.write_stream)
+            .set_offset(offset)
+            .send()
+            .await
+    }
+
+    /// Finalize the buffered stream, preventing further writes.
+    pub async fn finalize(&self) -> Result<FinalizeWriteStreamResponse> {
+        self.client
+            .finalize_write_stream()
+            .set_name(&self.write_stream)
+            .send()
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runner::tests::*;
+    use crate::transport::tests::*;
+    use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+    use gaxi::grpc::tonic::Response as TonicResponse;
+    use tokio::sync::mpsc;
+
+    use crate::error::AppendError;
+
+    #[tokio::test]
+    async fn request_fields() -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let writer = BufferedWriter::new(transport, write_stream(), schema());
+
+        let b = writer.append(rows(1));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "1");
+
+        let b = writer.append(rows(2));
+        assert_eq!(b.req.write_stream, write_stream());
+        let data = b.req.arrow_rows().expect("arrow rows should be set");
+        let s = data.writer_schema.as_ref().expect("schema should be set");
+        assert_eq!(s.serialized_schema, "test");
+        let r = data.rows.as_ref().expect("rows should be set");
+        assert_eq!(r.serialized_record_batch, "2");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn basic_success() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+
+        mock.expect_flush_rows()
+            .return_once(|req| {
+                assert_eq!(req.get_ref().offset, Some(3));
+                assert_eq!(req.get_ref().write_stream, write_stream());
+                Ok(TonicResponse::new(
+                    bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FlushRowsResponse::default()
+                ))
+            });
+
+        mock.expect_finalize_write_stream()
+            .return_once(|req| {
+                assert_eq!(req.get_ref().name, write_stream());
+                Ok(TonicResponse::new(
+                    bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FinalizeWriteStreamResponse::default()
+                ))
+            });
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+
+        let writer = BufferedWriter::new(transport, write_stream(), schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let resp = writer.append(rows(1)).send().await?;
+        assert_eq!(resp.offset, Some(1));
+
+        response_tx.send(Ok(convert(&test_response(2)))).await?;
+        let resp = writer.append(rows(2)).send().await?;
+        assert_eq!(resp.offset, Some(2));
+
+        response_tx.send(Ok(convert(&test_response(3)))).await?;
+        let resp = writer.append(rows(3)).send().await?;
+        assert_eq!(resp.offset, Some(3));
+
+        drop(response_tx);
+        let err = writer.append(rows(4)).send().await.expect_err("channel");
+        assert!(matches!(err, AppendError::UnexpectedEndOfStream));
+
+        writer.flush(3).await?;
+        writer.finalize().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn multiple_flushes() -> anyhow::Result<()> {
+        let (response_tx, response_rx) = mpsc::channel(10);
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_append_rows()
+            .return_once(|_| Ok(TonicResponse::from(response_rx)));
+
+        mock.expect_flush_rows().times(2).returning(|req| {
+            Ok(TonicResponse::new(
+                bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::FlushRowsResponse {
+                    offset: req.get_ref().offset.unwrap_or(0),
+                },
+            ))
+        });
+
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let writer = BufferedWriter::new(transport, write_stream(), schema());
+
+        response_tx.send(Ok(convert(&test_response(1)))).await?;
+        let _ = writer.append(rows(1)).send().await?;
+        let flush1 = writer.flush(1).await?;
+        assert_eq!(flush1.offset, 1);
+
+        response_tx.send(Ok(convert(&test_response(2)))).await?;
+        let _ = writer.append(rows(2)).send().await?;
+        let flush2 = writer.flush(2).await?;
+        assert_eq!(flush2.offset, 2);
+
+        Ok(())
+    }
+
+    fn write_stream() -> String {
+        "projects/p/datasets/d/tables/t/streams/s".to_string()
+    }
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::new().set_serialized_schema("test")
+    }
+
+    fn rows(id: i64) -> ArrowRecordBatch {
+        ArrowRecordBatch::new().set_serialized_record_batch(id.to_string())
+    }
+}

--- a/src/bigquery-write/src/arrow/writer_builder.rs
+++ b/src/bigquery-write/src/arrow/writer_builder.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::arrow::{CommittedWriter, DefaultWriter, PendingWriter};
+use crate::arrow::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter};
 use crate::generated::gapic_storage::client::BigQueryWrite;
 use crate::model::write_stream::Type;
 use crate::model::{ArrowSchema, WriteStream};
@@ -80,6 +80,26 @@ impl WriterBuilder {
             .await?;
 
         Ok(CommittedWriter::new(
+            self.inner,
+            write_stream.name,
+            self.schema,
+        ))
+    }
+
+    /// Creates a buffered writer for the given table.
+    pub async fn buffered<T: Into<String>>(self, table: T) -> Result<BufferedWriter> {
+        let table = table.into();
+        validate_table(table.as_str())?;
+
+        let client = BigQueryWrite::from_stub::<Transport>(self.inner.clone());
+        let write_stream = client
+            .create_write_stream()
+            .set_parent(table)
+            .set_write_stream(WriteStream::new().set_type(Type::Buffered))
+            .send()
+            .await?;
+
+        Ok(BufferedWriter::new(
             self.inner,
             write_stream.name,
             self.schema,
@@ -232,6 +252,49 @@ mod tests {
         let builder = WriterBuilder::new(transport, schema.clone());
         let err = builder
             .default(table)
+            .expect_err("should fail locally on bad format");
+        assert!(err.is_binding(), "{err:?}");
+        Ok(())
+    }
+    #[tokio::test]
+    async fn buffered_success() -> anyhow::Result<()> {
+        use bigquery_write_grpc_mock::google::cloud::bigquery::storage::v1::WriteStream as MockWriteStream;
+        use bigquery_write_grpc_mock::{MockBigQueryWrite, start};
+        let mut mock = MockBigQueryWrite::new();
+        mock.expect_create_write_stream().return_once(|req| {
+            let req = req.into_inner();
+            assert_eq!(req.parent, "projects/p/datasets/d/tables/t");
+            let ws = req.write_stream.expect("write_stream populated");
+            assert_eq!(Type::from(ws.r#type), Type::Buffered);
+            Ok(gaxi::grpc::tonic::Response::new(MockWriteStream {
+                name: "projects/p/datasets/d/tables/t/streams/s".to_string(),
+                ..Default::default()
+            }))
+        });
+        let (endpoint, _server) = start("0.0.0.0:0", mock).await?;
+        let transport = Arc::new(test_transport(endpoint).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let writer = builder.buffered("projects/p/datasets/d/tables/t").await?;
+        assert_eq!(
+            writer.write_stream,
+            "projects/p/datasets/d/tables/t/streams/s"
+        );
+        assert_eq!(writer.schema, schema);
+        Ok(())
+    }
+
+    #[test_case("projects/p")]
+    #[test_case("projects/p/tables/t")]
+    #[test_case("projects/p/datasets/d/tables/")]
+    #[tokio::test]
+    async fn buffered_bad_table_format(table: &str) -> anyhow::Result<()> {
+        let transport = Arc::new(test_transport("http://ignored:1".to_string()).await?);
+        let schema = ArrowSchema::new().set_serialized_schema("test");
+        let builder = WriterBuilder::new(transport, schema.clone());
+        let err = builder
+            .buffered(table)
+            .await
             .expect_err("should fail locally on bad format");
         assert!(err.is_binding(), "{err:?}");
         Ok(())

--- a/tests/bigquery/src/writes.rs
+++ b/tests/bigquery/src/writes.rs
@@ -39,7 +39,8 @@ pub async fn run_writes() -> Result<()> {
         let client = Write::builder().build().await?;
         arrow::basic(&client, &project_id, &dataset_id, table_id).await?;
         arrow::pending(&client, &project_id, &dataset_id, table_id).await?;
-        arrow::committed(&client, &project_id, &dataset_id, table_id).await
+        arrow::committed(&client, &project_id, &dataset_id, table_id).await?;
+        arrow::buffered(&client, &project_id, &dataset_id, table_id).await
     }
     .await;
 

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -247,3 +247,99 @@ pub async fn committed(
 
     Ok(())
 }
+
+pub async fn buffered(
+    client: &Write,
+    project_id: &str,
+    dataset_id: &str,
+    table_id: &str,
+) -> Result<()> {
+    let table = format!("projects/{project_id}/datasets/{dataset_id}/tables/{table_id}");
+    let schema = create_test_schema();
+
+    // Create a writer for a buffered stream
+    let writer = client
+        .arrow(ArrowSchema::new().set_serialized_schema(serialize_schema(&schema)?))
+        .buffered(table)
+        .await?;
+
+    // Write the batches (no implicit commit yet)
+    let batch1 = create_test_batch(
+        schema.clone(),
+        vec!["Kelly", "Liam"],
+        vec![30, 32],
+        "buffered",
+    )?;
+    let resp1 = writer.append(batch1).set_offset(0).send().await?;
+    assert_eq!(resp1.offset, Some(0));
+
+    let batch2 = create_test_batch(schema.clone(), vec!["Mia"], vec![34], "buffered")?;
+    let resp2 = writer.append(batch2).set_offset(2).send().await?;
+    assert_eq!(resp2.offset, Some(2));
+
+    // Verify no writes have been committed
+    let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
+    assert!(users.is_empty(), "{users:?}");
+
+    // Flush to offset 2 (Kelly and Liam)
+    let flush1 = writer.flush(2).await?;
+    assert_eq!(flush1.offset, 2);
+
+    // Verify first batch is visible
+    let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
+    assert_eq!(
+        users,
+        vec![
+            WriteUserRecord {
+                name: "Kelly".to_string(),
+                age: 30,
+                test: "buffered".to_string()
+            },
+            WriteUserRecord {
+                name: "Liam".to_string(),
+                age: 32,
+                test: "buffered".to_string()
+            },
+        ]
+    );
+
+    // Flush to offset 3 (Mia)
+    let flush2 = writer.flush(3).await?;
+    assert_eq!(flush2.offset, 3);
+
+    let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
+    assert_eq!(
+        users,
+        vec![
+            WriteUserRecord {
+                name: "Kelly".to_string(),
+                age: 30,
+                test: "buffered".to_string()
+            },
+            WriteUserRecord {
+                name: "Liam".to_string(),
+                age: 32,
+                test: "buffered".to_string()
+            },
+            WriteUserRecord {
+                name: "Mia".to_string(),
+                age: 34,
+                test: "buffered".to_string()
+            },
+        ]
+    );
+
+    // Finalize the stream
+    writer.finalize().await?;
+
+    // Verify that appending to a finalized stream fails
+    let batch3 = create_test_batch(schema.clone(), vec!["Noah"], vec![36], "buffered")?;
+    let _err = writer
+        .append(batch3)
+        .set_offset(3)
+        .send()
+        .await
+        .expect_err("Appending to a finalized stream should fail");
+
+    Ok(())
+}

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -281,9 +281,9 @@ pub async fn buffered(
     let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
     assert!(users.is_empty(), "{users:?}");
 
-    // Flush to offset 2 (Kelly and Liam)
-    let flush1 = writer.flush(2).await?;
-    assert_eq!(flush1.offset, 2);
+    // Flush to offset 1 (Kelly and Liam)
+    let flush1 = writer.flush(1).await?;
+    assert_eq!(flush1.offset, 1);
 
     // Verify first batch is visible
     let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
@@ -303,9 +303,9 @@ pub async fn buffered(
         ]
     );
 
-    // Flush to offset 3 (Mia)
-    let flush2 = writer.flush(3).await?;
-    assert_eq!(flush2.offset, 3);
+    // Flush to offset 2 (Mia)
+    let flush2 = writer.flush(2).await?;
+    assert_eq!(flush2.offset, 2);
 
     let users = read_writes_table(project_id, dataset_id, table_id, "buffered").await?;
     assert_eq!(


### PR DESCRIPTION
Add support for buffered streams.

Buffered streams require flushing append horizons by providing an offset before the downstream platform makes the data visible to queries.

Fixes #6404 