### PR TITLE
docs(bigquery): add more examples for write api

### DIFF
--- a/src/bigquery/src/write/append_builder.rs
+++ b/src/bigquery/src/write/append_builder.rs
@@ -130,13 +130,13 @@ impl Append {
     /// # Example
     ///
     /// ```
-    /// # use google_cloud_bigquery::write::arrow::PendingWriter;
-    /// # async fn sample(writer: PendingWriter) -> anyhow::Result<()> {
+    /// # use google_cloud_bigquery::write::arrow::DefaultWriter;
+    /// # async fn sample(writer: DefaultWriter) -> anyhow::Result<()> {
     /// let f1 = tokio::spawn(writer.append(rows()).send());
     /// let f2 = tokio::spawn(writer.append(rows()).send());
     ///
-    /// let resp1 = f1.await?;
-    /// let resp2 = f2.await?;
+    /// let resp1 = f1.await??;
+    /// let resp2 = f2.await??;
     /// # Ok(()) }
     ///
     /// use google_cloud_bigquery::model::ArrowRecordBatch;

--- a/src/bigquery/src/write/append_builder.rs
+++ b/src/bigquery/src/write/append_builder.rs
@@ -35,13 +35,53 @@ impl AppendWithOffset {
         Self { req_tx, req }
     }
 
-    /// Sets the target stream offset to guarantee exactly-once execution.
+    /// Sets the target stream offset to guarantee [exactly-once] writes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::write::arrow::PendingWriter;
+    /// # async fn sample(writer: PendingWriter) -> anyhow::Result<()> {
+    /// let resp = writer.append(rows()).set_offset(0).send().await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowRecordBatch;
+    /// fn rows() -> ArrowRecordBatch {
+    ///   todo!("Define your rows...")
+    /// }
+    /// ```
+    ///
+    /// [exactly-once]: https://docs.cloud.google.com/bigquery/docs/write-api-best-practices#manage_stream_offsets_to_achieve_exactly-once_semantics
     pub fn set_offset(mut self, offset: i64) -> Self {
         self.req.offset = Some(offset);
         self
     }
 
     /// Append rows to the stream.
+    ///
+    /// Applications are encouraged to queue up requests and await their
+    /// responses independently.
+    ///
+    /// Note that the service will reject requests with a mismatched offset, so
+    /// requests must be queued in order.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::write::arrow::PendingWriter;
+    /// # async fn sample(writer: PendingWriter) -> anyhow::Result<()> {
+    /// let f1 = writer.append(rows()).set_offset(0).send();
+    /// let f2 = writer.append(rows()).set_offset(1).send();
+    ///
+    /// let resp1 = f1.await?;
+    /// let resp2 = f2.await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowRecordBatch;
+    /// fn rows() -> ArrowRecordBatch {
+    ///   todo!("Define your rows...")
+    /// }
+    /// ```
     pub fn send(self) -> AppendFuture {
         let (tx, rx) = oneshot::channel();
 
@@ -83,6 +123,27 @@ impl Append {
     }
 
     /// Append rows to the stream.
+    ///
+    /// Applications are encouraged to queue up requests and await their
+    /// responses independently.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::write::arrow::PendingWriter;
+    /// # async fn sample(writer: PendingWriter) -> anyhow::Result<()> {
+    /// let f1 = tokio::spawn(writer.append(rows()).send());
+    /// let f2 = tokio::spawn(writer.append(rows()).send());
+    ///
+    /// let resp1 = f1.await?;
+    /// let resp2 = f2.await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowRecordBatch;
+    /// fn rows() -> ArrowRecordBatch {
+    ///   todo!("Define your rows...")
+    /// }
+    /// ```
     pub async fn send(self) -> AppendResult<AppendResponse> {
         send_append_request(self.req_tx, self.req).await
     }

--- a/src/bigquery/src/write/arrow/buffered.rs
+++ b/src/bigquery/src/write/arrow/buffered.rs
@@ -24,7 +24,7 @@ use crate::model::{
 };
 use std::sync::Arc;
 
-/// A writer for the [buffered stream].
+/// A writer for a [buffered stream].
 ///
 /// [buffered stream]: https://docs.cloud.google.com/bigquery/docs/write-api-grpc#buffered_type
 #[derive(Debug)]

--- a/src/bigquery/src/write/arrow/committed.rs
+++ b/src/bigquery/src/write/arrow/committed.rs
@@ -21,7 +21,7 @@ use crate::model::append_rows_request::ArrowData;
 use crate::model::{AppendRowsRequest, ArrowRecordBatch, ArrowSchema, FinalizeWriteStreamResponse};
 use std::sync::Arc;
 
-/// A writer for the [committed stream].
+/// A writer for a [committed stream].
 ///
 /// [committed stream]: https://docs.cloud.google.com/bigquery/docs/write-api-grpc#committed_type
 #[derive(Debug)]

--- a/src/bigquery/src/write/arrow/pending.rs
+++ b/src/bigquery/src/write/arrow/pending.rs
@@ -24,7 +24,9 @@ use crate::model::{
 };
 use std::sync::Arc;
 
-/// A writer for a pending stream.
+/// A writer for a [pending stream].
+///
+/// [pending stream]: https://docs.cloud.google.com/bigquery/docs/write-api-grpc#pending_type
 #[derive(Debug)]
 pub struct PendingWriter {
     runner: Runner,

--- a/src/bigquery/src/write/arrow/writer_builder.rs
+++ b/src/bigquery/src/write/arrow/writer_builder.rs
@@ -37,6 +37,22 @@ impl WriterBuilder {
 
     /// Create a writer for the [default stream] for the given table.
     ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::client::Write;
+    /// # async fn sample(client: Write) -> anyhow::Result<()> {
+    /// let writer = client
+    ///     .arrow(schema())
+    ///     .default("projects/my-project/datasets/my-dataset/tables/my-table")?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowSchema;
+    /// fn schema() -> ArrowSchema {
+    ///   todo!("Define your table's schema...")
+    /// }
+    /// ```
+    ///
     /// [default stream]: https://docs.cloud.google.com/bigquery/docs/write-api#default_stream
     pub fn default<T: Into<String>>(self, table: T) -> Result<DefaultWriter> {
         let table = table.into();
@@ -47,6 +63,23 @@ impl WriterBuilder {
     }
 
     /// Creates a pending writer for the given table.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::client::Write;
+    /// # async fn sample(client: Write) -> anyhow::Result<()> {
+    /// let writer = client
+    ///     .arrow(schema())
+    ///     .pending("projects/my-project/datasets/my-dataset/tables/my-table")
+    ///     .await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowSchema;
+    /// fn schema() -> ArrowSchema {
+    ///   todo!("Define your table's schema...")
+    /// }
+    /// ```
     pub async fn pending<T: Into<String>>(self, table: T) -> Result<PendingWriter> {
         let table = table.into();
         validate_table(table.as_str())?;
@@ -67,6 +100,23 @@ impl WriterBuilder {
     }
 
     /// Creates a committed writer for the given table.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::client::Write;
+    /// # async fn sample(client: Write) -> anyhow::Result<()> {
+    /// let writer = client
+    ///     .arrow(schema())
+    ///     .committed("projects/my-project/datasets/my-dataset/tables/my-table")
+    ///     .await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowSchema;
+    /// fn schema() -> ArrowSchema {
+    ///   todo!("Define your table's schema...")
+    /// }
+    /// ```
     pub async fn committed<T: Into<String>>(self, table: T) -> Result<CommittedWriter> {
         let table = table.into();
         validate_table(table.as_str())?;
@@ -87,6 +137,23 @@ impl WriterBuilder {
     }
 
     /// Creates a buffered writer for the given table.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use google_cloud_bigquery::client::Write;
+    /// # async fn sample(client: Write) -> anyhow::Result<()> {
+    /// let writer = client
+    ///     .arrow(schema())
+    ///     .buffered("projects/my-project/datasets/my-dataset/tables/my-table")
+    ///     .await?;
+    /// # Ok(()) }
+    ///
+    /// use google_cloud_bigquery::model::ArrowSchema;
+    /// fn schema() -> ArrowSchema {
+    ///   todo!("Define your table's schema...")
+    /// }
+    /// ```
     pub async fn buffered<T: Into<String>>(self, table: T) -> Result<BufferedWriter> {
         let table = table.into();
         validate_table(table.as_str())?;


### PR DESCRIPTION
Add samples for the `WriterBuilder` and `Append*` builders

Part of the work for #6224 