### PR TITLE
cleanup(bigquery): restrict model exports

### DIFF
--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -20,8 +20,12 @@ pub mod arrow;
 // TODO(#6443) - relocate this.
 /// The messages and enums that are part of this client library
 pub mod model {
-    // TODO(#6224) - restrict exports
-    pub use crate::write::generated::gapic_storage::model::*;
+    pub(crate) use crate::write::generated::gapic_storage::model::*;
+    pub use crate::write::generated::gapic_storage::model::{
+        ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
+        FinalizeWriteStreamResponse, FlushRowsResponse, RowError, StorageError, TableFieldSchema,
+        TableSchema, row_error, storage_error, table_field_schema,
+    };
 }
 
 pub use append_future::AppendFuture;


### PR DESCRIPTION
Restrict the set of exported models to the ones we use from the veneer.

I don't have a good long term plan for keeping this set up to date. (The main concern is that a new child message is added which applications would not be able to name).[^1]

In the long run, we might add the Read GAPIC and export all `google.cloud.bigquery.storage.v1` types in this mod. Then it matters less.

Fixes #6224 

[^1]: One option is to support both `included_ids` and `skipped_ids` together in sidekick, and then just use the `*`. It might already work.