### PR TITLE
refactor(bigquery): use `crate::model` for `storage/v1` types

### DIFF
--- a/src/bigquery/src/lib.rs
+++ b/src/bigquery/src/lib.rs
@@ -108,7 +108,20 @@ pub mod client {
     // TODO(#6152) - add Write admin client
 }
 
-/// Extends [google_cloud_bigquery_v2::model] with types that improve ergonomics.
+/// The messages and enums that are part of this client library
+pub mod model {
+    pub(crate) use crate::write::generated::gapic_storage::model::*;
+    pub use crate::write::generated::gapic_storage::model::{
+        ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
+        FinalizeWriteStreamResponse, FlushRowsResponse, RowError, StorageError, TableFieldSchema,
+        TableSchema, row_error, storage_error, table_field_schema,
+    };
+}
+
+/// Extends [crate::model].
+///
+/// Note that there is no real distinction between the types in `model` and
+/// `model_ext`. The two modules are separate for library maintenance reasons.
 pub mod model_ext {
     pub use crate::generated::{CompleteQueryMetadata, QueryMetadata, QueryRequest};
     pub use crate::write::append_response::AppendResponse;

--- a/src/bigquery/src/write.rs
+++ b/src/bigquery/src/write.rs
@@ -17,17 +17,6 @@
 /// [arrow]: https://arrow.apache.org/
 pub mod arrow;
 
-// TODO(#6443) - relocate this.
-/// The messages and enums that are part of this client library
-pub mod model {
-    pub(crate) use crate::write::generated::gapic_storage::model::*;
-    pub use crate::write::generated::gapic_storage::model::{
-        ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
-        FinalizeWriteStreamResponse, FlushRowsResponse, RowError, StorageError, TableFieldSchema,
-        TableSchema, row_error, storage_error, table_field_schema,
-    };
-}
-
 pub use append_future::AppendFuture;
 
 pub(super) mod append_builder;

--- a/src/bigquery/src/write/append_builder.rs
+++ b/src/bigquery/src/write/append_builder.rs
@@ -15,9 +15,9 @@
 use super::append_future::AppendFuture;
 use super::append_response::{AppendResponse, to_result};
 use super::error::{AppendError, AppendResult};
-use super::model::AppendRowsRequest;
 use super::runner::WriteRequest;
 use crate::Error;
+use crate::model::AppendRowsRequest;
 use gaxi::prost::{FromProto, ToProto};
 use tokio::sync::{mpsc, oneshot};
 
@@ -90,12 +90,12 @@ impl Append {
 
 #[cfg(test)]
 mod tests {
-    use super::super::model::TableSchema;
     use super::*;
     use crate::google::cloud::bigquery::storage::v1;
     use crate::google::cloud::bigquery::storage::v1::append_rows_response::{
         AppendResult, Response,
     };
+    use crate::model::TableSchema;
 
     #[tokio::test]
     async fn success() -> anyhow::Result<()> {

--- a/src/bigquery/src/write/append_future.rs
+++ b/src/bigquery/src/write/append_future.rs
@@ -50,8 +50,8 @@ impl Future for AppendFuture {
 
 #[cfg(test)]
 mod tests {
-    use super::super::model::TableSchema;
     use super::*;
+    use crate::model::TableSchema;
 
     #[tokio::test]
     async fn happy_path() {

--- a/src/bigquery/src/write/append_response.rs
+++ b/src/bigquery/src/write/append_response.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 use super::error::{AppendError, AppendResult};
-use super::model::append_rows_response::Response;
-use super::model::{AppendRowsResponse, TableSchema};
 use crate::Error;
+use crate::model::append_rows_response::Response;
+use crate::model::{AppendRowsResponse, TableSchema};
 
 /// The return type of an `append()` operation.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -56,10 +56,10 @@ pub(crate) fn to_result(resp: AppendRowsResponse) -> AppendResult<AppendResponse
 
 #[cfg(test)]
 mod tests {
-    use super::super::model::RowError;
-    use super::super::model::append_rows_response::AppendResult;
-    use super::super::model::row_error::RowErrorCode;
     use super::*;
+    use crate::model::RowError;
+    use crate::model::append_rows_response::AppendResult;
+    use crate::model::row_error::RowErrorCode;
     use google_cloud_gax::error::rpc::Code;
     use google_cloud_rpc::model::Status as RpcStatus;
 

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -14,14 +14,14 @@
 
 use super::super::append_builder::AppendWithOffset;
 use super::super::generated::gapic_storage::client::BigQueryWrite;
-use super::super::model::append_rows_request::ArrowData;
-use super::super::model::{
-    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse,
-    FlushRowsResponse,
-};
 use super::super::runner::Runner;
 use super::super::transport::Transport;
 use crate::Result;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{
+    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse,
+    FlushRowsResponse,
+};
 use std::sync::Arc;
 
 /// A writer for the [buffered stream].

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -14,13 +14,11 @@
 
 use super::super::append_builder::AppendWithOffset;
 use super::super::generated::gapic_storage::client::BigQueryWrite;
-use super::super::model::append_rows_request::ArrowData;
-use super::super::model::{
-    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse,
-};
 use super::super::runner::Runner;
 use super::super::transport::Transport;
 use crate::Result;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse};
 use std::sync::Arc;
 
 /// A writer for the [committed stream].

--- a/src/bigquery/src/write/arrow/default.rs
+++ b/src/bigquery/src/write/arrow/default.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use super::super::append_builder::Append;
-use super::super::model::append_rows_request::ArrowData;
-use super::super::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema};
 use super::super::runner::Runner;
 use super::super::transport::Transport;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema};
 use std::sync::Arc;
 
 /// A writer for the [default stream]

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -14,14 +14,14 @@
 
 use super::super::append_builder::AppendWithOffset;
 use super::super::generated::gapic_storage::client::BigQueryWrite;
-use super::super::model::append_rows_request::ArrowData;
-use super::super::model::{
-    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
-    FinalizeWriteStreamResponse,
-};
 use super::super::runner::Runner;
 use super::super::transport::Transport;
 use crate::Result;
+use crate::model::append_rows_request::ArrowData;
+use crate::model::{
+    AppendRowsRequest, ArrowRecordBatch, ArrowSchema, BatchCommitWriteStreamsResponse,
+    FinalizeWriteStreamResponse,
+};
 use std::sync::Arc;
 
 /// A writer for a pending stream.

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 use super::super::generated::gapic_storage::client::BigQueryWrite;
-use super::super::model::write_stream::Type;
-use super::super::model::{ArrowSchema, WriteStream};
 use super::super::transport::Transport;
 use super::{BufferedWriter, CommittedWriter, DefaultWriter, PendingWriter};
+use crate::model::write_stream::Type;
+use crate::model::{ArrowSchema, WriteStream};
 use crate::{Error, Result};
 use gaxi::path_parameter::{PathMismatchBuilder, try_match};
 use gaxi::routing_parameter::Segment;

--- a/src/bigquery/src/write/client.rs
+++ b/src/bigquery/src/write/client.rs
@@ -14,9 +14,9 @@
 
 use super::arrow::WriterBuilder as ArrowWriterBuilder;
 use super::client_builder::ClientBuilder;
-use super::model::ArrowSchema;
 use super::transport::Transport;
 use crate::ClientBuilderResult as BuilderResult;
+use crate::model::ArrowSchema;
 use std::sync::Arc;
 
 /// A client for BigQuery Storage Write API.
@@ -50,7 +50,7 @@ impl Write {
     ///   .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
     /// # Ok(()) }
     ///
-    /// use google_cloud_bigquery::write::model::ArrowSchema;
+    /// use google_cloud_bigquery::model::ArrowSchema;
     /// fn schema() -> ArrowSchema {
     ///   todo!("Define your table's schema...")
     /// }
@@ -65,8 +65,8 @@ impl Write {
 #[cfg(test)]
 mod tests {
     use super::super::error::AppendError;
-    use super::super::model::{ArrowRecordBatch, ArrowSchema};
     use super::*;
+    use crate::model::{ArrowRecordBatch, ArrowSchema};
     use bigquery_grpc_mock::{MockBigQueryWrite, start};
     use gaxi::grpc::tonic::Status as TonicStatus;
     use google_cloud_auth::credentials::anonymous::Builder as Anonymous;

--- a/src/bigquery/src/write/error.rs
+++ b/src/bigquery/src/write/error.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::model::RowError;
 use crate::Error;
+use crate::model::RowError;
 
 /// Represents an error that can occur when appending rows.
 #[derive(thiserror::Error, Debug)]

--- a/src/bigquery/src/write/proto_schema.rs
+++ b/src/bigquery/src/write/proto_schema.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::model::ProtoSchema;
 use crate::google::cloud::bigquery::storage::v1;
+use crate::model::ProtoSchema;
 use gaxi::prost::{ConvertError, FromProto, ToProto};
 
 impl ToProto<v1::ProtoSchema> for ProtoSchema {

--- a/tests/bigquery/src/writes/arrow.rs
+++ b/tests/bigquery/src/writes/arrow.rs
@@ -19,7 +19,7 @@ use ::arrow::ipc::writer::StreamWriter;
 use ::arrow::record_batch::RecordBatch;
 use anyhow::Result;
 use google_cloud_bigquery::client::Write;
-use google_cloud_bigquery::write::model::{ArrowRecordBatch, ArrowSchema};
+use google_cloud_bigquery::model::{ArrowRecordBatch, ArrowSchema};
 use std::sync::Arc;
 
 pub async fn basic(


### PR DESCRIPTION
Use the top level `crate::model` to host the generated `bigquery/storage/v1` types.

Fixes #6443 