### PR TITLE
perf(bigquery): borrow schemas during REST row conversion

### DIFF
--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -14,6 +14,7 @@
 
 use crate::error::{ConvertError, RowError};
 use crate::query::{FromSql, Schema};
+use google_cloud_bigquery_v2::model::TableFieldSchema;
 use std::sync::Arc;
 use wkt::{ListValue, Struct, Value};
 
@@ -101,30 +102,7 @@ impl ColumnIndex for String {
 
 impl Row {
     pub(crate) fn try_new(row: Struct, schema: &Arc<Schema>) -> Result<Self> {
-        let field_list = get_field_list(row)?;
-
-        if field_list.len() != schema.len() {
-            return Err(RowError::InvalidRowFormat(format!(
-                "schema and row cell mismatch (expected {}, got {})",
-                schema.len(),
-                field_list.len()
-            )));
-        }
-
-        let mut values = ListValue::new();
-        for (i, cell) in field_list.into_iter().enumerate() {
-            let value = get_field_value(cell)?;
-            match schema.get_field_by_index(i) {
-                Some(f) => {
-                    let field_name = &f.name;
-                    let field_type = &f.r#type;
-                    let schema = Arc::new(Schema::new_from_field(f.clone()));
-                    let value = convert_value(value, field_name, field_type, &schema)?;
-                    values.push(value);
-                }
-                None => continue,
-            }
-        }
+        let values = convert_row(row, schema.fields())?;
 
         Ok(Self {
             values: Value::Array(values),
@@ -246,6 +224,24 @@ impl Row {
     }
 }
 
+fn convert_row(row: Struct, fields: &[TableFieldSchema]) -> Result<ListValue> {
+    let field_list = get_field_list(row)?;
+
+    if field_list.len() != fields.len() {
+        return Err(RowError::InvalidRowFormat(format!(
+            "schema and row cell mismatch (expected {}, got {})",
+            fields.len(),
+            field_list.len()
+        )));
+    }
+
+    let mut values = ListValue::with_capacity(fields.len());
+    for (cell, field) in field_list.into_iter().zip(fields) {
+        values.push(convert_value(get_field_value(cell)?, field)?);
+    }
+    Ok(values)
+}
+
 fn get_field_list(mut row: Struct) -> Result<Vec<Value>> {
     match row.remove("f") {
         Some(Value::Array(arr)) => Ok(arr),
@@ -264,49 +260,35 @@ fn get_field_value(value: Value) -> Result<Value> {
     }
 }
 
-fn convert_value(
-    value: Value,
-    field_name: &str,
-    field_type: &str,
-    schema: &Arc<Schema>,
-) -> Result<Value> {
+fn convert_value(value: Value, field: &TableFieldSchema) -> Result<Value> {
     match value {
         Value::Null => Ok(Value::Null),
-        Value::String(v) => convert_basic_type(v, field_name, field_type),
-        Value::Object(v) => convert_nested(v, schema),
-        Value::Array(v) => convert_repeated(v, field_name, field_type, schema),
+        Value::String(v) => convert_basic_type(v, &field.name, &field.r#type),
+        Value::Object(v) => convert_nested(v, &field.fields),
+        Value::Array(v) => convert_repeated(v, field),
         _ => Err(RowError::InvalidRowFormat(format!(
             "cell value is not an object: value={:?}, field_type={:?}",
-            value, field_type
+            value, field.r#type
         ))),
     }
 }
 
-fn convert_repeated(
-    value: ListValue,
-    field_name: &str,
-    field_type: &str,
-    schema: &Arc<Schema>,
-) -> Result<Value> {
+fn convert_repeated(value: ListValue, field: &TableFieldSchema) -> Result<Value> {
     let mut values = ListValue::new();
     for cell in value {
         // each cell contains a single entry, keyed by "v"
         let val = get_field_value(cell)?;
-        let v = convert_value(val, field_name, field_type, schema)?;
+        let v = convert_value(val, field)?;
         values.push(v);
     }
     Ok(Value::Array(values))
 }
 
-fn convert_nested(value: Struct, schema: &Arc<Schema>) -> Result<Value> {
-    let row = Row::try_new(value, schema)?;
+fn convert_nested(value: Struct, fields: &[TableFieldSchema]) -> Result<Value> {
+    let values = convert_row(value, fields)?;
     let mut obj = Struct::new();
-    if let Value::Array(list) = row.values {
-        for (i, val) in list.into_iter().enumerate() {
-            if let Some(field) = schema.get_field_by_index(i) {
-                obj.insert(field.name.clone(), val);
-            }
-        }
+    for (field, value) in fields.iter().zip(values) {
+        obj.insert(field.name.clone(), value);
     }
     Ok(Value::Object(obj))
 }

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -225,7 +225,7 @@ impl Row {
 }
 
 fn convert_row(row: Struct, fields: &[TableFieldSchema]) -> Result<ListValue> {
-    let field_list = get_field_list(row)?;
+    let mut field_list = get_field_list(row)?;
 
     if field_list.len() != fields.len() {
         return Err(RowError::InvalidRowFormat(format!(
@@ -235,11 +235,10 @@ fn convert_row(row: Struct, fields: &[TableFieldSchema]) -> Result<ListValue> {
         )));
     }
 
-    let mut values = ListValue::with_capacity(fields.len());
-    for (cell, field) in field_list.into_iter().zip(fields) {
-        values.push(convert_value(get_field_value(cell)?, field)?);
+    for (cell, field) in field_list.iter_mut().zip(fields) {
+        *cell = convert_value(get_field_value(cell.take())?, field)?;
     }
-    Ok(values)
+    Ok(field_list)
 }
 
 fn get_field_list(mut row: Struct) -> Result<Vec<Value>> {
@@ -273,15 +272,13 @@ fn convert_value(value: Value, field: &TableFieldSchema) -> Result<Value> {
     }
 }
 
-fn convert_repeated(value: ListValue, field: &TableFieldSchema) -> Result<Value> {
-    let mut values = ListValue::with_capacity(value.len());
-    for cell in value {
+fn convert_repeated(mut value: ListValue, field: &TableFieldSchema) -> Result<Value> {
+    for cell in &mut value {
         // each cell contains a single entry, keyed by "v"
-        let val = get_field_value(cell)?;
-        let v = convert_value(val, field)?;
-        values.push(v);
+        let val = get_field_value(cell.take())?;
+        *cell = convert_value(val, field)?;
     }
-    Ok(Value::Array(values))
+    Ok(Value::Array(value))
 }
 
 fn convert_nested(value: Struct, fields: &[TableFieldSchema]) -> Result<Value> {

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -730,6 +730,17 @@ mod tests {
         assert!(matches!(err, RowError::InvalidRowFormat(_)));
     }
 
+    #[test]
+    fn convert_value_unsupported_value() {
+        let field = TableFieldSchema::new()
+            .set_name("test_col")
+            .set_type("BOOLEAN")
+            .set_mode("NULLABLE");
+        let res = convert_value(Value::Bool(true), &field);
+        let err = res.unwrap_err();
+        assert!(matches!(err, RowError::InvalidRowFormat(_)));
+    }
+
     #[derive(FromRow, Debug, PartialEq)]
     struct TestRow {
         name: String,

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -283,10 +283,11 @@ fn convert_repeated(mut value: ListValue, field: &TableFieldSchema) -> Result<Va
 
 fn convert_nested(value: Struct, fields: &[TableFieldSchema]) -> Result<Value> {
     let values = convert_row(value, fields)?;
-    let mut obj = Struct::new();
-    for (field, value) in fields.iter().zip(values) {
-        obj.insert(field.name.clone(), value);
-    }
+    let obj: Struct = fields
+        .iter()
+        .zip(values)
+        .map(|(field, value)| (field.name.clone(), value))
+        .collect();
     Ok(Value::Object(obj))
 }
 

--- a/src/bigquery/src/query/row.rs
+++ b/src/bigquery/src/query/row.rs
@@ -274,7 +274,7 @@ fn convert_value(value: Value, field: &TableFieldSchema) -> Result<Value> {
 }
 
 fn convert_repeated(value: ListValue, field: &TableFieldSchema) -> Result<Value> {
-    let mut values = ListValue::new();
+    let mut values = ListValue::with_capacity(value.len());
     for cell in value {
         // each cell contains a single entry, keyed by "v"
         let val = get_field_value(cell)?;

--- a/src/bigquery/src/query/schema.rs
+++ b/src/bigquery/src/query/schema.rs
@@ -23,10 +23,6 @@ impl Schema {
         Self(schema)
     }
 
-    pub(crate) fn new_from_field(field: TableFieldSchema) -> Self {
-        Self(TableSchema::new().set_fields(field.fields))
-    }
-
     pub(crate) fn get_field_index_by_name(&self, name: &str) -> Option<usize> {
         self.0.fields.iter().position(|f| f.name == name)
     }
@@ -37,5 +33,9 @@ impl Schema {
 
     pub(crate) fn len(&self) -> usize {
         self.0.fields.len()
+    }
+
+    pub(crate) fn fields(&self) -> &[TableFieldSchema] {
+        &self.0.fields
     }
 }


### PR DESCRIPTION
Row conversion cloned table field schemas and allocated temporary schema wrappers for every cell, even though conversion only reads schema metadata.

Pass borrowed field slices through the recursive conversion instead, which removes a deep `TableFieldSchema` clone, an `Arc`, and a `TableSchema` allocation per cell for scalar, nested and repeated values.

Also reserve the cell vector up front, now that the column count is known before the loop runs.