### PR TITLE
cleanup(gaxi): deprecate _internal-grpc-server-streaming feature flag

### DIFF
--- a/.gcb/scripts/features-gax-internal.sh
+++ b/.gcb/scripts/features-gax-internal.sh
@@ -23,7 +23,7 @@ cargo clean
 echo "==== google-cloud-gax-internal ===="
 cargo test --package google-cloud-gax-internal --no-default-features
 cargo doc  --package google-cloud-gax-internal --no-default-features --no-deps
-for feature in _internal-common _internal-http-client _internal-grpc-client _internal-http-multipart _internal-http-stream _internal-grpc-server-streaming; do
+for feature in _internal-common _internal-http-client _internal-grpc-client _internal-http-multipart _internal-http-stream; do
     cargo test --package google-cloud-gax-internal --no-default-features --features "${feature}"
     cargo doc  --package google-cloud-gax-internal --no-default-features --features "${feature}" --no-deps
 done

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -92,7 +92,12 @@ _internal-common = [
 
 # Enables the default rustls crypto provider for whatever client(s) are enabled.
 _default-rustls-provider = ["google-cloud-auth?/default-rustls-provider", "tonic?/tls-aws-lc"]
-# Enables the unstable server streaming functionality in the gRPC client.
+# Deprecated: Server streaming functionality is now enabled by default when `_internal-grpc-client` is active.
+# This feature is retained as a no-op for backwards compatibility.
+#
+# TODO: Remove this feature flag during the next breaking version bump of
+# `google-cloud-gax-internal` (e.g., 0.8.0). It is retained as a no-op to avoid breaking
+# SemVer compatibility in the current 0.7.x series.
 _internal-grpc-server-streaming = []
 
 [dependencies]

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -304,7 +304,6 @@ impl Client {
     }
 
     /// Opens a server stream.
-    #[cfg(feature = "_internal-grpc-server-streaming")]
     pub async fn server_streaming<Request, Response>(
         &self,
         extensions: tonic::Extensions,

--- a/src/gax-internal/tests/grpc_server_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_server_streaming_request.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(all(
-    test,
-    feature = "_internal-grpc-client",
-    feature = "_internal-grpc-server-streaming"
-))]
+#[cfg(all(test, feature = "_internal-grpc-client"))]
 mod tests {
     use google_cloud_auth::credentials::{
         Credentials, anonymous::Builder as Anonymous, testing::error_credentials,

--- a/src/spanner/Cargo.toml
+++ b/src/spanner/Cargo.toml
@@ -46,7 +46,7 @@ async-trait.workspace                  = true
 base64.workspace                       = true
 bytes.workspace                        = true
 futures                                = { workspace = true, optional = true }
-gaxi                                   = { workspace = true, features = ["_internal-common", "_internal-grpc-client", "_internal-grpc-server-streaming"] }
+gaxi                                   = { workspace = true, features = ["_internal-common", "_internal-grpc-client"] }
 google-cloud-auth                      = { workspace = true }
 google-cloud-gax                       = { workspace = true }
 google-cloud-spanner-admin-database-v1 = { workspace = true }


### PR DESCRIPTION
Remove uses of the _internal-grpc-server-streaming feature. The functionality is now a part of _internal-grpc-client by default. To avoid a breaking change, we keep the feature flag in Cargo.toml to be removed the next time that we plan to bump gaxi to 0.8.0.