### PR TITLE
chore(spanner): remove allow(dead_code) annotations

### DIFF
--- a/src/spanner/src/client.rs
+++ b/src/spanner/src/client.rs
@@ -1508,7 +1508,6 @@ mod tests {
                 let stmt = Statement::builder("SELECT 1")
                     .with_attempt_timeout(Duration::from_secs(10))
                     .build();
-                // TODO(#5673): ensure that transaction ID is processed even if ResultSet is dropped
                 let _rs = tx.execute_query(stmt).await?;
 
                 // Read

--- a/src/spanner/src/key.rs
+++ b/src/spanner/src/key.rs
@@ -156,7 +156,6 @@ impl KeyRange {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn into_proto(self) -> crate::model::KeyRange {
         let mut proto = crate::model::KeyRange::new();
 
@@ -216,7 +215,6 @@ impl KeySet {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn into_proto(self) -> crate::model::KeySet {
         let mut proto = crate::model::KeySet::new();
         if self.all {

--- a/src/spanner/src/mutation.rs
+++ b/src/spanner/src/mutation.rs
@@ -322,7 +322,6 @@ impl MutationGroup {
         &self.mutations
     }
 
-    #[allow(dead_code)]
     pub(crate) fn build_proto(self) -> ProtoMutationGroup {
         ProtoMutationGroup::new().set_mutations(self.mutations.into_iter().map(|m| m.build_proto()))
     }

--- a/src/spanner/src/server_streaming/builder.rs
+++ b/src/spanner/src/server_streaming/builder.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#4969)
-#![allow(dead_code)]
-
 use crate::Error;
 use crate::RequestBuilder;
 use crate::RequestOptions;

--- a/src/spanner/src/server_streaming/stream.rs
+++ b/src/spanner/src/server_streaming/stream.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#4969)
-#![allow(dead_code)]
-
 use crate::google::spanner::v1::BatchWriteResponse;
 use crate::google::spanner::v1::CacheUpdate as ProtoCacheUpdate;
 use crate::google::spanner::v1::PartialResultSet;
@@ -52,6 +49,8 @@ impl PartialResultSetStream {
 #[derive(Debug)]
 pub(crate) struct BatchWriteStream {
     pub(crate) inner: Streaming<BatchWriteResponse>,
+    // TODO(#6083): Used when recording attempt metrics and server-timing headers for BatchWrite.
+    #[allow(dead_code)]
     pub(crate) headers: HeaderMap,
 }
 
@@ -61,6 +60,8 @@ impl BatchWriteStream {
     }
 
     /// Returns the initial response headers for the stream.
+    // TODO(#6083): Used when recording attempt metrics and server-timing headers for BatchWrite.
+    #[allow(dead_code)]
     pub(crate) fn headers(&self) -> &HeaderMap {
         &self.headers
     }

--- a/src/spanner/src/types.rs
+++ b/src/spanner/src/types.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(#4969)
-#![allow(dead_code)]
-
 use crate::generated::gapic_dataplane::model;
 use crate::generated::gapic_dataplane::model::TypeAnnotationCode;
 use crate::google::spanner::v1 as spanner_v1;


### PR DESCRIPTION
Remove several obsolete allow(dead_code) annotations from the Spanner client.