### PR TITLE
impl(gax-internal): support server-side streaming

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1468,6 +1468,7 @@ libraries:
     skip_release: true
     rust:
       include_bidi_streaming_methods: true
+      include_server_streaming_methods: true
   - name: google-cloud-spanner
     version: 0.34.4-preview
     copyright_year: "2026"

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -380,6 +380,46 @@ impl Client {
         Ok(result)
     }
 
+    /// Opens a server stream with automatic model <-> proto conversion and stream mapping.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    pub async fn execute_server_streaming<DomainReq, DomainResp, ProstReq, ProstResp>(
+        &self,
+        extensions: tonic::Extensions,
+        path: http::uri::PathAndQuery,
+        request: DomainReq,
+        options: RequestOptions,
+        api_client_header: &'static str,
+        request_params: &str,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<DomainResp>>
+    where
+        DomainReq: crate::prost::ToProto<ProstReq, Output = ProstReq>,
+        DomainResp: Send + 'static,
+        ProstReq: prost::Message + Clone + 'static,
+        ProstResp: prost::Message + Default + crate::prost::FromProto<DomainResp> + 'static,
+    {
+        let req = request
+            .to_proto()
+            .map_err(google_cloud_gax::error::Error::ser)?;
+
+        let result = self
+            .server_streaming_with_status::<ProstReq, ProstResp>(
+                extensions,
+                path,
+                req,
+                options,
+                api_client_header,
+                request_params,
+            )
+            .await?
+            .map_err(to_gax_error)?;
+
+        let response_receiver = google_cloud_gax::streaming::ResponseReceiver::from_stream(
+            streaming::decode_response_stream(result.into_inner()),
+        );
+
+        Ok(response_receiver)
+    }
+
     /// Runs the retry loop.
     async fn retry_loop<Request, Response>(
         &self,

--- a/src/gax-internal/src/unimplemented.rs
+++ b/src/gax-internal/src/unimplemented.rs
@@ -38,6 +38,11 @@ pub fn unimplemented_bidi_stub<I, O>() -> (RequestSender<I>, ResponseReceiver<O>
     unimplemented!("{UNIMPLEMENTED}");
 }
 
+#[cfg(google_cloud_unstable_gapic_streaming)]
+pub async fn unimplemented_server_streaming_stub<O: Send>() -> Result<ResponseReceiver<O>> {
+    unimplemented!("{UNIMPLEMENTED}");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -53,5 +58,12 @@ mod tests {
     #[should_panic(expected = "to prevent breaking changes as services gain new RPCs")]
     fn test_unimplemented_bidi_stub() {
         let _ = unimplemented_bidi_stub::<(), ()>();
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[tokio::test]
+    #[should_panic(expected = "to prevent breaking changes as services gain new RPCs")]
+    async fn test_unimplemented_server_streaming_stub() {
+        let _ = unimplemented_server_streaming_stub::<()>().await;
     }
 }

--- a/src/gax-internal/tests/grpc_server_streaming_request.rs
+++ b/src/gax-internal/tests/grpc_server_streaming_request.rs
@@ -254,4 +254,100 @@ mod tests {
             )
             .await
     }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct DomainEchoRequest {
+        message: String,
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl google_cloud_gax_internal::prost::ToProto<EchoRequest> for DomainEchoRequest {
+        type Output = EchoRequest;
+        fn to_proto(
+            self,
+        ) -> std::result::Result<EchoRequest, google_cloud_gax_internal::prost::ConvertError>
+        {
+            Ok(EchoRequest {
+                message: self.message,
+                ..Default::default()
+            })
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug, PartialEq)]
+    struct DomainEchoResponse {
+        message: String,
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl google_cloud_gax_internal::prost::FromProto<DomainEchoResponse> for EchoResponse {
+        fn cnv(
+            self,
+        ) -> std::result::Result<DomainEchoResponse, google_cloud_gax_internal::prost::ConvertError>
+        {
+            Ok(DomainEchoResponse {
+                message: self.message,
+            })
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[tokio::test]
+    async fn execute_server_streaming_basic() -> anyhow::Result<()> {
+        let (endpoint, _server) = start_echo_server().await?;
+        let client = builder(endpoint)
+            .with_credentials(test_credentials())
+            .build()
+            .await?;
+
+        let extensions = {
+            let mut e = tonic::Extensions::new();
+            e.insert(tonic::GrpcMethod::new(
+                "google.test.v1.EchoServices",
+                "Expand",
+            ));
+            e
+        };
+        let request_options = {
+            let mut o = RequestOptions::default();
+            o.set_retry_policy(NeverRetry);
+            o
+        };
+
+        let mut receiver = client
+            .execute_server_streaming::<DomainEchoRequest, DomainEchoResponse, EchoRequest, EchoResponse>(
+                extensions,
+                http::uri::PathAndQuery::from_static("/google.test.v1.EchoService/Expand"),
+                DomainEchoRequest {
+                    message: "msg0 msg1".to_string(),
+                },
+                request_options,
+                "test-only-api-client/1.0",
+                "resource=test",
+            )
+            .await?;
+
+        let r0 = receiver.recv().await;
+        assert_eq!(
+            r0.transpose()?,
+            Some(DomainEchoResponse {
+                message: "msg0".to_string()
+            })
+        );
+
+        let r1 = receiver.recv().await;
+        assert_eq!(
+            r1.transpose()?,
+            Some(DomainEchoResponse {
+                message: "msg1".to_string()
+            })
+        );
+
+        let r2 = receiver.recv().await;
+        assert!(r2.is_none());
+
+        Ok(())
+    }
 }

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -2711,6 +2711,102 @@ pub mod echo {
         }
     }
 
+    /// The request builder for [Echo::expand][crate::client::Echo::expand] calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::builder::echo::Expand;
+    /// # async fn sample() -> google_cloud_showcase_v1beta1::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let mut receiver = builder.send().await?;
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> Expand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug)]
+    pub struct Expand(RequestBuilder<crate::model::ExpandRequest>);
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl Expand {
+        pub(crate) fn new(stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::ExpandRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>>
+        {
+            (*self.0.stub).expand(self.0.request, self.0.options).await
+        }
+
+        /// Sets the value of [content][crate::model::ExpandRequest::content].
+        pub fn set_content<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.content = v.into();
+            self
+        }
+
+        /// Sets the value of [error][crate::model::ExpandRequest::error].
+        pub fn set_error<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<google_cloud_rpc::model::Status>,
+        {
+            self.0.request.error = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [error][crate::model::ExpandRequest::error].
+        pub fn set_or_clear_error<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<google_cloud_rpc::model::Status>,
+        {
+            self.0.request.error = v.map(|x| x.into());
+            self
+        }
+
+        /// Sets the value of [stream_wait_time][crate::model::ExpandRequest::stream_wait_time].
+        pub fn set_stream_wait_time<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<wkt::Duration>,
+        {
+            self.0.request.stream_wait_time = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [stream_wait_time][crate::model::ExpandRequest::stream_wait_time].
+        pub fn set_or_clear_stream_wait_time<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<wkt::Duration>,
+        {
+            self.0.request.stream_wait_time = v.map(|x| x.into());
+            self
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for Expand {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
     /// The request builder for [Echo::chat][crate::client::Echo::chat] calls.
     ///
     /// # Example
@@ -6274,6 +6370,94 @@ pub mod messaging {
         }
     }
 
+    /// The request builder for [Messaging::stream_blurbs][crate::client::Messaging::stream_blurbs] calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::builder::messaging::StreamBlurbs;
+    /// # async fn sample() -> google_cloud_showcase_v1beta1::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let mut receiver = builder.send().await?;
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> StreamBlurbs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug)]
+    pub struct StreamBlurbs(RequestBuilder<crate::model::StreamBlurbsRequest>);
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl StreamBlurbs {
+        pub(crate) fn new(
+            stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
+        ) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::StreamBlurbsRequest>>(mut self, v: V) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>>
+        {
+            (*self.0.stub)
+                .stream_blurbs(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [name][crate::model::StreamBlurbsRequest::name].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.name = v.into();
+            self
+        }
+
+        /// Sets the value of [expire_time][crate::model::StreamBlurbsRequest::expire_time].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_expire_time<T>(mut self, v: T) -> Self
+        where
+            T: std::convert::Into<wkt::Timestamp>,
+        {
+            self.0.request.expire_time = std::option::Option::Some(v.into());
+            self
+        }
+
+        /// Sets or clears the value of [expire_time][crate::model::StreamBlurbsRequest::expire_time].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_or_clear_expire_time<T>(mut self, v: std::option::Option<T>) -> Self
+        where
+            T: std::convert::Into<wkt::Timestamp>,
+        {
+            self.0.request.expire_time = v.map(|x| x.into());
+            self
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for StreamBlurbs {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
     /// The request builder for [Messaging::connect][crate::client::Messaging::connect] calls.
     ///
     /// # Example
@@ -7489,6 +7673,86 @@ pub mod sequence_service {
 
     #[doc(hidden)]
     impl crate::RequestBuilder for AttemptSequence {
+        fn request_options(&mut self) -> &mut crate::RequestOptions {
+            &mut self.0.options
+        }
+    }
+
+    /// The request builder for [SequenceService::attempt_streaming_sequence][crate::client::SequenceService::attempt_streaming_sequence] calls.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_showcase_v1beta1::builder::sequence_service::AttemptStreamingSequence;
+    /// # async fn sample() -> google_cloud_showcase_v1beta1::Result<()> {
+    /// let builder = prepare_request_builder();
+    /// let mut receiver = builder.send().await?;
+    /// # Ok(()) }
+    ///
+    /// fn prepare_request_builder() -> AttemptStreamingSequence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[derive(Clone, Debug)]
+    pub struct AttemptStreamingSequence(
+        RequestBuilder<crate::model::AttemptStreamingSequenceRequest>,
+    );
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    impl AttemptStreamingSequence {
+        pub(crate) fn new(
+            stub: std::sync::Arc<dyn super::super::stub::dynamic::SequenceService>,
+        ) -> Self {
+            Self(RequestBuilder::new(stub))
+        }
+
+        /// Sets the full request, replacing any prior values.
+        pub fn with_request<V: Into<crate::model::AttemptStreamingSequenceRequest>>(
+            mut self,
+            v: V,
+        ) -> Self {
+            self.0.request = v.into();
+            self
+        }
+
+        /// Sets all the options, replacing any prior values.
+        pub fn with_options<V: Into<crate::RequestOptions>>(mut self, v: V) -> Self {
+            self.0.options = v.into();
+            self
+        }
+
+        /// Initiates the server stream.
+        pub async fn send(
+            self,
+        ) -> Result<
+            google_cloud_gax::streaming::ResponseReceiver<
+                crate::model::AttemptStreamingSequenceResponse,
+            >,
+        > {
+            (*self.0.stub)
+                .attempt_streaming_sequence(self.0.request, self.0.options)
+                .await
+        }
+
+        /// Sets the value of [name][crate::model::AttemptStreamingSequenceRequest::name].
+        ///
+        /// This is a **required** field for requests.
+        pub fn set_name<T: Into<std::string::String>>(mut self, v: T) -> Self {
+            self.0.request.name = v.into();
+            self
+        }
+
+        /// Sets the value of [last_fail_index][crate::model::AttemptStreamingSequenceRequest::last_fail_index].
+        pub fn set_last_fail_index<T: Into<i32>>(mut self, v: T) -> Self {
+            self.0.request.last_fail_index = v.into();
+            self
+        }
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    #[doc(hidden)]
+    impl crate::RequestBuilder for AttemptStreamingSequence {
         fn request_options(&mut self) -> &mut crate::RequestOptions {
             &mut self.0.options
         }

--- a/src/generated/showcase/src/client.rs
+++ b/src/generated/showcase/src/client.rs
@@ -731,6 +731,13 @@ impl Echo {
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    /// This method splits the given content into words and will pass each word back
+    /// through the stream. This method showcases server-side streaming RPCs.
+    pub fn expand(&self) -> super::builder::echo::Expand {
+        super::builder::echo::Expand::new(self.inner.clone())
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This method, upon receiving a request on the stream, will pass the same
     /// content back on the stream. This method showcases bidirectional
     /// streaming RPCs.
@@ -1878,6 +1885,13 @@ impl Messaging {
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    /// This returns a stream that emits the blurbs that are created for a
+    /// particular chat room or user profile.
+    pub fn stream_blurbs(&self) -> super::builder::messaging::StreamBlurbs {
+        super::builder::messaging::StreamBlurbs::new(self.inner.clone())
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     /// This method starts a bidirectional stream that receives all blurbs that
     /// are being created after the stream has started and sends requests to create
     /// blurbs. If an invalid blurb is requested to be created, the stream will
@@ -2320,6 +2334,17 @@ impl SequenceService {
     /// ```
     pub fn attempt_sequence(&self) -> super::builder::sequence_service::AttemptSequence {
         super::builder::sequence_service::AttemptSequence::new(self.inner.clone())
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    /// Attempts a server streaming call with a sequence of responses
+    /// Can be used to test retries and stream resumption logic
+    /// May not function as expected in HTTP mode due to when http statuses are sent
+    /// See <https://github.com/googleapis/gapic-showcase/issues/1377> for more details
+    pub fn attempt_streaming_sequence(
+        &self,
+    ) -> super::builder::sequence_service::AttemptStreamingSequence {
+        super::builder::sequence_service::AttemptStreamingSequence::new(self.inner.clone())
     }
 
     /// Provides the [Locations][google.cloud.location.Locations] service functionality in this service.

--- a/src/generated/showcase/src/convert.rs
+++ b/src/generated/showcase/src/convert.rs
@@ -123,6 +123,28 @@ impl gaxi::prost::FromProto<crate::model::EchoResponse> for EchoResponse {
     }
 }
 
+impl gaxi::prost::ToProto<ExpandRequest> for crate::model::ExpandRequest {
+    type Output = ExpandRequest;
+    fn to_proto(self) -> std::result::Result<ExpandRequest, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            content: self.content.to_proto()?,
+            error: self.error.map(|v| v.to_proto()).transpose()?,
+            stream_wait_time: self.stream_wait_time.map(|v| v.to_proto()).transpose()?,
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::ExpandRequest> for ExpandRequest {
+    fn cnv(self) -> std::result::Result<crate::model::ExpandRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::ExpandRequest::new()
+                .set_content(self.content)
+                .set_or_clear_error(self.error.map(|v| v.cnv()).transpose()?)
+                .set_or_clear_stream_wait_time(self.stream_wait_time.map(|v| v.cnv()).transpose()?)
+        )
+    }
+}
+
 impl gaxi::prost::ToProto<blurb::Content> for crate::model::blurb::Content {
     type Output = blurb::Content;
     fn to_proto(self) -> std::result::Result<Self::Output, gaxi::prost::ConvertError> {
@@ -187,6 +209,26 @@ impl gaxi::prost::FromProto<crate::model::Blurb> for Blurb {
                 .set_or_clear_update_time(self.update_time.map(|v| v.cnv()).transpose()?)
                 .set_content(self.content.map(|v| v.cnv()).transpose()?)
                 .set_legacy_id(self.legacy_id.map(|v| v.cnv()).transpose()?)
+        )
+    }
+}
+
+impl gaxi::prost::ToProto<StreamBlurbsRequest> for crate::model::StreamBlurbsRequest {
+    type Output = StreamBlurbsRequest;
+    fn to_proto(self) -> std::result::Result<StreamBlurbsRequest, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            name: self.name.to_proto()?,
+            expire_time: self.expire_time.map(|v| v.to_proto()).transpose()?,
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::StreamBlurbsRequest> for StreamBlurbsRequest {
+    fn cnv(self) -> std::result::Result<crate::model::StreamBlurbsRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::StreamBlurbsRequest::new()
+                .set_name(self.name)
+                .set_or_clear_expire_time(self.expire_time.map(|v| v.cnv()).transpose()?)
         )
     }
 }
@@ -270,6 +312,44 @@ impl gaxi::prost::FromProto<crate::model::ConnectRequest> for ConnectRequest {
         Ok(
             crate::model::ConnectRequest::new()
                 .set_request(self.request.map(|v| v.cnv()).transpose()?)
+        )
+    }
+}
+
+impl gaxi::prost::ToProto<AttemptStreamingSequenceRequest> for crate::model::AttemptStreamingSequenceRequest {
+    type Output = AttemptStreamingSequenceRequest;
+    fn to_proto(self) -> std::result::Result<AttemptStreamingSequenceRequest, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            name: self.name.to_proto()?,
+            last_fail_index: self.last_fail_index.to_proto()?,
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::AttemptStreamingSequenceRequest> for AttemptStreamingSequenceRequest {
+    fn cnv(self) -> std::result::Result<crate::model::AttemptStreamingSequenceRequest, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::AttemptStreamingSequenceRequest::new()
+                .set_name(self.name)
+                .set_last_fail_index(self.last_fail_index)
+        )
+    }
+}
+
+impl gaxi::prost::ToProto<AttemptStreamingSequenceResponse> for crate::model::AttemptStreamingSequenceResponse {
+    type Output = AttemptStreamingSequenceResponse;
+    fn to_proto(self) -> std::result::Result<AttemptStreamingSequenceResponse, gaxi::prost::ConvertError> {
+        Ok(Self::Output {
+            content: self.content.to_proto()?,
+        })
+    }
+}
+
+impl gaxi::prost::FromProto<crate::model::AttemptStreamingSequenceResponse> for AttemptStreamingSequenceResponse {
+    fn cnv(self) -> std::result::Result<crate::model::AttemptStreamingSequenceResponse, gaxi::prost::ConvertError> {
+        Ok(
+            crate::model::AttemptStreamingSequenceResponse::new()
+                .set_content(self.content)
         )
     }
 }

--- a/src/generated/showcase/src/prost/google.showcase.v1beta1.rs
+++ b/src/generated/showcase/src/prost/google.showcase.v1beta1.rs
@@ -55,6 +55,25 @@ impl ::prost::Name for EchoResponse {
         "type.googleapis.com/google.showcase.v1beta1.EchoResponse".into()
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExpandRequest {
+    #[prost(string, tag = "1")]
+    pub content: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub error: ::core::option::Option<super::super::rpc::Status>,
+    #[prost(message, optional, tag = "3")]
+    pub stream_wait_time: ::core::option::Option<::prost_types::Duration>,
+}
+impl ::prost::Name for ExpandRequest {
+    const NAME: &'static str = "ExpandRequest";
+    const PACKAGE: &'static str = "google.showcase.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "google.showcase.v1beta1.ExpandRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "type.googleapis.com/google.showcase.v1beta1.ExpandRequest".into()
+    }
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum Severity {
@@ -127,6 +146,23 @@ impl ::prost::Name for Blurb {
     }
     fn type_url() -> ::prost::alloc::string::String {
         "type.googleapis.com/google.showcase.v1beta1.Blurb".into()
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct StreamBlurbsRequest {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub expire_time: ::core::option::Option<::prost_types::Timestamp>,
+}
+impl ::prost::Name for StreamBlurbsRequest {
+    const NAME: &'static str = "StreamBlurbsRequest";
+    const PACKAGE: &'static str = "google.showcase.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "google.showcase.v1beta1.StreamBlurbsRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "type.googleapis.com/google.showcase.v1beta1.StreamBlurbsRequest".into()
     }
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
@@ -230,5 +266,39 @@ impl ::prost::Name for ConnectRequest {
     }
     fn type_url() -> ::prost::alloc::string::String {
         "type.googleapis.com/google.showcase.v1beta1.ConnectRequest".into()
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AttemptStreamingSequenceRequest {
+    #[prost(string, tag = "1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(int32, tag = "2")]
+    pub last_fail_index: i32,
+}
+impl ::prost::Name for AttemptStreamingSequenceRequest {
+    const NAME: &'static str = "AttemptStreamingSequenceRequest";
+    const PACKAGE: &'static str = "google.showcase.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "google.showcase.v1beta1.AttemptStreamingSequenceRequest".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "type.googleapis.com/google.showcase.v1beta1.AttemptStreamingSequenceRequest"
+            .into()
+    }
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct AttemptStreamingSequenceResponse {
+    #[prost(string, tag = "1")]
+    pub content: ::prost::alloc::string::String,
+}
+impl ::prost::Name for AttemptStreamingSequenceResponse {
+    const NAME: &'static str = "AttemptStreamingSequenceResponse";
+    const PACKAGE: &'static str = "google.showcase.v1beta1";
+    fn full_name() -> ::prost::alloc::string::String {
+        "google.showcase.v1beta1.AttemptStreamingSequenceResponse".into()
+    }
+    fn type_url() -> ::prost::alloc::string::String {
+        "type.googleapis.com/google.showcase.v1beta1.AttemptStreamingSequenceResponse"
+            .into()
     }
 }

--- a/src/generated/showcase/src/stub.rs
+++ b/src/generated/showcase/src/stub.rs
@@ -295,6 +295,20 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_stub()
     }
 
+    /// Implements [super::client::Echo::expand].
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn expand(
+        &self,
+        _req: crate::model::ExpandRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+
     /// Implements [super::client::Echo::chat].
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
@@ -785,6 +799,20 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_stub()
     }
 
+    /// Implements [super::client::Messaging::stream_blurbs].
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn stream_blurbs(
+        &self,
+        _req: crate::model::StreamBlurbsRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
+    }
+
     /// Implements [super::client::Messaging::connect].
     #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
@@ -995,6 +1023,22 @@ pub trait SequenceService: std::fmt::Debug + Send + Sync {
         _options: crate::RequestOptions,
     ) -> impl std::future::Future<Output = crate::Result<crate::Response<()>>> + Send {
         gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::SequenceService::attempt_streaming_sequence].
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    fn attempt_streaming_sequence(
+        &self,
+        _req: crate::model::AttemptStreamingSequenceRequest,
+        _options: crate::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<
+            google_cloud_gax::streaming::ResponseReceiver<
+                crate::model::AttemptStreamingSequenceResponse,
+            >,
+        >,
+    > + Send {
+        gaxi::unimplemented::unimplemented_server_streaming_stub()
     }
 
     /// Implements [super::client::SequenceService::list_locations].

--- a/src/generated/showcase/src/stub/dynamic.rs
+++ b/src/generated/showcase/src/stub/dynamic.rs
@@ -331,6 +331,13 @@ pub trait Echo: std::fmt::Debug + Send + Sync {
     ) -> crate::Result<crate::Response<crate::model::FailEchoWithDetailsResponse>>;
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>>;
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -467,6 +474,17 @@ impl<T: super::Echo> Echo for T {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<crate::model::FailEchoWithDetailsResponse>> {
         T::fail_echo_with_details(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>>
+    {
+        T::expand(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.
@@ -921,6 +939,15 @@ pub trait Messaging: std::fmt::Debug + Send + Sync {
     ) -> crate::Result<crate::Response<google_cloud_longrunning::model::Operation>>;
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn stream_blurbs(
+        &self,
+        req: crate::model::StreamBlurbsRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
+    >;
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1103,6 +1130,18 @@ impl<T: super::Messaging> Messaging for T {
 
     /// Forwards the call to the implementation provided by `T`.
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn stream_blurbs(
+        &self,
+        req: crate::model::StreamBlurbsRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>,
+    > {
+        T::stream_blurbs(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1251,6 +1290,17 @@ pub trait SequenceService: std::fmt::Debug + Send + Sync {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<()>>;
 
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn attempt_streaming_sequence(
+        &self,
+        req: crate::model::AttemptStreamingSequenceRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<
+            crate::model::AttemptStreamingSequenceResponse,
+        >,
+    >;
+
     async fn list_locations(
         &self,
         req: google_cloud_location::model::ListLocationsRequest,
@@ -1352,6 +1402,20 @@ impl<T: super::SequenceService> SequenceService for T {
         options: crate::RequestOptions,
     ) -> crate::Result<crate::Response<()>> {
         T::attempt_sequence(self, req, options).await
+    }
+
+    /// Forwards the call to the implementation provided by `T`.
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn attempt_streaming_sequence(
+        &self,
+        req: crate::model::AttemptStreamingSequenceRequest,
+        options: crate::RequestOptions,
+    ) -> crate::Result<
+        google_cloud_gax::streaming::ResponseReceiver<
+            crate::model::AttemptStreamingSequenceResponse,
+        >,
+    > {
+        T::attempt_streaming_sequence(self, req, options).await
     }
 
     /// Forwards the call to the implementation provided by `T`.

--- a/src/generated/showcase/src/tracing.rs
+++ b/src/generated/showcase/src/tracing.rs
@@ -417,6 +417,15 @@ where
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+        self.inner.expand(req, options).await
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -1133,6 +1142,16 @@ where
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn stream_blurbs(
+        &self,
+        req: crate::model::StreamBlurbsRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>>
+    {
+        self.inner.stream_blurbs(req, options).await
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -1429,6 +1448,19 @@ where
             method: "client::SequenceService::attempt_sequence",
             self.inner.attempt_sequence(req, options));
         pending.await
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn attempt_streaming_sequence(
+        &self,
+        req: crate::model::AttemptStreamingSequenceRequest,
+        options: crate::RequestOptions,
+    ) -> Result<
+        google_cloud_gax::streaming::ResponseReceiver<
+            crate::model::AttemptStreamingSequenceResponse,
+        >,
+    > {
+        self.inner.attempt_streaming_sequence(req, options).await
     }
 
     #[tracing::instrument(level = tracing::Level::DEBUG, ret)]

--- a/src/generated/showcase/src/transport.rs
+++ b/src/generated/showcase/src/transport.rs
@@ -1794,6 +1794,44 @@ impl super::stub::Echo for Echo {
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn expand(
+        &self,
+        req: crate::model::ExpandRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::EchoResponse>> {
+        let x_goog_request_params = [None::<String>; 0]
+            .into_iter()
+            .flatten()
+            .fold(String::new(), |b, p| b + "&" + &p);
+
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.showcase.v1beta1.Echo",
+                "Expand",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Echo/Expand");
+
+        self.grpc_inner
+            .execute_server_streaming::<
+                crate::model::ExpandRequest,
+                crate::model::EchoResponse,
+                crate::prost::google::showcase::v1beta1::ExpandRequest,
+                crate::prost::google::showcase::v1beta1::EchoResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn chat(
         &self,
         options: crate::RequestOptions,
@@ -5033,6 +5071,49 @@ impl super::stub::Messaging for Messaging {
     }
 
     #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn stream_blurbs(
+        &self,
+        req: crate::model::StreamBlurbsRequest,
+        options: crate::RequestOptions,
+    ) -> Result<google_cloud_gax::streaming::ResponseReceiver<crate::model::StreamBlurbsResponse>>
+    {
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.showcase.v1beta1.Messaging",
+                "StreamBlurbs",
+            ));
+            e
+        };
+        let path =
+            http::uri::PathAndQuery::from_static("/google.showcase.v1beta1.Messaging/StreamBlurbs");
+
+        self.grpc_inner
+            .execute_server_streaming::<
+                crate::model::StreamBlurbsRequest,
+                crate::model::StreamBlurbsResponse,
+                crate::prost::google::showcase::v1beta1::StreamBlurbsRequest,
+                crate::prost::google::showcase::v1beta1::StreamBlurbsResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
     fn connect(
         &self,
         options: crate::RequestOptions,
@@ -5929,26 +6010,45 @@ impl super::stub::Messaging for Messaging {
 #[derive(Clone)]
 pub struct SequenceService {
     inner: gaxi::http::ReqwestClient,
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    grpc_inner: gaxi::grpc::Client,
 }
 
 impl std::fmt::Debug for SequenceService {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        f.debug_struct("SequenceService")
-            .field("inner", &self.inner)
-            .finish()
+        let mut builder = f.debug_struct("SequenceService");
+        builder.field("inner", &self.inner);
+        #[cfg(google_cloud_unstable_gapic_streaming)]
+        builder.field("grpc_inner", &self.grpc_inner);
+        builder.finish()
     }
 }
 
 impl SequenceService {
     pub async fn new(config: gaxi::options::ClientConfig) -> crate::ClientBuilderResult<Self> {
         let tracing_is_enabled = gaxi::options::tracing_enabled(&config);
-        let inner = gaxi::http::ReqwestClient::new(config, crate::DEFAULT_HOST).await?;
+        let inner = gaxi::http::ReqwestClient::new(config.clone(), crate::DEFAULT_HOST).await?;
         let inner = if tracing_is_enabled {
             inner.with_instrumentation(&super::tracing::info::INSTRUMENTATION_CLIENT_INFO)
         } else {
             inner
         };
-        Ok(Self { inner })
+        #[cfg(google_cloud_unstable_gapic_streaming)]
+        let grpc_inner = if tracing_is_enabled {
+            gaxi::grpc::Client::new_with_instrumentation(
+                config,
+                crate::DEFAULT_HOST,
+                &super::tracing::info::INSTRUMENTATION_CLIENT_INFO,
+            )
+            .await?
+        } else {
+            gaxi::grpc::Client::new(config, crate::DEFAULT_HOST).await?
+        };
+        Ok(Self {
+            inner,
+            #[cfg(google_cloud_unstable_gapic_streaming)]
+            grpc_inner,
+        })
     }
 }
 
@@ -6241,6 +6341,53 @@ impl super::stub::SequenceService for SequenceService {
                 let (parts, _) = r.into_parts();
                 crate::Response::from_parts(parts, ())
             })
+    }
+
+    #[cfg(google_cloud_unstable_gapic_streaming)]
+    async fn attempt_streaming_sequence(
+        &self,
+        req: crate::model::AttemptStreamingSequenceRequest,
+        options: crate::RequestOptions,
+    ) -> Result<
+        google_cloud_gax::streaming::ResponseReceiver<
+            crate::model::AttemptStreamingSequenceResponse,
+        >,
+    > {
+        let x_goog_request_params = [Some(&req)
+            .map(|m| &m.name)
+            .map(|s| s.as_str())
+            .map(|v| format!("name={v}"))]
+        .into_iter()
+        .flatten()
+        .fold(String::new(), |b, p| b + "&" + &p);
+
+        let extensions = {
+            let mut e = gaxi::grpc::tonic::Extensions::new();
+            e.insert(gaxi::grpc::tonic::GrpcMethod::new(
+                "google.showcase.v1beta1.SequenceService",
+                "AttemptStreamingSequence",
+            ));
+            e
+        };
+        let path = http::uri::PathAndQuery::from_static(
+            "/google.showcase.v1beta1.SequenceService/AttemptStreamingSequence",
+        );
+
+        self.grpc_inner
+            .execute_server_streaming::<
+                crate::model::AttemptStreamingSequenceRequest,
+                crate::model::AttemptStreamingSequenceResponse,
+                crate::prost::google::showcase::v1beta1::AttemptStreamingSequenceRequest,
+                crate::prost::google::showcase::v1beta1::AttemptStreamingSequenceResponse,
+            >(
+                extensions,
+                path,
+                req,
+                options,
+                &crate::info::X_GOOG_API_CLIENT_HEADER,
+                &x_goog_request_params,
+            )
+            .await
     }
 
     async fn list_locations(

--- a/tests/showcase/src/streaming.rs
+++ b/tests/showcase/src/streaming.rs
@@ -32,6 +32,10 @@ pub async fn run() -> Result<()> {
     chat_server_error(&client).await?;
     chat_options_and_headers(&client).await?;
 
+    expand_happy_path(&client).await?;
+    expand_server_error(&client).await?;
+    expand_options_and_headers(&client).await?;
+
     Ok(())
 }
 
@@ -156,6 +160,88 @@ async fn chat_options_and_headers(client: &Echo) -> Result<()> {
     let res = receiver.recv().await.expect("expected response")?;
     assert_eq!(res.content, "header-and-capacity-test");
     drop(sender);
+    assert!(receiver.recv().await.is_none());
+
+    Ok(())
+}
+
+async fn expand_happy_path(client: &Echo) -> Result<()> {
+    let mut receiver = client
+        .expand()
+        .set_content("The quick brown fox jumps over the lazy dog")
+        .send()
+        .await?;
+
+    let mut words = Vec::new();
+    while let Some(res) = receiver.recv().await {
+        words.push(res?.content);
+    }
+
+    let expected = vec![
+        "The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog",
+    ];
+    assert_eq!(words, expected);
+
+    // Further recv() calls on closed receiver must return None.
+    assert!(receiver.recv().await.is_none());
+    assert!(receiver.recv().await.is_none());
+
+    Ok(())
+}
+
+async fn expand_server_error(client: &Echo) -> Result<()> {
+    let mut receiver = client
+        .expand()
+        .set_content("hello world")
+        .set_error(
+            google_cloud_rpc::model::Status::default()
+                .set_code(Code::InvalidArgument as i32)
+                .set_message("injected error for expand test"),
+        )
+        .send()
+        .await?;
+
+    // Words are streamed first.
+    let first = receiver.recv().await.expect("expected first word")?;
+    assert_eq!(first.content, "hello");
+
+    let second = receiver.recv().await.expect("expected second word")?;
+    assert_eq!(second.content, "world");
+
+    // Server error is delivered after the words.
+    let res = receiver
+        .recv()
+        .await
+        .expect("expected error item from receiver");
+    let err = res.expect_err("response should be an error");
+    let status = err
+        .status()
+        .expect("the error should include the service payload");
+    assert_eq!(status.code, Code::InvalidArgument);
+    assert_eq!(status.message.as_str(), "injected error for expand test");
+
+    // Server stream should now be closed.
+    assert!(receiver.recv().await.is_none());
+
+    Ok(())
+}
+
+async fn expand_options_and_headers(client: &Echo) -> Result<()> {
+    let header_name = http::header::HeaderName::from_static("x-custom-test-header");
+    let header_value = http::header::HeaderValue::from_static("custom-header-value");
+    let mut receiver = client
+        .expand()
+        .with_custom_header(header_name, header_value)
+        .set_content("header test")
+        .send()
+        .await?;
+
+    let first = receiver.recv().await.expect("expected first word")?;
+    assert_eq!(first.content, "header");
+
+    let second = receiver.recv().await.expect("expected second word")?;
+    assert_eq!(second.content, "test");
+
     assert!(receiver.recv().await.is_none());
 
     Ok(())


### PR DESCRIPTION
Add the execute_server_streaming helper on the gRPC transport client to support server-side streaming RPCs. The helper handles converting domain requests to proto messages and decodes the response stream using decode_response_stream into a ResponseReceiver.

Gate server streaming execution helpers under the
google_cloud_unstable_gapic_streaming cfg.

Enable include_server_streaming_methods for Showcase in librarian.yaml, regenerate google-cloud-showcase-v1beta1, and add integration tests for server-side streaming.

For #2318 